### PR TITLE
[BUGFIX] Corriger un test flaky sur PixAdmin (PIX-16958)

### DIFF
--- a/admin/tests/integration/components/common/tubes-selection-test.gjs
+++ b/admin/tests/integration/components/common/tubes-selection-test.gjs
@@ -190,8 +190,8 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
         });
 
         // then
-        assert.dom(screen.getByRole('textbox')).hasAttribute('placeholder', 'Pix plus');
-        assert.dom(screen.getByText('2/3 sujet(s) sélectionné(s)')).exists();
+        assert.dom(await screen.findByRole('textbox')).hasAttribute('placeholder', 'Pix plus');
+        assert.dom(await screen.findByText('2/3 sujet(s) sélectionné(s)')).exists();
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème
Petit flaky dans les tests de l'application 

![image](https://github.com/user-attachments/assets/aacc8647-cc92-4079-a5de-2a090713fb13)


## :bacon: Proposition
Attendre un peu avec un find plutôt qu'un get pour être sur que l'élement existe avant de tester sa présence

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
Tests passent toujours ✅ 
🐈‍⬛ 
