### PR TITLE
[FEATURE] Enregistrer la date de dernière connexion aux orgas & cdc seulement sur les memberships actifs (PIX-16990)

### DIFF
--- a/api/src/shared/domain/models/Membership.js
+++ b/api/src/shared/domain/models/Membership.js
@@ -6,12 +6,13 @@ const roles = {
 };
 
 class Membership {
-  constructor({ id, organizationRole = roles.MEMBER, updatedByUserId, organization, user } = {}) {
+  constructor({ id, organizationRole = roles.MEMBER, updatedByUserId, organization, user, disabledAt } = {}) {
     this.id = id;
     this.organizationRole = organizationRole;
     this.updatedByUserId = updatedByUserId;
     this.organization = organization;
     this.user = user;
+    this.disabledAt = disabledAt;
   }
 
   get isAdmin() {

--- a/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
@@ -72,11 +72,11 @@ const updateReferer = async function (request, h) {
 
 const updateLastAccessedAt = async function (request, h, dependencies = { requestResponseUtils }) {
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
-  const certificationCenterId = request.params.certificationCenterId;
+  const certificationCenterMembershipId = request.params.certificationCenterMembershipId;
 
   await usecases.updateCertificationCenterMembershipLastAccessedAt({
     userId,
-    certificationCenterId,
+    certificationCenterMembershipId,
   });
 
   return h.response().code(204);

--- a/api/src/team/application/certification-center-membership/certification-center-membership.route.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.route.js
@@ -93,18 +93,12 @@ export const certificationCenterMembershipRoute = [
     },
   },
   {
-    method: 'PATCH',
-    path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships/me',
+    method: 'POST',
+    path: '/api/certification-center-memberships/{certificationCenterMembershipId}/access',
     config: {
-      pre: [
-        {
-          method: (request, h) => securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, h),
-          assign: 'isMemberOfCertificationCenter',
-        },
-      ],
       validate: {
         params: Joi.object({
-          certificationCenterId: identifiersType.certificationCenterId,
+          certificationCenterMembershipId: identifiersType.certificationCenterMembershipId,
         }),
       },
       handler: (request, h) => certificationCenterMembershipController.updateLastAccessedAt(request, h),

--- a/api/src/team/application/membership/membership.controller.js
+++ b/api/src/team/application/membership/membership.controller.js
@@ -61,11 +61,11 @@ const findPaginatedFilteredMemberships = async function (request) {
 
 async function updateLastAccessedAt(request, h, dependencies = { requestResponseUtils }) {
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
-  const organizationId = request.params.organizationId;
+  const membershipId = request.params.membershipId;
 
   await usecases.updateMembershipLastAccessedAt({
     userId,
-    organizationId,
+    membershipId,
   });
 
   return h.response().code(204);

--- a/api/src/team/application/membership/membership.route.js
+++ b/api/src/team/application/membership/membership.route.js
@@ -121,18 +121,12 @@ export const membershipRoutes = [
     },
   },
   {
-    method: 'PATCH',
-    path: '/api/organizations/{organizationId}/me',
+    method: 'POST',
+    path: '/api/memberships/{membershipId}/access',
     config: {
-      pre: [
-        {
-          method: (request, h) => securityPreHandlers.checkUserBelongsToOrganization(request, h),
-          assign: 'belongsToOrganization',
-        },
-      ],
       validate: {
         params: Joi.object({
-          organizationId: identifiersType.organizationId,
+          membershipId: identifiersType.membershipId,
         }),
       },
       handler: (request, h) => membershipController.updateLastAccessedAt(request, h),

--- a/api/src/team/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.js
+++ b/api/src/team/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.js
@@ -1,18 +1,27 @@
+import { ForbiddenError } from '../../../shared/application/http-errors.js';
+
 /**
  * @param {Object} params
  * @param {string} params.userId
- * @param {string} params.certificationCenterId
+ * @param {string} params.certificationCenterMembershipId
  * @param {CertificationCenterMembershipRepository} params.certificationCenterMembershipRepository
  */
 const updateCertificationCenterMembershipLastAccessedAt = async function ({
   userId,
-  certificationCenterId,
+  certificationCenterMembershipId,
   certificationCenterMembershipRepository,
 }) {
+  const certificationCenterMembership = await certificationCenterMembershipRepository.findById(
+    certificationCenterMembershipId,
+  );
+  if (certificationCenterMembership.user.id !== userId || certificationCenterMembership.disabledAt) {
+    throw new ForbiddenError();
+  }
+
   return certificationCenterMembershipRepository.updateLastAccessedAt({
     lastAccessedAt: new Date(),
     userId,
-    certificationCenterId,
+    certificationCenterMembershipId,
   });
 };
 

--- a/api/src/team/domain/usecases/update-membership-last-accessed-at.usecase.js
+++ b/api/src/team/domain/usecases/update-membership-last-accessed-at.usecase.js
@@ -1,13 +1,19 @@
+import { ForbiddenError } from '../../../shared/application/http-errors.js';
+
 /**
  * @param {Object} params
  * @param {string} params.userId
- * @param {string} params.organizationId
+ * @param {string} params.membershipId
  * @param {MembershipRepository} params.membershipRepository
  */
-const updateMembershipLastAccessedAt = async function ({ userId, organizationId, membershipRepository }) {
+const updateMembershipLastAccessedAt = async function ({ userId, membershipId, membershipRepository }) {
+  const membership = await membershipRepository.get(membershipId);
+  if (membership.user.id !== userId || membership.disabledAt) {
+    throw new ForbiddenError();
+  }
+
   return membershipRepository.updateLastAccessedAt({
-    userId,
-    organizationId,
+    membershipId,
     lastAccessedAt: new Date(),
   });
 };

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -45,6 +45,7 @@ function _toDomain(certificationCenterMembershipDTO) {
     updatedAt: certificationCenterMembershipDTO.updatedAt,
     role: certificationCenterMembershipDTO.role,
     lastAccessedAt: certificationCenterMembershipDTO.lastAccessedAt,
+    disabledAt: certificationCenterMembershipDTO.disabledAt,
   });
 }
 

--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -288,11 +288,11 @@ const update = async function (certificationCenterMembership) {
   await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).update(data).where({ id: certificationCenterMembership.id });
 };
 
-const updateLastAccessedAt = async function ({ lastAccessedAt, userId, certificationCenterId }) {
+const updateLastAccessedAt = async function ({ lastAccessedAt, certificationCenterMembershipId }) {
   const knexConnection = DomainTransaction.getConnection();
 
   await knexConnection(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
-    .where({ userId, certificationCenterId })
+    .where({ id: certificationCenterMembershipId })
     .update({ lastAccessedAt, updatedAt: lastAccessedAt });
 };
 

--- a/api/src/team/infrastructure/repositories/membership.repository.js
+++ b/api/src/team/infrastructure/repositories/membership.repository.js
@@ -177,12 +177,10 @@ export const disableMembershipsByUserId = async function ({ userId, updatedByUse
     .update({ disabledAt: new Date(), updatedAt: new Date(), updatedByUserId });
 };
 
-export const updateLastAccessedAt = async function ({ userId, organizationId, lastAccessedAt }) {
+export const updateLastAccessedAt = async function ({ membershipId, lastAccessedAt }) {
   const knexConnection = DomainTransaction.getConnection();
 
-  await knexConnection(MEMBERSHIPS_TABLE)
-    .where({ userId, organizationId })
-    .update({ lastAccessedAt, updatedAt: new Date() });
+  await knexConnection(MEMBERSHIPS_TABLE).where({ id: membershipId }).update({ lastAccessedAt, updatedAt: new Date() });
 };
 
 const toDomain = (membershipData, userData = null, organizationData = null, organizationTags = null) => {

--- a/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-membership/certification-center-membership.route.test.js
@@ -193,15 +193,15 @@ describe('Acceptance | Team | Application | Routes | certification-center-member
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
 
         const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
+        const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
           certificationCenterId,
           userId,
-        });
+        }).id;
 
         await databaseBuilder.commit();
         const request = {
-          method: 'PATCH',
-          url: `/api/certification-centers/${certificationCenterId}/certification-center-memberships/me`,
+          method: 'POST',
+          url: `/api/certification-center-memberships/${certificationCenterMembershipId}/access`,
           payload: {},
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };

--- a/api/tests/team/acceptance/application/membership/membership.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.route.test.js
@@ -407,25 +407,26 @@ describe('Acceptance | Team | Application | Route | membership', function () {
     });
   });
 
-  describe('PATCH /api/organizations/{id}/me', function () {
+  describe('POST /api/memberships/{id}/access', function () {
     context('when user is one of the members of the organization', function () {
       it('updates user membership lastAccessedAt', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const organizationMemberUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildMembership({
+        const membershipId = databaseBuilder.factory.buildMembership({
           userId: organizationMemberUserId,
           organizationId,
           organizationRole: Membership.roles.MEMBER,
           lastAccessedAt: null,
           updatedAt: new Date('2020-01-01'),
-        });
+          disabledAt: null,
+        }).id;
 
         await databaseBuilder.commit();
 
         const options = {
-          method: 'PATCH',
-          url: `/api/organizations/${organizationId}/me`,
+          method: 'POST',
+          url: `/api/memberships/${membershipId}/access`,
           payload: {},
           headers: generateAuthenticatedUserRequestHeaders({ userId: organizationMemberUserId }),
         };

--- a/api/tests/team/integration/application/membership/membership.controller.test.js
+++ b/api/tests/team/integration/application/membership/membership.controller.test.js
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '../../../../../src/shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { InvalidMembershipOrganizationRoleError } from '../../../../../src/shared/domain/errors.js';
 import { Membership } from '../../../../../src/shared/domain/models/index.js';
@@ -322,16 +323,15 @@ describe('Integration | Team | Application | Memberships | membership-controller
 
   describe('#updateLastAccessedAt', function () {
     context('Error case', function () {
-      describe('when user does not belong to organization', function () {
+      describe('when user does not own the membership', function () {
         it('returns an HTTP response with status code 403', async function () {
           // given
-          const organizationId = 1234;
+          const membershipId = 1234;
           const userId = 5678;
-          sinon
-            .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
-            .callsFake((request, h) => h.response().code(403).takeover());
+          sinon.stub(usecases, 'updateMembershipLastAccessedAt').throws(new ForbiddenError());
+
           // when
-          const response = await httpTestServer.request('PATCH', `/api/organizations/${organizationId}/me`, {
+          const response = await httpTestServer.request('POST', `/api/memberships/${membershipId}/access`, {
             auth: { credentials: { userId } },
           });
 

--- a/api/tests/team/integration/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/update-certification-center-membership-last-accessed-at.usecase.test.js
@@ -1,9 +1,76 @@
+import { ForbiddenError } from '../../../../../src/shared/application/http-errors.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { CERTIFICATION_CENTER_MEMBERSHIP_ROLES } from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import { certificationCenterMembershipRepository } from '../../../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
-import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Team | UseCases | update-certification-center-membership-last-accessed-at', function () {
+  context('when the certification center membership does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      const certificationCenterMembershipId = 4567;
+      const userId = 1234;
+
+      const error = await catchErr(usecases.updateCertificationCenterMembershipLastAccessedAt)({
+        userId,
+        certificationCenterMembershipId,
+        certificationCenterMembershipRepository,
+      });
+
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when the user is not the owner of the certification center membership', function () {
+    it('throws a ForbiddenError', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
+        userId,
+        certificationCenterRole: CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const error = await catchErr(usecases.updateCertificationCenterMembershipLastAccessedAt)({
+        userId: userId + 1,
+        certificationCenterMembershipId,
+        certificationCenterMembershipRepository,
+      });
+
+      expect(error).to.be.instanceOf(ForbiddenError);
+    });
+  });
+
+  context('when the certification center membership is disabled', function () {
+    it('throws a ForbiddenError', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
+        userId,
+        certificationCenterRole: CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER,
+        disabledAt: new Date(),
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const error = await catchErr(usecases.updateCertificationCenterMembershipLastAccessedAt)({
+        userId,
+        certificationCenterMembershipId,
+        certificationCenterMembershipRepository,
+      });
+
+      expect(error).to.be.instanceOf(ForbiddenError);
+    });
+  });
+
   it('updates certification center membership lastAccessedAt', async function () {
     // given
     const now = new Date('2021-01-02');
@@ -12,19 +79,20 @@ describe('Integration | Team | UseCases | update-certification-center-membership
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
     const userId = databaseBuilder.factory.buildUser().id;
 
-    databaseBuilder.factory.buildCertificationCenterMembership({
+    const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
       certificationCenterId,
       userId,
       certificationCenterRole: CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER,
       lastAccessedAt: null,
-    });
+      disabledAt: null,
+    }).id;
 
     await databaseBuilder.commit();
 
     // when
     await usecases.updateCertificationCenterMembershipLastAccessedAt({
       userId,
-      certificationCenterId,
+      certificationCenterMembershipId,
       certificationCenterMembershipRepository,
     });
 

--- a/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
+++ b/api/tests/team/integration/domain/usecases/update-membership-last-accessed-at.usecase.test.js
@@ -1,7 +1,9 @@
+import { ForbiddenError } from '../../../../../src/shared/application/http-errors.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import * as membershipRepository from '../../../../../src/team/infrastructure/repositories/membership.repository.js';
-import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Team | UseCases | update-membership-last-accessed-at', function () {
   let clock;
@@ -15,29 +17,102 @@ describe('Integration | Team | UseCases | update-membership-last-accessed-at', f
     clock.restore();
   });
 
+  context('when the membership does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      const membershipId = 4567;
+      const userId = 1234;
+
+      // when
+      const error = await catchErr(usecases.updateMembershipLastAccessedAt)({
+        membershipId,
+        userId,
+        membershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when the membership is disabled', function () {
+    it('throws a ForbiddenError', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const membershipId = databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId,
+        organizationRole: Membership.roles.MEMBER,
+        disabledAt: new Date(),
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.updateMembershipLastAccessedAt)({
+        membershipId,
+        userId,
+        membershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenError);
+    });
+  });
+
+  context('when the membership does not belong to the user', function () {
+    it('throws a ForbiddenError', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const anotherUserId = databaseBuilder.factory.buildUser().id;
+
+      const membershipId = databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId,
+        organizationRole: Membership.roles.MEMBER,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.updateMembershipLastAccessedAt)({
+        membershipId,
+        userId: anotherUserId,
+        membershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenError);
+    });
+  });
+
   it('updates membership lastAccessedAt', async function () {
     // given
     const organizationId = databaseBuilder.factory.buildOrganization().id;
     const userId = databaseBuilder.factory.buildUser().id;
 
-    databaseBuilder.factory.buildMembership({
+    const membershipId = databaseBuilder.factory.buildMembership({
       organizationId,
       userId,
       organizationRole: Membership.roles.MEMBER,
       lastAccessedAt: null,
-    });
+      disabledAt: null,
+    }).id;
 
     await databaseBuilder.commit();
 
     // when
     await usecases.updateMembershipLastAccessedAt({
       userId,
-      organizationId,
+      membershipId,
       membershipRepository,
     });
 
     // then
-    const membership = await knex('memberships').where({ userId, organizationId }).first();
+    const membership = await knex('memberships').where({ id: membershipId }).first();
     expect(membership.lastAccessedAt).to.deep.equal(now);
     expect(membership.updatedAt).to.deep.equal(now);
   });

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -1057,23 +1057,22 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
 
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+      const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
         userId,
         certificationCenterId,
-      });
+      }).id;
 
       await databaseBuilder.commit();
 
       // when
       await certificationCenterMembershipRepository.updateLastAccessedAt({
         lastAccessedAt: now,
-        userId,
-        certificationCenterId,
+        certificationCenterMembershipId,
       });
 
       // then
       const foundCertificationCenterMembership = await knex('certification-center-memberships')
-        .where({ id: certificationCenterMembership.id })
+        .where({ id: certificationCenterMembershipId })
         .first();
 
       expect(foundCertificationCenterMembership.lastAccessedAt).to.deep.equal(now);

--- a/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
@@ -890,15 +890,15 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId, organizationId });
+      const membershipId = databaseBuilder.factory.buildMembership({ userId, organizationId }).id;
 
       await databaseBuilder.commit();
 
       // when
-      await membershipRepository.updateLastAccessedAt({ userId, organizationId, lastAccessedAt: now });
+      await membershipRepository.updateLastAccessedAt({ membershipId, lastAccessedAt: now });
 
       // then
-      const updatedMembership = await knex('memberships').where({ userId, organizationId }).first();
+      const updatedMembership = await knex('memberships').where({ id: membershipId }).first();
       expect(updatedMembership.lastAccessedAt).to.deep.equal(now);
       expect(updatedMembership.updatedAt).to.deep.equal(now);
     });

--- a/certif/app/adapters/certification-center-membership.js
+++ b/certif/app/adapters/certification-center-membership.js
@@ -5,11 +5,11 @@ export default class CertificationCenterMembershipAdapter extends ApplicationAda
     const { adapterOptions } = snapshot;
 
     if (adapterOptions && adapterOptions.updateLastAccessedAt) {
-      const url = `${this.host}/api/certification-centers/${adapterOptions.certificationCenterId}/certification-center-memberships/me`;
+      const url = `${this.host}/api/certification-center-memberships/${snapshot.id}/access`;
 
       delete adapterOptions.updateLastAccessedAt;
 
-      return this.ajax(url, 'PATCH');
+      return this.ajax(url, 'POST');
     }
 
     return super.updateRecord(...arguments);

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -70,7 +70,6 @@ export default class CurrentUserService extends Service {
       await this.currentCertificationCenterMembership.save({
         adapterOptions: {
           updateLastAccessedAt: true,
-          certificationCenterId: this.currentCertificationCenterMembership.certificationCenterId,
         },
       });
     }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -432,7 +432,7 @@ function _configureCertificationCenterInvitationRoutes(context) {
     return certificationCenterInvitation;
   });
 
-  context.patch('/certification-centers/:certificationCenterId/certification-center-memberships/me', () => {
+  context.post('/certification-center-memberships/:certificationCenterMembershipId/access', () => {
     return new Response(204);
   });
 

--- a/certif/tests/unit/adapters/certification-center-membership-test.js
+++ b/certif/tests/unit/adapters/certification-center-membership-test.js
@@ -16,16 +16,15 @@ module('Unit | Adapter | certificationCenterMembership', function (hooks) {
     module('when updateLastAccessedAt is true', function () {
       test('should call /api/certification-centers/{certification-center-id}/certification-center-memberships/me', async function (assert) {
         // given
-        const certificationCenterId = 1;
 
         const snapshot = {
+          id: 1,
           adapterOptions: {
             updateLastAccessedAt: true,
-            certificationCenterId,
           },
         };
-        const expectedUrl = `http://localhost:3000/api/certification-centers/${certificationCenterId}/certification-center-memberships/me`;
-        const expectedMethod = 'PATCH';
+        const expectedUrl = `http://localhost:3000/api/certification-center-memberships/1/access`;
+        const expectedMethod = 'POST';
 
         // when
         await adapter.updateRecord(null, null, snapshot);

--- a/certif/tests/unit/services/current-user-test.js
+++ b/certif/tests/unit/services/current-user-test.js
@@ -58,7 +58,7 @@ module('Unit | Service | current-user', function (hooks) {
       assert.deepEqual(currentUser.currentCertificationCenterMembership, certificationCenterMembershipA);
       assert.true(currentUser.isAdminOfCurrentCertificationCenter);
       sinon.assert.calledWith(certificationCenterMembershipA.save, {
-        adapterOptions: { updateLastAccessedAt: true, certificationCenterId: 789 },
+        adapterOptions: { updateLastAccessedAt: true },
       });
       assert.ok(true);
     });
@@ -213,7 +213,7 @@ module('Unit | Service | current-user', function (hooks) {
       assert.strictEqual(currentUser.currentCertificationCenterMembership, newCertificationCenterMembership);
       assert.true(currentUser.isAdminOfCurrentCertificationCenter);
       sinon.assert.calledWith(newCertificationCenterMembership.save, {
-        adapterOptions: { updateLastAccessedAt: true, certificationCenterId: 222 },
+        adapterOptions: { updateLastAccessedAt: true },
       });
       assert.ok(true);
     });

--- a/orga/app/adapters/membership.js
+++ b/orga/app/adapters/membership.js
@@ -19,9 +19,9 @@ export default class MembershipAdapter extends ApplicationAdapter {
     }
 
     if (snapshot.adapterOptions && snapshot.adapterOptions.updateLastAccessedAt) {
-      const url = `${this.host}/${this.namespace}/organizations/${snapshot.adapterOptions.organizationId}/me`;
+      const url = `${this.host}/${this.namespace}/memberships/${snapshot.id}/access`;
 
-      return this.ajax(url, 'PATCH');
+      return this.ajax(url, 'POST');
     }
     return super.updateRecord(...arguments);
   }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -68,7 +68,7 @@ export default class CurrentUserService extends Service {
         await this._setOrganizationProperties(membership);
 
         await membership.save({
-          adapterOptions: { updateLastAccessedAt: true, organizationId: this.organization.id },
+          adapterOptions: { updateLastAccessedAt: true },
         });
       } catch {
         this.prescriber = null;

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -101,7 +101,7 @@ function routes() {
   });
 
   this.patch('/memberships/:id');
-  this.patch('/organizations/:organizationId/me', () => {
+  this.post('/memberships/:membershipId/access', () => {
     return new Response(204);
   });
   this.get('/organizations/:id/import-information', () => {

--- a/orga/tests/unit/adapters/membership-test.js
+++ b/orga/tests/unit/adapters/membership-test.js
@@ -49,11 +49,11 @@ module('Unit | Adapter | membership', function (hooks) {
         await adapter.updateRecord(
           {},
           { modelName: 'membership' },
-          { id: 1, adapterOptions: { updateLastAccessedAt: true, organizationId: 1 } },
+          { id: 1, adapterOptions: { updateLastAccessedAt: true } },
         );
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/organizations/1/me', 'PATCH');
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/access', 'POST');
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -80,7 +80,7 @@ module('Unit | Service | current-user', function (hooks) {
 
       // then
       sinon.assert.calledWith(membership.save, {
-        adapterOptions: { updateLastAccessedAt: true, organizationId: organization.id },
+        adapterOptions: { updateLastAccessedAt: true },
       });
       assert.ok(true);
     });


### PR DESCRIPTION
## :pancakes: Problème

Si l’utilisateur accède à une organisation / centre de certification et possède des memberships désactivés associés, alors la date de dernière connexion ne doit être enregistrée que sur le ou les memberships actif.

## :bacon: Proposition

Ne faire l'update que pour les memberships actifs

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

## Test 1
- Se connecter sur pix-certif avec [james-paledroits@example.net](mailto:james-paledroits@example.net)
- Switcher entre les différents centres de certification de l'utilisateur
- Verifier que le lastAccessedAt des certification-center-memberships actifs se met à jour

## Test 2
- Se connecter sur pix-orga avec admin-orga@example.net
- Switcher entre les différentes orgas de l'utilisateur
- Verifier que le lastAccessedAt des memberships actifs se met à jour