### PR TITLE
[BUGFIX] (Correctif sans ilike) Pour les demandes de réinitialisation de mot de passe, rendre la recherche des comptes vraiment insensible à la casse (PIX-17005)

### DIFF
--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -265,7 +265,7 @@ const checkIfEmailIsAvailable = async function (email) {
 };
 
 const isUserExistingByEmail = async function (email) {
-  const existingUser = await knex('users').where('email', email.toLowerCase()).first();
+  const existingUser = await knex('users').whereRaw('LOWER("email") = ?', email.toLowerCase()).first();
   if (!existingUser) throw new UserNotFoundError();
   return true;
 };

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -55,7 +55,7 @@ const getFullById = async function (userId) {
 
 const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
   const userDTO = await knex('users')
-    .where({ email: username.toLowerCase() })
+    .whereRaw('LOWER("email") = ?', username.toLowerCase())
     .orWhere({ username: username.toLowerCase() })
     .first();
 

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -390,7 +390,7 @@ const findByExternalIdentifier = async function ({ externalIdentityId, identityP
 };
 
 const findAnotherUserByEmail = async function (userId, email) {
-  const anotherUsers = await knex('users').whereNot('id', userId).where({ email: email.toLowerCase() });
+  const anotherUsers = await knex('users').whereNot('id', userId).whereRaw('LOWER("email") = ?', email.toLowerCase());
 
   return anotherUsers.map((anotherUser) => new User(anotherUser));
 };

--- a/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -22,6 +22,29 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-r
     expect(resetPasswordDemand).to.exist;
   });
 
+  context('when a user account exists but with an email differing by case', function () {
+    it('creates a reset password demand', async function () {
+      // given
+      const accountEmail = 'DIFFERING_BY_CASE@example.net';
+      const passwordResetDemandEmail = 'differing_by_case@example.net';
+      const userId = databaseBuilder.factory.buildUser({ email: accountEmail }).id;
+      databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.createResetPasswordDemand({
+        email: passwordResetDemandEmail,
+        locale,
+      });
+
+      // then
+      const resetPasswordDemand = await knex('reset-password-demands')
+        .whereRaw('LOWER("email") = LOWER(?)', passwordResetDemandEmail)
+        .first();
+      expect(resetPasswordDemand).to.exist;
+    });
+  });
+
   context('when user account does not exist with given email', function () {
     it('does not create a reset password demand', async function () {
       // given

--- a/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -45,7 +45,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-r
     });
   });
 
-  context('when user account does not exist with given email', function () {
+  context('when no user account with a matching email exists', function () {
     it('does not create a reset password demand', async function () {
       // given
       const unknownEmail = 'unknown@example.net';

--- a/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -1,8 +1,4 @@
-import { resetPasswordService } from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
-import { createResetPasswordDemand } from '../../../../../src/identity-access-management/domain/usecases/create-reset-password-demand.usecase.js';
-import { resetPasswordDemandRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
-import * as userRepository from '../../../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-import * as emailRepository from '../../../../../src/shared/mail/infrastructure/repositories/email.repository.js';
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | create-reset-password-demand', function () {
@@ -16,13 +12,9 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-r
     await databaseBuilder.commit();
 
     // when
-    await createResetPasswordDemand({
+    await usecases.createResetPasswordDemand({
       email,
       locale,
-      emailRepository,
-      resetPasswordService,
-      resetPasswordDemandRepository,
-      userRepository,
     });
 
     // then
@@ -36,13 +28,9 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-r
       const unknownEmail = 'unknown@example.net';
 
       // when
-      await createResetPasswordDemand({
+      await usecases.createResetPasswordDemand({
         email: unknownEmail,
         locale,
-        emailRepository,
-        resetPasswordService,
-        resetPasswordDemandRepository,
-        userRepository,
       });
 
       // then

--- a/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-reset-password-demand.usecase.test.js
@@ -31,21 +31,23 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-r
   });
 
   context('when user account does not exist with given email', function () {
-    it('does not throw an error', async function () {
+    it('does not create a reset password demand', async function () {
       // given
       const unknownEmail = 'unknown@example.net';
 
-      // when & then
-      expect(
-        createResetPasswordDemand({
-          email: unknownEmail,
-          locale,
-          emailRepository,
-          resetPasswordService,
-          resetPasswordDemandRepository,
-          userRepository,
-        }),
-      ).not.to.be.rejected;
+      // when
+      await createResetPasswordDemand({
+        email: unknownEmail,
+        locale,
+        emailRepository,
+        resetPasswordService,
+        resetPasswordDemandRepository,
+        userRepository,
+      });
+
+      // then
+      const resetPasswordDemand = await knex('reset-password-demands').where({ email: unknownEmail }).first();
+      expect(resetPasswordDemand).to.not.exist;
     });
   });
 });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1816,7 +1816,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#isUserExistingByEmail', function () {
-    const email = 'shi@fu.fr';
+    const email = 'user_account_created_with_SOME_UPPER_CASE_LETTERS@example.net';
 
     beforeEach(function () {
       databaseBuilder.factory.buildUser({ email });
@@ -1824,25 +1824,30 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       return databaseBuilder.commit();
     });
 
-    it('returns true when the user exists by email', async function () {
+    it('finds a user with the exact email', async function () {
       const userExists = await userRepository.isUserExistingByEmail(email);
       expect(userExists).to.be.true;
     });
 
-    it('returns true when the user exists by email (case insensitive)', async function () {
-      // given
-      const uppercaseEmailAlreadyInDb = email.toUpperCase();
+    context('when a user exists but with an email differing by case (case insensitive search)', function () {
+      it('finds the user', async function () {
+        // given
+        const uppercaseEmailAlreadyInDb = email.toUpperCase();
 
-      // when
-      const userExists = await userRepository.isUserExistingByEmail(uppercaseEmailAlreadyInDb);
+        // when
+        const userExists = await userRepository.isUserExistingByEmail(uppercaseEmailAlreadyInDb);
 
-      // then
-      expect(userExists).to.be.true;
+        // then
+        expect(userExists).to.be.true;
+      });
     });
 
-    it('throws an error when the user does not exist by email', async function () {
-      const err = await catchErr(userRepository.isUserExistingByEmail)('none');
-      expect(err).to.be.instanceOf(UserNotFoundError);
+    context('when no user account with a matching email exist', function () {
+      it('throws an error', async function () {
+        const searchedEmail = 'Address_Unknown@example.net';
+        const err = await catchErr(userRepository.isUserExistingByEmail)(searchedEmail);
+        expect(err).to.be.instanceOf(UserNotFoundError);
+      });
     });
   });
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -43,7 +43,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   const userToInsert = {
     firstName: 'Jojo',
     lastName: 'LaFripouille',
-    email: 'jojo@example.net',
+    email: 'user_name_with_mix_of_lower_AND_UPPER_case_letters@example.net',
     cgu: true,
     locale: 'fr-FR',
     createdAt: creationDate,
@@ -740,7 +740,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(user.id).to.equal(userInDb.id);
         expect(user.firstName).to.equal(userInDb.firstName);
         expect(user.lastName).to.equal(userInDb.lastName);
-        expect(user.email).to.equal(userInDb.email);
+        expect(user.email).to.equal(userInDb.email.toLowerCase());
         expect(user.cgu).to.be.true;
         expect(user.createdAt.toISOString()).to.equal('2019-03-12T19:37:03.000Z');
         expect(user.updatedAt.toISOString()).to.equal('2019-03-12T19:37:03.000Z');
@@ -1120,7 +1120,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
         // then
         expect(user.username).to.equal(userInDb.username);
-        expect(user.email).to.equal(userInDb.email);
+        expect(user.email).to.equal(userInDb.email.toLowerCase());
       });
 
       it('throws an error when user not found', async function () {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1842,10 +1842,15 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
     });
 
-    context('when no user account with a matching email exist', function () {
-      it('throws an error', async function () {
+    context('when no user account with a matching email exists', function () {
+      it('throws a UserNotFoundError', async function () {
+        // given
         const searchedEmail = 'Address_Unknown@example.net';
+
+        // when
         const err = await catchErr(userRepository.isUserExistingByEmail)(searchedEmail);
+
+        // then
         expect(err).to.be.instanceOf(UserNotFoundError);
       });
     });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -601,7 +601,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           email: 'current.user@example.net',
         });
         const anotherUser = databaseBuilder.factory.buildUser({
-          email: 'another.user@example.net',
+          email: 'another.user.with_mix_of_lower_AND_UPPER_case_letters@example.net',
         });
         await databaseBuilder.commit();
 
@@ -611,7 +611,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         // then
         expect(foundUsers).to.be.an('array').that.have.lengthOf(1);
         expect(foundUsers[0]).to.be.an.instanceof(User);
-        expect(foundUsers[0].email).to.equal(anotherUser.email);
+        expect(foundUsers[0].email).to.equal(anotherUser.email.toLowerCase());
       });
 
       it('returns an empty list if email is not used', async function () {


### PR DESCRIPTION
## :pancakes: Problème

Certains e-mails transactionnels ne sont pas reçus lors de demandes de réinitialisation de mot de passe. Cela se produit avec des comptes dont l'adresse email contient des majuscules.

Le sujet de cette PR était déjà traité dans #11610, mais il a fallu revert cette PR avec #11643 car la PR introduisait l'utilisation de `ilike` qui ne tire pas parti de l'index `users_email_lower`.

## :bacon: Proposition

Le code de recherche des utilisateurs par la fonction `isUserExistingByEmail` ne fait pas une recherche _complètement_ insensible à la casse. Donc certains comptes ne sont pas trouvés (les comptes avec des majuscules dans l'adresse email) et ainsi on n'envoie pas d’email lorsqu'on ne trouve pas ces comptes.

De plus la fonction `getByUsernameOrEmailWithRolesAndPassword` qui est utilisée lors du login souffre du même problème.

Ainsi la proposition est de rendre les fonctions `isUserExistingByEmail` et  `getByUsernameOrEmailWithRolesAndPassword` _complètement_ insensibles à la casse.

## 🧃 Remarques

On profite de cette PR pour faire que toutes les fonctions du `userRepository` effectuent des recherches par adresse email de la même manière _complètement_ insensible à la casse.

## :yum: Pour tester

1. Sur Pix App, créer un utilisateur avec un mélange de minuscules et de majuscules dans son adresse email (par exemple `MonAdresseEmailProfessionnelleQuiFonctionne@ma-structure.org`),
2. Comme le processus de création des comptes modifie l'adresse email fournie pour la transformer en minuscule (pour contourner – au lieu de corriger – les problèmes que corrige cette PR), aller dans Pix Admin et modifier le compte de cet utilisateur pour remettre un mélange de minuscules et de majuscules dans son adresse email (par exemple `MonAdresseEmailProfessionnelleQuiFonctionne@ma-structure.org`),
3. Sur Pix App, effectuer des demandes de réinitialisation de mot de passe en allant sur le formulaire de connexion et en suivant le lien « _Mot de passe oublié ? »_ avec différents mélanges de minuscules et de majuscules,
4. Vérifier que l'email est bien envoyé pour chacune des demandes effectuées avec différents mélanges de minuscules et de majuscules,
5. Sur Pix App, vérifier la connexion avec succès de l'utilisateur avec n'importe mélange de minuscules et de majuscules dans son adresse email (par exemple `MonAdresseEmailProfessionnelleQuiFonctionne@ma-structure.org`, `MONadresseEMAILprofessionnelleQUIfonctionne@ma-structure.org`, etc.).
