### PR TITLE
[TECH] Créer le FT pour les attestations PDF V3 avec le nouveau système (PIX-16957).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,4 +5,10 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isV3CertificationAttestationEnabled: {
+    description: 'Used to enable new certification attestation for V3',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['team-certification'],
+  },
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -883,13 +883,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIX_ADMIN_NEW_SIDEBAR_ENABLED=false
 
-# Enable V3 certification attestation
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_V3_CERTIFICATION_ATTESTATION_ENABLED=true
-
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -136,7 +136,6 @@ const schema = Joi.object({
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   FT_PIX_COMPANION_ENABLED: Joi.string().optional().valid('true', 'false'),
-  FT_V3_CERTIFICATION_ATTESTATION_ENABLED: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
@@ -313,7 +312,6 @@ const configuration = (function () {
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
-      isV3CertificationAttestationEnabled: toBoolean(process.env.FT_V3_CERTIFICATION_ATTESTATION_ENABLED),
     },
     hapi: {
       options: {},

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -39,7 +39,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,
-            'is-v3-certification-attestation-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## :pancakes: Problème

Une PR avait été faite avec l'ancien système de FT pour initialiser le feature-toggle lié aux nouvelles attestations #11512 

## :bacon: Proposition

On utilise le nouveau système de FT à la place.

## 🧃 Remarques

Il ne s'agit que d'initialisation, le FT n'ayant pas été utilisé jusque là dans le code.

## :yum: Pour tester

Tests verts.
