### PR TITLE
[FEATURE] Initialiser la génération de l'attestation V3 avec PDFKit (PIX-17007).

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -113,6 +113,7 @@
         "nock": "^13.2.7",
         "nodemon": "^3.0.0",
         "npm-run-all2": "^7.0.0",
+        "pdfjs-dist": "^4.10.38",
         "prettier": "^3.0.0",
         "sinon": "^19.0.0",
         "sinon-chai": "^4.0.0",
@@ -2620,6 +2621,199 @@
       "license": "MIT",
       "dependencies": {
         "make-plural": "^7.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.68.tgz",
+      "integrity": "sha512-LQESrePLEBLvhuFkXx9jjBXRC2ClYsO5mqQ1m/puth5z9SOuM3N/B3vDuqnC3RJFktDktyK9khGvo7dTkqO9uQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.68",
+        "@napi-rs/canvas-darwin-arm64": "0.1.68",
+        "@napi-rs/canvas-darwin-x64": "0.1.68",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.68",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.68",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.68",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.68",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.68",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.68",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.68"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.68.tgz",
+      "integrity": "sha512-h1KcSR4LKLfRfzeBH65xMxbWOGa1OtMFQbCMVlxPCkN1Zr+2gK+70pXO5ktojIYcUrP6KDcOwoc8clho5ccM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.68.tgz",
+      "integrity": "sha512-/VURlrAD4gDoxW1GT/b0nP3fRz/fhxmHI/xznTq2FTwkQLPOlLkDLCvTmQ7v6LtGKdc2Ed6rvYpRan+JXThInQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.68.tgz",
+      "integrity": "sha512-tEpvGR6vCLTo1Tx9wmDnoOKROpw57wiCWwCpDOuVlj/7rqEJOUYr9ixW4aRJgmeGBrZHgevI0EURys2ER6whmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.68.tgz",
+      "integrity": "sha512-U9xbJsumPOiAYeAFZMlHf62b9dGs2HJ6Q5xt7xTB0uEyPeurwhgYBWGgabdsEidyj38YuzI/c3LGBbSQB3vagw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.68.tgz",
+      "integrity": "sha512-KFkn8wEm3mPnWD4l8+OUUkxylSJuN5q9PnJRZJgv15RtCA1bgxIwTkBhI/+xuyVMcHqON9sXq7cDkEJtHm35dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.68.tgz",
+      "integrity": "sha512-IQzts91rCdOALXBWQxLZRCEDrfFTGDtNRJMNu+2SKZ1uT8cmPQkPwVk5rycvFpvgAcmiFiOSCp1aRrlfU8KPpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.68.tgz",
+      "integrity": "sha512-e9AS5UttoIKqXSmBzKZdd3NErSVyOEYzJfNOCGtafGk1//gibTwQXGlSXmAKuErqMp09pyk9aqQRSYzm1AQfBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.68.tgz",
+      "integrity": "sha512-Pa/I36VE3j57I3Obhrr+J48KGFfkZk2cJN/2NmW/vCgmoF7kCP6aTVq5n+cGdGWLd/cN9CJ9JvNwEoMRDghu0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.68.tgz",
+      "integrity": "sha512-9c6rkc5195wNxuUHJdf4/mmnq433OQey9TNvQ9LspJazvHbfSkTij8wtKjASVQsJyPDva4fkWOeV/OQ7cLw0GQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.68.tgz",
+      "integrity": "sha512-Fc5Dez23u0FoSATurT6/w1oMytiRnKWEinHivdMvXpge6nG4YvhrASrtqMk8dGJMVQpHr8QJYF45rOrx2YU2Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -10324,6 +10518,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/pdfkit": {
       "version": "0.16.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -63,6 +63,7 @@
         "openid-client": "^6.3.3",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
+        "pdfkit": "^0.16.0",
         "pg": "^8.7.3",
         "pg-boss": "^9.0.0",
         "pg-connection-string": "^2.5.0",
@@ -3602,6 +3603,15 @@
       "integrity": "sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==",
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
@@ -4329,6 +4339,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -4975,6 +4994,12 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/current-module-paths": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.2.tgz",
@@ -5328,6 +5353,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -6832,6 +6863,23 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -8055,6 +8103,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8635,6 +8689,25 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -10252,6 +10325,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/pdfkit": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.16.0.tgz",
+      "integrity": "sha512-oXMxkIqXH4uTAtohWdYA41i/f6i2ReB78uhgizN8H4hJEpgR3/Xjy3iu2InNAuwCIabN3PVs8P1D6G4+W2NH0A==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/peek-readable": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
@@ -10542,6 +10628,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/postcss": {
       "version": "8.4.49",
@@ -11297,6 +11388,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -12494,6 +12591,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12676,6 +12779,32 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/api/package.json
+++ b/api/package.json
@@ -69,6 +69,7 @@
     "openid-client": "^6.3.3",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
+    "pdfkit": "^0.16.0",
     "pg": "^8.7.3",
     "pg-boss": "^9.0.0",
     "pg-connection-string": "^2.5.0",

--- a/api/package.json
+++ b/api/package.json
@@ -119,6 +119,7 @@
     "nock": "^13.2.7",
     "nodemon": "^3.0.0",
     "npm-run-all2": "^7.0.0",
+    "pdfjs-dist": "^4.10.38",
     "prettier": "^3.0.0",
     "sinon": "^19.0.0",
     "sinon-chai": "^4.0.0",

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -1,0 +1,5 @@
+const generateV3AttestationTemplate = (pdf, data) => {
+  pdf.text(`${data.firstName} ${data.lastName}`);
+};
+
+export default generateV3AttestationTemplate;

--- a/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
@@ -1,0 +1,30 @@
+import PDFDocument from 'pdfkit';
+
+import generateV3AttestationTemplate from './templates/v3-attestation.js';
+
+const generate = ({ certificates, i18n }) => {
+  const doc = new PDFDocument({
+    size: 'A4',
+    layout: 'landscape',
+  });
+
+  doc.info = {
+    Title: i18n.__('certification-confirmation.file-metadata.title'),
+    Author: 'Pix',
+    Keywords: 'v3',
+    CreationDate: new Date(),
+  };
+
+  certificates.forEach((certificate, index) => {
+    if (index > 0) {
+      doc.addPage();
+    }
+    generateV3AttestationTemplate(doc, certificate);
+  });
+
+  doc.end();
+
+  return doc;
+};
+
+export { generate };

--- a/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
@@ -161,6 +161,13 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
 
             // then
             expect(response.statusCode).to.equal(200);
+            expect(response.headers['content-type']).to.equal('application/pdf');
+
+            const filename = `filename=attestation-pix-20181201.pdf`;
+            expect(response.headers['content-disposition']).to.include(filename);
+
+            const fileFormat = response.result.substring(1, 4);
+            expect(fileFormat).to.equal('PDF');
           });
         });
       });

--- a/api/tests/certification/results/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/certification/results/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -33,6 +33,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificate = domainBuilder.buildCertificationAttestation({
       id: 1,
+      version: SESSIONS_VERSIONS.V2,
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
@@ -72,6 +73,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificate = domainBuilder.buildCertificationAttestation({
       id: 1,
+      version: SESSIONS_VERSIONS.V2,
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
@@ -108,6 +110,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificate = domainBuilder.buildCertificationAttestation({
       id: 1,
+      version: SESSIONS_VERSIONS.V2,
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
@@ -149,6 +152,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const certificateWithComplementaryCertificationsAndWithoutProfessionalizingMessage =
       domainBuilder.buildCertificationAttestation({
         id: 1,
+        version: SESSIONS_VERSIONS.V2,
         firstName: 'Jean',
         lastName: 'Bon',
         resultCompetenceTree,
@@ -163,11 +167,11 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
           },
         ],
         deliveredAt: deliveredBeforeStartDate,
-        version: SESSIONS_VERSIONS.V2,
       });
     const certificateWithComplementaryCertificationsAndWithProfessionalizingMessage =
       domainBuilder.buildCertificationAttestation({
         id: 2,
+        version: SESSIONS_VERSIONS.V2,
         firstName: 'Harry',
         lastName: 'Covert',
         resultCompetenceTree,
@@ -182,7 +186,6 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
           },
         ],
         deliveredAt: deliveredAfterStartDate,
-        version: SESSIONS_VERSIONS.V2,
       });
     const certificateWithoutComplementaryCertificationsAndWithoutProfessionalizingMessage =
       domainBuilder.buildCertificationAttestation({
@@ -200,13 +203,13 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       domainBuilder.buildCertificationAttestation({
         ...certificateWithComplementaryCertificationsAndWithoutProfessionalizingMessage,
         id: 2,
+        version: SESSIONS_VERSIONS.V2,
         firstName: 'Quentin',
         lastName: 'Bug Arrive En Prod',
         cleaCertificationImagePath: null,
         pixPlusDroitCertificationImagePath: null,
         certifiedBadges: [],
         deliveredAt: deliveredAfterStartDate,
-        version: SESSIONS_VERSIONS.V2,
       });
     const referencePdfPath = 'certification-attestation-pdf_several_pages.pdf';
     const i18n = getI18n();
@@ -240,6 +243,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificate = domainBuilder.buildCertificationAttestation({
       id: 1,
+      version: SESSIONS_VERSIONS.V2,
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
@@ -268,6 +272,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificate = domainBuilder.buildCertificationAttestation({
       id: 1,
+      version: SESSIONS_VERSIONS.V2,
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
@@ -303,11 +308,11 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       const certificateWithoutProfessionalizingMessage = domainBuilder.buildCertificationAttestation({
         id: 1,
         firstName: 'Alain',
+        version: SESSIONS_VERSIONS.V3,
         lastName: 'Cendy',
         resultCompetenceTree,
         certifiedBadges: [],
         deliveredAt: deliveredAfterStartDate,
-        version: SESSIONS_VERSIONS.V3,
       });
       const referencePdfPath = 'certification-attestation-pdf-v3-without-professionalizing-message_test.pdf';
       const i18n = getI18n();

--- a/api/tests/certification/results/integration/infrastructure/utils/pdf/v3-certification-attestation-pdf_test.js
+++ b/api/tests/certification/results/integration/infrastructure/utils/pdf/v3-certification-attestation-pdf_test.js
@@ -1,0 +1,84 @@
+import { getDocument } from 'pdfjs-dist';
+
+import { generate } from '../../../../../../../src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js';
+import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestation Pdf', function () {
+  let i18n;
+
+  beforeEach(function () {
+    i18n = getI18n();
+  });
+
+  it('should generate a PDF buffer', async function () {
+    // when
+    const pdfStream = generate({
+      certificates: [Symbol('attestation')],
+      i18n,
+    });
+
+    const pdfBuffer = await _convertStreamToBuffer(pdfStream);
+
+    // then
+    expect(pdfBuffer.toString().substring(1, 4)).to.equal('PDF');
+    expect(pdfBuffer.toString()).to.contain('/Type /Pages\n/Count 1');
+  });
+
+  it('should generate a page for each certificate', async function () {
+    // when
+    const pdfStream = await generate({
+      certificates: [Symbol('attestation'), Symbol('attestation'), Symbol('attestation')],
+      i18n,
+    });
+
+    const pdfBuffer = await _convertStreamToBuffer(pdfStream);
+
+    // then
+    expect(pdfBuffer.toString()).to.contain('/Type /Pages\n/Count 3');
+  });
+
+  it('should display data content', async function () {
+    // given
+    const certificates = [
+      { firstName: 'Jane', lastName: 'Doe' },
+      { firstName: 'John', lastName: 'Doe' },
+    ];
+
+    // when
+    const pdfStream = await generate({ certificates, i18n });
+
+    const pdfBuffer = await _convertStreamToBuffer(pdfStream);
+
+    // then
+    const parsedPdf = await getDocument({ data: new Uint8Array(pdfBuffer) }).promise;
+
+    const pagesContent = [];
+    for (let i = 1; i <= parsedPdf.numPages; i++) {
+      const page = await parsedPdf.getPage(i);
+      const content = await page.getTextContent();
+      pagesContent.push(content.items.map((item) => item.str).join(' '));
+    }
+
+    expect(pagesContent.length).to.equal(2);
+    expect(pagesContent[0]).to.eql(`${certificates[0].firstName} ${certificates[0].lastName}`);
+    expect(pagesContent[1]).to.eql(`${certificates[1].firstName} ${certificates[1].lastName}`);
+  });
+});
+
+function _convertStreamToBuffer(streamData) {
+  return new Promise(function (resolve) {
+    const chunks = [];
+
+    streamData.on('readable', () => {
+      let chunk;
+      while (null !== (chunk = streamData.read())) {
+        chunks.push(chunk);
+      }
+    });
+
+    streamData.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+  });
+}

--- a/api/tests/certification/results/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificationAttestation_test.js
@@ -1,3 +1,4 @@
+import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertificationAttestation', function () {
@@ -5,7 +6,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should set the resultCompetenceTree on CertificationAttestation model', function () {
       // given
       const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({ id: 'someId' });
-      const certificationAttestation = domainBuilder.buildCertificationAttestation();
+      const certificationAttestation = domainBuilder.buildCertificationAttestation({ version: SESSIONS_VERSIONS.V2 });
 
       // when
       certificationAttestation.setResultCompetenceTree(resultCompetenceTree);
@@ -19,6 +20,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return true if certified badge for attestation is not empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
+        version: SESSIONS_VERSIONS.V2,
         certifiedBadges: [{ stickerUrl: 'https://images.pix.fr/stickers/test.pdf', message: null }],
       });
 
@@ -33,6 +35,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return false if certified badge images for attestation is empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
+        version: SESSIONS_VERSIONS.V2,
         certifiedBadges: [],
       });
 

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
@@ -1,0 +1,29 @@
+import { V3CertificationAttestation } from '../../../../src/certification/results/domain/models/V3CertificationAttestation.js';
+
+const buildV3CertificationAttestation = async function ({
+  id = 1,
+  firstName = 'Jean',
+  lastName = 'Bon',
+  birthdate = '1992-06-12',
+  birthplace = 'Paris',
+  certificationCenter = 'L’université du Pix',
+  deliveredAt = new Date('2025-10-30T01:02:03Z'),
+  pixScore = 123,
+  maxReachableLevelOnCertificationDate = 5,
+  verificationCode = 'P-SOMECODE',
+} = {}) {
+  return new V3CertificationAttestation({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    birthplace,
+    certificationCenter,
+    deliveredAt,
+    pixScore,
+    maxReachableLevelOnCertificationDate,
+    verificationCode,
+  });
+};
+
+export { buildV3CertificationAttestation };

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -173,6 +173,9 @@
   },
   "certification-confirmation": {
     "absolute-max-level-indication": "When the 8 levels of the Pix framework will be available, that maximum number will be of 1024 pix.",
+    "file-metadata": {
+      "title": "Pix certification confirmation"
+    },
     "file-name": "pix-confirmation-{deliveredAt}.pdf",
     "from-birthplace": " in { birthplace }",
     "max-level": "(levels on { maxReachableLevelOnCertificationDate })",

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -185,6 +185,9 @@
   "certification-confirmation": {
     "absolute-max-level-indication": "Cuando estén disponibles los 8 niveles del repositorio de píxeles, este número máximo será de 1024 píxeles.",
     "file-name": "attestation-pix-{deliveredAt}.pdf",
+    "file-metadata": {
+      "title": "Pix certificacion confirmación"
+    },
     "from-birthplace": "a { birthplace }",
     "max-level": "(niveles en { maxReachableLevelOnCertificationDate })",
     "max-reachable-level-indication": "* En la fecha en que se obtuvo esta certificación, el número máximo de píxeles alcanzables era { maxReachableScore }, correspondiente al nivel { maxReachableLevelOnCertificationDate }."

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -184,6 +184,9 @@
   },
   "certification-confirmation": {
     "absolute-max-level-indication": "Lorsque les 8 niveaux du référentiel Pix seront disponibles, ce nombre maximum sera de 1024 pix.",
+    "file-metadata": {
+      "title": "Attestation(s) de certification Pix"
+    },
     "file-name": "attestation-pix-{deliveredAt}.pdf",
     "from-birthplace": " à { birthplace }",
     "max-level": "(niveaux sur { maxReachableLevelOnCertificationDate })",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -185,6 +185,9 @@
   "certification-confirmation": {
     "absolute-max-level-indication": "Als de 8 niveaus van de Pix-opslagplaats beschikbaar zijn, zal dit maximumaantal 1024 pixels zijn.",
     "file-name": "attest-pix-{geleverdbij}.pdf",
+    "file-metadata": {
+      "title": "Pix certification attest"
+    },
     "from-birthplace": "naar { geboorteplaats }",
     "max-level": "(niveaus op { maxReachableLevelOnCertificationDate })",
     "max-reachable-level-indication": "* Op de datum waarop deze certificering werd behaald, was het maximaal haalbare aantal pix { maxReachableScore }, wat overeenkomt met het niveau { maxReachableLevelOnCertificationDate }."


### PR DESCRIPTION
## :pancakes: Problème

Pour la l'attestation de certification V3, nous avons besoin de générer un nouveau PDF.

Malheureusement, le package `pdf-lib` que nous utilisons n'est plus mise à jour du 2021, elle n'est donc plus un choix viable.

## :bacon: Proposition

Utiliser la lib `pdfkit` (https://github.com/foliojs/pdfkit) pour la génération des attestations.

## 🧂 Remarques

Nous générons un Stream plutôt qu'un Buffer pour de meilleures performances ([en savoir plus](https://grafikart.fr/tutoriels/nodejs-streams-2084)).

## :yum: Pour tester

- Créer une session et inscrire un candidat
- Passer le test de certif
- Finaliser la session et publier
- Télécharger l'attestation de certification avec le FT `isV3CertificationAttestationEnabled` à false
- Vérifier que l'attestation est sous l'ancien format
- Télécharger l'attestation de certification avec le FT `isV3CertificationAttestationEnabled` à true
- Vérifier que l'attestation est au nouveau format
