### PR TITLE
[FEATURE] afficher sur Pix Admin le dernier accès à un centre de certification (PIX-16634)

### DIFF
--- a/admin/app/components/certification-centers/membership-item.gjs
+++ b/admin/app/components/certification-centers/membership-item.gjs
@@ -62,6 +62,11 @@ export default class CertificationCentersMembershipItemComponent extends Compone
           @onRoleSelected={{this.onRoleSelected}}
         />
       </td>
+      <td class="member-information">
+        {{#if @certificationCenterMembership.lastAccessedAt}}
+          {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD-MM-YYYY - HH:mm:ss"}}
+        {{/if}}
+      </td>
       <td>
         {{dayjsFormat @certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
       </td>

--- a/admin/app/components/certification-centers/memberships-section.gjs
+++ b/admin/app/components/certification-centers/memberships-section.gjs
@@ -15,12 +15,13 @@ import MembershipItem from './membership-item';
           <thead>
             <tr>
               <th class="table__column table__column--id">ID Utilisateur</th>
-              <th class="table__column table__column--wide">Prénom</th>
-              <th class="table__column table__column--wide">Nom</th>
+              <th class="table__column">Prénom</th>
+              <th class="table__column">Nom</th>
               <th class="table__column table__column--wide">Adresse e-mail</th>
-              <th class="table__column table__column--wide">Rôle</th>
-              <th class="table__column table__column--wide">Date de rattachement</th>
-              <th class="table__column table__column--wide">Actions</th>
+              <th class="table__column table__column--medium">Rôle</th>
+              <th class="table__column">Dernier accès</th>
+              <th class="table__column">Date de rattachement</th>
+              <th class="table__column">Actions</th>
             </tr>
           </thead>
 

--- a/admin/app/models/certification-center-membership.js
+++ b/admin/app/models/certification-center-membership.js
@@ -8,6 +8,7 @@ const ROLE_LABEL_KEYS = {
 export default class CertificationCenterMembership extends Model {
   @attr('date') createdAt;
   @attr() role;
+  @attr('date') lastAccessedAt;
   @belongsTo('certification-center', { async: true, inverse: null }) certificationCenter;
   @belongsTo('user', { async: true, inverse: 'certificationCenterMemberships' }) user;
 

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -33,6 +33,7 @@ module('Integration | Component |  certification-centers/membership-item', funct
       user,
       role: 'MEMBER',
       createdAt: new Date('2023-09-13T10:47:07Z'),
+      lastAccessedAt: new Date('2023-12-30T15:21:09Z'),
     });
 
     const disableCertificationCenterMembership = sinon.stub();
@@ -48,7 +49,10 @@ module('Integration | Component |  certification-centers/membership-item', funct
     );
 
     // then
-    const expectedDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
+    const expectedLastAccessedAtDate = dayjs(certificationCenterMembership.lastAccessedAt).format(
+      'DD-MM-YYYY - HH:mm:ss',
+    );
+    const expectedCreationDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
 
     assert
       .dom(screen.getByLabelText('Informations du membre Jojo La Gringue'))
@@ -57,7 +61,10 @@ module('Integration | Component |  certification-centers/membership-item', funct
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.lastName);
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.email);
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText('Membre');
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(expectedDate);
+    assert
+      .dom(screen.getByLabelText('Informations du membre Jojo La Gringue'))
+      .containsText(expectedLastAccessedAtDate);
+    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(expectedCreationDate);
     assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
   });

--- a/api/src/shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
@@ -10,7 +10,7 @@ const serialize = function (certificationCenterMemberships) {
       record.certificationCenter.sessions = [];
       return record;
     },
-    attributes: ['createdAt', 'certificationCenter', 'user', 'role'],
+    attributes: ['createdAt', 'certificationCenter', 'user', 'role', 'lastAccessedAt'],
     certificationCenter: {
       ref: 'id',
       included: true,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
@@ -42,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
             attributes: {
               'created-at': certificationCenterMembership.createdAt,
               role: certificationCenterMembership.role,
+              'last-accessed-at': certificationCenterMembership.lastAccessedAt,
             },
             relationships: {
               'certification-center': {


### PR DESCRIPTION
## :pancakes: Problème

On souhaite afficher la date de dernier accès des membres des organisations dans Pix Admin.

## :bacon: Proposition

Ajout de la colonne “Dernier accès” dans le tableau des membres d’une organisation sur pix-admin:

- La date est récupérée dans la table memberships sur la colonne lastAccessedAt 

- Utiliser la route existante qui récupère les memberships 

- Nom de la colonne: Dernier accès

- Écrire sous la forme: 01/01/2025 20:02

## 🧃 Remarques

le format de date demandé est respecté mais pour suivre la présentation déjà utilisée dans la colonne Date de rattachement", les / sont remplacés par des -

## :yum: Pour tester

- Depuis Pix Admin
   - En tant que superadmin, aller sur la page du centre Accèssorium, constater que la colonne "Dernier accès" est présente mais vide

- Depuis pix certif
  - Se connecter avec james-paledroits@example.net : vous êtes dans le centre Accèssorium
  - Après une minute changer de centre pour Accèssovolt
  
- Depuis pix admin (avec un compte superadmin)
  - Aller sur la page de détail de l'organisation "Accèssorium"
  - Constater que la date de dernier accès pour James Paledroits est correcte
  - Aller sur la page de détail de l'organisation "Accèssovolt"
  - Constater que la date de dernier accès pour James Paledroits est correcte
  - Aller sur la page de détail de l'organisation "Accèstral"
  -  Constater la nouvelle colonne Dernier accès du tableau est restée vide
  
 