### PR TITLE
[FEATURE] Modifier et rendre conditionnel le wording d'information sur le reset/retry en fin de parcours (PIX-16683)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -11,7 +11,7 @@ import { t } from 'ember-intl';
 
 export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   @service metrics;
-
+  @service intl;
   @tracked isResetModalVisible = false;
 
   retryQueryParams = { retry: true };
@@ -71,6 +71,15 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
       'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
       'pix-event-name': "Confirmation de la modale 'Remettre à zéro et tout retenter'",
     });
+  }
+
+  get retryOrResetExplanation() {
+    const { campaignParticipationResult } = this.args;
+
+    if (campaignParticipationResult.canReset && campaignParticipationResult.canRetry) {
+      return this.intl.t('pages.skill-review.reset.notification');
+    }
+    return this.intl.t('pages.skill-review.retry.notification');
   }
 
   <template>
@@ -133,7 +142,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
           {{/if}}
         </div>
         <PixNotificationAlert class="evaluation-results-hero-retry__message" @withIcon={{true}}>
-          {{t "pages.skill-review.reset.notifications"}}
+          {{this.retryOrResetExplanation}}
         </PixNotificationAlert>
       </div>
     </div>

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
@@ -27,7 +27,7 @@ module(
       // then
       assert.dom(screen.getByText(t('pages.skill-review.hero.retry.title'))).exists();
       assert.dom(screen.getByText(t('pages.skill-review.hero.retry.description'))).exists();
-      assert.dom(screen.getByText(t('pages.skill-review.reset.notifications'))).exists();
+      assert.dom(screen.getByText(t('pages.skill-review.retry.notification'))).exists();
 
       assert.dom(screen.queryByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).doesNotExist();
 
@@ -58,6 +58,7 @@ module(
         assert
           .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') }))
           .doesNotExist();
+        assert.dom(screen.getByText(t('pages.skill-review.retry.notification'))).exists();
       });
     });
 
@@ -82,6 +83,7 @@ module(
         // then
         assert.dom(screen.getByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).exists();
         assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') })).exists();
+        assert.dom(screen.getByText(t('pages.skill-review.reset.notification'))).exists();
       });
 
       test('it should open a modal when user wants to reset the assessment', async function (assert) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
@@ -14,7 +14,7 @@ module(
     test('displays a title, a description and a message', async function (assert) {
       // given
       this.set('campaign', {});
-      this.set('campaignParticipationResult', {});
+      this.set('campaignParticipationResult', { canRetry: true, canReset: false });
 
       // when
       const screen = await render(
@@ -67,7 +67,7 @@ module(
       hooks.beforeEach(async function () {
         // given
         this.set('campaign', { code: 'CODECAMPAIGN', targetProfileName: 'targetProfileName' });
-        this.set('campaignParticipationResult', { canRetry: false, canReset: true });
+        this.set('campaignParticipationResult', { canRetry: true, canReset: true });
 
         // when
         screen = await render(
@@ -80,9 +80,7 @@ module(
 
       test('it should display a reset button', async function (assert) {
         // then
-        assert
-          .dom(screen.queryByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') }))
-          .doesNotExist();
+        assert.dom(screen.getByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).exists();
         assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') })).exists();
       });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1912,11 +1912,12 @@
           "text": "You are about to reset and restart your customised test <strong>{targetProfileName}</strong>, in order to try to improve your results. At the end of this customised test, you can submit your results.",
           "warning-text": "Your pix score, levels and eligibility for certification obtained during this customised test will be deleted."
         },
-        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer."
+        "notification": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer."
       },
       "retry": {
         "button": "Retake my customised test",
-        "message": "{organizationName} encourages you to retake your test to measure your progress."
+        "message": "{organizationName} encourages you to retake your test to measure your progress.",
+        "notification": "Retake the failed questions to improve your result and continue to progress. You will need to send in your results again so that they can be counted by the organiser. The organiser will continue to have access to your previously submitted results."
       },
       "send-results": "Don't forget to submit your results.",
       "send-status": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1994,11 +1994,12 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notifications": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo."
+        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo."
       },
       "retry": {
         "button": "Repetir el test",
-        "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando."
+        "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
+        "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1913,11 +1913,12 @@
           "text": "Vous êtes sur le point de remettre à zéro votre parcours <strong>{targetProfileName}</strong>, afin de tenter d’améliorer votre niveau. A la fin du parcours, vous pourrez à nouveau envoyer vos résultats.",
           "warning-text": "Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés."
         },
-        "notifications": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés."
+        "notification": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "retry": {
         "button": "Repasser mon parcours",
-        "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser."
+        "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser.",
+        "notification": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. Vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilités par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1995,11 +1995,12 @@
           "text": "Je staat op het punt om je <strong>{targetProfileName}</strong> cursus te resetten in een poging om je niveau te verbeteren. Aan het einde van de cursus kun je je resultaten weer insturen.",
           "warning-text": "Je Pix, niveaus en certificeerbaarheid verkregen tijdens deze cursus zullen worden verwijderd."
         },
-        "notifications": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen."
+        "notification": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen."
       },
       "retry": {
         "button": "Mijn reis naspelen",
-        "message": "{organizationName} nodigt je uit om deze test opnieuw te doen om je resultaat te verbeteren en vooruitgang te blijven boeken."
+        "message": "{organizationName} nodigt je uit om deze test opnieuw te doen om je resultaat te verbeteren en vooruitgang te blijven boeken.",
+        "notification": "Herhaal de vragen waarvoor je gezakt bent om je resultaat te verbeteren en verder te komen. Je moet je resultaten opnieuw insturen zodat ze kunnen worden geteld door de organisator. De organisator blijft toegang houden tot je eerder ingestuurde resultaten."
       },
       "send-results": "Vergeet niet je resultaten naar de cursusorganisator te sturen.",
       "send-status": {


### PR DESCRIPTION
## :pancakes: Problème
Le wording dans le bloc info n’est pas adapté à l’affichage du bouton “Repasser mon parcours” seul. 


## :bacon: Proposition
Il faut bien garder ce wording quand il y a “Repasser mon parcours” + la RAZ mais changer le wording lorsque “Repasser mon parcours” est seul. 

## 🧃 Remarques
On a remit les tests "cohérent" dans le premier commit, car on ne peut pas avoir un cas ou le reset est a true avec un retry a false. (Vu avec @Faraopix)
Egalement, on ajoute une condition pour le wording avec le "canRetry" inclus, mais dans tous les cas, l'affichage de ce composant RETRY/RESET est déjà conditionné par le canRetry a TRUE. Mais bon, un double check n'est pas de trop j'imagine

## :yum: Pour tester

- Creer une 1ère campagne avec un profil cible SANS reset de compétences possible ( areKnowledgeElementsResettable )
- Creer une 2nde campagne avec cette fois un PC AVEC reset.
- Les deux doivent être a envoi multiple.
- Participer a la 1ere campagne -> En fin de parcours le texte doit seulement mentionner la mention repasser
- Participer a la 2nde campagne -> En fin de parcours le texte doit maintenant mentionner la remise a zéro
- 🐈‍⬛ 

