### PR TITLE
[BUGFIX] Quand on retente un QCM, les réponses sélectionnées avant ne sont pas prises en compte (PIX-16822)

### DIFF
--- a/mon-pix/app/components/module/element/module-element.gjs
+++ b/mon-pix/app/components/module/element/module-element.gjs
@@ -47,7 +47,7 @@ export default class ModuleElement extends Component {
 
   @action
   retry(event) {
-    const retryButton = event.target;
+    const retryButton = event.currentTarget;
     const form = retryButton.form;
 
     this.isOnRetryMode = true;


### PR DESCRIPTION
## :pancakes: Problème

Comment reproduire le bug : 
- Dans un Module, répondre en se trompant à un QCM, en cochant au moins 3 options.
- Cliquer sur le bouton “Ré essayer”, mais en cliquant sur l’icône et non le label du bouton
- Décocher une case
- Cliquer sur vérifier. Un message d’erreur apparaît, disant qu’il faut cocher au moins deux options

## :bacon: Proposition

Au lieu d'utiliser `event.target `dans la méthode retry, qui cible l'élément cliqué, utiliser `event.currentTarget`.
Celui-ci correspond au véritable composant qui reçoit l'event.

## 🧃 Remarques

- Besoin d'ajouter des tests d'intégration ?

## :yum: Pour tester

- Dans un Module, répondre en se trompant à un QCM, en cochant au moins 3 options.
- Cliquer sur le bouton “Ré essayer”, mais en cliquant sur l’icône et non le label du bouton
- Toutes les propositions doivent être décochées.
