### PR TITLE
[TECH] Correction de flaky sur le test d'acceptance de Account Recovery (PIX-16873)

### DIFF
--- a/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
@@ -98,7 +98,10 @@ describe('Acceptance | Identity Access Management | Application | Route | accoun
         expect(response.statusCode).to.equal(204);
         expect(newUserEmail).to.equal('new-email@example.net');
         expect(cgu).to.equal(true);
-        expect(userAuthenticationMethods).to.deepEqualArray([{ identityProvider: 'GAR' }, { identityProvider: 'PIX' }]);
+        expect(userAuthenticationMethods).to.have.deep.members([
+          { identityProvider: 'GAR' },
+          { identityProvider: 'PIX' },
+        ]);
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème

Un test flaky a été identifié sur `api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js`

![image](https://github.com/user-attachments/assets/2c642644-b49c-4de5-b218-a35a453a943d)

## :bacon: Proposition

Le flaky vient d'une assertion `to.deepEqualArray` sur un tableau d'objets **sans garantie d'ordre** (liste des méthodes d'authentification). Or `to.deepEqualArray` s'attend d'avoir les éléments dans l'ordre.

Remplacer l'assertion par `to.have.deep.members` permet de s'abstraire de l'ordre des éléments dans le tableau (qui n'a pas d'importance dans ce test) et garanti que le test passera peut importe l'ordre des éléments testés.

## :yum: Pour tester

Les tests devraient passer correctement dans la CI.
