### PR TITLE
[FEATURE] Permettre de télécharger le csv des résultats d'une campagne de type EXAM (PIX-16976)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -56,7 +56,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   const campaign = await campaignRepository.get(campaignId);
   const translate = i18n.__;
 
-  if (!campaign.isAssessment) {
+  if (!campaign.isAssessment && !campaign.isExam) {
     throw new CampaignTypeError();
   }
 

--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -120,11 +120,15 @@ class CampaignAssessmentResultLine {
       ...this._group,
       ...this._studentNumber,
       ...(this.campaign.externalIdLabel ? [this.campaignParticipationInfo.participantExternalId] : []),
-      this.campaignParticipationService.progress(
-        this.campaignParticipationInfo.isCompleted,
-        this.targetedKnowledgeElementsCount,
-        this.learningContent.skills.length,
-      ),
+      ...(this.campaign.isAssessment
+        ? [
+            this.campaignParticipationService.progress(
+              this.campaignParticipationInfo.isCompleted,
+              this.targetedKnowledgeElementsCount,
+              this.learningContent.skills.length,
+            ),
+          ]
+        : []),
       dayjs.utc(this.campaignParticipationInfo.createdAt).tz('Europe/Paris').format('DD/MM/YYYY HH:mm'),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -90,7 +90,7 @@ class CampaignAssessmentExport {
       ...(forSupStudents ? [this.translate('campaign-export.common.participant-student-number')] : []),
       ...(this.campaign.externalIdLabel ? [this.campaign.externalIdLabel] : []),
 
-      this.translate('campaign-export.assessment.progress'),
+      ...(this.campaign.isAssessment ? [this.translate('campaign-export.assessment.progress')] : []),
       this.translate('campaign-export.assessment.started-on'),
       this.translate('campaign-export.assessment.is-shared'),
       this.translate('campaign-export.assessment.shared-on'),

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -1,0 +1,32 @@
+import { startWritingCampaignAssessmentResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
+import { CampaignTypeError } from '../../../../../../src/shared/domain/errors.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
+  let campaignRepository;
+  let i18n;
+
+  beforeEach(function () {
+    campaignRepository = { get: sinon.stub() };
+    i18n = getI18n();
+    campaignRepository.get.rejects('error for campaignRepository.get');
+  });
+
+  it('should throw a CampaignTypeError when campaign is PROFILES_COLLECTION type', async function () {
+    // given
+    const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection();
+    campaignRepository.get.withArgs(campaign.id).resolves(campaign);
+
+    // when
+    const err = await catchErr(startWritingCampaignAssessmentResultsToStream)({
+      campaignId: campaign.id,
+      i18n,
+      campaignRepository,
+    });
+
+    // then
+    expect(err).to.be.instanceOf(CampaignTypeError);
+    expect(err.message).to.equal(`Ce type de campagne n'est pas autorisé.`);
+  });
+});

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
@@ -19,7 +19,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
 
     beforeEach(function () {
       organization = domainBuilder.buildOrganization({ isManagingStudents: false });
-      campaign = domainBuilder.buildCampaign({ externalIdLabel: null });
+      campaign = domainBuilder.prescription.campaign.buildCampaign.ofTypeAssessment({ externalIdLabel: null });
       targetProfile = domainBuilder.buildTargetProfile();
       learningContent = domainBuilder.buildLearningContent.withSimpleContent();
       areas = learningContent.areas;
@@ -31,105 +31,208 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
     });
 
     describe('common participation case', function () {
-      it('should return shared info, on shared participation', function () {
-        // given
-        const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
-          createdAt,
-          sharedAt,
+      context('campaign of type EXAM', function () {
+        it('should return shared info, on shared participation', function () {
+          // given
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
+            createdAt,
+            sharedAt,
+          });
+
+          const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
+            organization,
+            campaign: domainBuilder.prescription.campaign.buildCampaign.ofTypeExam({ externalIdLabel: null }),
+            campaignParticipationInfo,
+            targetProfile,
+            learningContent,
+            competences,
+            areas,
+            stageCollection,
+            participantKnowledgeElementsByCompetenceId: {
+              [competences[0].id]: [],
+            },
+            translate,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          const csvExcpectedLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"${campaign.code}";` +
+            `"${campaign.name}";` +
+            `"${targetProfile.name}";` +
+            `"${campaignParticipationInfo.participantLastName}";` +
+            `"${campaignParticipationInfo.participantFirstName}";` +
+            `"${createdAtFormated}";` +
+            '"Oui";' +
+            `"${sharedAtFormated}";` +
+            '1;' +
+            '0;' +
+            '1;' +
+            '0;' +
+            '0;' +
+            '1;' +
+            '0' +
+            '\n';
+
+          // then
+          expect(csvLine).to.equal(csvExcpectedLine);
         });
 
-        const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
-          organization,
-          campaign,
-          campaignParticipationInfo,
-          targetProfile,
-          learningContent,
-          competences,
-          areas,
-          stageCollection,
-          participantKnowledgeElementsByCompetenceId: {
-            [competences[0].id]: [],
-          },
-          translate,
+        it('should not return shared info, on participation not already shared', function () {
+          // given
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
+            createdAt,
+            sharedAt: null,
+            isCompleted: false,
+          });
+
+          const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
+            organization,
+            campaign: domainBuilder.prescription.campaign.buildCampaign.ofTypeExam({ externalIdLabel: null }),
+            campaignParticipationInfo,
+            targetProfile,
+            learningContent,
+            competences,
+            areas,
+            stageCollection,
+            participantKnowledgeElementsByCompetenceId: {
+              [competences[0].id]: [],
+            },
+            translate,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          const csvExcpectedLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"${campaign.code}";` +
+            `"${campaign.name}";` +
+            `"${targetProfile.name}";` +
+            `"${campaignParticipationInfo.participantLastName}";` +
+            `"${campaignParticipationInfo.participantFirstName}";` +
+            `"${createdAtFormated}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"' +
+            '\n';
+
+          // then
+          expect(csvLine).to.equal(csvExcpectedLine);
         });
-
-        // when
-        const csvLine = campaignAssessmentCsvLine.toCsvLine();
-
-        const csvExcpectedLine =
-          `"${organization.name}";` +
-          `${campaign.id};` +
-          `"${campaign.code}";` +
-          `"${campaign.name}";` +
-          `"${targetProfile.name}";` +
-          `"${campaignParticipationInfo.participantLastName}";` +
-          `"${campaignParticipationInfo.participantFirstName}";` +
-          '1;' +
-          `"${createdAtFormated}";` +
-          '"Oui";' +
-          `"${sharedAtFormated}";` +
-          '1;' +
-          '0;' +
-          '1;' +
-          '0;' +
-          '0;' +
-          '1;' +
-          '0' +
-          '\n';
-
-        // then
-        expect(csvLine).to.equal(csvExcpectedLine);
       });
 
-      it('should not return shared info, on participation not already shared', function () {
-        // given
-        const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
-          createdAt,
-          sharedAt: null,
-          isCompleted: false,
+      context('campaign of type ASSESSMENT', function () {
+        it('should return shared info, on shared participation', function () {
+          // given
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
+            createdAt,
+            sharedAt,
+          });
+
+          const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            learningContent,
+            competences,
+            areas,
+            stageCollection,
+            participantKnowledgeElementsByCompetenceId: {
+              [competences[0].id]: [],
+            },
+            translate,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          const csvExcpectedLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"${campaign.code}";` +
+            `"${campaign.name}";` +
+            `"${targetProfile.name}";` +
+            `"${campaignParticipationInfo.participantLastName}";` +
+            `"${campaignParticipationInfo.participantFirstName}";` +
+            '1;' +
+            `"${createdAtFormated}";` +
+            '"Oui";' +
+            `"${sharedAtFormated}";` +
+            '1;' +
+            '0;' +
+            '1;' +
+            '0;' +
+            '0;' +
+            '1;' +
+            '0' +
+            '\n';
+
+          // then
+          expect(csvLine).to.equal(csvExcpectedLine);
         });
 
-        const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
-          organization,
-          campaign,
-          campaignParticipationInfo,
-          targetProfile,
-          learningContent,
-          competences,
-          areas,
-          stageCollection,
-          participantKnowledgeElementsByCompetenceId: {
-            [competences[0].id]: [],
-          },
-          translate,
+        it('should not return shared info, on participation not already shared', function () {
+          // given
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
+            createdAt,
+            sharedAt: null,
+            isCompleted: false,
+          });
+
+          const campaignAssessmentCsvLine = new CampaignAssessmentResultLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            learningContent,
+            competences,
+            areas,
+            stageCollection,
+            participantKnowledgeElementsByCompetenceId: {
+              [competences[0].id]: [],
+            },
+            translate,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          const csvExcpectedLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"${campaign.code}";` +
+            `"${campaign.name}";` +
+            `"${targetProfile.name}";` +
+            `"${campaignParticipationInfo.participantLastName}";` +
+            `"${campaignParticipationInfo.participantFirstName}";` +
+            '0;' +
+            `"${createdAtFormated}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"' +
+            '\n';
+
+          // then
+          expect(csvLine).to.equal(csvExcpectedLine);
         });
-
-        // when
-        const csvLine = campaignAssessmentCsvLine.toCsvLine();
-
-        const csvExcpectedLine =
-          `"${organization.name}";` +
-          `${campaign.id};` +
-          `"${campaign.code}";` +
-          `"${campaign.name}";` +
-          `"${targetProfile.name}";` +
-          `"${campaignParticipationInfo.participantLastName}";` +
-          `"${campaignParticipationInfo.participantFirstName}";` +
-          '0;' +
-          `"${createdAtFormated}";` +
-          '"Non";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA";' +
-          '"NA"' +
-          '\n';
-
-        // then
-        expect(csvLine).to.equal(csvExcpectedLine);
       });
 
       context('on additionalInfos info', function () {

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/csv/campaign-assessment-export_test.js
@@ -29,7 +29,7 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
       };
       stageCollection = {};
       learningContent = { skillNames: [], competences: [], areas: [] };
-      campaign = {};
+      campaign = domainBuilder.prescription.campaign.buildCampaign.ofTypeAssessment({ externalIdLabel: null });
 
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
       const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
@@ -70,6 +70,43 @@ describe('Unit | Serializer | CSV | campaign-assessment-export', function () {
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
         '"% de progression";' +
+        '"Date et heure de début (Europe/Paris)";' +
+        '"Partage (O/N)";' +
+        '"Date et heure du partage (Europe/Paris)";' +
+        '"% maitrise de l\'ensemble des acquis du profil"' +
+        '\n';
+      //when
+      await campaignProfile.export();
+
+      outputStream.end();
+
+      const csv = await csvPromise;
+
+      // then
+      expect(csv).to.equal(expectedHeader);
+    });
+
+    it('should hide progression header on campaign of type Exam', async function () {
+      //given
+      const campaignProfile = new CampaignAssessmentExport({
+        outputStream,
+        organization,
+        campaign: domainBuilder.prescription.campaign.buildCampaign.ofTypeExam({ externalIdLabel: null }),
+        competences,
+        targetProfile,
+        learningContent,
+        stageCollection,
+        translate,
+      });
+
+      const expectedHeader =
+        '\uFEFF"Nom de l\'organisation";' +
+        '"ID Campagne";' +
+        '"Code";' +
+        '"Nom de la campagne";' +
+        '"Parcours";' +
+        '"Nom du Participant";' +
+        '"Prénom du Participant";' +
         '"Date et heure de début (Europe/Paris)";' +
         '"Partage (O/N)";' +
         '"Date et heure du partage (Europe/Paris)";' +

--- a/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign.js
@@ -52,7 +52,7 @@ function buildCampaign({
     participationCount,
   });
 }
-
+buildCampaign.ofTypeExam = (input) => buildCampaign({ ...input, type: CampaignTypes.EXAM });
 buildCampaign.ofTypeAssessment = (input) => buildCampaign({ ...input, type: CampaignTypes.ASSESSMENT });
 buildCampaign.ofTypeProfilesCollection = (input) =>
   buildCampaign({ ...input, type: CampaignTypes.PROFILES_COLLECTION });


### PR DESCRIPTION
## :pancakes: Problème

On ne peut pas télécharger les csv de type EXAM

## :bacon: Proposition

autoriser la téléchargement des csv de type EXAM

## 🧃 Remarques

RAS

## :yum: Pour tester

Aller sur PixOrga
admin-orga@example.net / pix123

créer une campagne de type EXAM. et télécharger le csv . Vérifier que nous avons bien les headers. 

* vérifier que la progression est toujours disponible sur les campagne de type evaluation
* vérifier que la progression n'est pas disponible pour les campagne de type Exam.