### PR TITLE
Revert "[TECH] Ne pas pinger `team-devcomp` en cas d'évols du référentiel Modulix (PIX-17006)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
 /api/src/devcomp/ @1024pix/team-devcomp
-!/api/src/devcomp/infrastructure/datasources/learning-content/modules/*.json
-/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json @1024pix/team-devcomp
 /api/tests/devcomp/ @1024pix/team-devcomp
 
 /mon-pix/app/components/module/ @1024pix/team-devcomp


### PR DESCRIPTION
Ne fonctionne pas 😕 

Reverts 1024pix/pix#11651