### PR TITLE
[BUGFIX]PixAdmin: Autoriser le profil SUPPORT à détacher un profil cible d'une organisation

### DIFF
--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -279,6 +279,7 @@ const register = async function (server) {
               securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/tests/prescription/target-profile/integration/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/integration/application/admin-target-profile-route_test.js
@@ -50,9 +50,9 @@ describe('Integration | Application | target-profiles-management | Routes ', fun
       expect(response.statusCode).to.equal(401);
     });
 
-    it('should return a 403 status code when calling route with a user with no admin role', async function () {
+    it('should return a 403 status code when calling route with a user with certif role', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: 'CERTIF' }).id;
       await databaseBuilder.commit();
 
       // when
@@ -77,6 +77,18 @@ describe('Integration | Application | target-profiles-management | Routes ', fun
     it('should reach handler when calling route with an admin user with role metier', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser.withRole({ role: 'METIER' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await httpTestServer.request(method, url, payload, null, getHeaders(userId));
+
+      // then
+      expect(targetProfileController.detachOrganizations).to.have.been.calledOnce;
+    });
+
+    it('should reach handler when calling route with an admin user with role support', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: 'SUPPORT' }).id;
       await databaseBuilder.commit();
 
       // when


### PR DESCRIPTION
## :pancakes: Problème

Dans PixAdmin, avec le profil SUPPORT, dans Organisations -> Profil Cible, si un PC est présent, le bouton "Détacher" apparaît. 
Lorsqu'on clique dessus, l'API retourne un 403.

## :bacon: Proposition

Modifier l'endpoint côté API pour permettre de détacher le profil cible pour le rôle Support.

## 🧃 Remarques

RAS

## :yum: Pour tester

- Aller sur la page d'une organisation
- Dans l'onglet Profil Cibles ajouter un profil cible (56, 78, 6000, 6001 ... peu importe)
- Puis cliquer sur le bouton Détacher
- Vérifier que celui ci ne throw pas d'erreur dans le network et que le PC est bien détaché