### PR TITLE
[TECH] Ne pas pinger `team-devcomp` en cas d'évols du référentiel Modulix (PIX-17006)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
 /api/src/devcomp/ @1024pix/team-devcomp
+!/api/src/devcomp/infrastructure/datasources/learning-content/modules/*.json
+/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json @1024pix/team-devcomp
 /api/tests/devcomp/ @1024pix/team-devcomp
 
 /mon-pix/app/components/module/ @1024pix/team-devcomp


### PR DESCRIPTION
## :pancakes: Problème
L'équipe @1024pix/team-devcomp est pingée en cas de modifs du référentiel de Modulix.

## :bacon: Proposition
Nous ne validons pas manuellement les contenus. L'équipe contenus est garante de la qualité de production.

Supprimer la review automatique de `team-devcomp` sur ces fichiers, hors `bac-a-sable`.

## 🧃 Remarques
RAS

## :yum: Pour tester
🤔 