### PR TITLE
[BUGFIX] Corriger un test flaky sur Pix App (PIX-16872)

### DIFF
--- a/mon-pix/app/services/storage.js
+++ b/mon-pix/app/services/storage.js
@@ -10,4 +10,8 @@ export default class Storage extends Service {
   getLogin() {
     return sessionStorage.getItem(SESSIONSTORAGE_LOGIN);
   }
+
+  clear() {
+    return sessionStorage.clear();
+  }
 }

--- a/mon-pix/tests/integration/components/authentication/login-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/login-form-test.gjs
@@ -24,6 +24,7 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
   let routerService;
   let sessionService;
   let urlService;
+  let storageService;
 
   hooks.beforeEach(async function () {
     storeService = this.owner.lookup('service:store');
@@ -32,6 +33,10 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
     urlService = this.owner.lookup('service:url');
 
     screen = await render(<template><LoginForm /></template>);
+  });
+  hooks.afterEach(async function () {
+    storageService = this.owner.lookup('service:storage');
+    storageService.clear();
   });
 
   test('it displays all elements of component successfully', async function (assert) {

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -121,7 +121,7 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
     });
 
     module('when email value is missing', function () {
-      test('it displays an error message on email', async function (assert) {
+      test('it displays an error message on email and does not execute reset password request', async function (assert) {
         // given
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
@@ -135,30 +135,6 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
         // then
         assert.dom(screen.queryByText(t(I18N_KEYS.emailError))).exists();
         assert.true(window.fetch.notCalled);
-      });
-    });
-
-    // TODO: This test module will need to be removed when the API doesn't leak anymore that an account doesn't exist with a "404 Not Found".
-    module('when there is no corresponding user account', function () {
-      test('it displays a "password reset demand received" info (without any error message to avoid email enumeration)', async function (assert) {
-        // given
-        requestManagerService.request.rejects({ status: 404 });
-
-        const email = 'someone@example.net';
-        const screen = await render(<template><PasswordResetDemandForm /></template>);
-
-        // when
-        await fillByLabel(t(I18N_KEYS.emailInput), email);
-        await click(
-          screen.getByRole('button', {
-            name: t(I18N_KEYS.resetDemandButton),
-          }),
-        );
-
-        // then
-        assert.dom(screen.queryByRole('alert')).doesNotExist();
-
-        assert.dom(screen.queryByRole('heading', { name: t(I18N_KEYS.demandReceivedInfo) })).exists();
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Le test Integration | Component | Authentication | PasswordResetDemand | password-reset-demand-form
when user submits the password reset demand
when email value is missing

## :bacon: Proposition

Vider le champ "email" avant l'exécution du test

## 🧃 Remarques

ras
## :yum: Pour tester

Lancer plusieurs fois les tests d'intégration du composant PasswordResetDemand
Vérifier que la ci passe
