### PR TITLE
[FEATURE]: Migration pour ajouter la colonne "internalName" a la table "target-profiles" (PIX-16929)

### DIFF
--- a/api/db/migrations/20250227142425_add-internal-name-column-on-target-profile-table.js
+++ b/api/db/migrations/20250227142425_add-internal-name-column-on-target-profile-table.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'target-profiles';
+const INTERNAL_NAME_COLUMN = 'internalName';
+const NAME_COLUMN = 'name';
+
+const up = async function (knex) {
+  // add column
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table
+      .string(INTERNAL_NAME_COLUMN)
+      .comment('Internal name of the target profile, used for target profiles administration, not displayed to users');
+  });
+
+  // copy data from name to internalName
+  await knex.raw(
+    `
+      UPDATE :tableName:
+      SET :internalNameColumn: = :columnName:
+    `,
+    {
+      tableName: TABLE_NAME,
+      internalNameColumn: INTERNAL_NAME_COLUMN,
+      columnName: NAME_COLUMN,
+    },
+  );
+
+  // add not null constraint on internalName column
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(INTERNAL_NAME_COLUMN).notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.dropColumn(INTERNAL_NAME_COLUMN);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :pancakes: Problème

Nous souhaitons ajouter une colonne `internalName` a la table `target-profiles`.

## :bacon: Proposition

Creer une migration qui:

- Cree la nouvelle colonne
- Duplique les donnees de la colonne `name` dans la nouvelle colonne `internalName`
- Ajoute une contrainte `not null` sur la nouvelle colonne `internalName`

## 🧃 Remarques

Cette migration peut etre revert sans consequence.  

## :yum: Pour tester

Effectuer la migration en recette et verifier que la nouvelle colonne `internalName` a bien ete remplie  