### PR TITLE
[BUGFIX] Mettre à jour et rajouter les attributs nécessaire sur la navbar de Pix app (PIX-16773)

### DIFF
--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -31,7 +31,12 @@ export default class AppNavigation extends Component {
   }
 
   <template>
-    <PixNavigation class="app-navigation" @navigationAriaLabel="navigation principale">
+    <PixNavigation
+      class="app-navigation"
+      @navigationAriaLabel="{{t 'navigation.nav-bar.aria-label'}}"
+      @openLabel="{{t 'navigation.nav-bar.open'}}"
+      @closeLabel="{{t 'navigation.nav-bar.close'}}"
+    >
       <:brand>
         {{#if this.isFrenchLocale}}
           <img

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -15,7 +15,7 @@
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/epreuves-components": "^0.1.0",
         "@1024pix/eslint-plugin": "^2.1.1",
-        "@1024pix/pix-ui": "^55.11.0",
+        "@1024pix/pix-ui": "^55.11.1",
         "@1024pix/stylelint-config": "^5.1.28",
         "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-proposal-decorators": "^7.24.7",
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "55.11.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-55.11.0.tgz",
-      "integrity": "sha512-SaUUN1LN/lORMzM/H9GFUQ69Xob+5tMPnG+NoNVlaJG3tgW43yRsVBZtQPo8wrfuEHArxySfRX1vstUCyNQ7+A==",
+      "version": "55.11.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-55.11.1.tgz",
+      "integrity": "sha512-CbYFafiY8odLBfICh0e+jbDK06yLjUceLF/J5+o+B3ZmC5zuiOW00CyLHSkqlBxHi1qsB0cOr/4AewEl40f1lw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -48,7 +48,7 @@
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/epreuves-components": "^0.1.0",
     "@1024pix/eslint-plugin": "^2.1.1",
-    "@1024pix/pix-ui": "^55.11.0",
+    "@1024pix/pix-ui": "^55.11.1",
     "@1024pix/stylelint-config": "^5.1.28",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -342,6 +342,11 @@
       "tutorials": "My tutorials"
     },
     "mobile-button-title": "Open menu",
+    "nav-bar": {
+      "aria-label": "main navigation",
+      "close": "Close navigation",
+      "open": "Open navigation"
+    },
     "not-logged": {
       "sign-in": "Log in",
       "sign-up": "Sign up"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -342,6 +342,11 @@
       "tutorials": "Mis tutoriales"
     },
     "mobile-button-title": "Abrir el menú",
+    "nav-bar": {
+      "aria-label": "navegación principal",
+      "close": "Cerrar la navegación",
+      "open": "Abrir la navegación"
+    },
     "not-logged": {
       "sign-in": "Conectarse",
       "sign-up": "Inscribirse"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -342,6 +342,11 @@
       "tutorials": "Mes tutos"
     },
     "mobile-button-title": "Ouvrir le menu",
+    "nav-bar": {
+      "aria-label": "navigation principale",
+      "close": "Fermer la navigation",
+      "open": "Ouvrir la navigation"
+    },
     "not-logged": {
       "sign-in": "Se connecter",
       "sign-up": "S'inscrire"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -342,6 +342,11 @@
       "tutorials": "Mijn tutorials"
     },
     "mobile-button-title": "Open het menu",
+    "nav-bar": {
+      "aria-label": "hoofdnavigatie",
+      "close": "Sluit de navigatie",
+      "open": "Open navigatie"
+    },
     "not-logged": {
       "sign-in": "Inloggen",
       "sign-up": "Meld je nu aan"


### PR DESCRIPTION
## :pancakes: Problème

On a mis à jour pix-ui pour pouvoir nommer le bouton pour ouvrir la navbar sur la page d'accueil de Pix app. On doit maintenant mettre à jour le composant et l'adapter sur Pix app.

## :bacon: Proposition

- Ajouter à l'appel du composant les attributs openLabel et closeLabel en leur donnant des labels traduits,
- Traduire ses nouveaux labels.

## 🧃 Remarques

Le aria-label de la navbar était écrit en dur dans le code, on l'a placé dans les traductions et traduit au passage.

## :yum: Pour tester

- Se rendre sur Pix app,
- Se connecter avec un compte comme alex-terieur@example.net,
- Mettre la page en petit format (mobile),
- En inspectant la page, constater que sur le bouton pour ouvrir la navbar est écrit "Ouvrir la navigation",
- Cliquer dessus,
- Constater que sur le bouton pour fermer la navbar est écrit "Fermer la navigation".