### PR TITLE
[FEATURE] Empêcher les campagnes de Type EXAM à pouvoir faire du reset de campagne (Pix-16497)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/PreviousCampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/PreviousCampaignParticipation.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../../../../shared/domain/constants.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 class PreviousCampaignParticipation {
+  #isResetAllowed;
   constructor({
     id,
     participantExternalId,
@@ -12,6 +13,7 @@ class PreviousCampaignParticipation {
     isTargetProfileResetAllowed,
     isOrganizationLearnerActive,
     isCampaignMultipleSendings,
+    isResetAllowed,
     sharedAt,
   }) {
     this.id = id;
@@ -23,10 +25,12 @@ class PreviousCampaignParticipation {
     this.isOrganizationLearnerActive = isOrganizationLearnerActive;
     this.isCampaignMultipleSendings = isCampaignMultipleSendings;
     this.sharedAt = sharedAt;
+    this.#isResetAllowed = isResetAllowed;
   }
 
   get canReset() {
     return (
+      this.#isResetAllowed &&
       this.status === CampaignParticipationStatuses.SHARED &&
       this.isTargetProfileResetAllowed &&
       this.isCampaignMultipleSendings &&

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
@@ -35,16 +35,16 @@ async function get({ userId, campaignId, organizationFeatureAPI }) {
 
   const campaignToStartParticipation = await _getCampaignToStart({
     campaignId,
-
     organizationFeatureAPI,
   });
 
   const organizationLearner = await _getOrganizationLearner(campaignId, userId);
 
-  const previousCampaignParticipationForUser = await _findpreviousCampaignParticipationForUser({
+  const previousCampaignParticipationForUser = await _findPreviousCampaignParticipationForUser({
     campaignId,
     userId,
     isCampaignMultipleSendings: campaignToStartParticipation.multipleSendings,
+    isResetAllowed: campaignToStartParticipation.isAssessment,
   });
 
   return new CampaignParticipant({
@@ -236,7 +236,12 @@ async function _getOrganizationLearner(campaignId, userId) {
   });
 }
 
-async function _findpreviousCampaignParticipationForUser({ campaignId, userId, isCampaignMultipleSendings }) {
+async function _findPreviousCampaignParticipationForUser({
+  campaignId,
+  userId,
+  isCampaignMultipleSendings,
+  isResetAllowed,
+}) {
   const knexConnection = DomainTransaction.getConnection();
   const campaignParticipationAttributes = await knexConnection('campaign-participations')
     .select('id', 'participantExternalId', 'validatedSkillsCount', 'status', 'deletedAt', 'sharedAt')
@@ -256,6 +261,7 @@ async function _findpreviousCampaignParticipationForUser({ campaignId, userId, i
     isDeleted: Boolean(campaignParticipationAttributes.deletedAt),
     sharedAt: campaignParticipationAttributes.sharedAt,
     isCampaignMultipleSendings,
+    isResetAllowed,
     isTargetProfileResetAllowed,
     isOrganizationLearnerActive,
   });

--- a/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
@@ -82,6 +82,7 @@ class AssessmentResult {
       isDisabled: this.isDisabled,
       sharedAt,
       isShared: this.isShared,
+      campaignType,
     });
 
     if (flashScoringResults) {
@@ -144,6 +145,7 @@ class AssessmentResult {
   }
 
   _computeCanReset({
+    campaignType,
     isTargetProfileResetAllowed,
     isOrganizationLearnerActive,
     isCampaignMultipleSendings,
@@ -151,6 +153,10 @@ class AssessmentResult {
     isShared,
     sharedAt,
   }) {
+    if (campaignType !== CampaignTypes.ASSESSMENT) {
+      return false;
+    }
+
     return (
       isShared &&
       isTargetProfileResetAllowed &&

--- a/api/tests/prescription/campaign-participation/unit/domain/models/PreviousCampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/PreviousCampaignParticipation_test.js
@@ -53,6 +53,7 @@ describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function
         isDeleted: true,
         isTargetProfileResetAllowed: true,
         isCampaignMultipleSendings: true,
+        isResetAllowed: true,
         isOrganizationLearnerActive: true,
         sharedAt: new Date('2020-01-01T01:02:03Z'),
       };
@@ -142,6 +143,32 @@ describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function
 
         // when & then
         expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+
+    describe('isResetAllowed', function () {
+      it('should return true when isResetAllowed is true', function () {
+        // given
+        const isResetAllowed = true;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isResetAllowed,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+
+      it('should return false when isResetAllowed is false', function () {
+        // given
+        const isResetAllowed = true;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isResetAllowed,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
       });
     });
 

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -1,6 +1,7 @@
 import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js';
 import {
   CampaignParticipationStatuses,
+  CampaignTypes,
   KnowledgeElement,
 } from '../../../../../../../src/shared/domain/models/index.js';
 import { AssessmentResult } from '../../../../../../../src/shared/domain/read-models/participant-results/AssessmentResult.js';
@@ -96,6 +97,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         reachedStage,
         stages,
         isCampaignMultipleSendings,
+        campaignType: CampaignTypes.ASSESSMENT,
         isOrganizationLearnerActive,
         isCampaignArchived,
         isTargetProfileResetAllowed,
@@ -107,7 +109,6 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'can-improve': false,
             'can-reset': true,
             'can-retry': true,
-
             'is-completed': true,
             'is-disabled': false,
             'is-shared': true,

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -895,6 +895,36 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
+    context('when campaign type is not assessement', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isTargetProfileResetAllowed = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          status: CampaignParticipationStatuses.SHARED,
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          campaignType: CampaignTypes.EXAM,
+          isTargetProfileResetAllowed,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
     it('returns true', function () {
       const isCampaignMultipleSendings = true;
       const isOrganizationLearnerActive = true;
@@ -917,6 +947,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         isCampaignMultipleSendings,
         isOrganizationLearnerActive,
         isCampaignArchived,
+        campaignType: CampaignTypes.ASSESSMENT,
       });
 
       expect(assessmentResult.canReset).to.be.true;


### PR DESCRIPTION
## :pancakes: Problème

Actuellement on peut faire une campagne de Type Exam et afficher le bouton de reset de compétence côté PixAPP
## :bacon: Proposition

Enrichir le canReset pour conditionner aussi au type de campagne

## 🧃 Remarques

Ce repo model et un peu what the heck. il faudra songer à mettre à plat tout ça côté Prescription

## :yum: Pour tester

Pour faire le truc de remise à zéro :
- Faire un profil cible en cochant la case “Permettre la remise à zero des acquis du profil cible”
- Créer une campagne avec ce profil cible et en activant l’envoi multiple
- Lancer la campagne, tout passer (fait un petit profil cible du coup et pars sur un nouveau compte comme ça c’est plus simple)
- Arriver en fin de campagne, partager
- Recharger la page, et voir apparaître plusieurs boutons/liens dont un dit un truc du style “Remettre à zéro et tout retenter”