### PR TITLE
[FEATURE] Pix Junior - Adaptation du style du champ de saisie du code (PIX-16762)

### DIFF
--- a/junior/app/styles/pages/organization-code.scss
+++ b/junior/app/styles/pages/organization-code.scss
@@ -39,6 +39,11 @@
     padding-top: var(--pix-spacing-4x);
   }
 
+  &__pix-code {
+    border: solid 1px var(--pix-neutral-100);
+    border-radius: var(--pix-spacing-2x);
+  }
+
   &__rotated-bubble {
     align-self: flex-end;
     width: fit-content;
@@ -98,14 +103,5 @@
       height: 112px;
     }
   }
-
 }
 
-.pix-input-code input.pix-input-code__input.school-code__input {
-  width: 55px;
-  height: 55px;
-  padding: 8px;
-  font-weight: bold;
-  font-size: 1.250rem;
-  border-color: var(--pix-primary-500);
-}

--- a/junior/app/templates/organization-code.hbs
+++ b/junior/app/templates/organization-code.hbs
@@ -13,6 +13,7 @@
       @value={{this.schoolCode}}
       aria-label={{t "pages.home.code-description"}}
       {{on "input" this.handleCode}}
+      class="school-code__pix-code"
     >
       <:label>{{t "pages.home.code-label"}}</:label>
     </PixCode>


### PR DESCRIPTION
## :pancakes: Problème

Le champ de saisie du code dans la page d'accueil de Pix Junior n'a pas le design souhaité.

## :bacon: Proposition

Modifier la couleur et la largeur de l'arrondi de la bordure du champ.

## :yum: Pour tester

Accéder à l'écran de saisie de code école de Pix Junior.
Le champ de saisie de code est gris et l'arrondi est plus important que sur le design system.