### PR TITLE
[FEATURE] :memo:  Révision du texte à propos de pix companion dans l'espace surveillant (PIX-17042)

### DIFF
--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -55,20 +55,18 @@
     </div>
   </dl>
 
-  {{#if this.isPixCompanionExtensionEnabled}}
-    <PixNotificationAlert @type="info" @withIcon={{true}}>
-      {{t "pages.session-supervising.header.companion.message"}}
-      <a
-        href={{this.pixCompanionDocumentationUrl}}
-        target="_blank"
-        class="link session-supervising-header__companion-link"
-        rel="noopener noreferrer"
-      >
-        {{t "pages.session-supervising.header.companion.link"}}
-        <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
-      </a>
-    </PixNotificationAlert>
-  {{/if}}
+  <PixNotificationAlert @type="info" @withIcon={{true}}>
+    {{t "pages.session-supervising.header.invigilator-documentation.message"}}
+    <a
+      href={{this.InvigilatorDocumentationUrl}}
+      target="_blank"
+      class="link session-supervising-header__invigilator-link"
+      rel="noopener noreferrer"
+    >
+      {{t "pages.session-supervising.header.invigilator-documentation.link"}}
+      <PixIcon @name="openNew" @title={{t "navigation.external-link-title"}} />
+    </a>
+  </PixNotificationAlert>
 
   <PixButton
     class="session-supervising-header__download-button"

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -58,7 +58,7 @@
   <PixNotificationAlert @type="info" @withIcon={{true}}>
     {{t "pages.session-supervising.header.invigilator-documentation.message"}}
     <a
-      href={{this.InvigilatorDocumentationUrl}}
+      href={{this.invigilatorDocumentationUrl}}
       target="_blank"
       class="link session-supervising-header__invigilator-link"
       rel="noopener noreferrer"

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -37,7 +37,7 @@ export default class Header extends Component {
     return this.router.replaceWith('login-session-supervisor');
   }
 
-  get InvigilatorDocumentationUrl() {
-    return this.url.InvigilatorDocumentationUrl;
+  get invigilatorDocumentationUrl() {
+    return this.url.invigilatorDocumentationUrl;
   }
 }

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -37,11 +37,7 @@ export default class Header extends Component {
     return this.router.replaceWith('login-session-supervisor');
   }
 
-  get pixCompanionDocumentationUrl() {
-    return this.url.pixCompanionDocumentationUrl;
-  }
-
-  get isPixCompanionExtensionEnabled() {
-    return this.featureToggles.featureToggles?.isPixCompanionEnabled;
+  get InvigilatorDocumentationUrl() {
+    return this.url.InvigilatorDocumentationUrl;
   }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -74,8 +74,8 @@ export default class Url extends Service {
     return 'https://form-eu.123formbuilder.com/41052/form';
   }
 
-  get pixCompanionDocumentationUrl() {
-    return 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX';
+  get InvigilatorDocumentationUrl() {
+    return 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f';
   }
 
   #isFrenchSpoken() {

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -74,7 +74,7 @@ export default class Url extends Service {
     return 'https://form-eu.123formbuilder.com/41052/form';
   }
 
-  get InvigilatorDocumentationUrl() {
+  get invigilatorDocumentationUrl() {
     return 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f';
   }
 

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -59,7 +59,7 @@
     margin-right: 8px;
   }
 
-  &__companion-link {
+  &__invigilator-link {
     align-items: center;
     gap: var(--pix-spacing-1x);
 

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -176,7 +176,7 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
     assert
       .dom(
         screen.getByRole('link', {
-          name: 'Documentation du rôle de surveillant Ouverture dans une nouvelle fenêtre',
+          name: 'Documentation sur la gestion des signalements Ouverture dans une nouvelle fenêtre',
         }),
       )
       .hasAttribute('href', 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -150,71 +150,35 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
     });
   });
 
-  module('when the FT_PIX_COMPANION_ENABLED feature toggle is enabled', function () {
-    test('should display a companion information with documentation url', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isPixCompanionEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-      const sessionForSupervising = store.createRecord('session-for-supervising', {
-        id: '12345',
-        date: '2020-01-01',
-        time: '12:00:00',
-        room: 'Salle 12',
-        examiner: 'Star Lord',
-        certificationCandidates: [],
-      });
-      this.set('sessionForSupervising', sessionForSupervising);
-
-      // when
-      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}} />`);
-
-      // then
-      assert
-        .dom(screen.getByText('L’extension Pix Companion est désormais obligatoire pour tous les candidats.'))
-        .exists();
-      assert
-        .dom(
-          screen.getByRole('link', {
-            name: 'Lien vers la documentation d’installation/activation Ouverture dans une nouvelle fenêtre',
-          }),
-        )
-        .hasAttribute('href', 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX');
+  test('should display an invigilator information with documentation url', async function (assert) {
+    // given
+    const sessionForSupervising = store.createRecord('session-for-supervising', {
+      id: '12345',
+      date: '2020-01-01',
+      time: '12:00:00',
+      room: 'Salle 12',
+      examiner: 'Star Lord',
+      certificationCandidates: [],
     });
-  });
+    this.set('sessionForSupervising', sessionForSupervising);
 
-  module('when the FT_PIX_COMPANION_ENABLED feature toggle is disabled', function () {
-    test('should not display a companion information with documentation url', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isPixCompanionEnabled: false };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-      const sessionForSupervising = store.createRecord('session-for-supervising', {
-        id: '12345',
-        date: '2020-01-01',
-        time: '12:00:00',
-        room: 'Salle 12',
-        examiner: 'Star Lord',
-        certificationCandidates: [],
-      });
-      this.set('sessionForSupervising', sessionForSupervising);
+    // when
+    const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}} />`);
 
-      // when
-      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}} />`);
-
-      // then
-      assert
-        .dom(screen.queryByText('L’extension Pix Companion est désormais obligatoire pour tous les candidats.'))
-        .doesNotExist();
-      assert
-        .dom(
-          screen.queryByRole('link', {
-            name: 'Lien vers la documentation d’installation/activation Ouverture dans une nouvelle fenêtre',
-          }),
-        )
-        .doesNotExist();
-    });
+    // then
+    assert
+      .dom(
+        screen.getByText(
+          'Important : Les problèmes techniques liés aux questions doivent uniquement être gérés pendant le test depuis l’interface du candidat et l’Espace Surveillant (ces signalements ne pourront pas être pris en compte a posteriori).',
+        ),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('link', {
+          name: 'Documentation du rôle de surveillant Ouverture dans une nouvelle fenêtre',
+        }),
+      )
+      .hasAttribute('href', 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');
   });
 });

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -284,16 +284,16 @@ module('Unit | Service | url', function (hooks) {
     });
   });
 
-  module('#pixCompanionDocumentationUrl', function () {
+  module('#invigilatorDocumentationUrl', function () {
     test('should return the pix companion documentation url', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
 
       // when
-      const pixCompanionDocumentationUrl = service.pixCompanionDocumentationUrl;
+      const invigilatorDocumentationUrl = service.invigilatorDocumentationUrl;
 
       // then
-      assert.strictEqual(pixCompanionDocumentationUrl, 'https://cloud.pix.fr/s/fpeEyDpYEkMeqRX');
+      assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');
     });
   });
 });

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -285,7 +285,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#invigilatorDocumentationUrl', function () {
-    test('should return the pix companion documentation url', function (assert) {
+    test('should return the invigilator documentation url', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -559,8 +559,8 @@
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "invigilator": "Invigilator(s)",
         "invigilator-documentation": {
-          "link": "Invigilator role's documentation",
-          "message": "The Pix Companion extension is now mandatory for all candidates."
+          "link": "Documentation of the invigilator role",
+          "message": "Please note: Any technical problems relating to the questions must only be managed during the test from the candidate interface and the invigilator area (these reports cannot be taken into account afterwards)."
         },
         "invigilator-kit": {
           "extra-information": "Download invigilator’s kit",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -556,12 +556,12 @@
           "exit-extra-information": "Exit the session’s invigilation {sessionId}"
         },
         "address": "Location name",
-        "companion": {
-          "link": "Link to installation/activation documentation",
-          "message": "The Pix Companion extension is now mandatory for all candidates."
-        },
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "invigilator": "Invigilator(s)",
+        "invigilator-documentation": {
+          "link": "Invigilator role's documentation",
+          "message": "The Pix Companion extension is now mandatory for all candidates."
+        },
         "invigilator-kit": {
           "extra-information": "Download invigilator’s kit",
           "label": "Invigilator’s kit"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -559,7 +559,7 @@
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "invigilator": "Invigilator(s)",
         "invigilator-documentation": {
-          "link": "Documentation of the invigilator role",
+          "link": "Report management documentation",
           "message": "Please note: Any technical problems relating to the questions must only be managed during the test from the candidate interface and the invigilator area (these reports cannot be taken into account afterwards)."
         },
         "invigilator-kit": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -559,7 +559,7 @@
         "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
         "invigilator": "Surveillant(s)",
         "invigilator-documentation": {
-          "link": "Documentation du rôle de surveillant",
+          "link": "Documentation sur la gestion des signalements",
           "message": "Important : Les problèmes techniques liés aux questions doivent uniquement être gérés pendant le test depuis l’interface du candidat et l’Espace Surveillant (ces signalements ne pourront pas être pris en compte a posteriori)."
         },
         "invigilator-kit": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -556,12 +556,12 @@
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
         },
         "address": "Nom du site",
-        "companion": {
-          "link": "Lien vers la documentation d’installation/activation",
-          "message": "L’extension Pix Companion est désormais obligatoire pour tous les candidats."
-        },
         "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
         "invigilator": "Surveillant(s)",
+        "invigilator-documentation": {
+          "link": "Documentation du rôle de surveillant",
+          "message": "Important : Les problèmes techniques liés aux questions doivent uniquement être gérés pendant le test depuis l’interface du candidat et l’Espace Surveillant (ces signalements ne pourront pas être pris en compte a posteriori)."
+        },
         "invigilator-kit": {
           "extra-information": "Télécharger le kit surveillant",
           "label": "Kit surveillant"


### PR DESCRIPTION
## :pancakes: Problème

Les signalements à traiter pendant la session sont une nouveauté de la certification v3, les surveillants ne se rendent pas toujours compte qu’ils doivent obligatoirement les prendre en compte pendant la session.

![image](https://github.com/user-attachments/assets/cef37548-d24f-4b73-a449-1d89ca2a93de)


## :bacon: Proposition

Modifier le contenu de la bannière d'information pour évoquer maintenant la documentation des surveillants.

![image](https://github.com/user-attachments/assets/81b0e289-54ea-4ad3-8b50-b1ef821f169f)

## 🧃 Remarques

## :yum: Pour tester

Allez dans l'espace surveillant d'une session, vérifier que le message et le lien fonctionne
