### PR TITLE
[TECH] 🚚  deplace le learning-content-repository de `lib` ➡️ `src` (Pix-17008)

### DIFF
--- a/api/src/certification/evaluation/domain/services/certification-challenges-service.js
+++ b/api/src/certification/evaluation/domain/services/certification-challenges-service.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
 import {
   MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS,
   MAX_CHALLENGES_PER_COMPETENCE_FOR_CERTIFICATION,

--- a/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/tutorial-repository.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
-import { LearningContentRepository } from '../../../shared/infrastructure/repositories/learning-content-repository.js';
+import { LearningContentDatasource } from '../../../shared/infrastructure/repositories/learning-content-datasource.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import * as paginateModule from '../../../shared/infrastructure/utils/paginate.js';
 import { Tutorial } from '../../domain/models/Tutorial.js';
@@ -161,12 +161,12 @@ export function clearCache(id) {
   return getInstance().clearCache(id);
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as compareStagesAndAcquiredStages from '../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
@@ -61,7 +61,7 @@ import * as poleEmploiSendingRepository from '../../infrastructure/repositories/
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/competence-evaluation-repository.js')} CompetenceEvaluationRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/competence-repository.js')} CompetenceRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
+ * @typedef { import ('../../../../shared/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/organization-learner-repository.js')} OrganizationLearnerRepository
  * @typedef { import ('../../infrastructure/repositories/participant-result-repository.js')} ParticipantResultRepository
  * @typedef { import ('../../infrastructure/repositories/participant-results-shared-repository.js')} participantResultsSharedRepository

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { CampaignAssessmentParticipationResult } from '../../domain/models/CampaignAssessmentParticipationResult.js';

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
@@ -45,7 +45,7 @@ import * as campaignUpdateValidator from '../validators/campaign-update-validato
  * @typedef { import ('../../../../devcomp/infrastructure/repositories/tutorial-repository.js')} TutorialRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js')} KnowledgeElementSnapshotRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
+ * @typedef { import ('../../../../shared/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef { import ('../../../../team/infrastructure/repositories/membership-repository.js')} MembershipRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js')} StageCollectionRepository
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/badge-repository.js')} BadgeRepository

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -18,7 +18,7 @@ import * as targetProfileSummaryForAdminRepository from '../../infrastructure/re
 /**
  * @typedef {import('../../infrastructure/repositories/')} AdminMemberRepository
  * @typedef {import('../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js')} LearningContentConversionService
- * @typedef {import('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
+ * @typedef {import('../../../../shared/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef {import('../../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
  * @typedef {import('../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js')} OrganizationsToAttachToTargetProfileRepository
  * @typedef {import('../../infrastructure/repositories/target-profile-administration-repository.js')} TargetProfileAdministrationRepository

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,7 +1,7 @@
 import { config } from '../../../shared/config.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { getTranslatedKey } from '../../../shared/domain/services/get-translated-text.js';
-import { LearningContentRepository } from '../../../shared/infrastructure/repositories/learning-content-repository.js';
+import { LearningContentDatasource } from '../../../shared/infrastructure/repositories/learning-content-datasource.js';
 import { Mission, MissionContent, MissionStep } from '../../domain/models/Mission.js';
 import { MissionNotFoundError } from '../../domain/school-errors.js';
 
@@ -61,12 +61,12 @@ function toDomain(missionDto, locale) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME, idType: 'integer' });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME, idType: 'integer' });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/area-repository.js
+++ b/api/src/shared/infrastructure/repositories/area-repository.js
@@ -4,7 +4,7 @@ import { Area } from '../../domain/models/Area.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { child, SCOPES } from '../utils/logger.js';
 import * as competenceRepository from './competence-repository.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const TABLE_NAME = 'learningcontent.areas';
 
@@ -118,12 +118,12 @@ async function toDomainWithCompetences(areaDtos, locale) {
   return areas;
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -6,7 +6,7 @@ import { Accessibility } from '../../domain/models/Challenge.js';
 import { Challenge } from '../../domain/models/index.js';
 import * as solutionAdapter from '../../infrastructure/adapters/solution-adapter.js';
 import { child, SCOPES } from '../utils/logger.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONTENT });
 
@@ -261,12 +261,12 @@ function toDomain({ challengeDto, webComponentTagName, webComponentProps, skill,
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/competence-repository.js
+++ b/api/src/shared/infrastructure/repositories/competence-repository.js
@@ -3,7 +3,7 @@ import { NotFoundError } from '../../domain/errors.js';
 import { Competence } from '../../domain/models/index.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { child, SCOPES } from '../utils/logger.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 const TABLE_NAME = 'learningcontent.competences';
@@ -77,12 +77,12 @@ function toDomain({ competenceDto, locale }) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/course-repository.js
+++ b/api/src/shared/infrastructure/repositories/course-repository.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '../../domain/errors.js';
 import { Course } from '../../domain/models/Course.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const TABLE_NAME = 'learningcontent.courses';
 
@@ -36,12 +36,12 @@ function toDomain(courseDto) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/framework-repository.js
+++ b/api/src/shared/infrastructure/repositories/framework-repository.js
@@ -1,7 +1,7 @@
 import { NotFoundError } from '../../domain/errors.js';
 import { Framework } from '../../domain/models/index.js';
 import { child, SCOPES } from '../utils/logger.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const TABLE_NAME = 'learningcontent.frameworks';
 
@@ -51,12 +51,12 @@ function byName(framework1, framework2) {
   return collator.compare(framework1.name, framework2.name);
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/learning-content-datasource.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-datasource.js
@@ -14,7 +14,7 @@ const logger = child('learningcontent:repository', { event: SCOPES.LEARNING_CONT
  * Datasource for learning content repositories.
  * This datasource uses a {@link Dataloader} to load and cache entities.
  */
-export class LearningContentRepository {
+export class LearningContentDatasource {
   #tableName;
   #idType;
   #dataloader;

--- a/api/src/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,17 +1,17 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
-import * as campaignRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
-import { NoSkillsInCampaignError, NotFoundError } from '../../../src/shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../src/shared/domain/models/CampaignLearningContent.js';
-import { LearningContent } from '../../../src/shared/domain/models/LearningContent.js';
-import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
-import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as frameworkRepository from '../../../src/shared/infrastructure/repositories/framework-repository.js';
-import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
-import * as thematicRepository from '../../../src/shared/infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
-import * as learningContentConversionService from '../../domain/services/learning-content/learning-content-conversion-service.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import * as learningContentConversionService from '../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
+import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { NoSkillsInCampaignError, NotFoundError } from '../../domain/errors.js';
+import { CampaignLearningContent } from '../../domain/models/CampaignLearningContent.js';
+import { LearningContent } from '../../domain/models/LearningContent.js';
+import * as areaRepository from './area-repository.js';
+import * as competenceRepository from './competence-repository.js';
+import * as frameworkRepository from './framework-repository.js';
+import * as skillRepository from './skill-repository.js';
+import * as thematicRepository from './thematic-repository.js';
+import * as tubeRepository from './tube-repository.js';
 
 async function findByCampaignId(campaignId, locale) {
   const skills = await campaignRepository.findSkills({ campaignId });

--- a/api/src/shared/infrastructure/repositories/skill-repository.js
+++ b/api/src/shared/infrastructure/repositories/skill-repository.js
@@ -3,7 +3,7 @@ import { NotFoundError } from '../../domain/errors.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { child, SCOPES } from '../utils/logger.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const TABLE_NAME = 'learningcontent.skills';
 const ACTIVE_STATUS = 'actif';
@@ -119,12 +119,12 @@ function toDomain(skillDto, locale, useFallback) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/thematic-repository.js
+++ b/api/src/shared/infrastructure/repositories/thematic-repository.js
@@ -1,7 +1,7 @@
 import { LOCALE } from '../../domain/constants.js';
 import { Thematic } from '../../domain/models/Thematic.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 const TABLE_NAME = 'learningcontent.thematics';
@@ -48,12 +48,12 @@ function toDomain(thematicDto, locale) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/src/shared/infrastructure/repositories/tube-repository.js
+++ b/api/src/shared/infrastructure/repositories/tube-repository.js
@@ -3,7 +3,7 @@ import { LearningContentResourceNotFound } from '../../domain/errors.js';
 import { Tube } from '../../domain/models/Tube.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { child, SCOPES } from '../utils/logger.js';
-import { LearningContentRepository } from './learning-content-repository.js';
+import { LearningContentDatasource } from './learning-content-datasource.js';
 
 const TABLE_NAME = 'learningcontent.tubes';
 const ACTIVE_STATUS = 'actif';
@@ -85,12 +85,12 @@ function toDomain(tubeDto, locale) {
   });
 }
 
-/** @type {LearningContentRepository} */
+/** @type {LearningContentDatasource} */
 let instance;
 
 function getInstance() {
   if (!instance) {
-    instance = new LearningContentRepository({ tableName: TABLE_NAME });
+    instance = new LearningContentDatasource({ tableName: TABLE_NAME });
   }
   return instance;
 }

--- a/api/tests/shared/integration/infrastructure/repositories/learning-content-datasource_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/learning-content-datasource_test.js
@@ -1,14 +1,14 @@
-import { LearningContentRepository } from '../../../../../src/shared/infrastructure/repositories/learning-content-repository.js';
+import { LearningContentDatasource } from '../../../../../src/shared/infrastructure/repositories/learning-content-datasource.js';
 import { catchErr, expect, knex, sinon } from '../../../../test-helper.js';
 
 const SCHEMA_NAME = 'learningcontent';
 const TABLE_NAME = 'entities';
 
-describe('Integration | Repository | learning-repository', function () {
+describe('Integration | Repository | learning-datasource', function () {
   /** @type {string} */
   let tableName;
 
-  /** @type {LearningContentRepository} */
+  /** @type {LearningContentDatasource} */
   let repository;
 
   /** @type {sinon.SinonStub} */
@@ -16,7 +16,7 @@ describe('Integration | Repository | learning-repository', function () {
 
   before(function () {
     tableName = `${SCHEMA_NAME}.${TABLE_NAME}`;
-    repository = new LearningContentRepository({ tableName });
+    repository = new LearningContentDatasource({ tableName });
   });
 
   beforeEach(async function () {

--- a/api/tests/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -1,6 +1,6 @@
-import * as learningContentRepository from '../../../../lib/infrastructure/repositories/learning-content-repository.js';
-import { NoSkillsInCampaignError, NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import { NoSkillsInCampaignError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import * as learningContentRepository from '../../../../../src/shared/infrastructure/repositories/learning-content-repository.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | learning-content', function () {
   let framework1Fr, framework1En, framework2Fr, framework2En;


### PR DESCRIPTION
## :pancakes: Problème

on veut plus rien dans lib

## :bacon: Proposition

on déplace le repository

## 🧃 Remarques

c'etait un peu compliqué ar il y avait déja un fichier avec le meme nom mais on a décidé de le renommer en datasource car c'etait une classe absctraite utilisée pour intérroger les objet du learning content

## :yum: Pour tester

ras
