### PR TITLE
Revert "[BUGFIX] Pour les demandes de réinitialisation de mot de passe, rendre la recherche des comptes vraiment insensible à la casse (PIX-16896)"

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -22,7 +22,7 @@ import { UserDetailsForAdmin } from '../../domain/models/UserDetailsForAdmin.js'
 import { UserLogin } from '../../domain/models/UserLogin.js';
 
 const getByEmail = async function (email) {
-  const foundUser = await knex.from('users').whereILike('email', email).first();
+  const foundUser = await knex.from('users').whereRaw('LOWER("email") = ?', email.toLowerCase()).first();
   if (!foundUser) {
     throw new UserNotFoundError(`User not found for email ${email}`);
   }
@@ -55,7 +55,7 @@ const getFullById = async function (userId) {
 
 const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
   const userDTO = await knex('users')
-    .whereILike('email', username)
+    .where({ email: username.toLowerCase() })
     .orWhere({ username: username.toLowerCase() })
     .first();
 
@@ -257,7 +257,7 @@ const updateWithEmailConfirmed = function ({ id, userAttributes }) {
 };
 
 const checkIfEmailIsAvailable = async function (email) {
-  const existingUserEmail = await knex('users').whereILike('email', email).first();
+  const existingUserEmail = await knex('users').whereRaw('LOWER("email") = ?', email.toLowerCase()).first();
 
   if (existingUserEmail) throw new InvalidOrAlreadyUsedEmailError();
 
@@ -265,7 +265,7 @@ const checkIfEmailIsAvailable = async function (email) {
 };
 
 const isUserExistingByEmail = async function (email) {
-  const existingUser = await knex('users').whereILike('email', email).first();
+  const existingUser = await knex('users').where('email', email.toLowerCase()).first();
   if (!existingUser) throw new UserNotFoundError();
   return true;
 };
@@ -390,7 +390,7 @@ const findByExternalIdentifier = async function ({ externalIdentityId, identityP
 };
 
 const findAnotherUserByEmail = async function (userId, email) {
-  const anotherUsers = await knex('users').whereNot('id', userId).whereILike('email', email);
+  const anotherUsers = await knex('users').whereNot('id', userId).where({ email: email.toLowerCase() });
 
   return anotherUsers.map((anotherUser) => new User(anotherUser));
 };

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -43,7 +43,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   const userToInsert = {
     firstName: 'Jojo',
     lastName: 'LaFripouille',
-    email: 'user_name_with_mix_of_lower_AND_UPPER_case_letters@example.net',
+    email: 'jojo@example.net',
     cgu: true,
     locale: 'fr-FR',
     createdAt: creationDate,
@@ -601,7 +601,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           email: 'current.user@example.net',
         });
         const anotherUser = databaseBuilder.factory.buildUser({
-          email: 'another.user.with_mix_of_lower_AND_UPPER_case_letters@example.net',
+          email: 'another.user@example.net',
         });
         await databaseBuilder.commit();
 
@@ -611,7 +611,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         // then
         expect(foundUsers).to.be.an('array').that.have.lengthOf(1);
         expect(foundUsers[0]).to.be.an.instanceof(User);
-        expect(foundUsers[0].email).to.equal(anotherUser.email.toLowerCase());
+        expect(foundUsers[0].email).to.equal(anotherUser.email);
       });
 
       it('returns an empty list if email is not used', async function () {
@@ -740,7 +740,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.id).to.equal(userInDb.id);
         expect(user.firstName).to.equal(userInDb.firstName);
         expect(user.lastName).to.equal(userInDb.lastName);
-        expect(user.email).to.equal(userInDb.email.toLowerCase());
+        expect(user.email).to.equal(userInDb.email);
         expect(user.cgu).to.be.true;
         expect(user.createdAt.toISOString()).to.equal('2019-03-12T19:37:03.000Z');
         expect(user.updatedAt.toISOString()).to.equal('2019-03-12T19:37:03.000Z');
@@ -1120,7 +1120,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
         // then
         expect(user.username).to.equal(userInDb.username);
-        expect(user.email).to.equal(userInDb.email.toLowerCase());
+        expect(user.email).to.equal(userInDb.email);
       });
 
       it('throws an error when user not found', async function () {
@@ -1816,7 +1816,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#isUserExistingByEmail', function () {
-    const email = 'user_account_created_with_SOME_UPPER_CASE_LETTERS@example.net';
+    const email = 'shi@fu.fr';
 
     beforeEach(function () {
       databaseBuilder.factory.buildUser({ email });
@@ -1824,30 +1824,25 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       return databaseBuilder.commit();
     });
 
-    it('finds a user with the exact email', async function () {
+    it('returns true when the user exists by email', async function () {
       const userExists = await userRepository.isUserExistingByEmail(email);
       expect(userExists).to.be.true;
     });
 
-    context('when a user exists but with an email differing by case (case insensitive search)', function () {
-      it('finds the user', async function () {
-        // given
-        const uppercaseEmailAlreadyInDb = email.toUpperCase();
+    it('returns true when the user exists by email (case insensitive)', async function () {
+      // given
+      const uppercaseEmailAlreadyInDb = email.toUpperCase();
 
-        // when
-        const userExists = await userRepository.isUserExistingByEmail(uppercaseEmailAlreadyInDb);
+      // when
+      const userExists = await userRepository.isUserExistingByEmail(uppercaseEmailAlreadyInDb);
 
-        // then
-        expect(userExists).to.be.true;
-      });
+      // then
+      expect(userExists).to.be.true;
     });
 
-    context('when no user account with a matching email exist', function () {
-      it('throws an error', async function () {
-        const searchedEmail = 'Address_Unknown@example.net';
-        const err = await catchErr(userRepository.isUserExistingByEmail)(searchedEmail);
-        expect(err).to.be.instanceOf(UserNotFoundError);
-      });
+    it('throws an error when the user does not exist by email', async function () {
+      const err = await catchErr(userRepository.isUserExistingByEmail)('none');
+      expect(err).to.be.instanceOf(UserNotFoundError);
     });
   });
 


### PR DESCRIPTION
Reverts 1024pix/pix#11610

Revert de la PR qui modifie une recherche `LOWER('email') =` par un `ILIKE` ce qui empêche l'utilisation de l'index `"users_email_lower" btree (lower(email::text))`. 
```
pix_api_pre_5955=> explain select * from users where email ilike 'mathieu.gilet@pix.fr';
                                   QUERY PLAN                                    
---------------------------------------------------------------------------------
 Gather  (cost=1000.00..295274.97 rows=639 width=141)
   Workers Planned: 2
   ->  Parallel Seq Scan on users  (cost=0.00..294211.07 rows=266 width=141)
         Filter: ((email)::text ~~* 'mathieu.gilet@pix.fr'::text)
 JIT:
   Functions: 2
   Options: Inlining false, Optimization false, Expressions true, Deforming true
(7 rows)

pix_api_pre_5955=> explain select * from users where lower("email") =  'mathieu.gilet@pix.fr';
                                   QUERY PLAN                                    
---------------------------------------------------------------------------------
 Index Scan using users_email_lower on users  (cost=0.56..2.58 rows=1 width=141)
   Index Cond: (lower((email)::text) = 'mathieu.gilet@pix.fr'::text)
(2 rows)

```