### PR TITLE
[TECH] Corriger des tests flacky sur le lastAccessedAt d'une organisation (PIX-16991)

### DIFF
--- a/api/tests/team/acceptance/application/membership/membership.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.route.test.js
@@ -417,6 +417,8 @@ describe('Acceptance | Team | Application | Route | membership', function () {
           userId: organizationMemberUserId,
           organizationId,
           organizationRole: Membership.roles.MEMBER,
+          lastAccessedAt: null,
+          updatedAt: new Date('2020-01-01'),
         });
 
         await databaseBuilder.commit();
@@ -438,7 +440,7 @@ describe('Acceptance | Team | Application | Route | membership', function () {
           .where({ userId: organizationMemberUserId, organizationId })
           .first();
         expect(membership.lastAccessedAt).to.be.a('date');
-        expect(membership.lastAccessedAt).to.deep.equal(membership.updatedAt);
+        expect(membership.updatedAt).to.not.equal(new Date('2020-01-01'));
         expect(response.statusCode).to.equal(204);
       });
     });

--- a/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
@@ -1,9 +1,20 @@
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import * as membershipRepository from '../../../../../src/team/infrastructure/repositories/membership.repository.js';
-import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Team | UseCases | update-membership-last-accessed-at', function () {
+  let clock;
+  const now = new Date('2022-12-01');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
   it('updates membership lastAccessedAt', async function () {
     // given
     const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -27,7 +38,7 @@ describe('Integration | Team | UseCases | update-membership-last-accessed-at', f
 
     // then
     const membership = await knex('memberships').where({ userId, organizationId }).first();
-    expect(membership.lastAccessedAt).to.be.a('date');
-    expect(membership.lastAccessedAt).to.deep.equal(membership.updatedAt);
+    expect(membership.lastAccessedAt).to.deep.equal(now);
+    expect(membership.updatedAt).to.deep.equal(now);
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Dans les tests les dates du lastLoggedAt et du updatedAt sont faites à la volée (new Date()) donc on ne peut pas être  sûr qu'elles seront absolument identiques

## :bacon: Proposition

corriger les tests


## :yum: Pour tester

- Vérifier que les tests sont au vert