### PR TITLE
[FEATURE] Autoriser de repasser une campagne de type EXAM avec un score de  100% (PIX-17029)

### DIFF
--- a/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
@@ -67,14 +67,12 @@ class AssessmentResult {
     this.reachedStage = reachedStage;
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt, this.isShared, campaignType);
     this.isDisabled = this._computeIsDisabled(isCampaignArchived, isCampaignDeleted, participationResults.isDeleted);
-    this.canRetry = this._computeCanRetry(
+    this.canRetry = this.#computeCanRetry({
       isCampaignMultipleSendings,
       sharedAt,
       isOrganizationLearnerActive,
-      this.masteryRate,
-      this.isDisabled,
-      this.isShared,
-    );
+      campaignType,
+    });
     this.canReset = this._computeCanReset({
       isTargetProfileResetAllowed,
       isCampaignMultipleSendings,
@@ -126,21 +124,14 @@ class AssessmentResult {
     return isImprovementPossible && !isShared;
   }
 
-  _computeCanRetry(
-    isCampaignMultipleSendings,
-    sharedAt,
-    isOrganizationLearnerActive,
-    masteryRate,
-    isDisabled,
-    isShared,
-  ) {
+  #computeCanRetry({ isCampaignMultipleSendings, sharedAt, isOrganizationLearnerActive, campaignType }) {
     return (
-      isShared &&
-      isCampaignMultipleSendings &&
-      this._timeBeforeRetryingPassed(sharedAt) &&
-      masteryRate < MAX_MASTERY_RATE &&
       isOrganizationLearnerActive &&
-      !isDisabled
+      !this.isDisabled &&
+      isCampaignMultipleSendings &&
+      this.isShared &&
+      this._timeBeforeRetryingPassed(sharedAt) &&
+      (this.masteryRate < MAX_MASTERY_RATE || campaignType === CampaignTypes.EXAM)
     );
   }
 

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -621,7 +621,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     );
 
     context('when the mastery rate equals to 1', function () {
-      it('returns false', function () {
+      it('returns false on campaign of type ASSESSMENT', function () {
         const isCampaignMultipleSendings = true;
         const isOrganizationLearnerActive = true;
         const isCampaignArchived = false;
@@ -639,13 +639,40 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           competences: [],
           stages: [],
           badgeResultsDTO: [],
-
+          campaignType: CampaignTypes.ASSESSMENT,
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
           isCampaignArchived,
         });
 
         expect(assessmentResult.canRetry).to.be.false;
+      });
+
+      it('returns true on campaign of type EXAM', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '1',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          status: CampaignParticipationStatuses.SHARED,
+          isDeleted: false,
+        };
+
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          campaignType: CampaignTypes.EXAM,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canRetry).to.be.true;
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Pour repasser son parcours, il faut avoir un score inférieur à 100%, Or dans le type EXAM ce n'est pas ce que nous voulons

## :bacon: Proposition

Ajouter la condition qui permet de repasser son parcours dans le cas d'un type EXAM peu importe le score obtenu, tout en respectant les autres règles.

## 🧃 Remarques

Un deuxième canRetry existe dans la code base mais ne prend pas en compte cette restriction. il n'est pas utile de le modifier. le deuxième est sur de la collecte de profile. donc en s'en fiche (pour rester poli)

## :yum: Pour tester

Faire une campagne de Type EXAM a 100% et vérifier que l'on peut repasser son parcours