### PR TITLE
[FEATURE] PixTable sur Pix Admin épisode 7 : Centres de certification (PIX-17063).

### DIFF
--- a/admin/app/components/certification-centers/invitations.gjs
+++ b/admin/app/components/certification-centers/invitations.gjs
@@ -1,4 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -17,56 +19,67 @@ export default class CertificationCenterInvitations extends Component {
       <header class="page-section__header">
         <h2 class="page-section__title">Invitations</h2>
       </header>
-      <div class="content-text content-text--small">
-        <div class="table-admin">
-          {{#if this.sortedCertificationCenterInvitations}}
-            <table>
-              <thead>
-                <tr>
-                  <th>Adresse e-mail</th>
-                  <th>Rôle</th>
-                  <th>Date de dernier envoi</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {{#each this.sortedCertificationCenterInvitations as |invitation|}}
-                  <tr aria-label="Invitation en attente de {{invitation.email}}">
-                    <td>{{invitation.email}}</td>
-                    <td>{{invitation.roleLabel}}</td>
-                    <td>{{dayjsFormat invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}</td>
-                    <td>
-                      <div class="certification-center-invitations__actions-buttons">
-                        <PixButton
-                          @size="small"
-                          class="certification-center-invitations-actions__button"
-                          aria-label={{t "common.invitations.send-new-label" invitationEmail=invitation.email}}
-                          @triggerAction={{fn @onSendNewCertificationCenterInvitation invitation}}
-                          @iconBefore="refresh"
-                        >
-                          {{t "common.invitations.send-new"}}
-                        </PixButton>
-                        <PixButton
-                          @size="small"
-                          @variant="error"
-                          class="certification-center-invitations-actions__button"
-                          aria-label="Annuler l’invitation de {{invitation.email}}"
-                          @triggerAction={{fn @onCancelCertificationCenterInvitation invitation}}
-                          @iconBefore="delete"
-                        >
-                          Annuler l’invitation
-                        </PixButton>
-                      </div>
-                    </td>
-                  </tr>
-                {{/each}}
-              </tbody>
-            </table>
-          {{else}}
-            <p class="certification-center-invitations__message">Aucune invitation en attente</p>
-          {{/if}}
-        </div>
-      </div>
+
+      {{#if this.sortedCertificationCenterInvitations}}
+        <PixTable
+          @variant="primary"
+          @caption={{t "components.certification-centers.invitations.table.caption"}}
+          @data={{this.sortedCertificationCenterInvitations}}
+        >
+          <:columns as |invitation context|>
+            <PixTableColumn @context={{context}} class="break-word">
+              <:header>
+                Adresse e-mail
+              </:header>
+              <:cell>
+                {{invitation.email}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                Rôle
+              </:header>
+              <:cell>
+                {{invitation.roleLabel}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                Date de dernier envoi
+              </:header>
+              <:cell>
+                {{dayjsFormat invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}} class="certification-center-invitations__actions-buttons">
+              <:header>
+                Actions
+              </:header>
+              <:cell>
+                <PixButton
+                  @size="small"
+                  aria-label={{t "common.invitations.send-new-label" invitationEmail=invitation.email}}
+                  @triggerAction={{fn @onSendNewCertificationCenterInvitation invitation}}
+                  @iconBefore="refresh"
+                >
+                  {{t "common.invitations.send-new"}}
+                </PixButton>
+                <PixButton
+                  @size="small"
+                  @variant="error"
+                  aria-label="Annuler l’invitation de {{invitation.email}}"
+                  @triggerAction={{fn @onCancelCertificationCenterInvitation invitation}}
+                  @iconBefore="delete"
+                >
+                  Annuler l’invitation
+                </PixButton>
+              </:cell>
+            </PixTableColumn>
+          </:columns>
+        </PixTable>
+      {{else}}
+        <p class="table__empty">Aucune invitation en attente</p>
+      {{/if}}
     </section>
   </template>
 }

--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -1,5 +1,8 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
@@ -12,61 +15,70 @@ export default class CertificationCenterListItems extends Component {
   searchedExternalId = this.args.externalId;
 
   <template>
-    <div class="content-text content-text--small">
-      <table class="table-admin">
-        <thead>
-          <tr>
-            <th class="table__column table__column--id"><label for="id">ID</label></th>
-            <th><label for="name">Nom</label></th>
-            <th><label for="type">Type</label></th>
-            <th><label for="externalId">ID externe</label></th>
-          </tr>
-          <tr>
-            <td class="table__column table__column--id">
-              <PixInput id="id" type="text" value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}} />
-            </td>
-            <td>
-              <PixInput id="name" type="text" value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}} />
-            </td>
-            <td>
-              <PixInput id="type" type="text" value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}} />
-            </td>
-            <td>
-              <PixInput
-                id="externalId"
-                type="text"
-                value={{this.searchedExternalId}}
-                oninput={{fn @triggerFiltering "externalId"}}
-              />
-            </td>
-          </tr>
-        </thead>
+    <div class="certification-centers-list">
+      <PixFilterBanner @title={{t "common.filters.title"}}>
+        <PixInput value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}}>
+          <:label>Identifiant</:label>
+        </PixInput>
+        <PixInput value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}}>
+          <:label>Nom</:label>
+        </PixInput>
+        <PixInput value={{this.searchedType}} oninput={{fn @triggerFiltering "type"}}>
+          <:label>Type</:label>
+        </PixInput>
+        <PixInput value={{this.searchedExternalId}} oninput={{fn @triggerFiltering "externalId"}}>
+          <:label>ID externe</:label>
+        </PixInput>
+      </PixFilterBanner>
 
-        {{#if @certificationCenters}}
-          <tbody>
-            {{#each @certificationCenters as |certificationCenter|}}
-              <tr aria-label="Centre de certification {{certificationCenter.name}}">
-                <td class="table__column table__column--id">
-                  <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
-                    {{certificationCenter.id}}
-                  </LinkTo>
-                </td>
-                <td>{{certificationCenter.name}}</td>
-                <td>{{certificationCenter.type}}</td>
-                <td class="break-word">{{certificationCenter.externalId}}</td>
-              </tr>
-            {{/each}}
-          </tbody>
-        {{/if}}
-      </table>
+      {{#if @certificationCenters}}
+        <PixTable
+          @variant="primary"
+          @caption={{t "components.certification-centers.list-items.table.caption"}}
+          @data={{@certificationCenters}}
+        >
+          <:columns as |certificationCenter context|>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                ID
+              </:header>
+              <:cell>
+                <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
+                  {{certificationCenter.id}}
+                </LinkTo>
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}} class="break-word">
+              <:header>
+                Nom
+              </:header>
+              <:cell>
+                {{certificationCenter.name}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}}>
+              <:header>
+                Type
+              </:header>
+              <:cell>
+                {{certificationCenter.type}}
+              </:cell>
+            </PixTableColumn>
+            <PixTableColumn @context={{context}} class="break-word">
+              <:header>
+                ID externe
+              </:header>
+              <:cell>
+                {{certificationCenter.externalId}}
+              </:cell>
+            </PixTableColumn>
+          </:columns>
+        </PixTable>
 
-      {{#unless @certificationCenters}}
+        <PixPagination @pagination={{@certificationCenters.meta}} />
+      {{else}}
         <div class="table__empty">{{t "common.tables.empty-result"}}</div>
-      {{/unless}}
+      {{/if}}
     </div>
-
-    {{#if @certificationCenters}}
-      <PixPagination @pagination={{@certificationCenters.meta}} />
-    {{/if}}
   </template>
 }

--- a/admin/app/components/certification-centers/membership-item.gjs
+++ b/admin/app/components/certification-centers/membership-item.gjs
@@ -1,3 +1,4 @@
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -43,34 +44,60 @@ export default class CertificationCentersMembershipItemComponent extends Compone
   }
 
   <template>
-    <tr
-      aria-label="Informations du membre {{@certificationCenterMembership.user.firstName}} {{@certificationCenterMembership.user.lastName}}"
-    >
-      <td>
+    <PixTableColumn @context={{@context}}>
+      <:header>ID Utilisateur</:header>
+      <:cell>
         <LinkTo @route="authenticated.users.get" @model={{@certificationCenterMembership.user.id}}>
           {{@certificationCenterMembership.user.id}}
         </LinkTo>
-      </td>
-      <td class="member-information">{{@certificationCenterMembership.user.firstName}}</td>
-      <td class="member-information">{{@certificationCenterMembership.user.lastName}}</td>
-      <td class="member-information">{{@certificationCenterMembership.user.email}}</td>
-      <td class="member-information">
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Prénom</:header>
+      <:cell>
+        {{@certificationCenterMembership.user.firstName}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Nom</:header>
+      <:cell>
+        {{@certificationCenterMembership.user.lastName}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}} class="break-word">
+      <:header>Adresse e-mail</:header>
+      <:cell>
+        {{@certificationCenterMembership.user.email}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Rôle</:header>
+      <:cell>
         <MembershipItemRole
           @isEditionMode={{this.isEditionMode}}
           @role={{@certificationCenterMembership.role}}
           @roleLabelKey={{@certificationCenterMembership.roleLabelKey}}
           @onRoleSelected={{this.onRoleSelected}}
         />
-      </td>
-      <td class="member-information">
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Dernier accès</:header>
+      <:cell>
         {{#if @certificationCenterMembership.lastAccessedAt}}
           {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD-MM-YYYY - HH:mm:ss"}}
         {{/if}}
-      </td>
-      <td>
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Date de rattachement</:header>
+      <:cell>
         {{dayjsFormat @certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
-      </td>
-      <td>
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
+      <:header>Actions</:header>
+      <:cell>
         <MembershipItemActions
           @isEditionMode={{this.isEditionMode}}
           @onDeactivateMembershipButtonClicked={{fn
@@ -81,7 +108,7 @@ export default class CertificationCentersMembershipItemComponent extends Compone
           @onSaveRoleButtonClicked={{this.saveMembershipRole}}
           @onCancelButtonClicked={{this.cancelMembershipRoleEditing}}
         />
-      </td>
-    </tr>
+      </:cell>
+    </PixTableColumn>
   </template>
 }

--- a/admin/app/components/certification-centers/memberships-section.gjs
+++ b/admin/app/components/certification-centers/memberships-section.gjs
@@ -1,47 +1,31 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
 import { t } from 'ember-intl';
 
 import MembershipItem from './membership-item';
 
 <template>
   <section class="page-section">
-
     <header class="page-section__header">
       <h2 class="page-section__title">Membres</h2>
     </header>
 
-    <div class="content-text content-text--small">
-      <div class="table-admin">
-        <table>
-          <thead>
-            <tr>
-              <th class="table__column table__column--id">ID Utilisateur</th>
-              <th class="table__column">Prénom</th>
-              <th class="table__column">Nom</th>
-              <th class="table__column table__column--wide">Adresse e-mail</th>
-              <th class="table__column table__column--medium">Rôle</th>
-              <th class="table__column">Dernier accès</th>
-              <th class="table__column">Date de rattachement</th>
-              <th class="table__column">Actions</th>
-            </tr>
-          </thead>
-
-          {{#if @certificationCenterMemberships}}
-            <tbody>
-              {{#each @certificationCenterMemberships as |certificationCenterMembership|}}
-                <MembershipItem
-                  @certificationCenterMembership={{certificationCenterMembership}}
-                  @disableCertificationCenterMembership={{@disableCertificationCenterMembership}}
-                  @onCertificationCenterMembershipRoleChange={{@onCertificationCenterMembershipRoleChange}}
-                />
-              {{/each}}
-            </tbody>
-          {{/if}}
-        </table>
-
-        {{#unless @certificationCenterMemberships}}
-          <div class="table__empty">{{t "common.tables.empty-result"}}</div>
-        {{/unless}}
-      </div>
-    </div>
+    {{#if @certificationCenterMemberships}}
+      <PixTable
+        @variant="primary"
+        @caption={{t "components.memberships-section.table.caption"}}
+        @data={{@certificationCenterMemberships}}
+      >
+        <:columns as |certificationCenterMembership context|>
+          <MembershipItem
+            @context={{context}}
+            @certificationCenterMembership={{certificationCenterMembership}}
+            @disableCertificationCenterMembership={{@disableCertificationCenterMembership}}
+            @onCertificationCenterMembershipRoleChange={{@onCertificationCenterMembershipRoleChange}}
+          />
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
+    {{/if}}
   </section>
 </template>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -38,6 +38,7 @@
 @use 'components/campaigns/update' as *;
 @use 'components/campaigns/type' as *;
 @use 'components/card' as *;
+@use 'components/certification-centers/list-items' as *;
 @use 'components/certification-center-invitations' as *;
 @use 'components/certification-details-answer' as *;
 @use 'components/certification-details-competence' as *;

--- a/admin/app/styles/components/certification-center-invitations.scss
+++ b/admin/app/styles/components/certification-center-invitations.scss
@@ -1,27 +1,12 @@
 .certification-center-invitations {
 
-  &__message {
-    text-align: center;
-  }
-
   &__actions-buttons   {
     display: flex;
     flex-direction: column;
+    gap: var(--pix-spacing-2x);
 
     button {
       width: 13rem;
-      margin:  0.2rem;
-    }
-
-    svg {
-      margin-right: 6px;
-    }
-  }
-
-  &-actions__button {
-
-    svg {
-      margin-right: 6px;
     }
   }
 }

--- a/admin/app/styles/components/certification-centers/list-items.scss
+++ b/admin/app/styles/components/certification-centers/list-items.scss
@@ -1,0 +1,5 @@
+.certification-centers-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+}

--- a/admin/tests/acceptance/authenticated/certification-centers/get/team-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/team-test.js
@@ -1,6 +1,7 @@
-import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
@@ -37,11 +38,17 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
     const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
-    assert.dom(screen.getByLabelText('Informations du membre Gilles Parbal')).exists();
-    assert.dom(screen.getByRole('link', { name: user1.id })).exists();
+    const table = screen.getByRole('table', {
+      name: t('components.memberships-section.table.caption'),
+    });
 
-    assert.dom(screen.getByLabelText('Informations du membre Eric Hochet')).exists();
-    assert.dom(screen.getByRole('link', { name: user2.id })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Gilles' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Parbal' })).exists();
+    assert.dom(within(table).getByRole('link', { name: user1.id })).exists();
+
+    assert.dom(within(table).getByRole('cell', { name: 'Eric' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Hochet' })).exists();
+    assert.dom(within(table).getByRole('link', { name: user2.id })).exists();
   });
 
   test('should be possible to deactivate a certification center membership', async function (assert) {
@@ -165,8 +172,12 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
       await clickByName('Ajouter le membre');
 
       // then
-      assert.dom(screen.getByLabelText('Informations du membre Jacques Use')).exists();
-      assert.dom(screen.getByText('test@example.net')).exists();
+      const table = screen.getByRole('table', {
+        name: t('components.memberships-section.table.caption'),
+      });
+      assert.dom(within(table).getByRole('cell', { name: 'Jacques' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Use' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'test@example.net' })).exists();
     });
   });
 
@@ -185,9 +196,12 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
         role: 'MEMBER',
         user,
       });
+      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+      const table = screen.getByRole('table', {
+        name: t('components.memberships-section.table.caption'),
+      });
 
       // when
-      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Modifier le rôle');
       await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
       await screen.findByRole('listbox');
@@ -196,7 +210,8 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
 
       // then
       assert.dom(screen.getByText('Le rôle du membre a été modifié.')).exists();
-      assert.dom(screen.getByLabelText('Informations du membre Eric Hochet')).containsText('Administrateur');
+      assert.dom(within(table).getByRole('cell', { name: 'Eric' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Administrateur' })).exists();
     });
   });
 
@@ -215,9 +230,12 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
         role: 'MEMBER',
         user,
       });
+      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+      const table = screen.getByRole('table', {
+        name: t('components.memberships-section.table.caption'),
+      });
 
       // when
-      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Modifier le rôle');
       await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
       await screen.findByRole('listbox');
@@ -226,7 +244,8 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
 
       // then
       assert.dom(screen.getByText("Une erreur est survenue, le rôle du membre n'a pas été modifié.")).exists();
-      assert.dom(screen.getByLabelText('Informations du membre Gilles Parbal')).containsText('Membre');
+      assert.dom(within(table).getByRole('cell', { name: 'Gilles' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Membre' })).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/certification-centers/list-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list-test.js
@@ -40,18 +40,6 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       assert.dom(screen.getByRole('link', { name: 'Centres de certification' })).hasClass('active');
     });
 
-    test('it should list the certification-centers', async function (assert) {
-      // given
-      const certificationCenter = server.createList('certification-center', 3);
-      // when
-      const screen = await visit('/certification-centers/list');
-
-      // then
-      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[0].name}`)).exists();
-      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[1].name}`)).exists();
-      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[2].name}`)).exists();
-    });
-
     test('it should display the current filter when certification-centers are filtered', async function (assert) {
       // given
       server.createList('certification-center', 1, { type: 'PRO' });

--- a/admin/tests/integration/components/certification-centers/invitations-test.gjs
+++ b/admin/tests/integration/components/certification-centers/invitations-test.gjs
@@ -1,5 +1,6 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { setupIntl } from 'ember-intl/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import Invitations from 'pix-admin/components/certification-centers/invitations';
 import { module, test } from 'qunit';
@@ -57,13 +58,16 @@ module('Integration | Component | Certification Centers | Invitations', function
       const formattedInvitationUpdatedAt1 = dayjsService.self(invitationUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
       const formattedInvitationUpdatedAt2 = dayjsService.self(invitationUpdatedAt2).format('DD/MM/YYYY [-] HH:mm');
 
+      const table = screen.getByRole('table', {
+        name: t('components.certification-centers.invitations.table.caption'),
+      });
       assert.dom(screen.getByRole('heading', { name: 'Invitations' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Adresse e-mail' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Date de dernier envoi' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'elo.dela@example.net' })).exists();
-      assert.dom(screen.getByRole('cell', { name: formattedInvitationUpdatedAt1 })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'alain.finis@example.net' })).exists();
-      assert.dom(screen.getByRole('cell', { name: formattedInvitationUpdatedAt2 })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Adresse e-mail' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Date de dernier envoi' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'elo.dela@example.net' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: formattedInvitationUpdatedAt1 })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'alain.finis@example.net' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: formattedInvitationUpdatedAt2 })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -54,17 +54,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
     );
     const expectedCreationDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
 
-    assert
-      .dom(screen.getByLabelText('Informations du membre Jojo La Gringue'))
-      .containsText(certificationCenterMembership.id);
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.firstName);
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.lastName);
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.email);
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText('Membre');
-    assert
-      .dom(screen.getByLabelText('Informations du membre Jojo La Gringue'))
-      .containsText(expectedLastAccessedAtDate);
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(expectedCreationDate);
+    assert.dom(screen.getByRole('link', { name: certificationCenterMembership.id })).exists();
+    assert.dom(screen.getByRole('cell', { name: user.firstName })).exists();
+    assert.dom(screen.getByRole('cell', { name: user.lastName })).exists();
+    assert.dom(screen.getByRole('cell', { name: user.email })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
+    assert.dom(screen.getByRole('cell', { name: expectedLastAccessedAtDate })).exists();
+    assert.dom(screen.getByRole('cell', { name: expectedCreationDate })).exists();
     assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
   });

--- a/admin/tests/integration/components/certification-centers/memberships-section-test.gjs
+++ b/admin/tests/integration/components/certification-centers/memberships-section-test.gjs
@@ -1,4 +1,5 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import MembershipsSection from 'pix-admin/components/certification-centers/memberships-section';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -52,8 +53,14 @@ module('Integration | Component | certification-centers/memberships-section', fu
     );
 
     // then
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).exists();
-    assert.dom(screen.getByLabelText('Informations du membre Froufrou Le froussard')).exists();
+    const table = screen.getByRole('table', {
+      name: t('components.memberships-section.table.caption'),
+    });
+
+    assert.dom(within(table).getByRole('cell', { name: 'Jojo' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'La Gringue' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Froufrou' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Le froussard' })).exists();
   });
 
   test('it should display a message when there is no membership', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
@@ -1,10 +1,12 @@
-import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
+import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ListItems from 'pix-admin/components/certification-centers/list-items';
 import { module, test } from 'qunit';
 
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/certification-centers | list-items', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display certification-centers list', async function (assert) {
     // given
@@ -16,20 +18,45 @@ module('Integration | Component | routes/authenticated/certification-centers | l
     certificationCenters.meta = {
       rowCount: 3,
     };
-    const triggerFiltering = function () {};
+    const triggerFiltering = () => {};
 
     // when
-    await render(
+    const screen = await render(
       <template>
         <ListItems @certificationCenters={{certificationCenters}} @triggerFiltering={{triggerFiltering}} />
       </template>,
     );
 
     // then
-    assert.dom('table tbody tr:first-child td:first-child').hasText('1');
-    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('John');
-    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('SCO');
-    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('123');
-    assert.dom('table tbody tr').exists({ count: 3 });
+    const table = screen.getByRole('table', { name: t('components.certification-centers.list-items.table.caption') });
+
+    assert.dom(within(table).getByRole('link', { name: '1' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'John' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'SCO' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: '123' })).exists();
+    const rows = within(table).getAllByRole('row');
+    assert.strictEqual(rows.length, 4);
+  });
+
+  test('it should display filters', async function (assert) {
+    // given
+    const certificationCenters = [{ id: 1, name: 'John', type: 'SCO', externalId: '123' }];
+    certificationCenters.meta = {
+      rowCount: 1,
+    };
+    const triggerFiltering = () => {};
+
+    // when
+    const screen = await render(
+      <template>
+        <ListItems @certificationCenters={{certificationCenters}} @triggerFiltering={{triggerFiltering}} />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: 'Type' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'ID externe' })).exists();
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -296,6 +296,11 @@
       }
     },
     "certification-centers": {
+      "list-items": {
+        "table": {
+          "caption": "Liste des centres de certification. Contient l'identifiant, le nom et le type du centre ainsi que son Id externe. Des filtres présents à l'extérieur du tableau permettent de trier les informations de ce dernier"
+        }
+      },
       "membership-item": {
         "actions": {
           "edit-role": "Edit role"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -391,6 +391,9 @@
       "roles": {
         "admin": "Administrator",
         "member": "Member"
+      },
+      "table": {
+        "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
     },
     "organizations": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -296,6 +296,11 @@
       }
     },
     "certification-centers": {
+      "invitations": {
+        "table": {
+          "caption": "Liste des invitations envoyées pour rejoindre un centre de certification. Contient une adresse e-mail de l'utilisateur, le rôle que l'on souhaite lui attribuer, la date de dernier envoi de l'invitation et des actions permettent de renvoyer l'invitation ou de la supprimer."
+        }
+      },
       "list-items": {
         "table": {
           "caption": "Liste des centres de certification. Contient l'identifiant, le nom et le type du centre ainsi que son Id externe. Des filtres présents à l'extérieur du tableau permettent de trier les informations de ce dernier"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -304,6 +304,11 @@
       }
     },
     "certification-centers": {
+      "invitations": {
+        "table": {
+          "caption": "Liste des invitations envoyées pour rejoindre un centre de certification. Contient une adresse e-mail de l'utilisateur, le rôle que l'on souhaite lui attribuer, la date de dernier envoi de l'invitation et des actions permettent de renvoyer l'invitation ou de la supprimer."
+        }
+      },
       "list-items": {
         "table": {
           "caption": "Liste des centres de certification. Contient l'identifiant, le nom et le type du centre ainsi que son Id externe. Des filtres présents à l'extérieur du tableau permettent de trier les informations de ce dernier"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -399,6 +399,9 @@
       "roles": {
         "admin": "Administrateur",
         "member": "Membre"
+      },
+      "table": {
+        "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
     },
     "organizations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -303,7 +303,12 @@
         }
       }
     },
-        "certification-centers": {
+    "certification-centers": {
+      "list-items": {
+        "table": {
+          "caption": "Liste des centres de certification. Contient l'identifiant, le nom et le type du centre ainsi que son Id externe. Des filtres présents à l'extérieur du tableau permettent de trier les informations de ce dernier"
+        }
+      },
       "membership-item": {
         "actions": {
           "edit-role": "Modifier le rôle"


### PR DESCRIPTION
## :pancakes: Problème

Le composant PixTable existe mais n'est pas encore appliqué dans toutes nos applications

## :bacon: Proposition

Continuer l'implémentation sur tous les tableaux lié au menu "Centres de certification"

## :yum: Pour tester

Les tableaux à checker sur Pix Admin : 

Le tableau qui liste tous les centres de certification : 
https://admin-pr11736.review.pix.fr/certification-centers/list
- Non régression sur tous les filtres
- Sur la pagination

Le tableau qui liste les membres
 https://admin-pr11736.review.pix.fr/certification-centers/5000
- Non régression sur la modification du rôle d'un membre
- Non reg sur la suppression d'un membre

Le tableau qui liste des invitations
https://admin-pr11736.review.pix.fr/certification-centers/5000/invitations
- Non reg sur le renvoi d'une invit
- Non reg sur la suppression d'une invit


<img width="1618" alt="Capture d’écran 2025-03-17 à 18 20 54" src="https://github.com/user-attachments/assets/166eea7e-d7ea-47ee-80a0-6b34167e4650" />
<img width="1618" alt="Capture d’écran 2025-03-17 à 18 21 07" src="https://github.com/user-attachments/assets/ed7677b2-47b6-4b9a-b072-dcac79bad2ae" />
<img width="1618" alt="Capture d’écran 2025-03-17 à 18 21 18" src="https://github.com/user-attachments/assets/5515ac51-af40-4203-81ab-6b5bf59a897e" />
