### PR TITLE
[FEATURE] Utilise le snapshot pour calculer les résultats de fin de campagne d'Exam (PIX-17004)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -17,7 +17,7 @@ import * as areaRepository from '../../../../shared/infrastructure/repositories/
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as badgeForCalculationRepository from '../../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
-import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
+import { repositories as injectedSharedRepositories } from '../../../../shared/infrastructure/repositories/index.js';
 import * as organizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -105,7 +105,7 @@ const dependencies = {
   compareStagesAndAcquiredStages,
   competenceEvaluationRepository,
   competenceRepository,
-  knowledgeElementRepository,
+  knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
   learningContentRepository,
   organizationLearnerRepository,
   organizationRepository,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -1,0 +1,159 @@
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { PIX_COUNT_BY_LEVEL } from '../../../../../../src/shared/domain/constants.js';
+import { Assessment, KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Prescription Integration | UseCase | get-user-campaign-assessment-result', function () {
+  context('when campaign is of type ASSESSMENT', function () {
+    it('should return an participant assessment result based on the user profile', async function () {
+      // given
+      const skillIds = ['acquisA', 'acquisB'];
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.ASSESSMENT,
+      }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        sharedAt: null,
+        status: CampaignParticipationStatuses.TO_SHARE,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+        skillIds,
+      });
+      skillIds.map((id, index) => {
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({
+          skillId: id,
+          status: KnowledgeElement.StatusType.VALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          userId,
+          assessmentId: assessmentDB.id,
+        });
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const participantAssessmentResult = await usecases.getUserCampaignAssessmentResult({
+        userId,
+        campaignId,
+        locale: 'fr',
+      });
+
+      // then
+      expect(participantAssessmentResult.masteryRate).to.equal(1);
+      expect(participantAssessmentResult.competenceResults.length).to.equal(1);
+      sinon.assert.match(participantAssessmentResult.competenceResults[0], {
+        id: 'maCompetenceId',
+      });
+    });
+  });
+  context('when campaign is of type EXAM', function () {
+    it('should return an participant assessment result based on the user profile', async function () {
+      // given
+      const skillIds = ['acquisA', 'acquisB'];
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.EXAM,
+      }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        sharedAt: null,
+        status: CampaignParticipationStatuses.TO_SHARE,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+        skillIds,
+      });
+      const domainKEs = skillIds.map((id, index) => {
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        });
+        return domainBuilder.buildKnowledgeElement({
+          skillId: id,
+          status: KnowledgeElement.StatusType.VALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          userId,
+          assessmentId: assessmentDB.id,
+        });
+      });
+      const knowledgeElementsBefore = new KnowledgeElementCollection(domainKEs);
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId,
+        snappedAt: new Date('2019-01-01'),
+        campaignParticipationId,
+        snapshot: knowledgeElementsBefore.toSnapshot(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const participantAssessmentResult = await usecases.getUserCampaignAssessmentResult({
+        userId,
+        campaignId,
+        locale: 'fr',
+      });
+
+      // then
+      expect(participantAssessmentResult.masteryRate).to.equal(1);
+      expect(participantAssessmentResult.competenceResults.length).to.equal(1);
+      sinon.assert.match(participantAssessmentResult.competenceResults[0], {
+        id: 'maCompetenceId',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

La page de fin de parcours d'une campagne d'évaluation se base sur les KEs du profil de l'utilisateur. Dans le cadre d'une campagne d'Exam on ne veut pas prendre en compte le profil de l'utilisateur pour calculer les résultats.

## :bacon: Proposition

Se baser sur le KE Snapshot qui a été construit au fur et à mesure de la participation.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Faire une participation à un profil cible en eval et repondre tout bon. Voir qu'on a 100%.
Faire une participation au même profil en exam et passer toutes les quetes. Voir qu'on a 0%.
