### PR TITLE
[FEATURE] Autoriser l'affichage des campagnes de type EXAM sur le dashboard d'un utilisateur (PIX-16821)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-current-user.usecase.js
@@ -1,3 +1,4 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserWithActivity } from '../read-models/UserWithActivity.js';
 
 /**
@@ -9,7 +10,7 @@ import { UserWithActivity } from '../read-models/UserWithActivity.js';
  * }} params
  * @return {Promise<UserWithActivity>}
  */
-export const getCurrentUser = async function ({
+export const getCurrentUser = withTransaction(async function ({
   authenticatedUserId,
   userRepository,
   campaignParticipationRepository,
@@ -20,8 +21,10 @@ export const getCurrentUser = async function ({
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(authenticatedUserId),
     userRecommendedTrainingRepository.hasRecommendedTrainings({ userId: authenticatedUserId }),
   ]);
+
   const user = await userRepository.get(authenticatedUserId);
   const shouldSeeDataProtectionPolicyInformationBanner = user.shouldSeeDataProtectionPolicyInformationBanner;
+
   return new UserWithActivity({
     user,
     hasAssessmentParticipations,
@@ -29,4 +32,4 @@ export const getCurrentUser = async function ({
     hasRecommendedTrainings,
     shouldSeeDataProtectionPolicyInformationBanner,
   });
-};
+});

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -13,7 +13,6 @@ const findByUserIdWithFilters = async function ({ userId, states, page }) {
   }
 
   const { results, pagination } = await fetchPage(queryBuilder, page);
-
   return {
     campaignParticipationOverviews: results.map(
       (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),
@@ -46,13 +45,13 @@ function _findByUserId({ userId }) {
         campaignId: 'campaigns.id',
       })
         .from('campaign-participations')
-        .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
-        .innerJoin('organizations', 'organizations.id', 'campaigns.organizationId')
+        .join('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
+        .join('organizations', 'organizations.id', 'campaigns.organizationId')
+        .whereIn('campaigns.type', [CampaignTypes.ASSESSMENT, CampaignTypes.EXAM])
+        .where('campaigns.isForAbsoluteNovice', false)
         .whereNot('organizations.id', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)
         .where('campaign-participations.userId', userId)
-        .where('campaign-participations.isImproved', false)
-        .where('campaigns.type', CampaignTypes.ASSESSMENT)
-        .whereNot('campaigns.isForAbsoluteNovice', true);
+        .where('campaign-participations.isImproved', false);
     })
     .from('campaign-participation-overviews')
     .orderByRaw(_computeCampaignParticipationOrder())

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -165,18 +165,22 @@ const findOneByCampaignIdAndUserId = async function ({ campaignId, userId }) {
 };
 
 const hasAssessmentParticipations = async function (userId) {
-  const { count } = await knex('campaign-participations')
+  const knexConn = DomainTransaction.getConnection();
+
+  const { count } = await knexConn('campaign-participations')
     .count('campaign-participations.id')
     .join('campaigns', 'campaigns.id', 'campaignId')
     .whereNot('campaigns.organizationId', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)
-    .where('campaigns.type', '=', CampaignTypes.ASSESSMENT)
+    .whereIn('campaigns.type', [CampaignTypes.ASSESSMENT, CampaignTypes.EXAM])
     .andWhere({ userId })
     .first();
   return count > 0;
 };
 
 const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async function (userId) {
-  const result = await knex('campaign-participations')
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('campaign-participations')
     .select('campaigns.code')
     .join('campaigns', 'campaigns.id', 'campaignId')
     .where({ userId })

--- a/api/tests/identity-access-management/unit/domain/usecases/get-current-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-current-user.usecase.test.js
@@ -1,4 +1,5 @@
 import { getCurrentUser } from '../../../../../src/identity-access-management/domain/usecases/get-current-user.usecase.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | get-current-user', function () {
@@ -7,6 +8,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | get-current-use
   let userRecommendedTrainingRepository;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     userRepository = { get: sinon.stub() };
     campaignParticipationRepository = {
       hasAssessmentParticipations: sinon.stub(),

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -634,5 +634,62 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         expect(campaignParticipationOverviews).to.have.lengthOf(0);
       });
     });
+
+    context('when there is an campaign of type PROFILE_COLLECTION', function () {
+      it('should not keep the autonomous course from the campaign participations list', async function () {
+        // given
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ ownerOrganizationId: userId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+          targetProfileId: null,
+        });
+        const organizationLearnerId =
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({ userId }).id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          organizationLearnerId,
+          campaignId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipationOverviews } =
+          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+
+        // then
+        expect(campaignParticipationOverviews).to.have.lengthOf(0);
+      });
+    });
+
+    context('when there is an campaign of type EXAM', function () {
+      it('should not keep the autonomous course from the campaign participations list', async function () {
+        // given
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ ownerOrganizationId: userId });
+        const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({ organizationId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.EXAM,
+          targetProfileId,
+        });
+        const organizationLearnerId =
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({ userId }).id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          organizationLearnerId,
+          campaignId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipationOverviews } =
+          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+
+        // then
+        expect(campaignParticipationOverviews).to.have.lengthOf(1);
+      });
+    });
   });
 });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -7,7 +7,6 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import { ApplicationTransaction } from '../../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
 import { constants } from '../../../../../../src/shared/domain/constants.js';
 import { DomainTransaction, withTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -54,7 +53,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation.participantExternalId = 'Laura';
 
       // when
-      await ApplicationTransaction.execute(async () => {
+      await DomainTransaction.execute(async () => {
         await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
       });
 
@@ -71,7 +70,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation.sharedAt = new Date();
 
       // when
-      await ApplicationTransaction.execute(async () => {
+      await DomainTransaction.execute(async () => {
         await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
       });
 
@@ -941,6 +940,22 @@ describe('Integration | Repository | Campaign Participation', function () {
     it('should return true if the user has participations to campaigns of type assement', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignParticipationRepository.hasAssessmentParticipations(userId);
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return true if the user has participations to campaigns of type exam', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         userId,


### PR DESCRIPTION
## :pancakes: Problème

Actuellement nous n'affichons pas la campagne de type EXAM sur le dashboard des overviews

## :bacon: Proposition

Ajouter la condition des type EXAM dans le repo `campaign-participation-overview-repository.js`

## 🧃 Remarques

RAS

## :yum: Pour tester

Faire une campagne de type EXAM, et vérifier qu'elle affiche la carte de la campagne de type EXAM