### PR TITLE
[BUGFIX] Pix Junior - Suppression du scroll excessif des épreuves avec 2 colonnes (PIX-16760)

### DIFF
--- a/junior/app/styles/components/challenge/challenge-content.scss
+++ b/junior/app/styles/components/challenge/challenge-content.scss
@@ -16,7 +16,7 @@
     grid-template-areas:
     "left right"
     "left actions";
-    grid-template-rows: 0fr 1fr;
+    grid-template-rows: min-content min-content;
     grid-template-columns: 1fr 1fr;
 
     &--40-60 {


### PR DESCRIPTION
## :pancakes: Problème

Certaines épreuves en affichage double présentent un scroll excessif.
![image](https://github.com/user-attachments/assets/5c3f7a40-1685-4f54-a222-982a21c99e03)

## :bacon: Proposition

Adapter l'affichage pour ne plus avoir de scroll excessif, mais pas non plus de dépassement du cadre bleu.

## :yum: Pour tester

Afficher les épreuves suivantes : 
https://junior-pr11670.review.pix.fr/challenges/challenge23zFAD1yEwFqBh/preview
https://junior-pr11670.review.pix.fr/challenges/challenge255eGkd4X58PpF/preview
