### PR TITLE
[FEATURE] Récupère le prochain challenge en fonction du knowledge element snapshot dans les campagnes d'Exam (PIX-16775).

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -3,10 +3,8 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as certificationChallengeLiveAlertRepository from '../../../src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as certificationCompanionAlertRepository from '../../../src/certification/shared/infrastructure/repositories/certification-companion-alert-repository.js';
-import * as flashAlgorithmConfigurationRepository from '../../../src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as algorithmDataFetcherService from '../../../src/evaluation/domain/services/algorithm-methods/data-fetcher.js';
 import * as smartRandom from '../../../src/evaluation/domain/services/algorithm-methods/smart-random.js';
 // Used with vicious ...arguments
@@ -68,7 +66,6 @@ import { certificationCenterMembershipRepository } from '../../../src/team/infra
 import * as membershipRepository from '../../../src/team/infrastructure/repositories/membership.repository.js';
 import { organizationInvitationRepository } from '../../../src/team/infrastructure/repositories/organization-invitation.repository.js';
 import * as obfuscationService from '../../domain/services/obfuscation-service.js';
-import * as flashAssessmentResultRepository from '../../infrastructure/repositories/flash-assessment-result-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import { certificationCompletedJobRepository } from '../../infrastructure/repositories/jobs/certification-completed-job-repository.js';
 import * as organizationMemberIdentityRepository from '../../infrastructure/repositories/organization-member-identity-repository.js';
@@ -129,9 +126,6 @@ const dependencies = {
   dataProtectionOfficerRepository,
   emailRepository,
   emailValidationDemandRepository,
-  flashAlgorithmConfigurationRepository,
-  flashAlgorithmService,
-  flashAssessmentResultRepository,
   frameworkRepository,
   userToCreateRepository,
   knowledgeElementRepository,

--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import { Assessment } from '../../../../shared/domain/models/Assessment.js';
+
 async function fetchForCampaigns({
   assessment,
   answerRepository,
@@ -44,7 +46,15 @@ async function _fetchKnowledgeElements({
   knowledgeElementRepository,
   improvementService,
 }) {
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
+  let knowledgeElements;
+  if (assessment.type === Assessment.types.CAMPAIGN) {
+    knowledgeElements = await knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
+      userId: assessment.userId,
+      campaignParticipationId: assessment.campaignParticipationId,
+    });
+  } else {
+    knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
+  }
   return improvementService.filterKnowledgeElementsIfImproving({ knowledgeElements, assessment, isRetrying });
 }
 

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -13,6 +13,10 @@ const getNextChallengeForCampaignAssessment = async function ({
   algorithmDataFetcherService,
   smartRandomService,
   flashAlgorithmService,
+  campaignRepository,
+  knowledgeElementRepository,
+  campaignParticipationRepository,
+  improvementService,
 }) {
   let algoResult;
 
@@ -44,8 +48,25 @@ const getNextChallengeForCampaignAssessment = async function ({
 
     return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
   } else {
-    const inputValues = await algorithmDataFetcherService.fetchForCampaigns(...arguments);
-    algoResult = smartRandomService.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
+    const { allAnswers, lastAnswer, targetSkills, challenges, knowledgeElements } =
+      await algorithmDataFetcherService.fetchForCampaigns({
+        assessment,
+        locale,
+        answerRepository,
+        campaignRepository,
+        challengeRepository,
+        knowledgeElementRepository,
+        campaignParticipationRepository,
+        improvementService,
+      });
+    algoResult = smartRandomService.getPossibleSkillsForNextChallenge({
+      knowledgeElements,
+      challenges,
+      targetSkills,
+      lastAnswer,
+      allAnswers,
+      locale,
+    });
 
     if (algoResult.hasAssessmentEnded) {
       throw new AssessmentEndedError();

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,17 +1,17 @@
-import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { AssessmentEndedError } from '../../../src/shared/domain/errors.js';
+import { FlashAssessmentAlgorithm } from '../../../certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { AssessmentEndedError } from '../../../shared/domain/errors.js';
 
 const getNextChallengeForCampaignAssessment = async function ({
+  assessment,
+  locale,
   challengeRepository,
   answerRepository,
   flashAlgorithmConfigurationRepository,
   flashAssessmentResultRepository,
-  assessment,
   pickChallengeService,
-  locale,
   algorithmDataFetcherService,
-  smartRandom,
+  smartRandomService,
   flashAlgorithmService,
 }) {
   let algoResult;
@@ -45,7 +45,7 @@ const getNextChallengeForCampaignAssessment = async function ({
     return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
   } else {
     const inputValues = await algorithmDataFetcherService.fetchForCampaigns(...arguments);
-    algoResult = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
+    algoResult = smartRandomService.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
 
     if (algoResult.hasAssessmentEnded) {
       throw new AssessmentEndedError();

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as flashAssessmentResultRepository from '../../../../lib/infrastructure
 import * as certificationEvaluationCandidateRepository from '../../../certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
 import * as flashAlgorithmService from '../../../certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as certificationChallengeLiveAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
+import * as flashAlgorithmConfigurationRepository from '../../../certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as targetProfileAdministrationRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js';
@@ -44,41 +45,42 @@ const usecasesWithoutInjectedDependencies = {
 };
 
 const dependencies = {
-  answerRepository,
+  algorithmDataFetcherService,
   answerJobRepository,
+  answerRepository,
   areaRepository,
   assessmentRepository,
-  badgeAcquisitionRepository,
-  badgeForCalculationRepository,
-  userRepository: repositories.userRepository,
   autonomousCourseRepository: repositories.autonomousCourseRepository,
   autonomousCourseTargetProfileRepository: repositories.autonomousCourseTargetProfileRepository,
-  badgeRepository,
+  badgeAcquisitionRepository,
   badgeCriteriaRepository,
-  certificationEvaluationCandidateRepository,
-  certificationChallengeLiveAlertRepository,
-  campaignRepository,
+  badgeForCalculationRepository,
+  badgeRepository,
   campaignParticipationRepository,
+  campaignRepository,
+  certificationChallengeLiveAlertRepository,
+  certificationEvaluationCandidateRepository,
   challengeRepository,
   competenceEvaluationRepository,
   competenceRepository,
+  correctionService,
   feedbackRepository,
-  flashAssessmentResultRepository,
+  flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
+  flashAssessmentResultRepository,
+  getCompetenceLevel,
+  improvementService,
   knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
+  pickChallengeService,
+  scorecardService,
   skillRepository,
-  stageCollectionForTargetProfileRepository,
+  smartRandomService,
   stageAcquisitionRepository,
+  stageCollectionForTargetProfileRepository,
   stageRepository,
   targetProfileAdministrationRepository,
   targetProfileRepository,
-  getCompetenceLevel,
-  smartRandomService,
-  improvementService,
-  pickChallengeService,
-  scorecardService,
-  algorithmDataFetcherService,
-  correctionService,
+  userRepository: repositories.userRepository,
 };
 
 const evaluationUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -60,6 +60,7 @@ const getNextChallenge = async function (
   h,
   dependencies = {
     usecases,
+    evaluationUsecases,
     assessmentRepository,
     certificationVersionRepository,
     repositories,
@@ -241,7 +242,7 @@ async function _getChallengeByAssessmentType({ assessment, request, dependencies
   }
 
   if (assessment.isForCampaign()) {
-    return dependencies.usecases.getNextChallengeForCampaignAssessment({ assessment, locale });
+    return dependencies.evaluationUsecases.getNextChallengeForCampaignAssessment({ assessment, locale });
   }
 
   if (assessment.isCompetenceEvaluation()) {

--- a/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -1,11 +1,11 @@
-import { getNextChallengeForCampaignAssessment } from '../../../../lib/domain/usecases/get-next-challenge-for-campaign-assessment.js';
-import * as algorithmDataFetcherService from '../../../../src/evaluation/domain/services/algorithm-methods/data-fetcher.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as algorithmDataFetcherService from '../../../../../src/evaluation/domain/services/algorithm-methods/data-fetcher.js';
+import { getNextChallengeForCampaignAssessment } from '../../../../../src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 const { FRENCH_SPOKEN } = LOCALE;
 
-describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-assessment', function () {
+describe('Evaluation | Integration | Domain | Use Cases | get-next-challenge-for-campaign-assessment', function () {
   describe('#getNextChallengeForCampaignAssessment : case for SMART RANDOM', function () {
     let userId,
       assessmentId,
@@ -28,7 +28,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       challengeWeb21,
       challengeWeb22,
       possibleSkillsForNextChallenge,
-      smartRandom,
+      smartRandomService,
       locale;
 
     beforeEach(async function () {
@@ -78,7 +78,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       locale = FRENCH_SPOKEN;
       possibleSkillsForNextChallenge = [web2, url2, search2];
 
-      smartRandom = {
+      smartRandomService = {
         getPossibleSkillsForNextChallenge: sinon.stub().returns({
           hasAssessmentEnded: false,
           possibleSkillsForNextChallenge,
@@ -95,7 +95,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
         improvementService,
         pickChallengeService,
         locale,
-        smartRandom,
+        smartRandomService,
         algorithmDataFetcherService,
       });
     });
@@ -132,7 +132,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
     it('should have fetched the next challenge with only most recent knowledge elements', function () {
       const allAnswers = [lastAnswer];
-      expect(smartRandom.getPossibleSkillsForNextChallenge).to.have.been.calledWithExactly({
+      expect(smartRandomService.getPossibleSkillsForNextChallenge).to.have.been.calledWithExactly({
         allAnswers,
         lastAnswer,
         challenges,

--- a/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -1,11 +1,12 @@
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Evaluation | Integration | Domain | Use Cases | get-next-challenge-for-campaign-assessment', function () {
+  const skillIds = ['acquisTube1Niveau1', 'acquisTube1Niveau2'];
   context('for a campaign of type assessment with method smart_random', function () {
-    const skillIds = ['acquisTube1Niveau1', 'acquisTube1Niveau2'];
     it('should return the next challenge for the participant according to the user profile', async function () {
       // given
       const locale = 'fr';
@@ -49,7 +50,7 @@ describe('Evaluation | Integration | Domain | Use Cases | get-next-challenge-for
       const answerId = databaseBuilder.factory.buildAnswer({
         userId,
         assessmentId: assessmentDB.id,
-        challengeId: challengeData[0].id,
+        challengeId: 'autrechose',
       }).id;
       databaseBuilder.factory.buildKnowledgeElement({
         answerId,
@@ -60,6 +61,82 @@ describe('Evaluation | Integration | Domain | Use Cases | get-next-challenge-for
         source: KnowledgeElement.SourceType.DIRECT,
         competenceId: 'maCompetenceId',
         createdAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      const challenge = await evaluationUsecases.getNextChallengeForCampaignAssessment({
+        assessment,
+        locale,
+      });
+
+      // then
+      expect(challenge.id).to.equal(challengeData[1].id);
+    });
+  });
+  context('for a campaign of type exam with method smart_random', function () {
+    it('should return the next challenge for the participant according to the user snapshot for campaign', async function () {
+      // given
+      const locale = 'fr';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.EXAM,
+      }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        sharedAt: null,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      const challengeData = [];
+      skillIds.map((skillId, index) => {
+        databaseBuilder.factory.learningContent.buildSkill({
+          id: skillId,
+          tubeId: 'tube1Id',
+          status: 'actif',
+          level: index + 1,
+        });
+        challengeData.push(
+          databaseBuilder.factory.learningContent.buildChallenge({
+            id: `challengeFor_${skillId}`,
+            tubeId: 'tube1Id',
+            status: 'validé',
+            locales: [locale],
+            skillId,
+          }),
+        );
+      });
+      const answerId = databaseBuilder.factory.buildAnswer({
+        userId,
+        assessmentId: assessmentDB.id,
+        challengeId: 'autrechose',
+      }).id;
+      const knowledgeElement = domainBuilder.buildKnowledgeElement({
+        answerId,
+        assessmentId: assessmentDB.id,
+        userId,
+        skillId: skillIds[0],
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      const knowledgeElementsBefore = new KnowledgeElementCollection([knowledgeElement]);
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId,
+        snappedAt: new Date('2019-01-01'),
+        campaignParticipationId,
+        snapshot: knowledgeElementsBefore.toSnapshot(),
       });
       await databaseBuilder.commit();
 

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -8,7 +8,7 @@ import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.j
 import { AnswerStatus, Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
-describe('Integration | Usecase | Save and correct answer for campaign', function () {
+describe('Evaluation | Integration | Usecase | Save and correct answer for campaign', function () {
   const skillIds = ['monAcquisA_Id', 'monAcquisB_Id', 'monAcquisC_Id'];
 
   context('for campaign of type assessment with method smart_random', function () {

--- a/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/evaluation/unit/domain/services/smart-random/data-fetcher_test.js
@@ -21,6 +21,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         findOperativeBySkills: sinon.stub(),
       };
       knowledgeElementRepository = {
+        findUniqByUserIdForCampaignParticipation: sinon.stub(),
         findUniqByUserId: sinon.stub(),
       };
       campaignParticipationRepository = {
@@ -50,7 +51,9 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
         .resolves(skills);
       challengeRepository.findOperativeBySkills.withArgs(skills).resolves(challenges);
-      knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
+      knowledgeElementRepository.findUniqByUserIdForCampaignParticipation
+        .withArgs({ userId: assessment.userId, campaignParticipationId: assessment.campaignParticipationId })
+        .resolves(knowledgeElements);
       campaignParticipationRepository.isRetrying
         .withArgs({ campaignParticipationId: assessment.campaignParticipationId })
         .resolves(isRetrying);
@@ -112,7 +115,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       challenges = [domainBuilder.buildChallenge()];
       knowledgeElements = [domainBuilder.buildKnowledgeElement()];
       skills = [domainBuilder.buildSkill()];
-      const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
+      const assessment = domainBuilder.buildAssessment.ofTypeCompetenceEvaluation();
       filteredKnowledgeElements = Symbol('filteredKnowledgeElements');
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);

--- a/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -1,11 +1,11 @@
-import { getNextChallengeForCampaignAssessment } from '../../../../lib/domain/usecases/get-next-challenge-for-campaign-assessment.js';
-import * as flash from '../../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
-import { config } from '../../../../src/shared/config.js';
-import { AssessmentEndedError } from '../../../../src/shared/domain/errors.js';
-import { AnswerStatus } from '../../../../src/shared/domain/models/index.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as flash from '../../../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
+import { getNextChallengeForCampaignAssessment } from '../../../../../src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js';
+import { config } from '../../../../../src/shared/config.js';
+import { AssessmentEndedError } from '../../../../../src/shared/domain/errors.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/index.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment', function () {
+describe('Evaluation | Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment', function () {
   describe('#get-next-challenge-for-campaign-assessment', function () {
     let challengeRepository;
     let answerRepository;
@@ -68,7 +68,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           flashAssessmentResultRepository,
           pickChallengeService,
           assessment,
-          smartRandom: smartRandomStub,
+          smartRandomService: smartRandomStub,
           algorithmDataFetcherService: algorithmDataFetcherServiceStub,
           flash,
           locale,

--- a/api/tests/shared/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -17,6 +17,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
     let dependencies;
     let scoredAsssessment;
     let usecases;
+    let evaluationUsecases;
 
     beforeEach(function () {
       assessmentWithoutScore = domainBuilder.buildAssessment({
@@ -47,16 +48,19 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
       usecases = {
         getAssessment: sinon.stub(),
         getNextChallengeForDemo: sinon.stub(),
-        getNextChallengeForCampaignAssessment: sinon.stub(),
         getNextChallengeForCompetenceEvaluation: sinon.stub(),
         getNextChallengeForPreview: sinon.stub(),
       };
       usecases.getAssessment.resolves(scoredAsssessment);
+      evaluationUsecases = {
+        getNextChallengeForCampaignAssessment: sinon.stub(),
+      };
       certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub() };
       certificationVersionRepository = { getByCertificationCourseId: sinon.stub() };
 
       dependencies = {
         usecases,
+        evaluationUsecases,
         certificationChallengeRepository,
         assessmentRepository,
         certificationVersionRepository,
@@ -176,7 +180,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         await assessmentController.getNextChallenge({ params: { id: 1 } }, null, dependencies);
 
         // then
-        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
+        expect(evaluationUsecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
           assessment,
           locale: defaultLocale,
         });
@@ -199,7 +203,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         );
 
         // then
-        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
+        expect(evaluationUsecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
           assessment,
           locale,
         });


### PR DESCRIPTION
## :pancakes: Problème

Le type exam se comporte comme le type évaluation lors de la sélection de la prochaine épreuve.
Or celui-ci devrait utiliser le snapshot créé et rempli au fur et à mesure des réponses, et non pas les KEs du profil de l'utilisateur.

## :bacon: Proposition
Utiliser le snapshot pour récupérer les knowledge-elements pertinents pour l'utilisateur.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
Participer à une campagne et arriver jusqu'à la page de fin de parcours (qui est pas fiable), mais voir qu'on nous a posé les questions du profil cible et que le snapshot a bien été généré.
Participer à une autre campagne avec le meme profil cible et voir qu'on nous repose toutes les questions.
