### PR TITLE
[FEATURE] Améliorer le style de la page de détail de compétence (PIX-16882).

### DIFF
--- a/mon-pix/app/components/circle-chart.hbs
+++ b/mon-pix/app/components/circle-chart.hbs
@@ -1,5 +1,5 @@
-<div class="circle-chart" ...attributes>
-  <svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " @chartClass}} aria-hidden="true">
+<div class={{concat "circle-chart " @chartClass}} ...attributes>
+  <svg class="cicle-chart__circle" viewBox="1.2 1.2 33.6 33.6" aria-hidden="true">
     <path class={{concat "circle " @thicknessClass}} d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
     </path>
 

--- a/mon-pix/app/components/competence-card-default.hbs
+++ b/mon-pix/app/components/competence-card-default.hbs
@@ -22,7 +22,7 @@
           <CircleChart
             @value={{@scorecard.capedPercentageAheadOfNextLevel}}
             @sliceColor={{@scorecard.area.color}}
-            @chartClass="circle-chart__content--big"
+            @chartClass="circle-chart--big"
             @thicknessClass="circle--thick"
             role="presentation"
           >

--- a/mon-pix/app/components/competence-card-mobile.hbs
+++ b/mon-pix/app/components/competence-card-mobile.hbs
@@ -17,7 +17,7 @@
           <CircleChart
             @value={{@scorecard.capedPercentageAheadOfNextLevel}}
             @sliceColor={{@scorecard.area.color}}
-            @chartClass="circle-chart__content--small"
+            @chartClass="circle-chart--small"
             @thicknessClass="circle--thick"
             role="presentation"
           >

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -1,27 +1,28 @@
 <div>
-  <div class="scorecard-details__header">
-    <PixButtonLink @route="authenticated.profile" @variant="tertiary" @iconBefore="arrowLeft">
+  <section class="scorecard-details__header">
+    <PixButtonLink
+      @route="authenticated.profile"
+      @variant="tertiary"
+      @iconBefore="arrowLeft"
+      class="scorecard-details-header__back-button"
+    >
       {{t "navigation.back-to-profile"}}
     </PixButtonLink>
-  </div>
+  </section>
 
-  <div class="scorecard-details__content">
-    <div class="scorecard-details-content__left">
-      <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{@scorecard.area.color}}">
-        {{@scorecard.area.title}}
-      </div>
-      <h1 class="scorecard-details-content-left__name">
+  <section class="scorecard-details__competence">
+    <div class="scorecard-details-competence__details">
+      <h1 class="scorecard-details-competence-details__name">
         {{@scorecard.name}}
       </h1>
-      <div class="scorecard-details-content-left__description">
+      <div class="scorecard-details-competence-details__description">
         {{@scorecard.description}}
       </div>
     </div>
 
-    <div class="scorecard-details-content__right">
-
+    <div class="scorecard-details-content__score">
       {{#if @scorecard.isFinished}}
-        <div class="scorecard-details-content-right__score-container">
+        <div class="scorecard-details-content-score__score-container">
           {{#if this.displayCongrats}}
             <div class="competence-card__congrats">
               <div class="competence-card__level competence-card__level--congrats">
@@ -35,7 +36,7 @@
             <CircleChart
               @value={{@scorecard.capedPercentageAheadOfNextLevel}}
               @sliceColor={{@scorecard.area.color}}
-              @chartClass="circle-chart__content--big"
+              @chartClass="circle-chart--big"
               @thicknessClass="circle--thick"
               role="img"
               aria-label="{{scorecard-aria-label @scorecard}}"
@@ -47,7 +48,7 @@
             </CircleChart>
           {{/if}}
 
-          <div class="scorecard-details-content-right-score-container__pix-earned">
+          <div class="pix-earned">
             <div class="score-label">{{t "common.pix"}}</div>
             <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
@@ -55,28 +56,29 @@
 
         {{#if this.displayImprovingWaitSentence}}
           <div class="scorecard-details__improvement-countdown">
-            <span class="scorecard-details-improvement-countdown__label">{{t
+            <div class="scorecard-details-improvement-countdown__label">{{t
                 "pages.competence-details.actions.improve.description.waiting-text"
-              }}</span>
-            <span class="scorecard-details-improvement-countdown__count">{{t
+              }}</div>
+            <strong class="scorecard-details-improvement-countdown__count">{{t
                 "pages.competence-details.actions.improve.description.countdown"
                 daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
-              }}</span>
+              }}</strong>
           </div>
         {{/if}}
 
         {{#if this.displayImprovingButton}}
           <PixButton
-            class="scorecard-details__improve-button button--big"
+            class="scorecard-details__improve-button"
             @variant="success"
+            @size="large"
             @triggerAction={{this.improveCompetenceEvaluation}}
           >
             {{t "pages.competence-details.actions.improve.label"}}
             <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
           </PixButton>
-          <span class="scorecard-details__improving-text">{{t
+          <div class="scorecard-details__improving-text">{{t
               "pages.competence-details.actions.improve.improvingText"
-            }}</span>
+            }}</div>
         {{/if}}
 
         {{#if this.displayResetButton}}
@@ -92,7 +94,7 @@
         {{/if}}
 
         {{#if this.displayResetWaitSentence}}
-          <p class="scorecard-details-content-right__reset-message">{{t
+          <p class="scorecard-details-content-score__reset-message">{{t
               "pages.competence-details.actions.reset.description"
               daysBeforeReset=@scorecard.remainingDaysBeforeReset
             }}</p>
@@ -100,11 +102,11 @@
       {{/if}}
 
       {{#if @scorecard.isStarted}}
-        <div class="scorecard-details-content-right__score-container">
+        <div class="scorecard-details-content-score__score-container">
           <CircleChart
             @value={{@scorecard.capedPercentageAheadOfNextLevel}}
             @sliceColor={{@scorecard.area.color}}
-            @chartClass="circle-chart__content--big"
+            @chartClass="circle-chart--big"
             @thicknessClass="circle--thick"
             role="img"
             aria-label="{{scorecard-aria-label @scorecard}}"
@@ -115,14 +117,14 @@
             </div>
           </CircleChart>
 
-          <div class="scorecard-details-content-right-score-container__pix-earned">
+          <div class="pix-earned">
             <div class="score-label">{{t "common.pix"}}</div>
             <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
         </div>
 
         {{#if this.displayRemainingPixToNextLevel}}
-          <div class="scorecard-details-content-right__level-info">
+          <div class="scorecard-details-content-score__level-info">
             {{t
               "pages.competence-details.next-level-info"
               remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
@@ -131,14 +133,15 @@
           </div>
         {{/if}}
 
-        <LinkTo
+        <PixButtonLink
+          class="scorecard-details__resume-button"
           @route="authenticated.competences.resume"
           @model={{@scorecard.competenceId}}
-          class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
+          @size="large"
         >
           {{t "pages.competence-details.actions.continue.label"}}
           <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
-        </LinkTo>
+        </PixButtonLink>
 
         {{#if this.displayResetButton}}
           <PixButton
@@ -153,7 +156,7 @@
         {{/if}}
 
         {{#if this.displayResetWaitSentence}}
-          <p class="scorecard-details-content-right__reset-message">{{t
+          <p class="scorecard-details-content-score__reset-message">{{t
               "pages.competence-details.actions.reset.description"
               daysBeforeReset=@scorecard.remainingDaysBeforeReset
             }}</p>
@@ -161,39 +164,43 @@
       {{/if}}
 
       {{#if @scorecard.isNotStarted}}
-        <LinkTo
+        <PixButtonLink
+          class="scorecard-details__start-button"
           @route="authenticated.competences.resume"
           @model={{@scorecard.competenceId}}
-          class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
+          @size="large"
+          @variant="success"
         >
           {{t "pages.competence-details.actions.start.label"}}
           <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
-        </LinkTo>
+        </PixButtonLink>
       {{/if}}
     </div>
-  </div>
+  </section>
+
   {{#if this.tutorialsGroupedByTubeName}}
-    <div class="scorecard-details__content">
-      <div class="tutorials">
-        <div class="tutorials__header">
-          <h2 class="tutorials-header__title">{{t "pages.competence-details.tutorials.title"}}</h2>
-          <p class="tutorials-header__description">{{t "pages.competence-details.tutorials.description"}}</p>
-        </div>
-        <div>
-          {{#each this.tutorialsGroupedByTubeName as |tube|}}
-            <div class="tube">
-              <h3 class="tube__title">{{tube.practicalTitle}}</h3>
-              <ul class="tube__content">
-                {{#each tube.tutorials as |tutorial|}}
-                  <Tutorials::Card @tutorial={{tutorial}} />
-                {{/each}}
-              </ul>
-            </div>
-          {{/each}}
-        </div>
+    <section class="scorecard-details__tutorials">
+      <div class="scorecard-details-tutorials__header">
+        <h2 class="scorecard-details-tutorials-header__title">{{t "pages.competence-details.tutorials.title"}}</h2>
+        <p class="scorecard-details-tutorials-header__description">{{t
+            "pages.competence-details.tutorials.description"
+          }}</p>
       </div>
-    </div>
+      <ul class="scorecard-details-tutorials__list">
+        {{#each this.tutorialsGroupedByTubeName as |tube|}}
+          <li class="tube">
+            <h3 class="tube__title">{{tube.practicalTitle}}</h3>
+            <ul class="tube__content">
+              {{#each tube.tutorials as |tutorial|}}
+                <Tutorials::Card @tutorial={{tutorial}} />
+              {{/each}}
+            </ul>
+          </li>
+        {{/each}}
+      </ul>
+    </section>
   {{/if}}
+
 </div>
 <PixModal
   @title={{t "pages.competence-details.actions.reset.modal.title" scoreCardName=@scorecard.name}}

--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -7,13 +7,8 @@
 
 .circle-chart {
   position: relative;
-  display: flex;
-}
-
-.circle-chart__content {
   width: 100px;
   height: 100px;
-  max-height: 128px;
 
   &--small {
     width: 70px;
@@ -24,6 +19,11 @@
     width: 120px;
     height: 120px;
   }
+}
+
+.circle-chart__circle {
+  width: 100%;
+  height: 100%;
 }
 
 .circle {
@@ -64,11 +64,7 @@
 
 .circle-chart__text {
   position: absolute;
-  top: 0;
-  left: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -1,273 +1,115 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
-@use 'pix-design-tokens/fonts';
 
-.tutorials {
-  width: 100%;
-  padding: 0 25px;
+/** Header */
+.scorecard-details-header__back-button {
+  display: inline-flex;
+}
 
-  &__header {
-    margin-bottom: 48px;
+/** Competence */
+.scorecard-details__competence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-6x);
+  margin-top: var(--pix-spacing-8x);
+}
+
+.scorecard-details-competence__details {
+  flex: 2;
+  flex-basis: 500px;
+}
+
+.scorecard-details-competence-details__name {
+  @extend %pix-title-m;
+}
+
+.scorecard-details-competence-details__description {
+  @extend %pix-body-m;
+
+  margin-top: var(--pix-spacing-3x);
+  color: var(--pix-neutral-500);
+  text-wrap: pretty;
+}
+
+.scorecard-details-content__score {
+  @extend %pix-body-m;
+
+  flex: 1;
+}
+
+.scorecard-details-content-score__score-container {
+  display: flex;
+  gap: var(--pix-spacing-12x);
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--pix-spacing-4x);
+  padding-inline: var(--pix-spacing-10x);
+
+  .pix-earned {
+    text-align: center;
   }
 }
 
-.tutorials-header {
-  &__title {
-    @extend %pix-title-s;
-
-    margin-bottom: var(--pix-spacing-4x);
-  }
-
-  &__description {
-    @extend %pix-body-m;
-
-    margin: 0 0 10px;
-    color: var(--pix-neutral-900);
-  }
+.scorecard-details-content-score__level-info {
+  font-weight: var(--pix-font-bold);
+  text-align: center;
+  text-transform: uppercase;
 }
 
-.tube {
-  margin-bottom: 40px;
-
-  &__title {
-    @extend %pix-title-xs;
-
-    margin-bottom: 24px;
-    color: var(--pix-neutral-900);
-    letter-spacing: 0;
-  }
-
-  &__content {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-
-    & .tutorial-card {
-      margin-bottom: 16px;
-    }
-  }
+.scorecard-details__resume-button,
+.scorecard-details__reset-button,
+.scorecard-details__improve-button,
+.scorecard-details__start-button {
+  width: 16rem;
+  margin: var(--pix-spacing-2x) auto;
 }
 
-.scorecard-details {
-  &__content {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin: 14px;
-    padding: 40px 0;
-    font-family: fonts.$font-roboto;
-    background-color: var(--pix-neutral-20);
-    border-radius: 6.75px;
+.scorecard-details__improvement-countdown,
+.scorecard-details-content-score__reset-message,
+.scorecard-details__improving-text {
+  @extend %pix-body-s;
 
-    @include breakpoints.device-is('desktop') {
-      flex-direction: row;
-    }
-  }
-
-  &__header {
-    width: fit-content;
-    padding: var(--pix-spacing-3x) var(--pix-spacing-3x) 0;
-  }
-
-  &__resume-or-start-button,
-  &__improve-button {
-    margin-top: var(--pix-spacing-6x);
-  }
-
-  &__reset-button {
-    width: 180px;
-    margin-top: var(--pix-spacing-6x);
-  }
-
-  &__reset-modal {
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-  &__improving-text {
-    margin-top: var(--pix-spacing-2x);
-    color: var(--pix-neutral-500);
-    font-size: 0.8rem;
-    font-family: fonts.$font-roboto;
-    letter-spacing: 0.0075rem;
-  }
-
-  &__improvement-countdown {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-top: 30px;
-    cursor: default;
-  }
+  text-align: center;
 }
 
-.scorecard-details-content {
-  &__left {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    justify-content: center;
-    max-width: 100%;
-    padding: 0 30px 30px;
-
-    @include breakpoints.device-is('desktop') {
-      max-width: 68%;
-      padding: 0 30px;
-      border-right: 2px dashed var(--pix-neutral-100);
-    }
-  }
-
-  &__right {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    max-width: 100%;
-    padding: 0 30px;
-    white-space: nowrap;
-
-    @include breakpoints.device-is('desktop') {
-      max-width: 30%;
-    }
-  }
+.scorecard-details-content-score__reset-message {
+  color: var(--pix-neutral-500);
 }
 
-.scorecard-details-content-left {
-  &__area {
-    font-size: 0.875rem;
-    letter-spacing: 0.125rem;
-    text-transform: uppercase;
+/** Tutorials */
+.scorecard-details__tutorials {
+  margin-top: var(--pix-spacing-8x);
+  padding-top: var(--pix-spacing-8x);
+  border-top: 1px solid var(--pix-primary-100);
+}
 
-    &--jaffa {
-      // stylelint-disable-next-line color-no-hex -- il nous manque un token suffisament sombre pour éviter les problèmes de contraste
-      --pix-information-darker: #db100f;
+.scorecard-details-tutorials__header {
+  padding-bottom: var(--pix-spacing-8x);
+}
 
-      color: var(--pix-information-darker);
-    }
+.scorecard-details-tutorials-header__title {
+  @extend %pix-title-s;
+}
 
-    &--emerald {
-      // stylelint-disable-next-line color-no-hex -- il nous manque un token suffisament sombre pour éviter les problèmes de contraste
-      --pix-content-darker: #12615f;
+.scorecard-details-tutorials-header__description {
+  @extend %pix-body-s;
 
-      color: var(--pix-content-darker);
-    }
+  margin-top: var(--pix-spacing-2x);
+  color: var(--pix-neutral-500);
+}
 
-    &--cerulean {
-      // stylelint-disable-next-line color-no-hex -- il nous manque un token suffisament sombre pour éviter les problèmes de contraste
-      --pix-communication-darker: #0a40ff;
-
-      color: var(--pix-communication-dark);
-    }
-
-    &--wild-strawberry {
-      color: var(--pix-security-dark);
-    }
-
-    &--butterfly-bush {
-      color: var(--pix-environment-light);
-    }
+.scorecard-details-tutorials__list {
+  .tube:not(:first-child) {
+    margin-top: var(--pix-spacing-8x);
   }
 
-  &__name {
-    @extend %pix-title-m;
-
-    margin: 15px 0;
-  }
-
-  &__description {
-    @extend %pix-body-m;
+  .tube__title {
+     @extend %pix-title-xs;
 
     color: var(--pix-neutral-500);
   }
-}
 
-.scorecard-details-content-right {
-  &__score-container {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &__level-info {
-    @extend %pix-body-m;
-
-    margin-top: 20px;
-    color: var(--pix-neutral-800);
-    white-space: nowrap;
-    text-transform: uppercase;
-  }
-
-  &__reset-message {
-    padding-top: 50px;
-    color: var(--pix-neutral-500);
-    font-size: 0.813rem;
-    font-family: fonts.$font-roboto;
-  }
-}
-
-.scorecard-details-content-right-score-container {
-  &__pix-earned {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-left: 60px;
-    color: var(--pix-neutral-800);
-    text-transform: uppercase;
-  }
-}
-
-.scorecard-details-reset-modal {
-  &__important-message {
-    margin-bottom: var(--pix-spacing-4x);
-    color: var(--pix-neutral-900);
-    font-weight: var(--pix-font-medium);
-    font-size: 1.375rem;
-    font-family: fonts.$font-roboto;
-  }
-
-  &__warning {
-    padding-bottom: 10px;
-    color: var(--pix-neutral-800);
-    font-size: 1rem;
-    font-family: fonts.$font-roboto;
-
-    p {
-      font-weight: bold;
-    }
-
-    .scorecard-details-reset-modal__list {
-      padding-left: var(--pix-spacing-8x);
-    }
-
-    .scorecard-details-reset-modal-list__item {
-      list-style: initial;
-    }
-  }
-
-  &__footer {
-    @include breakpoints.device-is('tablet') {
-      display: flex;
-
-      li + li {
-        margin-left: 1rem;
-      }
-    }
-  }
-}
-
-.scorecard-details-improvement-countdown {
-  &__label {
-    color: var(--pix-neutral-500);
-    font-size: 0.6875rem;
-    letter-spacing: 0.0075rem;
-  }
-
-  &__count {
-    margin-top: 6px;
-    color: var(--pix-neutral-900);
-    font-size: 1rem;
-    letter-spacing: 0.01rem;
+  .tube__content li {
+    margin-block: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/templates/authenticated/competences/details.hbs
+++ b/mon-pix/app/templates/authenticated/competences/details.hbs
@@ -1,11 +1,7 @@
 {{page-title @model.name}}
 
 <Global::AppLayout>
-  <main id="main" class="main background-banner-wrapper competence-details" role="main">
-    <div class="background-banner"></div>
-
-    <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
-      <ScorecardDetails @scorecard={{@model}} />
-    </div>
+  <main id="main" class="competence-details global-page-container" role="main">
+    <ScorecardDetails @scorecard={{@model}} />
   </main>
 </Global::AppLayout>

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -51,19 +51,11 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
 
     test('should display the competence details', async function (assert) {
       // when
-      await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
+      const screen = await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
       // then
-      assert.ok(find('.scorecard-details-content-left__area').textContent.includes(scorecardWithPoints.area.title));
-      assert.ok(
-        find('.scorecard-details-content-left__area')
-          .getAttribute('class')
-          .includes(`scorecard-details-content-left__area--${scorecardWithPoints.area.color}`),
-      );
-      assert.ok(find('.scorecard-details-content-left__name').textContent.includes(scorecardWithPoints.name));
-      assert.ok(
-        find('.scorecard-details-content-left__description').textContent.includes(scorecardWithPoints.description),
-      );
+      assert.dom(screen.getByText(scorecardWithPoints.name)).exists();
+      assert.dom(screen.getByText(scorecardWithPoints.description)).exists();
     });
 
     test('should transition to /competences when the user clicks on return', async function (assert) {
@@ -102,22 +94,18 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
     module('when the scorecard has points', function () {
       test('should display level and score', async function (assert) {
         // when
-        await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
+        const screen = await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
         // then
-        assert.strictEqual(
-          find('.competence-card__level .score-value').textContent,
-          scorecardWithPoints.level.toString(),
-        );
-        assert.strictEqual(
-          find('.scorecard-details-content-right-score-container__pix-earned .score-value').textContent,
-          scorecardWithPoints.earnedPix.toString(),
-        );
-        assert.ok(
-          find('.scorecard-details-content-right__level-info').textContent.includes(
-            `${scorecardWithPoints.remainingPixToNextLevel} pix avant le niveau ${scorecardWithPoints.level + 1}`,
-          ),
-        );
+        assert.dom(screen.getByText(scorecardWithPoints.level)).exists();
+        assert.dom(screen.getByText(scorecardWithPoints.earnedPix)).exists();
+        assert
+          .dom(
+            screen.getByText(
+              `${scorecardWithPoints.remainingPixToNextLevel} pix avant le niveau ${scorecardWithPoints.level + 1}`,
+            ),
+          )
+          .exists();
       });
 
       test('should not display pixScoreAheadOfNextLevel when next level is over the max level', async function (assert) {
@@ -142,15 +130,17 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
       module('when it has remaining some days before reset', function () {
         test('should display remaining days before reset', async function (assert) {
           // when
-          await visit(`/competences/${scorecardWithRemainingDaysBeforeReset.competenceId}/details`);
+          const screen = await visit(`/competences/${scorecardWithRemainingDaysBeforeReset.competenceId}/details`);
 
           // then
-          assert.ok(
-            find('.scorecard-details-content-right__reset-message').textContent.includes(
-              `Remise à zéro disponible dans ${scorecardWithRemainingDaysBeforeReset.remainingDaysBeforeReset} jours`,
-            ),
-          );
-          assert.dom('.scorecard-details__reset-button').doesNotExist();
+          assert
+            .dom(
+              screen.getByText(
+                `Remise à zéro disponible dans ${scorecardWithRemainingDaysBeforeReset.remainingDaysBeforeReset} jours.`,
+              ),
+            )
+            .exists();
+          assert.dom(screen.queryByRole('button', { name: 'Remettre à zéro' })).doesNotExist();
         });
       });
 

--- a/mon-pix/tests/integration/components/circle-chart-test.js
+++ b/mon-pix/tests/integration/components/circle-chart-test.js
@@ -56,15 +56,10 @@ module('Integration | Component | circle-chart', function (hooks) {
 
     test('should display the chart with given width and height', async function (assert) {
       // when
-      await render(hbs`<CircleChart @chartClass='circle-chart__content--big' />`);
+      await render(hbs`<CircleChart @chartClass='circle-chart--big' />`);
 
       // then
-      assert.ok(
-        this.element
-          .querySelector('.circle-chart__content')
-          .getAttribute('class')
-          .includes('circle-chart__content--big'),
-      );
+      assert.ok(this.element.querySelector('.circle-chart').getAttribute('class').includes('circle-chart--big'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -10,27 +10,6 @@ module('Integration | Component | scorecard-details', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('Component rendering', function () {
-    test('should display the scorecard header with area color', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const scorecard = store.createRecord('scorecard', {
-        area: store.createRecord('area', {
-          title: 'Area title',
-          color: 'jaffa',
-        }),
-      });
-
-      this.set('scorecard', scorecard);
-
-      // when
-      const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
-
-      // then
-      assert.ok(
-        screen.getByText('Area title').getAttribute('class').includes('scorecard-details-content-left__area--jaffa'),
-      );
-    });
-
     test('should display the competence information', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -306,7 +306,7 @@
   },
   "navigation": {
     "back-to-homepage": "Return to homepage",
-    "back-to-profile": "Return to profile",
+    "back-to-profile": "Return to skills",
     "copyrights": "©",
     "error": "Error",
     "external-link-title": "Open in a new window",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -306,7 +306,7 @@
   },
   "navigation": {
     "back-to-homepage": "Revenir à la page d’accueil",
-    "back-to-profile": "Revenir au profil",
+    "back-to-profile": "Revenir aux compétences",
     "copyrights": "©",
     "error": "Erreur",
     "external-link-title": "Ouverture dans une nouvelle fenêtre",


### PR DESCRIPTION
## :pancakes: Problème

L'ancien design des pages de PixApp ne fonctionne pas avec la nouvelle navigation.

## :bacon: Proposition

Retravailler le design de la page de détail de compétence.

## :yum: Pour tester

- Se connecter avec différents utilisateurs (`eval-campaign-with-stages@example.net`, `perfect-profile-user@example.net`)
- Visualiser des pages de détail de compétence.
