### PR TITLE
[BUGFIX] Corriger l'affichage de la certificabilité (PIX-17021)

### DIFF
--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -337,8 +337,8 @@ export default class List extends Component {
                 <:cell>
                   <div class="organization-participant__align-element organization-participant__align-element--column">
                     <CertificabilityCell
-                      @certifiableAt={{@participant.certifiableAt}}
-                      @isCertifiable={{@participant.isCertifiable}}
+                      @certifiableAt={{participant.certifiableAt}}
+                      @isCertifiable={{participant.isCertifiable}}
                       @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
                     />
                   </div>


### PR DESCRIPTION
## :pancakes: Problème

Une petite erreru c'est glissé lors du passage en PixTable dans la liste des prescrit d'une organisation classic ( isManaginStudents = false)

## :bacon: Proposition

enlever ces deux @ de trop. et le tour est joué

## 🧃 Remarques

RAS

## :yum: Pour tester

CI au vert, on voit bien non communiqué dans la liste sur l'orga Pro Classic