### PR TITLE
[TECH] Ajouter le dossier de migrations aux codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,5 +60,6 @@
 /admin/app/services/oidc-identity-providers.js @1024pix/team-acces
 /admin/app/services/session.js @1024pix/team-acces
 
-
+# Directories maintainted by team Captains
+/api/db/migrations/ @1024pix/team-captains
 


### PR DESCRIPTION
## :bacon: Proposition
Depuis #10929, on demande aux équipes de dev de pinger l'équipe @1024pix/team-captains lors des migrations.

Dans les équipes de dev plusieurs équipes remplissent le fichier CODEOWNERS pour être notifiées en cas de modifications liées à leur scope. On propose ici d'ajouter l'équipe Captain en "owner" des dossiers de migrations pour bénéficier de cette fonctionnalité.

## :yum: Pour tester
RAS