### PR TITLE
[FEATURE] Changement de taille du logo Pix dans le footer (PIX-16697)

### DIFF
--- a/mon-pix/app/components/footer/index.gjs
+++ b/mon-pix/app/components/footer/index.gjs
@@ -16,7 +16,11 @@ export default class Footer extends Component {
     <footer id="footer" class="footer" role="contentinfo">
       <div class="footer__logos">
         {{#if this.currentDomain.isFranceDomain}}
-          <img src="/images/logo/logo-de-la-republique-francaise.svg" alt="{{t 'common.french-republic'}}" />
+          <img
+            src="/images/logo/logo-de-la-republique-francaise.svg"
+            class="footer__logos__french-republic-logo"
+            alt="{{t 'common.french-republic'}}"
+          />
         {{/if}}
         <img src="/images/pix-logo.svg" class="footer__logos__pix-logo" alt={{t "common.pix"}} />
         <div class="copyrights">

--- a/mon-pix/app/components/footer/index.gjs
+++ b/mon-pix/app/components/footer/index.gjs
@@ -18,7 +18,7 @@ export default class Footer extends Component {
         {{#if this.currentDomain.isFranceDomain}}
           <img src="/images/logo/logo-de-la-republique-francaise.svg" alt="{{t 'common.french-republic'}}" />
         {{/if}}
-        <img src="/images/pix-logo.svg" alt={{t "common.pix"}} />
+        <img src="/images/pix-logo.svg" class="footer__logos__pix-logo" alt={{t "common.pix"}} />
         <div class="copyrights">
           <span>{{t "navigation.copyrights"}} {{this.currentYear}} {{t "navigation.pix"}}</span>
         </div>

--- a/mon-pix/app/components/footer/index.gjs
+++ b/mon-pix/app/components/footer/index.gjs
@@ -18,11 +18,11 @@ export default class Footer extends Component {
         {{#if this.currentDomain.isFranceDomain}}
           <img
             src="/images/logo/logo-de-la-republique-francaise.svg"
-            class="footer__logos__french-republic-logo"
+            class="footer__logos--french-republic-logo"
             alt="{{t 'common.french-republic'}}"
           />
         {{/if}}
-        <img src="/images/pix-logo.svg" class="footer__logos__pix-logo" alt={{t "common.pix"}} />
+        <img src="/images/pix-logo.svg" class="footer__logos--pix-logo" alt={{t "common.pix"}} />
         <div class="copyrights">
           <span>{{t "navigation.copyrights"}} {{this.currentYear}} {{t "navigation.pix"}}</span>
         </div>

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -25,11 +25,10 @@
   align-items: center;
 
   img {
-    height: 54px;
-  }
-
-  img[alt="pix"] {
-    height: 48px;
+    height: 3.375rem;
+    &__pix-logo {
+      height: 3rem;
+    }
   }
 
   .copyrights {

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -25,8 +25,10 @@
   align-items: center;
 
   img {
-    height: 3.375rem;
-    
+    &__french-republic-logo {
+      height: 3.375rem;
+    }
+
     &__pix-logo {
       height: 3rem;
     }

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -26,6 +26,7 @@
 
   img {
     height: 3.375rem;
+    
     &__pix-logo {
       height: 3rem;
     }

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -28,6 +28,10 @@
     height: 54px;
   }
 
+  img[alt="pix"] {
+    height: 48px;
+  }
+
   .copyrights {
     @extend %pix-body-xs;
 

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -24,14 +24,12 @@
   gap: 1em;
   align-items: center;
 
-  img {
-    &__french-republic-logo {
-      height: 3.375rem;
-    }
+  &--french-republic-logo {
+    height: 3.375rem;
+  }
 
-    &__pix-logo {
-      height: 3rem;
-    }
+  &--pix-logo {
+    height: 3rem;
   }
 
   .copyrights {


### PR DESCRIPTION
## :pancakes: Problème

Le logo de Pix dans le footer est trop grand et sa hierachie dans le contenu n'est pas cohérente (hauteur supérieur au logo principal présent dans la nav)

## :bacon: Proposition

Réduire le logo Pix de 54px à 48px.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Vérifier que le logo Pix s'affiche correctement et qu'il est lisible.