### PR TITLE
[FEATURE] Créer les events liés aux flashcards - (PIX-16953) 

### DIFF
--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -1,0 +1,19 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEvent } from './PassageEvent.js';
+
+/**
+ * @class FlashcardsStartedEvent
+ *
+ * A FlashcardsStartedEvent is generated when a set of Modulix flashcards is started and saved in DB.
+ */
+class FlashcardsStartedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, elementId }) {
+    super({ id, type: 'FLASHCARDS_STARTED', occurredAt, createdAt, passageId, data: { elementId } });
+
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsStartedEvent');
+
+    this.elementId = elementId;
+  }
+}
+
+export { FlashcardsStartedEvent };

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -58,6 +58,30 @@ class FlashcardsCardAutoAssessedEvent extends PassageEvent {
 }
 
 /**
+ * @class FlashcardsRectoReviewedEvent
+ *
+ * A FlashcardsRectoReviewedEvent is generated when a card's question is reviewed and saved in DB.
+ */
+class FlashcardsRectoReviewedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
+    super({
+      id,
+      type: 'FLASHCARDS_RECTO_REVIEWED',
+      occurredAt,
+      createdAt,
+      passageId,
+      data: { elementId, cardId },
+    });
+
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsRectoReviewedEvent');
+    assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsRectoReviewedEvent');
+
+    this.elementId = elementId;
+    this.cardId = cardId;
+  }
+}
+
+/**
  * @class FlashcardsRetriedEvent
  *
  * A FlashcardsRetriedEvent is generated when a set of Modulix flashcards is retried and saved in DB.
@@ -72,9 +96,9 @@ class FlashcardsRetriedEvent extends PassageEvent {
   }
 }
 
-export { FlashcardsRetriedEvent, FlashcardsStartedEvent };
 export {
   FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
   FlashcardsRetriedEvent,
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -31,6 +31,32 @@ class FlashcardsVersoSeenEvent extends PassageEvent {
     this.cardId = cardId;
   }
 }
+
+/**
+ * @class FlashcardsCardAutoAssessedEvent
+ *
+ * A FlashcardsCardAutoAssessedEvent is generated when an auto-assessment is given and saved in DB.
+ */
+class FlashcardsCardAutoAssessedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId, autoAssessment }) {
+    super({
+      id,
+      type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+      occurredAt,
+      createdAt,
+      passageId,
+      data: { elementId, cardId, autoAssessment },
+    });
+
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsCardAutoAssessedEvent');
+    assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsCardAutoAssessedEvent');
+    assertNotNullOrUndefined(autoAssessment, 'The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
+    this.elementId = elementId;
+    this.cardId = cardId;
+    this.autoAssessment = autoAssessment;
+  }
+}
+
 /**
  * @class FlashcardsRetriedEvent
  *
@@ -48,6 +74,7 @@ class FlashcardsRetriedEvent extends PassageEvent {
 
 export { FlashcardsRetriedEvent, FlashcardsStartedEvent };
 export {
+  FlashcardsCardAutoAssessedEvent,
   FlashcardsRetriedEvent,
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -17,6 +17,21 @@ class FlashcardsStartedEvent extends PassageEvent {
 }
 
 /**
+ * @class FlashcardsVersoSeenEvent
+ *
+ * A FlashcardsVersoSeenEvent is generated when a card's answer is seen and saved in DB.
+ */
+class FlashcardsVersoSeenEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
+    super({ id, type: 'FLASHCARDS_VERSO_SEEN', occurredAt, createdAt, passageId, data: { elementId, cardId } });
+
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsVersoSeenEvent');
+    assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsVersoSeenEvent');
+    this.elementId = elementId;
+    this.cardId = cardId;
+  }
+}
+/**
  * @class FlashcardsRetriedEvent
  *
  * A FlashcardsRetriedEvent is generated when a set of Modulix flashcards is retried and saved in DB.
@@ -32,3 +47,8 @@ class FlashcardsRetriedEvent extends PassageEvent {
 }
 
 export { FlashcardsRetriedEvent, FlashcardsStartedEvent };
+export {
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
+};

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -16,4 +16,19 @@ class FlashcardsStartedEvent extends PassageEvent {
   }
 }
 
-export { FlashcardsStartedEvent };
+/**
+ * @class FlashcardsRetriedEvent
+ *
+ * A FlashcardsRetriedEvent is generated when a set of Modulix flashcards is retried and saved in DB.
+ */
+class FlashcardsRetriedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, elementId }) {
+    super({ id, type: 'FLASHCARDS_RETRIED', occurredAt, createdAt, passageId, data: { elementId } });
+
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsRetriedEvent');
+
+    this.elementId = elementId;
+  }
+}
+
+export { FlashcardsRetriedEvent, FlashcardsStartedEvent };

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -1,4 +1,7 @@
-import { FlashcardsStartedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import {
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -39,6 +42,52 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         // then
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The elementId is required for a FlashcardsStartedEvent');
+      });
+    });
+  });
+
+  describe('#FlashcardsRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('date');
+      const createdAt = Symbol('date');
+      const passageId = Symbol('passage');
+      const elementId = Symbol('elementId');
+
+      // when
+      const flashcardsRetriedEvent = new FlashcardsRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        elementId,
+      });
+
+      // then
+      expect(flashcardsRetriedEvent.id).to.equal(id);
+      expect(flashcardsRetriedEvent.type).to.equal('FLASHCARDS_RETRIED');
+      expect(flashcardsRetriedEvent.occurredAt).to.equal(occurredAt);
+      expect(flashcardsRetriedEvent.createdAt).to.equal(createdAt);
+      expect(flashcardsRetriedEvent.passageId).to.equal(passageId);
+      expect(flashcardsRetriedEvent.elementId).to.equal(elementId);
+      expect(flashcardsRetriedEvent.data).to.deep.equal({ elementId });
+    });
+
+    describe('when elementId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new FlashcardsRetriedEvent({ id, occurredAt, createdAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a FlashcardsRetriedEvent');
       });
     });
   });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -1,6 +1,7 @@
 import {
   FlashcardsRetriedEvent,
   FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -46,12 +47,73 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     });
   });
 
-  describe('#FlashcardsRetriedEvent', function () {
+  describe('#FlashcardsVersoSeenEvent', function () {
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('date');
-      const createdAt = Symbol('date');
+      const occurredAt = Symbol('occurredAt');
+      const createdAt = Symbol('createdAt');
+      const passageId = Symbol('passage');
+      const elementId = Symbol('elementId');
+      const cardId = Symbol('cardId');
+
+      // when
+      const flashcardsCardAnswerSeenEvent = new FlashcardsVersoSeenEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        elementId,
+        cardId,
+      });
+
+      // then
+      expect(flashcardsCardAnswerSeenEvent.id).to.equal(id);
+      expect(flashcardsCardAnswerSeenEvent.type).to.equal('FLASHCARDS_VERSO_SEEN');
+      expect(flashcardsCardAnswerSeenEvent.occurredAt).to.equal(occurredAt);
+      expect(flashcardsCardAnswerSeenEvent.createdAt).to.equal(createdAt);
+      expect(flashcardsCardAnswerSeenEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardAnswerSeenEvent.elementId).to.equal(elementId);
+      expect(flashcardsCardAnswerSeenEvent.data).to.deep.equal({ elementId, cardId });
+    });
+
+    describe('when elementId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a FlashcardsVersoSeenEvent');
+      });
+    });
+
+    describe('when cardId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        const elementId = Symbol('elementId');
+
+        // when
+        const error = catchErrSync(
+          () => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId, elementId }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId is required for a FlashcardsVersoSeenEvent');
+      });
+    });
+  });
       const passageId = Symbol('passage');
       const elementId = Symbol('elementId');
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -1,5 +1,6 @@
 import {
   FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
   FlashcardsRetriedEvent,
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
@@ -188,6 +189,80 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     });
   });
 
+  describe('#FlashcardsRectoReviewedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('occurredAt');
+      const createdAt = Symbol('createdAt');
+      const passageId = Symbol('passage');
+      const elementId = Symbol('elementId');
+      const cardId = Symbol('cardId');
+
+      // when
+      const flashcardsCardQuestionReviewedEvent = new FlashcardsRectoReviewedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        elementId,
+        cardId,
+      });
+
+      // then
+      expect(flashcardsCardQuestionReviewedEvent.id).to.equal(id);
+      expect(flashcardsCardQuestionReviewedEvent.type).to.equal('FLASHCARDS_RECTO_REVIEWED');
+      expect(flashcardsCardQuestionReviewedEvent.occurredAt).to.equal(occurredAt);
+      expect(flashcardsCardQuestionReviewedEvent.createdAt).to.equal(createdAt);
+      expect(flashcardsCardQuestionReviewedEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardQuestionReviewedEvent.elementId).to.equal(elementId);
+      expect(flashcardsCardQuestionReviewedEvent.data).to.deep.equal({ elementId, cardId });
+    });
+
+    describe('when elementId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a FlashcardsRectoReviewedEvent');
+      });
+    });
+
+    describe('when cardId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        const elementId = Symbol('elementId');
+
+        // when
+        const error = catchErrSync(
+          () => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId, elementId }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId is required for a FlashcardsRectoReviewedEvent');
+      });
+    });
+  });
+
+  describe('#FlashcardsRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('occurredAt');
+      const createdAt = Symbol('createdAt');
       const passageId = Symbol('passage');
       const elementId = Symbol('elementId');
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -1,4 +1,5 @@
 import {
+  FlashcardsCardAutoAssessedEvent,
   FlashcardsRetriedEvent,
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
@@ -114,6 +115,79 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       });
     });
   });
+
+  describe('#FlashcardsCardAutoAssessedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('occurredAt');
+      const createdAt = Symbol('createdAt');
+      const passageId = Symbol('passage');
+      const elementId = Symbol('elementId');
+      const cardId = Symbol('cardId');
+      const autoAssessment = Symbol('yes');
+
+      // when
+      const flashcardsCardAutoAssessedEvent = new FlashcardsCardAutoAssessedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        elementId,
+        cardId,
+        autoAssessment,
+      });
+
+      // then
+      expect(flashcardsCardAutoAssessedEvent.id).to.equal(id);
+      expect(flashcardsCardAutoAssessedEvent.type).to.equal('FLASHCARDS_CARD_AUTO_ASSESSED');
+      expect(flashcardsCardAutoAssessedEvent.occurredAt).to.equal(occurredAt);
+      expect(flashcardsCardAutoAssessedEvent.createdAt).to.equal(createdAt);
+      expect(flashcardsCardAutoAssessedEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardAutoAssessedEvent.elementId).to.equal(elementId);
+      expect(flashcardsCardAutoAssessedEvent.data).to.deep.equal({ elementId, cardId, autoAssessment });
+    });
+
+    describe('when elementId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(
+          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a FlashcardsCardAutoAssessedEvent');
+      });
+    });
+
+    describe('when cardId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+        const elementId = Symbol('elementId');
+
+        // when
+        const error = catchErrSync(
+          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId, elementId }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId is required for a FlashcardsCardAutoAssessedEvent');
+      });
+    });
+  });
+
       const passageId = Symbol('passage');
       const elementId = Symbol('elementId');
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -1,0 +1,45 @@
+import { FlashcardsStartedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-events', function () {
+  describe('#FlashcardsStartedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = Symbol('date');
+      const createdAt = Symbol('date');
+      const passageId = Symbol('passage');
+      const elementId = Symbol('elementId');
+
+      // when
+      const flashcardsStartedEvent = new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId, elementId });
+
+      // then
+      expect(flashcardsStartedEvent.id).to.equal(id);
+      expect(flashcardsStartedEvent.type).to.equal('FLASHCARDS_STARTED');
+      expect(flashcardsStartedEvent.occurredAt).to.equal(occurredAt);
+      expect(flashcardsStartedEvent.createdAt).to.equal(createdAt);
+      expect(flashcardsStartedEvent.passageId).to.equal(passageId);
+      expect(flashcardsStartedEvent.elementId).to.equal(elementId);
+      expect(flashcardsStartedEvent.data).to.deep.equal({ elementId });
+    });
+
+    describe('when elementId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = Symbol('date');
+        const createdAt = Symbol('date');
+        const passageId = Symbol('passage');
+
+        // when
+        const error = catchErrSync(() => new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a FlashcardsStartedEvent');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

On veut créer des events côté serveur pour enregistrer les événements des flashcards.

## :bacon: Proposition

On créée une classe par événement.

## :yum: Pour tester
Pas de func à faire, Tech only