### PR TITLE
[TECH] inclus les banner dans le layout de AppLayout (PIX-17484)

### DIFF
--- a/orga/app/components/banner/communication.gjs
+++ b/orga/app/components/banner/communication.gjs
@@ -19,7 +19,7 @@ function bannerContent() {
 
 <template>
   {{#if (isEnabled)}}
-    <PixBannerAlert @type={{(bannerType)}} class="sticker-banner">
+    <PixBannerAlert @type={{(bannerType)}}>
       {{textWithMultipleLang (bannerContent)}}
     </PixBannerAlert>
   {{/if}}

--- a/orga/app/controllers/application.js
+++ b/orga/app/controllers/application.js
@@ -2,9 +2,12 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-export default class AuthenticatedController extends Controller {
-  @service currentUser;
-  @service store;
+export default class ApplicationController extends Controller {
+  @service router;
+
+  get isAuthenticatedRoute() {
+    return this.router.currentRouteName.startsWith('authenticated.');
+  }
 
   @action
   onChangeOrganization() {

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -1,6 +1,10 @@
-.sticker-banner {
-  position: sticky;
-  top: 0;
-  z-index: 200;
+.unauthenticated-page {
+  & > .pix-app-layout__main, .pix-app-layout__footer, .pix-app-layout__navigation {
+    padding: 0;
+  }
+
+  & > .pix-app-layout__main {
+    max-width: 100%;
+  }
 }
 

--- a/orga/app/templates/application.gjs
+++ b/orga/app/templates/application.gjs
@@ -1,16 +1,40 @@
+import NotificationContainer from '@1024pix/ember-cli-notifications/components/notification-container';
+import PixAppLayout from '@1024pix/pix-ui/components/pix-app-layout';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Communication from 'pix-orga/components/banner/communication';
 import InformationBanners from 'pix-orga/components/banner/information-banners';
+import Footer from 'pix-orga/components/layout/footer';
+import Sidebar from 'pix-orga/components/layout/sidebar';
+
 <template>
-  {{pageTitle @controller.model.title}}
-  {{#in-element @controller.model.headElement insertBefore=null}}
+  {{pageTitle @model.title}}
+  {{#in-element @model.headElement insertBefore=null}}
     {{! template-lint-disable no-forbidden-elements }}
     <meta name="description" content={{t "application.description"}} />
   {{/in-element}}
 
-  <Communication />
-  <InformationBanners @banners={{@controller.model.informationBanner.banners}} />
-
-  {{outlet}}
+  <PixAppLayout @variant="orga" class="{{unless @controller.isAuthenticatedRoute 'unauthenticated-page'}}">
+    <:banner>
+      <Communication />
+      <InformationBanners @banners={{@model.informationBanner.banners}} />
+    </:banner>
+    <:navigation>
+      {{#if @controller.isAuthenticatedRoute}}
+        <Sidebar
+          @placesCount={{@model.placeStatistics.available}}
+          @onChangeOrganization={{@controller.onChangeOrganization}}
+        />
+      {{/if}}
+    </:navigation>
+    <:main>
+      {{outlet}}
+    </:main>
+    <:footer>
+      {{#if @controller.isAuthenticatedRoute}}
+        <Footer />
+      {{/if}}
+    </:footer>
+  </PixAppLayout>
+  <NotificationContainer @position="bottom-right" />
 </template>

--- a/orga/app/templates/authenticated.gjs
+++ b/orga/app/templates/authenticated.gjs
@@ -1,24 +1,8 @@
-import NotificationContainer from '@1024pix/ember-cli-notifications/components/notification-container';
-import PixAppLayout from '@1024pix/pix-ui/components/pix-app-layout';
 import TopBanners from 'pix-orga/components/banner/top-banners';
-import Footer from 'pix-orga/components/layout/footer';
-import Sidebar from 'pix-orga/components/layout/sidebar';
+
 <template>
-  <PixAppLayout @variant="orga" class="app">
-    <:navigation>
-
-      <Sidebar @placesCount={{@model.available}} @onChangeOrganization={{@controller.onChangeOrganization}} />
-    </:navigation>
-    <:main>
-
-      <main class="main-content__body page">
-        <TopBanners />
-        {{outlet}}
-      </main>
-    </:main>
-    <:footer>
-      <Footer />
-    </:footer>
-  </PixAppLayout>
-  <NotificationContainer @position="bottom-right" />
+  <main class="main-content__body page">
+    <TopBanners />
+    {{outlet}}
+  </main>
 </template>

--- a/orga/tests/unit/controllers/application-test.js
+++ b/orga/tests/unit/controllers/application-test.js
@@ -2,12 +2,12 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated', function (hooks) {
+module('Unit | Controller | application', function (hooks) {
   setupTest(hooks);
 
   test('should call send method', async function (assert) {
     // given
-    const controller = this.owner.lookup('controller:authenticated');
+    const controller = this.owner.lookup('controller:application');
     controller.send = sinon.stub();
 
     // when


### PR DESCRIPTION
## :pancakes: Problème

Les bannière sur nos environnement de dev (et lorsqu'il y a des annonces) decale le layout de l'application vers le bas ajoutant un scroll non souhaité. cela peut cacher des boutons aux utilisateurs

## :bacon: Proposition

Intégrer les bannières dans le composant AppLayout
## 🧃 Remarques

nope nope nope

## :yum: Pour tester

- aller sur orga
- se connecter 
- voir la bannière et le menu non tronqué