### PR TITLE
[FEATURE] Enregistrer l'accès d'un utilisateur à un centre de certification (PIX-16629)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -14,6 +14,7 @@ const buildCertificationCenterMembership = function ({
   disabledAt,
   isReferer = false,
   role = 'MEMBER',
+  lastAccessedAt,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   certificationCenterId = _.isUndefined(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
@@ -32,6 +33,7 @@ const buildCertificationCenterMembership = function ({
     disabledAt,
     isReferer,
     role,
+    lastAccessedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-center-memberships',

--- a/api/src/shared/domain/models/CertificationCenterMembership.js
+++ b/api/src/shared/domain/models/CertificationCenterMembership.js
@@ -14,6 +14,7 @@ class CertificationCenterMembership {
     role,
     updatedByUserId,
     updatedAt,
+    lastAccessedAt,
   } = {}) {
     this.id = id;
     this.certificationCenter = certificationCenter;
@@ -24,6 +25,7 @@ class CertificationCenterMembership {
     this.role = role;
     this.updatedByUserId = updatedByUserId;
     this.updatedAt = updatedAt;
+    this.lastAccessedAt = lastAccessedAt;
   }
 
   get hasAdminRole() {

--- a/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
@@ -59,9 +59,22 @@ const updateReferer = async function (request, h) {
   return h.response().code(204);
 };
 
+const updateLastAccessedAt = async function (request, h, dependencies = { requestResponseUtils }) {
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const certificationCenterId = request.params.certificationCenterId;
+
+  await usecases.updateCertificationCenterMembershipLastAccessedAt({
+    userId,
+    certificationCenterId,
+  });
+
+  return h.response().code(204);
+};
+
 const certificationCenterMembershipController = {
   findCertificationCenterMemberships,
   updateFromPixCertif,
   updateReferer,
+  updateLastAccessedAt,
 };
 export { certificationCenterMembershipController };

--- a/api/src/team/application/certification-center-membership/certification-center-membership.route.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.route.js
@@ -70,4 +70,27 @@ export const certificationCenterMembershipRoute = [
       tags: ['api', 'certification-center-membership'],
     },
   },
+  {
+    method: 'PATCH',
+    path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships/me',
+    config: {
+      pre: [
+        {
+          method: (request, h) => securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, h),
+          assign: 'isMemberOfCertificationCenter',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          certificationCenterId: identifiersType.certificationCenterId,
+        }),
+      },
+      handler: (request, h) => certificationCenterMembershipController.updateLastAccessedAt(request, h),
+      tags: ['api', 'certification-center-membership'],
+      notes: [
+        "Cette route est restreinte aux membres authentifiés d'un centre de certification",
+        'Elle permet de mettre à jour la dernière date d’accès d’un utilisateur à un centre de certification.',
+      ],
+    },
+  },
 ];

--- a/api/src/team/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.js
+++ b/api/src/team/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.js
@@ -1,0 +1,19 @@
+/**
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {string} params.certificationCenterId
+ * @param {CertificationCenterMembershipRepository} params.certificationCenterMembershipRepository
+ */
+const updateCertificationCenterMembershipLastAccessedAt = async function ({
+  userId,
+  certificationCenterId,
+  certificationCenterMembershipRepository,
+}) {
+  return certificationCenterMembershipRepository.updateLastAccessedAt({
+    lastAccessedAt: new Date(),
+    userId,
+    certificationCenterId,
+  });
+};
+
+export { updateCertificationCenterMembershipLastAccessedAt };

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -44,6 +44,7 @@ function _toDomain(certificationCenterMembershipDTO) {
     updatedByUserId: certificationCenterMembershipDTO.updatedByUserId,
     updatedAt: certificationCenterMembershipDTO.updatedAt,
     role: certificationCenterMembershipDTO.role,
+    lastAccessedAt: certificationCenterMembershipDTO.lastAccessedAt,
   });
 }
 

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -288,6 +288,14 @@ const update = async function (certificationCenterMembership) {
   await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).update(data).where({ id: certificationCenterMembership.id });
 };
 
+const updateLastAccessedAt = async function ({ lastAccessedAt, userId, certificationCenterId }) {
+  const knexConnection = DomainTransaction.getConnection();
+
+  await knexConnection(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
+    .where({ userId, certificationCenterId })
+    .update({ lastAccessedAt, updatedAt: lastAccessedAt });
+};
+
 const findById = async function (certificationCenterMembershipId) {
   const certificationCenterMembership = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
     .select(
@@ -365,6 +373,7 @@ const certificationCenterMembershipRepository = {
   isMemberOfCertificationCenter,
   save,
   update,
+  updateLastAccessedAt,
   updateRefererStatusByUserIdAndCertificationCenterId,
 };
 

--- a/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
@@ -142,4 +142,35 @@ describe('Acceptance | Team | Application | Routes | certification-center-member
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('PATCH /api/certification-centers/{certificationCenterId}/certification-center-memberships/me', function () {
+    context('When user is member of the certification center', function () {
+      it('updates user certification center membership lastAccessedAt', async function () {
+        // given
+        server = await createServer();
+
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+        const request = {
+          method: 'PATCH',
+          url: `/api/certification-centers/${certificationCenterId}/certification-center-memberships/me`,
+          payload: {},
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        };
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+  });
 });

--- a/api/tests/team/integration/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.test.js
@@ -1,0 +1,37 @@
+import { CERTIFICATION_CENTER_MEMBERSHIP_ROLES } from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import { usecases } from '../../../../../src/team/domain/usecases/index.js';
+import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Team | UseCases | update-certification-center-membership-last-accessed-at', function () {
+  it('updates certification center membership lastAccessedAt', async function () {
+    // given
+    const now = new Date('2021-01-02');
+    sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    const userId = databaseBuilder.factory.buildUser().id;
+
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      certificationCenterId,
+      userId,
+      certificationCenterRole: CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER,
+      lastAccessedAt: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.updateCertificationCenterMembershipLastAccessedAt({
+      userId,
+      certificationCenterId,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    const certificationCenterMembership = await knex('certification-center-memberships')
+      .where({ userId, certificationCenterId })
+      .first();
+    expect(certificationCenterMembership.lastAccessedAt).to.deep.equal(now);
+  });
+});

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -1050,6 +1050,37 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
     });
   });
 
+  describe('#updateLastAccessedAt', function () {
+    it('updates last user access to a certification center', async function () {
+      // given
+      const now = new Date('2021-01-02');
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await certificationCenterMembershipRepository.updateLastAccessedAt({
+        lastAccessedAt: now,
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      const foundCertificationCenterMembership = await knex('certification-center-memberships')
+        .where({ id: certificationCenterMembership.id })
+        .first();
+
+      expect(foundCertificationCenterMembership.lastAccessedAt).to.deep.equal(now);
+      expect(foundCertificationCenterMembership.updatedAt).to.deep.equal(now);
+    });
+  });
+
   describe('#findById', function () {
     it('returns certification center membership', async function () {
       // given

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
@@ -21,6 +21,7 @@ const buildCertificationCenterMembership = function ({
   role = 'MEMBER',
   updatedByUserId = 1,
   updatedAt,
+  lastAccessedAt,
 } = {}) {
   const certificationCenterMembership = new CertificationCenterMembership({
     id,
@@ -32,6 +33,7 @@ const buildCertificationCenterMembership = function ({
     role,
     updatedByUserId,
     updatedAt,
+    lastAccessedAt,
   });
   if (!updatedAt) {
     certificationCenterMembership.updatedAt = disabledAt || createdAt;

--- a/certif/app/adapters/certification-center-membership.js
+++ b/certif/app/adapters/certification-center-membership.js
@@ -1,0 +1,19 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCenterMembershipAdapter extends ApplicationAdapter {
+  namespace = 'api/certification-centers';
+
+  updateRecord(store, type, snapshot) {
+    const { adapterOptions } = snapshot;
+
+    if (adapterOptions && adapterOptions.updateLastAccessedAt) {
+      const url = `${this.host}/${this.namespace}/${adapterOptions.certificationCenterId}/certification-center-memberships/me`;
+
+      delete adapterOptions.updateLastAccessedAt;
+
+      return this.ajax(url, 'PATCH');
+    }
+
+    return super.updateRecord(...arguments);
+  }
+}

--- a/certif/app/adapters/certification-center-membership.js
+++ b/certif/app/adapters/certification-center-membership.js
@@ -1,13 +1,11 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterMembershipAdapter extends ApplicationAdapter {
-  namespace = 'api/certification-centers';
-
   updateRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
 
     if (adapterOptions && adapterOptions.updateLastAccessedAt) {
-      const url = `${this.host}/${this.namespace}/${adapterOptions.certificationCenterId}/certification-center-memberships/me`;
+      const url = `${this.host}/api/certification-centers/${adapterOptions.certificationCenterId}/certification-center-memberships/me`;
 
       delete adapterOptions.updateLastAccessedAt;
 

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -23,7 +23,7 @@ export default class CurrentUserService extends Service {
         this.currentCertificationCenterMembership = this._findCertificationCenterMembershipByCertificationCenterId(
           this.currentAllowedCertificationCenterAccess?.id,
         );
-
+        await this._updateCurrentUserAccessToCertificationCenter();
         this.isAdminOfCurrentCertificationCenter = this.currentCertificationCenterMembership?.isAdmin;
       } catch (error) {
         this.certificationPointOfContact = null;
@@ -45,7 +45,7 @@ export default class CurrentUserService extends Service {
     }
   }
 
-  updateCurrentCertificationCenter(certificationCenterId) {
+  async updateCurrentCertificationCenter(certificationCenterId) {
     if (this.currentAllowedCertificationCenterAccess.id !== String(certificationCenterId)) {
       this.currentAllowedCertificationCenterAccess =
         this.certificationPointOfContact.allowedCertificationCenterAccesses.find(
@@ -55,6 +55,7 @@ export default class CurrentUserService extends Service {
       this.currentCertificationCenterMembership =
         this._findCertificationCenterMembershipByCertificationCenterId(certificationCenterId);
       this.isAdminOfCurrentCertificationCenter = this.currentCertificationCenterMembership?.isAdmin;
+      await this._updateCurrentUserAccessToCertificationCenter();
     }
   }
 
@@ -62,5 +63,16 @@ export default class CurrentUserService extends Service {
     return this.certificationPointOfContact.certificationCenterMemberships.find(
       ({ certificationCenterId: id }) => id === Number(certificationCenterId),
     );
+  }
+
+  async _updateCurrentUserAccessToCertificationCenter() {
+    if (this.currentCertificationCenterMembership) {
+      await this.currentCertificationCenterMembership.save({
+        adapterOptions: {
+          updateLastAccessedAt: true,
+          certificationCenterId: this.currentCertificationCenterMembership.certificationCenterId,
+        },
+      });
+    }
   }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -432,6 +432,10 @@ function _configureCertificationCenterInvitationRoutes(context) {
     return certificationCenterInvitation;
   });
 
+  context.patch('/certification-centers/:certificationCenterId/certification-center-memberships/me', () => {
+    return new Response(204);
+  });
+
   context.post(`${basePath}/:id/accept`, (schema) => {
     const certificationPointOfContact = schema.certificationPointOfContacts.first();
     const allowedCertificationCenterAccess = schema.allowedCertificationCenterAccesses.create({

--- a/certif/tests/unit/adapters/certification-center-membership-test.js
+++ b/certif/tests/unit/adapters/certification-center-membership-test.js
@@ -1,0 +1,39 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | certificationCenterMembership', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:certification-center-membership');
+    adapter.ajax = sinon.stub().resolves();
+  });
+
+  module('#updateRecord', function () {
+    module('when updateLastAccessedAt is true', function () {
+      test('should call /api/certification-centers/{certification-center-id}/certification-center-memberships/me', async function (assert) {
+        // given
+        const certificationCenterId = 1;
+
+        const snapshot = {
+          adapterOptions: {
+            updateLastAccessedAt: true,
+            certificationCenterId,
+          },
+        };
+        const expectedUrl = `http://localhost:3000/api/certification-centers/${certificationCenterId}/certification-center-memberships/me`;
+        const expectedMethod = 'PATCH';
+
+        // when
+        await adapter.updateRecord(null, null, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod);
+        assert.ok(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

On souhaite enregistrer la dernière date d’accès à un centre de certification d’un utilisateur.

## :bacon: Proposition

Enregistrer la dernière date d’accès à une application quand :

- l’utilisateur se connecte à Pix Certif et arrive sur la page d’une organisation.

- l’utilisateur change de centre de certification via le sélecteur.

L’enregistrement de la dernière date d’accès peut être réalisé depuis les fonctions #load et #update du service certif/app/services/current-user.js, qui chargent et mettent à jour les informations du centre de certification courant de l’utilisateur.

L’appel se fera via une nouvelle route dans le contexte Team (`PATCH /api/certification-centers/{certificationCenterId}/certification-center-memberships/me`), et va stocker la date d’accès sur le certification-center-membership  de l’utilisateur pour le centre de certification actuel

## 🧃 Remarques
A propos du namespace : 
Sans le dernier commit, un utilisateur connecté ne pouvait plus quitter son centre de certification. En effet lorsqu'un currentUser quitte un centre on appelle
    `await this.currentUser.currentCertificationCenterMembership.destroyRecord();`
 depuis `certif/app/controllers/authenticated/team/list/members.js` .
Comme cette action modifie le currentUser, cette requête passe dorénavant par la nouvelle fonction update de l'adapter qui avec cette ligne
`namespace = 'api/certification-centers'`; modifie la route.
Or la route de suppression de membership doit être 
    `/**api/certification-center-memberships**/{certificationCenterMembershipId}` et non `/**api/certification-centers**/{certificationCenterMembershipId}`

Si vous avez des propositions alternatives pour éviter d'autres éventuels effets de bord non identifiés par les tests automatisés...Faut-il/comment éviter que tous les updates ne passent par l'adapter?


## :yum: Pour tester

- Se connecter sur pix-certif avec james-paledroits@example.net
- Verifier que le lastAccessedAt du certification-center-membership courant se met à jour
- Switcher entre les différents centres de certification de l'utilisateur
- Verifier que le lastAccessedAt des certification-center-memberships affectés se met à jour
- Test de non régression : vérifiez que le current user peut quitter un centre de certification (il faut qu'il y ait un autre admin dans le centre pour que cette action soit possible).