### PR TITLE
[FEATURE] Cacher la progression dans les campagnes de Type EXAM (Pix-16921)

### DIFF
--- a/api/lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js
+++ b/api/lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js
@@ -1,10 +1,12 @@
-import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { StageCollection } from '../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
 import * as skillRepository from '../../../../src/shared/infrastructure/repositories/skill-repository.js';
 const MAX_STAGE_THRESHOLD = 100;
 
 const findStageCollection = async function ({ campaignId }) {
-  const stages = await knex('stages')
+  const knexConn = DomainTransaction.getConnection();
+
+  const stages = await knexConn('stages')
     .select('stages.*')
     .join('campaigns', 'campaigns.targetProfileId', 'stages.targetProfileId')
     .where('campaigns.id', campaignId)
@@ -44,5 +46,7 @@ async function _findSkills({ campaignId }) {
 }
 
 function _findSkillIds({ campaignId }) {
-  return knex('campaign_skills').where({ campaignId }).pluck('skillId');
+  const knexConn = DomainTransaction.getConnection();
+
+  return knexConn('campaign_skills').where({ campaignId }).pluck('skillId');
 }

--- a/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js
@@ -50,6 +50,7 @@ class CampaignAssessmentParticipation {
 
   _computeProgression(assessmentState, testedSkillsCount, targetedSkillsCount) {
     if (assessmentState === Assessment.states.COMPLETED) return 1;
+    if (!targetedSkillsCount) return null;
     return Number((testedSkillsCount / targetedSkillsCount).toFixed(2));
   }
 

--- a/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
@@ -1,6 +1,7 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
-const getCampaignAssessmentParticipation = async function ({
+const getCampaignAssessmentParticipation = withTransaction(async function ({
   userId,
   campaignId,
   campaignParticipationId,
@@ -34,6 +35,6 @@ const getCampaignAssessmentParticipation = async function ({
   campaignAssessmentParticipation.setStageInfo(reachedStage);
 
   return campaignAssessmentParticipation;
-};
+});
 
 export { getCampaignAssessmentParticipation };

--- a/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-campaign-assessment-participation.js
@@ -10,16 +10,20 @@ const getCampaignAssessmentParticipation = withTransaction(async function ({
   badgeAcquisitionRepository,
   stageCollectionRepository,
 }) {
+  // TODO : throw when campaignId not matching campaignParticipationId ? may be move this to pre handler
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
   }
 
+  const campaign = await campaignRepository.get(campaignId);
   const campaignAssessmentParticipation =
     await campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId({
       campaignId,
       campaignParticipationId,
+      shouldBuildProgression: campaign.isTypeAssessment,
     });
 
+  // TODO : avoid get data if participation is not shared badges/stages ?
   const acquiredBadgesByCampaignParticipations =
     await badgeAcquisitionRepository.getAcquiredBadgesByCampaignParticipations({
       campaignParticipationsIds: [campaignParticipationId],

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -8,10 +8,14 @@ import * as knowledgeElementRepository from '../../../../shared/infrastructure/r
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import { CampaignAssessmentParticipation } from '../../domain/models/CampaignAssessmentParticipation.js';
 
-const getByCampaignIdAndCampaignParticipationId = async function ({ campaignId, campaignParticipationId }) {
+const getByCampaignIdAndCampaignParticipationId = async function ({
+  campaignId,
+  campaignParticipationId,
+  shouldBuildProgression = true,
+}) {
   const result = await _fetchCampaignAssessmentAttributesFromCampaignParticipation(campaignId, campaignParticipationId);
 
-  return _buildCampaignAssessmentParticipation(result);
+  return _buildCampaignAssessmentParticipation(result, shouldBuildProgression);
 };
 
 export { getByCampaignIdAndCampaignParticipationId };
@@ -66,8 +70,15 @@ function _assessmentRankByCreationDate() {
   ]);
 }
 
-async function _buildCampaignAssessmentParticipation(result) {
-  const { targetedSkillsCount, testedSkillsCount } = await _setSkillsCount(result);
+async function _buildCampaignAssessmentParticipation(result, shouldBuildProgression) {
+  let targetedSkillsCount,
+    testedSkillsCount = null;
+
+  if (shouldBuildProgression) {
+    const userSkills = await _setSkillsCount(result);
+    targetedSkillsCount = userSkills.targetedSkillsCount;
+    testedSkillsCount = userSkills.testedSkillsCount;
+  }
 
   return new CampaignAssessmentParticipation({
     ...result,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
@@ -16,7 +17,8 @@ const getByCampaignIdAndCampaignParticipationId = async function ({ campaignId, 
 export { getByCampaignIdAndCampaignParticipationId };
 
 async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campaignId, campaignParticipationId) {
-  const [campaignAssessmentParticipation] = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const [campaignAssessmentParticipation] = await knexConn
     .with('campaignAssessmentParticipation', (qb) => {
       qb.select([
         'campaign-participations.userId',
@@ -43,6 +45,7 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
         )
         .where({
           'campaign-participations.id': campaignParticipationId,
+          'campaign-participations.campaignId': campaignId,
           'campaign-participations.deletedAt': null,
         });
     })

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-repository.js
@@ -27,11 +27,13 @@ const getByCode = async function (code) {
 };
 
 const get = async function (id) {
-  const campaign = await knex('campaigns').where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+
+  const campaign = await knexConn('campaigns').where({ id }).first();
   if (!campaign) {
     throw new NotFoundError(`Not found campaign for ID ${id}`);
   }
-  const featureExternalId = await knex('campaign-features')
+  const featureExternalId = await knexConn('campaign-features')
     .join('features', 'features.id', 'featureId')
     .where({
       campaignId: id,
@@ -49,7 +51,9 @@ const get = async function (id) {
 };
 
 const checkIfUserOrganizationHasAccessToCampaign = async function (campaignId, userId) {
-  const campaign = await knex('campaigns')
+  const knexConn = DomainTransaction.getConnection();
+
+  const campaign = await knexConn('campaigns')
     .innerJoin('memberships', 'memberships.organizationId', 'campaigns.organizationId')
     .innerJoin('organizations', 'organizations.id', 'campaigns.organizationId')
     .where({ 'campaigns.id': campaignId, 'memberships.userId': userId, 'memberships.disabledAt': null })

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-campaign-assessment-participation_test.js
@@ -1,0 +1,199 @@
+import { CampaignAssessmentParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignAssessmentParticipation.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | get-campaign-assessment-participation', function () {
+  let userId, campaignId, campaignParticipationId, targetProfileId;
+
+  context('when user has access to organization that owns campaign', function () {
+    beforeEach(async function () {
+      const skillId = 'recArea1_Competence1_Tube1_Skill1';
+      const learningContent = {
+        areas: [{ id: 'recArea1', competenceIds: ['recArea1_Competence1'] }],
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            areaId: 'recArea1',
+            skillIds: [skillId],
+            origin: 'Pix',
+          },
+        ],
+        thematics: [],
+        tubes: [
+          {
+            id: 'recArea1_Competence1_Tube1',
+            competenceId: 'recArea1_Competence1',
+          },
+        ],
+        skills: [
+          {
+            id: skillId,
+            name: '@recArea1_Competence1_Tube1_Skill1',
+            status: 'actif',
+            tubeId: 'recArea1_Competence1_Tube1',
+            competenceId: 'recArea1_Competence1',
+          },
+        ],
+        challenges: [
+          {
+            id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+            skillId: skillId,
+            competenceId: 'recArea1_Competence1',
+            status: 'validé',
+            locales: ['fr-fr'],
+          },
+        ],
+      };
+
+      await mockLearningContent(learningContent);
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      const organizationLearnerId = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        userId,
+        organizationId,
+      }).id;
+      targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
+
+      campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.ASSESSMENT,
+        targetProfileId,
+        organizationId,
+        creatorId: userId,
+        ownerId: userId,
+      }).id;
+
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId });
+
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId,
+        masteryRate: 0,
+        validatedSkillsCount: 0,
+      }).id;
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId,
+        userId,
+        type: Assessment.types.CAMPAIGN,
+        state: Assessment.states.STARTED,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should get the campaignAssessmentParticipation', async function () {
+      // when
+      const result = await usecases.getCampaignAssessmentParticipation({
+        userId,
+        campaignId,
+        campaignParticipationId,
+      });
+
+      // then
+      expect(result).to.instanceOf(CampaignAssessmentParticipation);
+    });
+
+    context('badges', function () {
+      let badgeId;
+
+      beforeEach(async function () {
+        // given
+        badgeId = databaseBuilder.factory.buildBadge({ key: 'badge1', targetProfileId }).id;
+
+        await databaseBuilder.commit();
+      });
+
+      it('should not set badges when participation has none', async function () {
+        // when
+        const result = await usecases.getCampaignAssessmentParticipation({
+          userId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(result.badges).to.be.undefined;
+      });
+
+      it('should set badges when participation obtained some', async function () {
+        databaseBuilder.factory.buildBadgeAcquisition({
+          userId,
+          badgeId,
+          campaignParticipationId,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await usecases.getCampaignAssessmentParticipation({
+          userId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(result.badges).to.lengthOf(1);
+      });
+    });
+
+    context('stages', function () {
+      it('should set stages when participation', async function () {
+        // given
+        databaseBuilder.factory.buildStage({
+          targetProfileId,
+          level: 1,
+          prescriberTitle: 'palier 0',
+          prescriberDescription: 'message 0',
+          threshold: null,
+        });
+        databaseBuilder.factory.buildStage({
+          targetProfileId,
+          isFirstSkill: true,
+          level: null,
+          prescriberTitle: 'premier acquis',
+          prescriberDescription: 'premier acquis',
+          threshold: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await usecases.getCampaignAssessmentParticipation({
+          userId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(result.totalStage).to.be.equal(2);
+        expect(result.reachedStage).to.be.equal(1);
+        expect(result.prescriberTitle).to.be.equal('palier 0');
+        expect(result.prescriberDescription).to.be.equal('message 0');
+      });
+
+      it('should not set stages when target profile does not have stages', async function () {
+        // when
+        const result = await usecases.getCampaignAssessmentParticipation({
+          userId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        // then
+        expect(result.totalStage).to.be.null;
+        expect(result.reachedStage).to.be.null;
+        expect(result.prescriberTitle).to.be.null;
+        expect(result.prescriberDescription).to.be.null;
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -187,6 +187,31 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
 
           expect(campaignAssessmentParticipation.progression).to.equal(0.5);
         });
+
+        it('not computes the progression given false to shouldBuildProgression params', async function () {
+          //given
+          databaseBuilder.factory.buildAssessment({
+            userId: campaignParticipation.userId,
+            campaignParticipationId,
+            state: Assessment.states.STARTED,
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            userId: campaignParticipation.userId,
+            skillId: skill1.id,
+            createdAt: new Date('2020-01-01'),
+          });
+          await databaseBuilder.commit();
+          // then
+          const campaignAssessmentParticipation =
+            await campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId({
+              campaignId,
+              campaignParticipationId,
+              shouldBuildProgression: false,
+            });
+
+          expect(campaignAssessmentParticipation.progression).to.equal(null);
+        });
       });
     });
 

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignAssessmentParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignAssessmentParticipation_test.js
@@ -16,6 +16,17 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipation', function ()
 
           expect(campaignAssessmentParticipation.progression).equal(0);
         });
+
+        it('should not compute a progression given no targetedSkillsCount', function () {
+          const testedSkillsCount = 0;
+          const campaignAssessmentParticipation = new CampaignAssessmentParticipation({
+            state: Assessment.states.STARTED,
+            testedSkillsCount,
+            targetedSkillsCount: null,
+          });
+
+          expect(campaignAssessmentParticipation.progression).equal(null);
+        });
       });
 
       context('when testedSkillsCount != 0', function () {

--- a/orga/tests/integration/components/participant/assessment/header-test.js
+++ b/orga/tests/integration/components/participant/assessment/header-test.js
@@ -158,16 +158,30 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
     assert.ok(screen.getByText('01 janv. 2020'));
   });
 
-  test('it displays campaign participation progression', async function (assert) {
-    this.participation = { progression: 0.75 };
-    this.campaign = {};
+  module('progression', function () {
+    test('it displays campaign participation progression on type ASSESSMENT', async function (assert) {
+      this.participation = { progression: 0.75 };
+      this.campaign = { isTypeExam: false, isTypeAssessment: true };
 
-    const screen = await render(
-      hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
-    );
+      const screen = await render(
+        hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
+      );
 
-    assert.ok(screen.getByText(t('pages.assessment-individual-results.progression')));
-    assert.ok(screen.getByText('75 %'));
+      assert.ok(screen.getByText(t('pages.assessment-individual-results.progression')));
+      assert.ok(screen.getByText('75 %'));
+    });
+
+    test('it hide campaign participation progression on type EXAM', async function (assert) {
+      this.participation = { progression: 0.75 };
+      this.campaign = { isTypeExam: true, isTypeAssessment: false };
+
+      const screen = await render(
+        hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
+      );
+
+      assert.notOk(screen.queryByText(t('pages.assessment-individual-results.progression')));
+      assert.notOk(screen.queryByText('75 %'));
+    });
   });
 
   module('is shared', function () {


### PR DESCRIPTION
## :pancakes: Problème

La progression se base sur les ke de l'utilisateur, or en mode EXAM nous n'enrichissons pas son compte de ke. ce qui fausse totalement le contenu de la progression

## :bacon: Proposition

Le cacher, et ne pas faire les appel API permettant de calculer la progression dans le cas d'une campagne de type EXAM

## 🧃 Remarques

Front déjà fait, il manquait un test

## :yum: Pour tester

CI au vert. et vérifier qu'une campagne de mode Exam avec une participation non finit. la progression ne s'affiche pas. 