### PR TITLE
[FEATURE] Utiliser le snapshot pour calculer l'obtention de RTs dans le cadre d'une campagne EXAM (PIX-17003)

### DIFF
--- a/api/src/evaluation/domain/usecases/handle-badge-acquisition.js
+++ b/api/src/evaluation/domain/usecases/handle-badge-acquisition.js
@@ -15,8 +15,9 @@ const handleBadgeAcquisition = async function ({
     if (_.isEmpty(associatedBadges)) {
       return;
     }
-    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdForCampaignParticipation({
       userId: assessment.userId,
+      campaignParticipationId,
     });
 
     const obtainedBadgesByUser = associatedBadges.filter((badge) => badge.shouldBeObtained(knowledgeElements));

--- a/api/tests/evaluation/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -1,5 +1,6 @@
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { SCOPES } from '../../../../../src/shared/domain/models/BadgeDetails.js';
@@ -78,6 +79,99 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
         source: KnowledgeElement.SourceType.DIRECT,
         competenceId: 'maCompetenceId',
         createdAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      await evaluationUsecases.handleBadgeAcquisition({ assessment });
+
+      // then
+      const allBadgeAcquisitionsDB = await knex('badge-acquisitions').select('*').orderBy('badgeId');
+      expect(allBadgeAcquisitionsDB.length).to.equal(1);
+      sinon.assert.match(allBadgeAcquisitionsDB[0], {
+        badgeId: badgeId1,
+        campaignParticipationId,
+        userId,
+      });
+    });
+  });
+  context('when campaign is of type EXAM', function () {
+    it('should compute badge acquisition based on knowledge-elements from user profile', async function () {
+      // given
+      const skillIds = ['acquisA', 'acquisB'];
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const badgeId1 = databaseBuilder.factory.buildBadge({
+        key: 'BADGE_1_KEY',
+        targetProfileId,
+      }).id;
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: SCOPES.CAMPAIGN_PARTICIPATION,
+        threshold: 20,
+        badgeId: badgeId1,
+      });
+      const badgeId2 = databaseBuilder.factory.buildBadge({
+        key: 'BADGE_2_KEY',
+        targetProfileId,
+      }).id;
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: SCOPES.CAMPAIGN_PARTICIPATION,
+        threshold: 100,
+        badgeId: badgeId2,
+      });
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM, targetProfileId }).id;
+      skillIds.map((skillId) =>
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId,
+          skillId,
+        }),
+      );
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+      }).id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+      skillIds.map((id, index) =>
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        }),
+      );
+      const ke1 = domainBuilder.buildKnowledgeElement({
+        skillId: skillIds[0],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        answerId: 123,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      const ke2 = domainBuilder.buildKnowledgeElement({
+        skillId: skillIds[1],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        answerId: 456,
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      const knowledgeElementsBefore = new KnowledgeElementCollection([ke1, ke2]);
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId,
+        snappedAt: new Date(),
+        campaignParticipationId,
+        snapshot: knowledgeElementsBefore.toSnapshot(),
       });
       await databaseBuilder.commit();
 

--- a/api/tests/evaluation/unit/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/handle-badge-acquisition_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
 
   beforeEach(function () {
     badgeForCalculationRepository = { findByCampaignParticipationId: sinon.stub() };
-    knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIdForCampaignParticipation: sinon.stub() };
     badgeAcquisitionRepository = { createOrUpdate: sinon.stub() };
     args = {
       badgeForCalculationRepository,
@@ -20,7 +20,7 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
     it('should not attempt to create any badge acquisition', async function () {
       // given
       badgeForCalculationRepository.findByCampaignParticipationId.rejects('I should not be called');
-      knowledgeElementRepository.findUniqByUserId.rejects('I should not be called');
+      knowledgeElementRepository.findUniqByUserIdForCampaignParticipation.rejects('I should not be called');
       const assessmentCertification = domainBuilder.buildAssessment.ofTypeCertification();
       const assessmentCompetenceEvaluation = domainBuilder.buildAssessment.ofTypeCompetenceEvaluation();
 
@@ -46,7 +46,7 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
       it('should not attempt to create any badge acquisition', async function () {
         // given
         badgeForCalculationRepository.findByCampaignParticipationId.withArgs({ campaignParticipationId }).resolves([]);
-        knowledgeElementRepository.findUniqByUserId.rejects('I should not be called');
+        knowledgeElementRepository.findUniqByUserIdForCampaignParticipation.rejects('I should not be called');
 
         // when
         await handleBadgeAcquisition(args);
@@ -70,8 +70,8 @@ describe('Unit | UseCase | handle-badge-acquisition', function () {
         badgeForCalculationRepository.findByCampaignParticipationId
           .withArgs({ campaignParticipationId })
           .resolves([badgeObtained1, badgeNotObtained2, badgeObtained3]);
-        knowledgeElementRepository.findUniqByUserId
-          .withArgs({ userId })
+        knowledgeElementRepository.findUniqByUserIdForCampaignParticipation
+          .withArgs({ userId, campaignParticipationId })
           .resolves([domainBuilder.buildKnowledgeElement()]);
 
         // when


### PR DESCRIPTION
## :pancakes: Problème

Le calcul de l'obtention de RTs prend le profil de l'utilisateur en entrée pour se faire. Or, en exam, il faut ignorer le profil et ne prendre que le snapshot.

## :bacon: Proposition
Ne prendre en compte que le snapshot lorsqu'on calcule l'obtention de RTs sur une campagne d'EXAM

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester
Obtenir des RTs via campagne EXAM
