### PR TITLE
[BUGFIX]: Réparer Smart Random Simulator (PIX-17038)

### DIFF
--- a/admin/app/components/smart-random-simulator/smart-random-params.gjs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.gjs
@@ -55,7 +55,7 @@ export default class SmartRandomParams extends Component {
     challenges: Joi.array()
       .items({
         id: Joi.string().required(),
-        timer: Joi.number(),
+        timer: Joi.number().allow(null),
         skill: {
           id: Joi.string().required(),
           name: Joi.string().required(),

--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -68,8 +68,8 @@ const getNextChallengeRoute = {
               .items({
                 id: identifiersType.challengeId,
                 skill: skillValidationObject.required(),
-                timer: Joi.number().integer(),
-                focused: Joi.boolean().optional(),
+                timer: Joi.number().integer().allow(null),
+                focused: Joi.boolean().optional().allow(null),
                 locales: Joi.array()
                   .items(
                     Joi.string().valid(


### PR DESCRIPTION
## :pancakes: Problème

Les paramètres de référentiel sont trop restrictifs.

## :bacon: Proposition
 
Accepter des valeurs "null" pour certains champs de challenge.

## :yum: Pour tester

Accéder au simulateur, charger une campagne (1000000 par exemple), vérifier que le simulateur fonctionne sans souci.