### PR TITLE
[FEATURE] Supprime le dégradé en haut de le page de saisie du code (pix-16880)

### DIFF
--- a/mon-pix/app/components/campaign-code-form.gjs
+++ b/mon-pix/app/components/campaign-code-form.gjs
@@ -1,4 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCode from '@1024pix/pix-ui/components/pix-code';
@@ -85,55 +84,53 @@ export default class CampaignCodeForm extends Component {
   }
 
   <template>
-    <PixBackgroundHeader>
-      <PixBlock class="fill-in-campaign-code__container">
-        <h1 class="fill-in-campaign-code__title">
-          {{this.firstTitle}}
-        </h1>
-        <p id="campaign-code-description" class="fill-in-campaign-code__instruction">{{t
-            "pages.fill-in-campaign-code.description"
-          }}</p>
+    <PixBlock class="fill-in-campaign-code__container">
+      <h1 class="fill-in-campaign-code__title">
+        {{this.firstTitle}}
+      </h1>
+      <p id="campaign-code-description" class="fill-in-campaign-code__instruction">{{t
+          "pages.fill-in-campaign-code.description"
+        }}</p>
 
-        <form class="fill-in-campaign-code__form" autocomplete="off">
-          <PixCode
-            @id="campaign-code"
-            @length="9"
-            @requiredLabel={{t "common.forms.mandatory"}}
-            @screenReaderOnly={{true}}
-            @value={{this.certificateVerificationCode}}
-            @validationStatus={{this.validationStatus}}
-            @errorMessage={{this.validationErrorMessage}}
-            aria-describedby="campaign-code-description"
-            {{on "keyup" this.clearErrorMessage}}
-            {{on "input" this.handleCampaignCodeInput}}
-          >
-            <:label>{{t "pages.fill-in-campaign-code.label"}}</:label>
-          </PixCode>
+      <form class="fill-in-campaign-code__form" autocomplete="off">
+        <PixCode
+          @id="campaign-code"
+          @length="9"
+          @requiredLabel={{t "common.forms.mandatory"}}
+          @screenReaderOnly={{true}}
+          @value={{this.certificateVerificationCode}}
+          @validationStatus={{this.validationStatus}}
+          @errorMessage={{this.validationErrorMessage}}
+          aria-describedby="campaign-code-description"
+          {{on "keyup" this.clearErrorMessage}}
+          {{on "input" this.handleCampaignCodeInput}}
+        >
+          <:label>{{t "pages.fill-in-campaign-code.label"}}</:label>
+        </PixCode>
 
-          {{#if @apiErrorMessage}}
-            <PixNotificationAlert @type="error" @withIcon={{true}}>
-              {{@apiErrorMessage}}
-            </PixNotificationAlert>
-          {{/if}}
-
-          <PixButton @type="submit" @triggerAction={{this.startCampaign}}>
-            {{t "pages.fill-in-campaign-code.start"}}
-          </PixButton>
-        </form>
-
-        {{#if this.showWarningMessage}}
-          <div class="fill-in-campaign-code__warning">
-            <span>{{this.warningMessage}}</span>
-            <a href="#" class="link" {{on "click" this.disconnect}}>
-              {{t "pages.fill-in-campaign-code.warning-message-logout"}}
-            </a>
-          </div>
+        {{#if @apiErrorMessage}}
+          <PixNotificationAlert @type="error" @withIcon={{true}}>
+            {{@apiErrorMessage}}
+          </PixNotificationAlert>
         {{/if}}
 
-      </PixBlock>
-      {{#if this.canDisplayLanguageSwitcher}}
-        <LanguageSwitcher @selectedLanguage={{@selectedLanguage}} @onLanguageChange={{@onLanguageChange}} />
+        <PixButton @type="submit" @triggerAction={{this.startCampaign}}>
+          {{t "pages.fill-in-campaign-code.start"}}
+        </PixButton>
+      </form>
+
+      {{#if this.showWarningMessage}}
+        <div class="fill-in-campaign-code__warning">
+          <span>{{this.warningMessage}}</span>
+          <a href="#" class="link" {{on "click" this.disconnect}}>
+            {{t "pages.fill-in-campaign-code.warning-message-logout"}}
+          </a>
+        </div>
       {{/if}}
-    </PixBackgroundHeader>
+
+    </PixBlock>
+    {{#if this.canDisplayLanguageSwitcher}}
+      <LanguageSwitcher @selectedLanguage={{@selectedLanguage}} @onLanguageChange={{@onLanguageChange}} />
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -25,12 +25,12 @@
     height: 0.5em;
     border-right: 2px solid currentcolor;
     border-bottom: 2px solid currentcolor;
-    transform: translateY(-80%) rotate(45deg);
+    transform: translateY(-80%) translateX(-2px) rotate(45deg);
     content: '';
   }
 
   &[aria-expanded="true"]::after {
-    transform: translateY(-30%) rotate(-135deg);
+    transform: translateY(-30%) translateX(-2px)  rotate(-135deg);
   }
 }
 

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -17,8 +17,6 @@ img {
 
 /* App main header */
 .app-main-header {
-  @extend %global-container;
-
   display: flex;
   flex-wrap: wrap;
   gap: var(--pix-spacing-6x);
@@ -92,7 +90,6 @@ img {
 .app-layout {
   z-index: 0;
 
-  .app-main-header,
   .global-page-container,
   #footer {
     padding: 0;

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -68,7 +68,6 @@ img {
 /* Global container */
 %global-container {
   width: 100%;
-  max-width: 96rem;
   margin-inline: auto;
   padding-inline: var(--pix-spacing-4x);
 

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -5,6 +5,7 @@
 .fill-in-campaign-code {
   &__container {
     width: 100%;
+    margin-top: var(--pix-spacing-6x);
     margin-bottom: var(--pix-spacing-8x);
     padding: 16px 16px var(--pix-spacing-4x);
 


### PR DESCRIPTION
## :pancakes: Problème

Suite à l'ajout de la nouvelle nav sur pix app, on doit corriger de petouilles graphique sur la page de saisie d'un code campagne. On doit aussi rajouter un lien vers le site support pour la saisie d'un code

## :bacon: Proposition

on corrige les pétouilles et on ajoute le lien

## 🧃 Remarques

Dans le ticket, on fait référence à 3 pages du support concernant la saisie d'un code en fonction du profil de l'utilisateur (particulier, étudiant, sco) sauf qu'on ne peut pas avoir cette info avant d'avoir saisie le code campagne. On a donc mis la page vers l'espace particulier. 

On profite de la PR pour fixer l'alignement du chevron du menu déroulant utilisateur et pour corriger le padding du header qui sauté. 

## :yum: Pour tester
### en étant déconnecté
- visiter l'url 
- voir le lien vers la doc (le lien change en fonction de la langue)
### en étant connecté
- se connecter sur pix-app 
- cliquer sur j'ai un code
- voir le beau design et le lien vers la doc (marche si on change la langue)
