### PR TITLE
[FEATURE] PixTable sur Pix Admin épisode 6 (PIX-16988).

### DIFF
--- a/admin/app/components/administration/certification/scoring-simulator.gjs
+++ b/admin/app/components/administration/certification/scoring-simulator.gjs
@@ -1,7 +1,8 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -118,27 +119,30 @@ export default class ScoringSimulator extends Component {
     </AdministrationBlockLayout>
 
     {{#if this.simulatorReport.data.attributes.competences}}
-      <PixBlock class="scoring-simulator__competences">
-        <table
-          aria-label="{{t 'pages.administration.certification.scoring-simulator.table.label'}}"
-          class="table-admin"
-        >
-          <thead class="scoring-simulator-competences-table__header">
-            <tr>
-              <th scope="col">{{t "pages.administration.certification.scoring-simulator.table.headers.competence"}}</th>
-              <th scope="col">{{t "pages.administration.certification.scoring-simulator.table.headers.level"}}</th>
-            </tr>
-          </thead>
-          <tbody class="scoring-simulator-competences-table__body">
-            {{#each this.simulatorReport.data.attributes.competences as |competence|}}
-              <tr>
-                <th scope="row">{{competence.competenceCode}}</th>
-                <td>{{competence.level}}</td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      </PixBlock>
+      <PixTable
+        @variant="primary"
+        @caption={{t "pages.administration.certification.scoring-simulator.table.label"}}
+        @data={{this.simulatorReport.data.attributes.competences}}
+      >
+        <:columns as |competence context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.administration.certification.scoring-simulator.table.headers.competence"}}
+            </:header>
+            <:cell>
+              {{competence.competenceCode}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.administration.certification.scoring-simulator.table.headers.level"}}
+            </:header>
+            <:cell>
+              {{competence.level}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
     {{/if}}
   </template>
 }

--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -1,10 +1,12 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -306,120 +308,124 @@ export default class DetailsV3 extends Component {
       <h2 class="certification-details-v3__title">
         {{t "pages.certifications.certification.details.v3.questions-list.title"}}
       </h2>
-      <div class="content-text content-text--small">
-        <div class="certification-details-v3-table table-admin">
-          <table>
-            <thead>
-              <tr>
-                <th class="table__column--small">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.number"}}
-                </th>
-                <th class="certification-details-v3-table__answered-at-column">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.answered-at"}}
-                </th>
-                <th class="certification-details-v3-table__answer-status-column">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.answer-status"}}
-                </th>
-                <th class="certification-details-v3-table__competence-column">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.competence"}}
-                </th>
-                <th class="certification-details-v3-table__skill-column">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.skill"}}
-                </th>
-                <th class="certification-details-v3-table__challenge-id-column">
-                  {{t "pages.certifications.certification.details.v3.questions-list.labels.challenge-id"}}
-                </th>
-                <th>{{t "pages.certifications.certification.details.v3.questions-list.labels.actions"}}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each @details.certificationChallengesForAdministration as |certificationChallenge|}}
-                <tr>
-                  <td>{{certificationChallenge.questionNumber}}</td>
-                  <td>
-                    {{#if certificationChallenge.answeredAt}}
-                      <time>
-                        {{dayjsFormat certificationChallenge.answeredAt "HH:mm:ss"}}
-                      </time>
-                    {{else}}
-                      -
-                    {{/if}}
-                  </td>
-                  <td>
-                    {{#if (this.shouldDisplayAnswerStatus certificationChallenge)}}
-                      <PixTag @color={{this.answerStatusColor certificationChallenge.answerStatus}}>
-                        {{t (this.answerStatusLabel certificationChallenge.answerStatus)}}
-                      </PixTag>
-                    {{else}}
-                      -
-                    {{/if}}
-                  </td>
-                  <td>{{certificationChallenge.competenceIndex}} {{certificationChallenge.competenceName}}</td>
-                  <td>{{certificationChallenge.skillName}}</td>
-                  <td class="certification-details-v3-table__challenge-informations-cell">
-                    <a
-                      href={{this.externalUrlForPixEditor certificationChallenge.id}}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={{t
-                        "pages.certifications.certification.details.v3.questions-list.actions.informations.extra-information"
-                      }}
-                    >
-                      {{certificationChallenge.id}}
-                      <PixIcon @name="openNew" />
-                    </a>
-                  </td>
-                  <td class="certification-details-v3-table__challenge-action-cell">
-                    <a
-                      href={{this.externalUrlForPreviewChallenge certificationChallenge.id}}
-                      target="_blank"
-                      title={{t
-                        "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.label"
-                      }}
-                      aria-label={{t
-                        "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.extra-information"
-                      }}
-                      rel="noopener noreferrer"
-                    >
-                      <PixIcon @name="eye" @plainIcon={{true}} />
-                    </a>
+      <PixTable
+        @variant="primary"
+        @caption={{t "pages.certifications.certification.details.v3.questions-list.caption"}}
+        @data={{@details.certificationChallengesForAdministration}}
+      >
+        <:columns as |certificationChallenge context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.number"}}
+            </:header>
+            <:cell>
+              {{certificationChallenge.questionNumber}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.answered-at"}}
+            </:header>
+            <:cell>
+              {{#if certificationChallenge.answeredAt}}
+                <time>
+                  {{dayjsFormat certificationChallenge.answeredAt "HH:mm:ss"}}
+                </time>
+              {{else}}
+                -
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.answer-status"}}
+            </:header>
+            <:cell>
+              {{#if (this.shouldDisplayAnswerStatus certificationChallenge)}}
+                <PixTag @color={{this.answerStatusColor certificationChallenge.answerStatus}}>
+                  {{t (this.answerStatusLabel certificationChallenge.answerStatus)}}
+                </PixTag>
+              {{else}}
+                -
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.competence"}}
+            </:header>
+            <:cell>
+              {{certificationChallenge.competenceIndex}}
+              {{certificationChallenge.competenceName}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.skill"}}
+            </:header>
+            <:cell>
+              {{certificationChallenge.skillName}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="certification-details-v3-table__challenge-information-cell">
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.challenge-id"}}
+            </:header>
+            <:cell>
+              <a
+                href={{this.externalUrlForPixEditor certificationChallenge.id}}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={{t
+                  "pages.certifications.certification.details.v3.questions-list.actions.informations.extra-information"
+                }}
+              >
+                {{certificationChallenge.id}}
+                <PixIcon @name="openNew" />
+              </a>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="certification-details-v3-table__challenge-action-cell">
+            <:header>
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.actions"}}
+            </:header>
+            <:cell>
+              <a
+                href={{this.externalUrlForPreviewChallenge certificationChallenge.id}}
+                target="_blank"
+                title={{t
+                  "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.label"
+                }}
+                aria-label={{t
+                  "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.extra-information"
+                }}
+                rel="noopener noreferrer"
+              >
+                <PixIcon @name="eye" @plainIcon={{true}} />
+              </a>
+              {{#if certificationChallenge.validatedLiveAlert}}
+                <PixIconButton
+                  @ariaLabel={{t
+                    "pages.certifications.certification.details.v3.questions-list.actions.display-live-alert.extra-information"
+                  }}
+                  @triggerAction={{fn this.openModal certificationChallenge}}
+                  @iconName="warning"
+                />
+              {{/if}}
 
-                    {{#if certificationChallenge.validatedLiveAlert}}
-                      <button
-                        title={{t
-                          "pages.certifications.certification.details.v3.questions-list.actions.display-live-alert.label"
-                        }}
-                        aria-label={{t
-                          "pages.certifications.certification.details.v3.questions-list.actions.display-live-alert.extra-information"
-                        }}
-                        type="button"
-                        {{on "click" (fn this.openModal certificationChallenge)}}
-                      >
-                        <PixIcon @name="warning" />
-                      </button>
-                    {{/if}}
-
-                    {{#if (this.shouldDisplayAnswerValueIcon certificationChallenge)}}
-                      <button
-                        title={{t
-                          "pages.certifications.certification.details.v3.questions-list.actions.display-answer.label"
-                        }}
-                        aria-label={{t
-                          "pages.certifications.certification.details.v3.questions-list.actions.display-answer.extra-information"
-                        }}
-                        type="button"
-                        {{on "click" (fn this.openModal certificationChallenge)}}
-                      >
-                        <PixIcon @name="chat" />
-                      </button>
-                    {{/if}}
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-      </div>
+              {{#if (this.shouldDisplayAnswerValueIcon certificationChallenge)}}
+                <PixIconButton
+                  @ariaLabel={{t
+                    "pages.certifications.certification.details.v3.questions-list.actions.display-answer.extra-information"
+                  }}
+                  @triggerAction={{fn this.openModal certificationChallenge}}
+                  @iconName="chat"
+                />
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
     </section>
 
     <PixModal

--- a/admin/app/components/certifications/certification/details-v3.scss
+++ b/admin/app/components/certifications/certification/details-v3.scss
@@ -9,7 +9,7 @@
 
   &__title {
     @extend %pix-title-xs;
-
+    padding-bottom: var(--pix-spacing-3x);
     color : var(--pix-neutral-800);
   }
 
@@ -47,59 +47,29 @@
 }
 
 .certification-details-v3-table {
-  svg {
-    height: 1.2rem;
-    width: 1.2rem;
-  }
 
-  &__answered-at-column {
-    width: 11%;
-  }
-
-  &__competence-column {
-    width: 27%;
-  }
-
-  &__skill-column {
+  &__challenge-information-cell {
     width: 17%;
-  }
 
-  &__answer-status-column {
-    width: 13%;
-  }
-
-  &__challenge-id-column {
-    width: 18%;
-  }
-
-  &__challenge-informations-cell {
     & a, a:visited {
       align-items: center;
       display: flex;
       gap: var(--pix-spacing-1x);
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
     }
   }
 
   &__challenge-action-cell {
     display: flex;
-    height: inherit;
-    align-items: center;
-
-    button:focus-visible {
-      padding: 2px 5px;
-    }
+    align-items: flex-end;
+    gap: var(--pix-spacing-1x);
 
     & a, a:visited, button {
-      align-items: center;
-      display: flex;
-      flex-direction: column;
-      padding-right: 3px;
       color: inherit;
-      text-decoration: none;
-    }
-
-    a:focus-visible {
-      padding-left: 4px;
     }
   }
 }

--- a/admin/app/components/certifications/competence-list.gjs
+++ b/admin/app/components/certifications/competence-list.gjs
@@ -1,3 +1,5 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { concat, fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -82,28 +84,40 @@ export default class CertificationCompetenceList extends Component {
         </div>
       {{/each}}
     {{else}}
-      <table aria-label="{{t 'pages.certifications.certification.result.table.label'}}" class="table-admin">
-        <thead>
-          <tr>
-            <th scope="col">{{t "pages.certifications.certification.result.table.headers.competence"}}</th>
-            {{#if @shouldDisplayPixScore}}
-              <th scope="col">{{t "pages.certifications.certification.result.table.headers.score"}}</th>
-            {{/if}}
-            <th scope="col">{{t "pages.certifications.certification.result.table.headers.level"}}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each @competences as |competence|}}
-            <tr>
-              <th scope="row">{{competence.index}}</th>
-              {{#if @shouldDisplayPixScore}}
-                <td>{{competence.score}}</td>
-              {{/if}}
-              <td>{{competence.level}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
+      <PixTable
+        @variant="primary"
+        @caption={{t "pages.certifications.certification.result.table.label"}}
+        @data={{@competences}}
+      >
+        <:columns as |competence context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.result.table.headers.competence"}}
+            </:header>
+            <:cell>
+              {{competence.index}}
+            </:cell>
+          </PixTableColumn>
+          {{#if @shouldDisplayPixScore}}
+            <PixTableColumn @context={{context}}>
+              <:header>
+                {{t "pages.certifications.certification.result.table.headers.score"}}
+              </:header>
+              <:cell>
+                {{competence.score}}
+              </:cell>
+            </PixTableColumn>
+          {{/if}}
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.certifications.certification.result.table.headers.level"}}
+            </:header>
+            <:cell>
+              {{competence.level}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
     {{/if}}
   </template>
 }

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -84,7 +84,6 @@ export default class ToBePublishedSessionsList extends Component {
               <:cell>
                 <PixButton
                   @triggerAction={{fn this.showConfirmModal row}}
-                  class="publish-session-button"
                   @size="small"
                   aria-label={{t
                     "pages.sessions.table.to-be-published.cell.publish-button.aria-label"

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -5,7 +5,6 @@
 @use 'globals/page-details' as *;
 @use 'globals/tables' as *;
 @use 'globals/table-admin' as *;
-@use 'globals/toggle' as *;
 
 /* pages */
 @use 'login' as *;
@@ -70,7 +69,6 @@
 @use 'components/organizations/places' as *;
 @use 'components/organizations/places-lot-creation-form' as *;
 @use 'components/participation-row' as *;
-@use 'components/publish-session-button' as *;
 @use 'components/sessions/jury-comment' as *;
 @use 'components/smart-random-simulator/current-challenge' as *;
 @use 'components/smart-random-simulator/previous-challenges' as *;

--- a/admin/app/styles/components/publish-session-button.scss
+++ b/admin/app/styles/components/publish-session-button.scss
@@ -1,6 +1,0 @@
-.publish-session-button {
-
-  svg {
-    margin-right: 6px;
-  }
-}

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -40,10 +40,6 @@
   }
 }
 
-.table-admin__wrapper {
-  overflow-x: auto;
-}
-
 .table-admin__auto-width {
   table-layout: auto;
 }

--- a/admin/app/styles/globals/toggle.scss
+++ b/admin/app/styles/globals/toggle.scss
@@ -1,5 +1,0 @@
-.x-toggle-component > :not(.x-toggle-container-checked)  {
-    .x-toggle-btn {
-      background: var(--pix-neutral-100) !important;
-    }
-}

--- a/admin/tests/acceptance/administration-test.js
+++ b/admin/tests/acceptance/administration-test.js
@@ -169,7 +169,7 @@ module('Acceptance | administration | common ', function (hooks) {
 
           assert.dom(within(table).getByRole('columnheader', { name: 'Compétence' })).exists();
           assert.dom(within(table).getByRole('columnheader', { name: 'Niveau' })).exists();
-          assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+          assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
           assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
         });
       });
@@ -195,7 +195,7 @@ module('Acceptance | administration | common ', function (hooks) {
 
           assert.dom(within(table).getByRole('columnheader', { name: 'Compétence' })).exists();
           assert.dom(within(table).getByRole('columnheader', { name: 'Niveau' })).exists();
-          assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+          assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
           assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
         });
       });

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -101,7 +101,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       assert.dom(within(table).getByRole('columnheader', { name: 'Compétence' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Score' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Niveau' })).exists();
-      assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
       assert.dom(within(rows[1]).getByRole('cell', { name: '10' })).exists();
       assert.dom(within(rows[1]).getByRole('cell', { name: '4' })).exists();
     });

--- a/admin/tests/integration/components/administration/deployment/organizations-import-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-import-test.gjs
@@ -24,7 +24,7 @@ module('Integration | Component |  administration/organizations-import', functio
   });
 
   module('when import succeeds', function () {
-    test.skip('it displays a success notification', async function (assert) {
+    test('it displays a success notification', async function (assert) {
       // given
       const file = new Blob(['foo'], { type: `valid-file` });
       class NotificationsStub extends Service {
@@ -39,10 +39,10 @@ module('Integration | Component |  administration/organizations-import', functio
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(
-        notificationSuccessStub,
-        t('components.administration.organizations-import.notifications.success'),
+      assert.true(
+        notificationSuccessStub.calledWith({
+          message: t('components.administration.organizations-import.notifications.success'),
+        }),
       );
     });
   });

--- a/admin/tests/integration/components/certifications/competence-list-test.gjs
+++ b/admin/tests/integration/components/certifications/competence-list-test.gjs
@@ -28,15 +28,15 @@ module('Integration | Component | certifications/competence-list', function (hoo
     assert.dom(within(rows[0]).getByRole('columnheader', { name: 'Score' })).exists();
     assert.dom(within(rows[0]).getByRole('columnheader', { name: 'Niveau' })).exists();
 
-    assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+    assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
     assert.dom(within(rows[1]).getByRole('cell', { name: '30' })).exists();
     assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
 
-    assert.dom(within(rows[2]).getByRole('rowheader', { name: '2.1' })).exists();
+    assert.dom(within(rows[2]).getByRole('cell', { name: '2.1' })).exists();
     assert.dom(within(rows[2]).getByRole('cell', { name: '20' })).exists();
     assert.dom(within(rows[2]).getByRole('cell', { name: '2' })).exists();
 
-    assert.dom(within(rows[3]).getByRole('rowheader', { name: '5.2' })).exists();
+    assert.dom(within(rows[3]).getByRole('cell', { name: '5.2' })).exists();
     assert.dom(within(rows[3]).getByRole('cell', { name: '10' })).exists();
     assert.dom(within(rows[3]).getByRole('cell', { name: '1' })).exists();
   });
@@ -57,7 +57,7 @@ module('Integration | Component | certifications/competence-list', function (hoo
     assert.dom(within(table).getByRole('columnheader', { name: 'Compétence' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Score' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Niveau' })).exists();
-    assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+    assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
     assert.dom(within(rows[1]).getByRole('cell', { name: '30' })).exists();
     assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
   });
@@ -120,7 +120,7 @@ module('Integration | Component | certifications/competence-list', function (hoo
       assert.dom(within(rows[0]).getByRole('columnheader', { name: 'Compétence' })).exists();
       assert.dom(within(rows[0]).getByRole('columnheader', { name: 'Niveau' })).exists();
 
-      assert.dom(within(rows[1]).getByRole('rowheader', { name: '1.1' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: '1.1' })).exists();
       assert.dom(within(rows[1]).getByRole('cell', { name: '3' })).exists();
 
       assert.dom(screen.queryByText('Score')).doesNotExist();

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -686,6 +686,7 @@
                   "extra-information": "Link to question information (Opens in new window)"
                 }
               },
+              "caption": "Liste des questions passées sur une certification. Contient le numéro de la question, l'heure de la réponse donnée, son statut, la compétence concernée, le nom de l'acquis et le recId. Des boutons d'action permettent d'accéder à un aperçu de la question ou de lire la réponse donnée par le candidat.",
               "labels": {
                 "actions": "Actions",
                 "answer-status": "Status",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -701,6 +701,7 @@
                   "extra-information": "Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
                 }
               },
+              "caption": "Liste des questions passées sur une certification. Contient le numéro de la question, l'heure de la réponse donnée, son statut, la compétence concernée, le nom de l'acquis et le recId. Des boutons d'action permettent d'accéder à un aperçu de la question ou de lire la réponse donnée par le candidat.",
               "labels": {
                 "actions": "Actions",
                 "answer-status": "Statut",


### PR DESCRIPTION
## :pancakes: Problème

Le composant PixTable existe mais n'est pas du tout utilisé dans nos applications

## :bacon: Proposition

Continuer les tableaux coté pages de la team Certif.

## 🧃 Remarques

Manque les tableaux des centres de certif, et j'aurais fini les tableaux certification 🥳 

## :yum: Pour tester

Les tableaux à checker sur Pix Admin : 

- Tableau de détails d'une certification V3 (celui avec les questions du candidat) https://admin-pr11626.review.pix.fr/certifications/128811/details
- Tableau du scoring-simulator https://admin-pr11626.review.pix.fr/administration/certification
- Tableau des compétences en V2 https://admin-pr11626.review.pix.fr/certifications/127326
