### PR TITLE
[TECH] Mettre à jour le CHANGELOG avec la version v5.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 ### :coffee: Autre
 - [#11643](https://github.com/1024pix/pix/pull/11643) Revert "[BUGFIX] Pour les demandes de réinitialisation de mot de passe, rendre la recherche des comptes vraiment insensible à la casse (PIX-16896)".
 
+## v5.61.1 (12/03/2025)
+
+
+### :bug: Correction
+- [#11643](https://github.com/1024pix/pix/pull/11643) Revert "[BUGFIX] Pour les demandes de réinitialisation de mot de passe, rendre la recherche des comptes vraiment insensible à la casse (PIX-16896)"
+
 ## v5.61.0 (11/03/2025)
 
 


### PR DESCRIPTION
## :pancakes: Problème
Suite à un bug en production, un hotfix a été réalisé et déployé. Cependant, il n'apparaît pas dans le CHANGELOG.

## :bacon: Proposition
Mettre à jour le CHANGELOG avec la version v5.61.1