### PR TITLE
[TECH] Supprimer le logo mis par défaut dans les seeds lors de la création de l'organisation (PIX-17072)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -4,7 +4,7 @@ const buildOrganization = function buildOrganization({
   id = databaseBuffer.getNextId(),
   type = 'PRO',
   name = 'Observatoire de Pix',
-  logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+  logoUrl = null,
   externalId = 'EXABC123',
   provinceCode = '66',
   isManagingStudents = false,


### PR DESCRIPTION
## :pancakes: Problème

La fonction [build-organization.js](https://github.com/1024pix/pix/blob/dev/api/db/database-builder/factory/build-organization.js#L7) côté seed passe un logo par défaut lors de la création d'une organisation.

Cela peut poser problème pour tester en local ou RA : 
- Sur le nouveau design de la page de début de parcours (centrage des logos)
- Page de détail d'une organisation (savoir qu'on peut upload une image en cliquant sur l'emplacement du logo) 

## :bacon: Proposition
Enlever la valeur par défaut pour le champ `logoUrl`

## 🧃 Remarques

RAS

## :yum: Pour tester
- Vérifier, sur les pages de début de campagne et de détail d'une organisation qu'il n'y a pas de régression.