### PR TITLE
[FEATURE] S'assurer que les UUIDs de modules ne sont pas en doublon dans les PRs de modif de contenu

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -197,6 +197,6 @@
     "toggles": "node src/shared/infrastructure/feature-toggles/feature-toggles-script.js",
     "monitoring:arborescence": "node scripts/arborescence-monitoring/arborescence-monitoring.js",
     "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js",
-    "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js'"
+    "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/integration/repositories/module-repository_test.js'"
   }
 }


### PR DESCRIPTION
## :pancakes: Problème
Il peut arriver que les UUIDs des grains/éléments soient doublonés dans les contenus de modules. On a ajouté un check dans nos tests mais il n'est pas appelé dans la GitHub Action utilisée quand le tag `contribution-modulix` est utilisé (`npm run modulix:test` est alors exécuté et remonte les infos dans la PR).

## :bacon: Proposition
Ajouter le fichier de test qui vérifie les UUIDs dans le script `modulix:test`.

## 🧃 Remarques
RAS

## :yum: Pour tester
1. Ctrl+c/ctrl+v un élément.
2. S'assurer que `npm run modulix:test` remonte le soucis grâce à cette PR.