### PR TITLE
[BUGFIX] Le `figcaption` des éléments images produisent toujours un espace vide

### DIFF
--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -24,13 +24,19 @@ export default class ModulixImageElement extends Component {
     this.modalIsOpen = false;
   }
 
+  get hasCaption() {
+    return this.args.image.legend?.length > 0 || this.args.image.licence?.length > 0;
+  }
+
   <template>
     <div class="element-image">
       <figure class="element-image__container">
         <img class="element-image-container__image" alt={{@image.alt}} src={{@image.url}} />
-        <figcaption class="element-image-container__caption">{{@image.legend}}<span
-            class="element-image-container__licence"
-          >{{@image.licence}}</span></figcaption>
+        {{#if this.hasCaption}}
+          <figcaption class="element-image-container__caption">{{@image.legend}}<span
+              class="element-image-container__licence"
+            >{{@image.licence}}</span></figcaption>
+        {{/if}}
       </figure>
       {{#if this.hasAlternativeText}}
         <PixButton class="element-image__button" @variant="tertiary" @triggerAction={{this.showModal}}>


### PR DESCRIPTION
## :pancakes: Problème
L'espacement entre la fin de l'image et la suite (bouton alternative textuelle ou contenu suivant) est trop grand dans le cas où on a pas de caption

## :bacon: Proposition
Ne pas afficher la `figcaption` si on en a pas.

## 🧃 Remarques
RAS

## :yum: Pour tester
Vérifier que les espacements en dessous des images de `bases-clavier-2` et `bien-ecrire-son-adresse-mail` sont bien cohérents et pas trop grands.