### PR TITLE
[FEATURE] Affichage de la date de dernier accès des membres d'une organisation (PIX-16633)

### DIFF
--- a/admin/app/components/organizations/member-item.gjs
+++ b/admin/app/components/organizations/member-item.gjs
@@ -1,13 +1,25 @@
 import { LinkTo } from '@ember/routing';
+import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 
 import ActionsOnUsersRoleInOrganization from '../actions-on-users-role-in-organization';
 
-<template>
-  <td><LinkTo @route="authenticated.users.get" @model={{@organizationMembership.user.id}}>
-      {{@organizationMembership.user.id}}
-    </LinkTo></td>
-  <td>{{@organizationMembership.user.firstName}}</td>
-  <td>{{@organizationMembership.user.lastName}}</td>
-  <td>{{@organizationMembership.user.email}}</td>
-  <ActionsOnUsersRoleInOrganization @organizationMembership={{@organizationMembership}} />
-</template>
+export default class MemberItem extends Component {
+  get lastAccessedAt() {
+    if (!this.args.organizationMembership.lastAccessedAt) {
+      return null;
+    }
+    return dayjs(this.args.organizationMembership.lastAccessedAt).format('DD/MM/YYYY HH:mm');
+  }
+
+  <template>
+    <td><LinkTo @route="authenticated.users.get" @model={{@organizationMembership.user.id}}>
+        {{@organizationMembership.user.id}}
+      </LinkTo></td>
+    <td>{{@organizationMembership.user.firstName}}</td>
+    <td>{{@organizationMembership.user.lastName}}</td>
+    <td>{{@organizationMembership.user.email}}</td>
+    <td>{{this.lastAccessedAt}}</td>
+    <ActionsOnUsersRoleInOrganization @organizationMembership={{@organizationMembership}} />
+  </template>
+}

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -36,6 +36,7 @@ export default class OrganizationTeamSection extends Component {
                 <th class="table__column table__column--wide">Prénom</th>
                 <th class="table__column table__column--wide">Nom</th>
                 <th class="table__column table__column--wide">Adresse e-mail</th>
+                <th class="table__column table__column--wide">Dernier accès</th>
                 <th class="table__column">Rôle</th>
                 {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
                   <th class="table__column">Actions</th>
@@ -70,6 +71,7 @@ export default class OrganizationTeamSection extends Component {
                     oninput={{fn @triggerFiltering "email"}}
                   />
                 </td>
+                <td class="table__column"></td>
                 <td class="table__column">
                   <PixSelect
                     class="pix-select-in-table"

--- a/admin/app/models/organization-membership.js
+++ b/admin/app/models/organization-membership.js
@@ -12,6 +12,7 @@ export default class OrganizationMembership extends Model {
   @attr() organizationName;
   @attr() organizationType;
   @attr() organizationExternalId;
+  @attr() lastAccessedAt;
 
   @belongsTo('organization', { async: true, inverse: 'organizationMemberships' }) organization;
   @belongsTo('user', { async: true, inverse: 'organizationMemberships' }) user;

--- a/admin/tests/integration/components/organizations/member-item-test.gjs
+++ b/admin/tests/integration/components/organizations/member-item-test.gjs
@@ -1,0 +1,47 @@
+import { render } from '@1024pix/ember-testing-library';
+import dayjs from 'dayjs';
+import MemberItem from 'pix-admin/components/organizations/member-item';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | MemberItem', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let currentUser;
+  const now = new Date('2021-01-01T12:00:00Z');
+
+  hooks.beforeEach(function () {
+    sinon.stub(Date, 'now').returns(now);
+    currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  test('displays an organization member details', async function (assert) {
+    // given
+    const member = {
+      user: {
+        id: 123,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'toto@example.net',
+      },
+      lastAccessedAt: now,
+    };
+
+    const screen = await render(<template><MemberItem @organizationMembership={{member}} /></template>);
+
+    // then
+
+    assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Doe' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'toto@example.net' })).exists();
+    assert.dom(screen.getByRole('cell', { name: dayjs(now).format('DD/MM/YYYY HH:mm') })).exists();
+  });
+});

--- a/api/src/shared/domain/models/Membership.js
+++ b/api/src/shared/domain/models/Membership.js
@@ -6,12 +6,21 @@ const roles = {
 };
 
 class Membership {
-  constructor({ id, organizationRole = roles.MEMBER, updatedByUserId, organization, user, disabledAt } = {}) {
+  constructor({
+    id,
+    organizationRole = roles.MEMBER,
+    updatedByUserId,
+    organization,
+    user,
+    lastAccessedAt,
+    disabledAt,
+  } = {}) {
     this.id = id;
     this.organizationRole = organizationRole;
     this.updatedByUserId = updatedByUserId;
     this.organization = organization;
     this.user = user;
+    this.lastAccessedAt = lastAccessedAt;
     this.disabledAt = disabledAt;
   }
 

--- a/api/src/shared/infrastructure/serializers/jsonapi/membership.serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/membership.serializer.js
@@ -93,7 +93,7 @@ const serializeForAdmin = function (membership, meta) {
       }
       return record;
     },
-    attributes: ['organization', 'organizationRole', 'user'],
+    attributes: ['organization', 'organizationRole', 'user', 'lastAccessedAt'],
     organization: {
       ref: 'id',
       included: true,

--- a/api/src/team/infrastructure/repositories/membership.repository.js
+++ b/api/src/team/infrastructure/repositories/membership.repository.js
@@ -124,6 +124,7 @@ export const findPaginatedFiltered = async function ({ organizationId, filter, p
         organizationRole: membership.organizationRole,
         updatedByUserId: membership.updatedByUserId,
         user: new User(membership),
+        lastAccessedAt: membership.lastAccessedAt,
       }),
   );
 

--- a/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
+++ b/api/tests/team/acceptance/application/membership/membership.admin.route.test.js
@@ -98,6 +98,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
           data: {
             type: 'organization-memberships',
             attributes: {
+              'last-accessed-at': null,
               'organization-role': 'ADMIN',
             },
             relationships: {
@@ -332,6 +333,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
       const membershipId = databaseBuilder.factory.buildMembership({
         userId: user.id,
         organizationId: organization.id,
+        lastAccessedAt: new Date('2020-01-01'),
       }).id;
 
       await databaseBuilder.commit();
@@ -350,6 +352,7 @@ describe('Acceptance | Team | Admin | Route | membership', function () {
           {
             attributes: {
               'organization-role': 'MEMBER',
+              'last-accessed-at': new Date('2020-01-01'),
             },
             id: membershipId.toString(),
             relationships: {

--- a/api/tests/tooling/domain-builder/factory/build-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-membership.js
@@ -30,8 +30,9 @@ const buildMembership = function ({
   organization = _buildOrganization(),
   organizationRole = Membership.roles.MEMBER,
   user = _buildUser(),
+  lastAccessedAt = null,
 } = {}) {
-  const membership = new Membership({ id, organization, organizationRole, user });
+  const membership = new Membership({ id, organization, organizationRole, user, lastAccessedAt });
 
   membership.user.memberships.push(membership);
 


### PR DESCRIPTION
## :pancakes: Problème

On souhaite afficher la date de dernier accès des membres des organisations dans Pix Admin.

## :bacon: Proposition

Ajout de la colonne “Dernier accès” dans le tableau des membres d’une organisation sur pix-admin:

- La date est récupérée dans la table memberships sur la colonne lastAccessedAt 

- Utiliser la route existante qui récupère les memberships 

- Nom de la colonne: Dernier accès

- Écrire sous la forme: 01/01/2025 20:02


## :yum: Pour tester

- Depuis pix orga
  - Se connecter avec admin-orga@example.net
  - Changer d'orga pour aller sur l'orga 'Attestation'
  
- Depuis pix admin
  - aller sur la page de détail de l'organisation "Attestation"
  - Constater la nouvelle colonne du tableau avec la date de dernier accès :
  
  
![image du tableau avec la nouvelle colonne et la date renseignée pour le dernier accès de admin-orga](https://github.com/user-attachments/assets/0b532a6c-8e06-48d4-9c5a-e73d4c1b610e)

