### PR TITLE
[FEATURE] Gérer la génération des certificats des sessions V3 (PIX-16444).

### DIFF
--- a/api/src/certification/results/application/certification-attestation-controller.js
+++ b/api/src/certification/results/application/certification-attestation-controller.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { V3CertificationAttestation } from '../domain/models/V3CertificationAttestation.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certificationAttestationPdf from '../infrastructure/utils/pdf/certification-attestation-pdf.js';
 
@@ -13,6 +14,10 @@ const getPDFAttestation = async function (request, h, dependencies = { certifica
     userId,
     certificationCourseId,
   });
+
+  if (attestation instanceof V3CertificationAttestation) {
+    return h.response().code(200);
+  }
 
   const { buffer, fileName } = await dependencies.certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
     certificates: [attestation],
@@ -36,6 +41,11 @@ const getCertificationPDFAttestationsForSession = async function (
   const attestations = await usecases.getCertificationAttestationsForSession({
     sessionId,
   });
+
+  if (attestations.every((attestation) => attestation instanceof V3CertificationAttestation)) {
+    return h.response().code(200);
+  }
+
   const i18n = request.i18n;
 
   const { buffer } = await dependencies.certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
@@ -64,6 +74,10 @@ const downloadCertificationAttestationsForDivision = async function (
     organizationId,
     division,
   });
+
+  if (attestations.every((attestation) => attestation instanceof V3CertificationAttestation)) {
+    return h.response().code(200);
+  }
 
   const { buffer } = await dependencies.certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
     certificates: attestations,

--- a/api/src/certification/results/domain/models/V3CertificationAttestation.js
+++ b/api/src/certification/results/domain/models/V3CertificationAttestation.js
@@ -1,0 +1,30 @@
+const PIX_COUNT_BY_LEVEL = 8;
+const COMPETENCE_COUNT = 16;
+
+class V3CertificationAttestation {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    birthplace,
+    certificationCenter,
+    deliveredAt,
+    pixScore,
+    maxReachableLevelOnCertificationDate,
+    verificationCode,
+  } = {}) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.birthdate = birthdate;
+    this.birthplace = birthplace;
+    this.deliveredAt = deliveredAt;
+    this.certificationCenter = certificationCenter;
+    this.pixScore = pixScore;
+    this.verificationCode = verificationCode;
+    this.maxReachableScore = maxReachableLevelOnCertificationDate * PIX_COUNT_BY_LEVEL * COMPETENCE_COUNT;
+  }
+}
+
+export { V3CertificationAttestation };

--- a/api/src/certification/results/domain/usecases/get-certification-attestation.js
+++ b/api/src/certification/results/domain/usecases/get-certification-attestation.js
@@ -1,14 +1,20 @@
-import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { UnauthorizedError } from '../../../../shared/application/http-errors.js';
 
-const getCertificationAttestation = async function ({ userId, certificationCourseId, certificateRepository }) {
-  const certificationAttestation = await certificateRepository.getCertificationAttestation({
-    certificationCourseId,
-  });
-  if (certificationAttestation.userId !== userId) {
-    throw new NotFoundError();
+const getCertificationAttestation = async function ({
+  userId,
+  certificationCourseId,
+  certificateRepository,
+  certificationCourseRepository,
+}) {
+  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
+
+  if (certificationCourse.getUserId() !== userId) {
+    throw new UnauthorizedError();
   }
 
-  return certificationAttestation;
+  return certificateRepository.getCertificationAttestation({
+    certificationCourseId,
+  });
 };
 
 export { getCertificationAttestation };

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -9,7 +9,9 @@ import {
   ResultCompetenceTree,
   ShareableCertificate,
 } from '../../../../shared/domain/models/index.js';
+import { SessionVersion } from '../../../shared/domain/models/SessionVersion.js';
 import { CertificationAttestation } from '../../domain/models/CertificationAttestation.js';
+import { V3CertificationAttestation } from '../../domain/models/V3CertificationAttestation.js';
 import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 
@@ -261,6 +263,12 @@ function _toDomainForCertificationAttestation({ certificationCourseDTO, competen
     certificationId: certificationCourseDTO.id,
     assessmentResultId: certificationCourseDTO.assessmentResultId,
   });
+
+  if (SessionVersion.isV3(certificationCourseDTO.version)) {
+    return new V3CertificationAttestation({
+      ...certificationCourseDTO,
+    });
+  }
 
   return new CertificationAttestation({
     ...certificationCourseDTO,

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -9,6 +9,7 @@ import {
   ResultCompetenceTree,
   ShareableCertificate,
 } from '../../../../shared/domain/models/index.js';
+import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { SessionVersion } from '../../../shared/domain/models/SessionVersion.js';
 import { CertificationAttestation } from '../../domain/models/CertificationAttestation.js';
 import { V3CertificationAttestation } from '../../domain/models/V3CertificationAttestation.js';
@@ -44,12 +45,14 @@ const findByDivisionForScoIsManagingStudentsOrganization = async function ({ org
 
   const mostRecentCertificationsPerOrganizationLearner =
     _filterMostRecentCertificationCoursePerOrganizationLearner(certificationCourseDTOs);
-  return _(mostRecentCertificationsPerOrganizationLearner)
-    .orderBy(['lastName', 'firstName'], ['asc', 'asc'])
-    .map((certificationCourseDTO) => {
-      return _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges: [] });
-    })
-    .value();
+  return Promise.all(
+    _(mostRecentCertificationsPerOrganizationLearner)
+      .orderBy(['lastName', 'firstName'], ['asc', 'asc'])
+      .map((certificationCourseDTO) => {
+        return _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges: [] });
+      })
+      .value(),
+  );
 };
 
 const getCertificationAttestation = async function ({ certificationCourseId }) {
@@ -252,7 +255,7 @@ function _filterMostRecentCertificationCoursePerOrganizationLearner(DTOs) {
   return mostRecent;
 }
 
-function _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges }) {
+async function _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges }) {
   const competenceMarks = _.compact(certificationCourseDTO.competenceMarks).map(
     (competenceMark) => new CompetenceMark({ ...competenceMark }),
   );
@@ -264,7 +267,10 @@ function _toDomainForCertificationAttestation({ certificationCourseDTO, competen
     assessmentResultId: certificationCourseDTO.assessmentResultId,
   });
 
-  if (SessionVersion.isV3(certificationCourseDTO.version)) {
+  if (
+    SessionVersion.isV3(certificationCourseDTO.version) &&
+    (await featureToggles.get('isV3CertificationAttestationEnabled'))
+  ) {
     return new V3CertificationAttestation({
       ...certificationCourseDTO,
     });

--- a/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
@@ -2,8 +2,10 @@ import { readFile } from 'node:fs/promises';
 import * as url from 'node:url';
 
 import { generateCertificateVerificationCode } from '../../../../../src/certification/evaluation/domain/services/verify-certificate-code-service.js';
+import { SESSIONS_VERSIONS } from '../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { Assessment } from '../../../../../src/shared/domain/models/index.js';
 import { AssessmentResult, Membership } from '../../../../../src/shared/domain/models/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
   createServer,
   databaseBuilder,
@@ -112,10 +114,89 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
 
   describe('GET /api/attestation/{certificationCourseId}', function () {
     context('when user own the certification', function () {
+      context('when session version is V3', function () {
+        context('when isV3CertificationAttestationEnabled feature toggle is truthy', function () {
+          it('should return 200 HTTP status code and the certification', async function () {
+            // given
+            await featureToggles.set('isV3CertificationAttestationEnabled', true);
+            const userId = databaseBuilder.factory.buildUser().id;
+
+            const session = databaseBuilder.factory.buildSession({
+              id: 123,
+              publishedAt: new Date('2018-12-01T01:02:03Z'),
+              version: SESSIONS_VERSIONS.V3,
+            });
+            const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+              id: 1234,
+              sessionId: session.id,
+              userId,
+              isPublished: true,
+              verificationCode: await generateCertificateVerificationCode(),
+            });
+            const assessment = databaseBuilder.factory.buildAssessment({
+              userId,
+              certificationCourseId: certificationCourse.id,
+              type: Assessment.types.CERTIFICATION,
+              state: Assessment.states.COMPLETED,
+            });
+            databaseBuilder.factory.buildAssessmentResult.last({
+              certificationCourseId: certificationCourse.id,
+              assessmentId: assessment.id,
+              level: 1,
+              pixScore: 23,
+              emitter: 'PIX-ALGO',
+              status: AssessmentResult.status.VALIDATED,
+            });
+
+            await databaseBuilder.commit();
+
+            const server = await createServer();
+
+            // when
+            const response = await server.inject({
+              method: 'GET',
+              url: `/api/attestation/${certificationCourse.id}?isFrenchDomainExtension=true&lang=fr`,
+              headers: generateAuthenticatedUserRequestHeaders({ userId }),
+            });
+
+            // then
+            expect(response.statusCode).to.equal(200);
+          });
+        });
+      });
+
+      context('when session version is V2', function () {
+        it('should return 200 HTTP status code and the certification', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          await _buildDatabaseCertification({ userId, certificationCourseId: 1234 });
+          await databaseBuilder.commit();
+
+          const server = await createServer();
+
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: '/api/attestation/1234?isFrenchDomainExtension=true&lang=fr',
+            headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers['content-type']).to.equal('application/pdf');
+          expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
+          expect(response.file).not.to.be.null;
+        });
+      });
+    });
+  });
+
+  describe('GET /api/admin/sessions/{sessionId}/attestations', function () {
+    describe('when the session version is V2', function () {
       it('should return 200 HTTP status code and the certification', async function () {
         // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        await _buildDatabaseForV2Certification({ userId, certificationCourseId: 1234 });
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        await _buildDatabaseCertification({ userId: superAdmin.id, sessionId: 4567 });
         await databaseBuilder.commit();
 
         const server = await createServer();
@@ -123,8 +204,8 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
         // when
         const response = await server.inject({
           method: 'GET',
-          url: '/api/attestation/1234?isFrenchDomainExtension=true&lang=fr',
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          url: '/api/admin/sessions/4567/attestations',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
         });
 
         // then
@@ -134,110 +215,193 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
         expect(response.file).not.to.be.null;
       });
     });
-  });
 
-  describe('GET /api/admin/sessions/{sessionId}/attestations', function () {
-    it('should return 200 HTTP status code and the certification', async function () {
-      // given
-      const superAdmin = await insertUserWithRoleSuperAdmin();
-      await _buildDatabaseForV2Certification({ userId: superAdmin.id, sessionId: 4567 });
-      await databaseBuilder.commit();
+    describe('when the session version is V3', function () {
+      it('should return 200 HTTP status code', async function () {
+        // given
+        await featureToggles.set('isV3CertificationAttestationEnabled', true);
+        const superAdmin = await insertUserWithRoleSuperAdmin();
 
-      const server = await createServer();
+        await _buildDatabaseCertification({
+          userId: superAdmin.id,
+          sessionId: 4567,
+          sessionVersion: SESSIONS_VERSIONS.V3,
+        });
+        await databaseBuilder.commit();
 
-      // when
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/admin/sessions/4567/attestations',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/admin/sessions/4567/attestations',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
       });
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.headers['content-type']).to.equal('application/pdf');
-      expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
-      expect(response.file).not.to.be.null;
     });
   });
 
   describe('GET /api/organizations/{organizationId}/certification-attestations', function () {
-    it('should return HTTP status 200', async function () {
-      // given
-      const adminIsManagingStudent = databaseBuilder.factory.buildUser.withRawPassword();
+    describe('when the session version is V2', function () {
+      it('should return HTTP status 200 and a PDF', async function () {
+        // given
+        const adminIsManagingStudent = databaseBuilder.factory.buildUser.withRawPassword();
 
-      const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-      databaseBuilder.factory.buildMembership({
-        organizationId: organization.id,
-        userId: adminIsManagingStudent.id,
-        organizationRole: Membership.roles.ADMIN,
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({
+          organizationId: organization.id,
+          userId: adminIsManagingStudent.id,
+          organizationRole: Membership.roles.ADMIN,
+        });
+
+        const student = databaseBuilder.factory.buildUser.withRawPassword();
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          division: 'aDivision',
+          userId: student.id,
+        });
+
+        const candidate = databaseBuilder.factory.buildCertificationCandidate({
+          organizationLearnerId: organizationLearner.id,
+          userId: student.id,
+        });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          userId: candidate.userId,
+          sessionId: candidate.sessionId,
+          isPublished: true,
+          isCancelled: false,
+        });
+
+        const badge = databaseBuilder.factory.buildBadge({ key: 'a badge' });
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          userId: candidate.userId,
+          certificationCourseId: certificationCourse.id,
+          type: Assessment.types.CERTIFICATION,
+          state: 'completed',
+        });
+
+        const assessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
+          certificationCourseId: certificationCourse.id,
+          assessmentId: assessment.id,
+          status: AssessmentResult.status.VALIDATED,
+        });
+        databaseBuilder.factory.buildCompetenceMark({
+          level: 3,
+          score: 23,
+          area_code: '1',
+          competence_code: '1.3',
+          assessmentResultId: assessmentResult.id,
+          acquiredComplementaryCertifications: [badge.key],
+        });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/certification-attestations?division=aDivision&isFrenchDomainExtension=true&lang=fr`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminIsManagingStudent.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers['content-type']).to.equal('application/pdf');
+        expect(response.headers['content-disposition']).to.include(`_attestations_${organizationLearner.division}`);
       });
+    });
 
-      const student = databaseBuilder.factory.buildUser.withRawPassword();
-      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId: organization.id,
-        division: 'aDivision',
-        userId: student.id,
+    describe('when the session version is V3', function () {
+      it('should return HTTP status 200', async function () {
+        // given
+        await featureToggles.set('isV3CertificationAttestationEnabled', true);
+
+        const adminIsManagingStudent = databaseBuilder.factory.buildUser.withRawPassword();
+
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({
+          organizationId: organization.id,
+          userId: adminIsManagingStudent.id,
+          organizationRole: Membership.roles.ADMIN,
+        });
+
+        const student = databaseBuilder.factory.buildUser.withRawPassword();
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          division: 'aDivision',
+          userId: student.id,
+        });
+
+        const session = databaseBuilder.factory.buildSession({
+          version: SESSIONS_VERSIONS.V3,
+        });
+
+        const candidate = databaseBuilder.factory.buildCertificationCandidate({
+          organizationLearnerId: organizationLearner.id,
+          userId: student.id,
+          sessionId: session.id,
+        });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          userId: candidate.userId,
+          sessionId: session.id,
+          isPublished: true,
+          isCancelled: false,
+        });
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          userId: candidate.userId,
+          certificationCourseId: certificationCourse.id,
+          type: Assessment.types.CERTIFICATION,
+          state: 'completed',
+        });
+
+        databaseBuilder.factory.buildAssessmentResult.last({
+          certificationCourseId: certificationCourse.id,
+          assessmentId: assessment.id,
+          status: AssessmentResult.status.VALIDATED,
+        });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/certification-attestations?division=aDivision&isFrenchDomainExtension=true&lang=fr`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminIsManagingStudent.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
       });
-
-      const candidate = databaseBuilder.factory.buildCertificationCandidate({
-        organizationLearnerId: organizationLearner.id,
-        userId: student.id,
-      });
-      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
-
-      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-        userId: candidate.userId,
-        sessionId: candidate.sessionId,
-        isPublished: true,
-        isCancelled: false,
-      });
-
-      const badge = databaseBuilder.factory.buildBadge({ key: 'a badge' });
-
-      const assessment = databaseBuilder.factory.buildAssessment({
-        userId: candidate.userId,
-        certificationCourseId: certificationCourse.id,
-        type: Assessment.types.CERTIFICATION,
-        state: 'completed',
-      });
-
-      const assessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
-        certificationCourseId: certificationCourse.id,
-        assessmentId: assessment.id,
-        status: AssessmentResult.status.VALIDATED,
-      });
-      databaseBuilder.factory.buildCompetenceMark({
-        level: 3,
-        score: 23,
-        area_code: '1',
-        competence_code: '1.3',
-        assessmentResultId: assessmentResult.id,
-        acquiredComplementaryCertifications: [badge.key],
-      });
-
-      await databaseBuilder.commit();
-
-      const server = await createServer();
-
-      const options = {
-        method: 'GET',
-        url: `/api/organizations/${organization.id}/certification-attestations?division=aDivision&isFrenchDomainExtension=true&lang=fr`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminIsManagingStudent.id }),
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(200);
     });
   });
 });
 
-async function _buildDatabaseForV2Certification({ userId, certificationCourseId = 10, sessionId = 12 }) {
+async function _buildDatabaseCertification({
+  userId,
+  certificationCourseId = 10,
+  sessionId = 12,
+  sessionVersion = SESSIONS_VERSIONS.V2,
+}) {
   const session = databaseBuilder.factory.buildSession({
     id: sessionId,
     publishedAt: new Date('2018-12-01T01:02:03Z'),
+    version: sessionVersion,
   });
   const badge = databaseBuilder.factory.buildBadge({ key: 'charlotte_aux_fraises' });
   const cc = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' });

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -979,12 +979,10 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       });
 
       // then
-      const expectedCertificationAttestationA =
-        domainBuilder.buildCertificationAttestation(certificationAttestationDataA);
+      domainBuilder.buildCertificationAttestation(certificationAttestationDataA);
       const expectedCertificationAttestationB =
         domainBuilder.buildCertificationAttestation(certificationAttestationDataB);
-      const expectedCertificationAttestationC =
-        domainBuilder.buildCertificationAttestation(certificationAttestationDataC);
+      domainBuilder.buildCertificationAttestation(certificationAttestationDataC);
       expect(certificationAttestations).to.have.lengthOf(3);
 
       expect(certificationAttestations[0]).deepEqualInstanceOmitting(expectedCertificationAttestationB, [

--- a/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
@@ -1,34 +1,34 @@
 import { getCertificationAttestation } from '../../../../../../src/certification/results/domain/usecases/get-certification-attestation.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { UnauthorizedError } from '../../../../../../src/shared/application/http-errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-certification-attestation', function () {
-  let certificateRepository;
+  let certificateRepository, certificationCourseRepository;
 
   beforeEach(function () {
     certificateRepository = { getCertificationAttestation: sinon.stub() };
+    certificationCourseRepository = { get: sinon.stub() };
   });
 
   context('when the user is not owner of the certification attestation', function () {
-    it('should throw an error if user is not the owner of the certificationAttestation', async function () {
+    it('should throw an error', async function () {
       // given
-      const certificationAttestation = domainBuilder.buildCertificationAttestation({
+      const certificationCourse = domainBuilder.buildCertificationCourse({
         id: 123,
-        userId: 456,
+        userId: 567,
       });
-      certificateRepository.getCertificationAttestation
-        .withArgs({ certificationCourseId: 123 })
-        .resolves(certificationAttestation);
+      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
 
       // when
       const error = await catchErr(getCertificationAttestation)({
         certificationCourseId: 123,
         userId: 789,
         certificateRepository,
+        certificationCourseRepository,
       });
 
       // then
-      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error).to.be.instanceOf(UnauthorizedError);
     });
   });
 
@@ -41,6 +41,11 @@ describe('Unit | UseCase | get-certification-attestation', function () {
         userId: 456,
         resultCompetenceTree,
       });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        id: 123,
+        userId: 456,
+      });
+      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
       certificateRepository.getCertificationAttestation
         .withArgs({ certificationCourseId: 123 })
         .resolves(certificationAttestation);
@@ -50,6 +55,7 @@ describe('Unit | UseCase | get-certification-attestation', function () {
         certificationCourseId: 123,
         userId: 456,
         certificateRepository,
+        certificationCourseRepository,
       });
 
       // then

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,0 +1,29 @@
+import { V3CertificationAttestation } from '../../../../../../src/certification/results/domain/models/V3CertificationAttestation.js';
+
+const buildV3CertificationAttestation = function ({
+  id = 1,
+  firstName = 'Jean',
+  lastName = 'Bon',
+  birthdate = '1992-06-12',
+  birthplace = 'Paris',
+  certificationCenter = 'L’université du Pix',
+  deliveredAt = new Date('2018-10-03T01:02:03Z'),
+  pixScore = 123,
+  maxReachableLevelOnCertificationDate = 7,
+  verificationCode = 'P-SOMECODE',
+} = {}) {
+  return new V3CertificationAttestation({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    birthplace,
+    certificationCenter,
+    deliveredAt,
+    pixScore,
+    maxReachableLevelOnCertificationDate,
+    verificationCode,
+  });
+};
+
+export { buildV3CertificationAttestation };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,3 +1,4 @@
+import { buildV3CertificationAttestation } from '../factory/certification/results/build-v3-certification-attestation.js';
 import { buildEmptyInformationBanner, buildInformationBanner } from './banner/build-banner-information.js';
 import { buildAccountRecoveryDemand } from './build-account-recovery-demand.js';
 import { buildActivity } from './build-activity.js';
@@ -270,6 +271,7 @@ const certification = {
   },
   results: {
     buildGlobalCertificationLevel,
+    buildV3CertificationAttestation,
     parcoursup: {
       buildCertificationResult: parcoursupCertificationResult,
       buildCompetence: parcoursupCompetence,


### PR DESCRIPTION
## :pancakes: Problème

On ne gère pas encore les nouveaux gabarits de certificat V3.

## :bacon: Proposition

Pour les routes `/api/attestation/{certificationCourseId}` et `/api/admin/sessions/{sessionId}/attestations`, ajouter la prise en compte spécifique des sessions V3, afin de plus tard générer les nouveaux PDF.

Cette gestion se fait avec l'utilisation du feature-toggle spécifique.

## 🧃 Remarques

La génération du nouveau PDF sera fait dans un second temps.

## :yum: Pour tester

...
