### PR TITLE
[FEATURE] Déplacer le champ "Date de dernière connexion" (PIX-16630)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -217,10 +217,6 @@ export default class AuthenticationMethod extends Component {
     </header>
 
     <ul class="authentication-method__connexions-information">
-      <li>
-        <strong>Date de dernière connexion :</strong>
-        {{#if @user.lastLoggedAt}}{{dayjsFormat @user.lastLoggedAt "DD/MM/YYYY"}}{{/if}}
-      </li>
       {{#if @user.emailConfirmedAt}}
         <li>
           <strong>Adresse e-mail confirmée le :</strong>

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -368,6 +368,10 @@ export default class UserOverview extends Component {
                     bloqué jusqu'au :
                     {{dayjsFormat @user.userLogin.temporaryBlockedUntil "DD/MM/YYYY HH:mm"}}</li>
                 {{/if}}
+                <li>
+                  Date de dernière connexion globale :
+                  {{#if @user.lastLoggedAt}}{{dayjsFormat @user.lastLoggedAt "DD/MM/YYYY"}}{{/if}}
+                </li>
               </ul>
             </div>
             <div>

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
@@ -60,49 +60,6 @@ module('Integration | Component | users | user-detail-personal-information | aut
         });
       });
 
-      module('when last logged date exists', function () {
-        test('should display date of latest connection', async function (assert) {
-          // given
-          const user = { lastLoggedAt: new Date('2022-07-01'), authenticationMethods: [] };
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
-
-          // then
-          assert
-            .dom(
-              screen.getAllByRole('listitem').find((listItem) => {
-                const childrenText = listItem.textContent.trim().split('\n');
-                return (
-                  childrenText[0]?.trim() === 'Date de dernière connexion :' && childrenText[1]?.trim() === '01/07/2022'
-                );
-              }),
-            )
-            .exists();
-        });
-      });
-
-      module('when last logged date does not exist', function () {
-        test('it should only display label', async function (assert) {
-          // given
-          const user = { lastLoggedAt: null, authenticationMethods: [] };
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
-
-          // then
-          assert
-            .dom(
-              screen
-                .getAllByRole('listitem')
-                .find((listItem) => listItem.textContent?.trim() === 'Date de dernière connexion :'),
-            )
-            .exists();
-        });
-      });
-
       module('when user has a PIX authentication method', function () {
         test('it displays user has to change password', async function (assert) {
           // given

--- a/admin/tests/integration/components/users/user-overview-test.gjs
+++ b/admin/tests/integration/components/users/user-overview-test.gjs
@@ -388,6 +388,21 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByText('Utilisateur totalement bloqué le : 01/02/2021', { exact: false })).exists();
           assert.dom(screen.queryByText("Utilisateur temporairement bloqué jusqu'au :")).doesNotExist();
         });
+
+        module('when the user has a last global connection', function () {
+          test('displays user last global connection', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+
+            const user = store.createRecord('user', { lastLoggedAt: new Date('2022-11-28T10:00:00Z') });
+
+            // when
+            const screen = await render(<template><UserOverview @user={{user}} /></template>);
+
+            // then
+            assert.dom(screen.getByText('Date de dernière connexion globale : 28/11/2022')).exists();
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Le champ “Date de dernière connexion” est une info importante pour le support et ils aimeraient avoir cette info plus facilement accessible. 

## :bacon: Proposition

- Déplacer ce champ “Date de dernière connexion :”, pour le positionner sous le champ “Nombre de tentatives de connexion en erreur”

- Le renommer “Date de dernière connexion globale”


## :yum: Pour tester

- Depuis PIx-Admin
- Constater que la date de dernière connexion globale est desormais présente dans le detail d'un user 

![image](https://github.com/user-attachments/assets/e3c055dc-d641-463d-bbaf-a36123d5827c)
