### PR TITLE
[FEATURE] Reporter l'email dans la page de réinitialisation du mot de passe (PIX-16730).

### DIFF
--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -27,7 +27,7 @@ export function createWarningConnectionEmail({ locale, email, firstName, validat
 
   const { i18n, defaultVariables } = factory;
   const pixAppUrl = urlBuilder.getPixAppBaseUrl(locale);
-  const resetUrl = `${pixAppUrl}/mot-de-passe-oublie?lang=${lang}`;
+  const resetUrl = `${pixAppUrl}/mot-de-passe-oublie?lang=${lang}&email=${email}`;
 
   return factory.buildEmail({
     template: mailer.warningConnectionTemplateId,

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -59,7 +59,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fen%2Fsupport';
 
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Den';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Den%26email%3Dtoto%40example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -83,7 +83,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const expectedSupportUrl =
         'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
       const expectedResetUrl =
-        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr';
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%40example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -107,7 +107,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const expectedSupportUrl =
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Ffr%2Fsupport';
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dfr';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%40example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -129,7 +129,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       // then
       const { resetUrl, helpDeskUrl } = email.variables;
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl%26email%3Dtoto%40example.net';
 
       const expectedSupportUrl =
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fnl-be%2Fsupport';

--- a/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
+++ b/mon-pix/app/components/authentication/password-reset-demand/password-reset-demand-form.gjs
@@ -18,6 +18,7 @@ export default class PasswordResetDemandForm extends Component {
   @service requestManager;
   @service storage;
   @service url;
+  @service router;
 
   @tracked globalError = this.errors.hasErrors && this.errors.shift();
   @tracked isLoading = false;
@@ -25,7 +26,7 @@ export default class PasswordResetDemandForm extends Component {
 
   constructor() {
     super(...arguments);
-    this.email = this.storage.getLogin();
+    this.email = this.storage.getLogin() || this.router.currentRoute?.queryParams?.email;
   }
 
   validation = new FormValidation({

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -55,6 +55,21 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
     assert.strictEqual(link.getAttribute('href'), 'https://pix.fr/support');
   });
 
+  module('when the email to reset is passed in query parameters', function () {
+    test('it displays the given email address in email input', async function (assert) {
+      // given
+      const currentRoute = { queryParams: { email: 'given-email@example.net' } };
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+
+      // when
+      const screen = await render(<template><PasswordResetDemandForm /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail' })).hasValue('given-email@example.net');
+    });
+  });
+
   module('email input validation', function () {
     module('when the email input is valid', function () {
       test('it doesn’t display any error message', async function (assert) {


### PR DESCRIPTION
## :pancakes: Problème
Si l’utilisateur ne s’est pas connecté depuis 12 mois alors il reçoit un e-mail pour l’alerter d’une connexion. S’il décide de modifier son mot de passe alors il clique sur “Définir un nouveau mot de passe” dans l’e-mail. 
L’utilisateur est redirigé vers la page de réinitialisation du mot de passe et il doit saisir de nouveau son adresse e-mail. Le fait de ressaisir son e-mail peut-être une friction dans le parcours utilisateur. 

## :bacon: Proposition
Passer l'email de l'utilisateur dans le lien de réinitialisation du mot de passe puis récupérer cet e-mail sur la page de réinitialisation du mot de passe pour renseigner le champ concerné. 

## :yum: Pour tester
- Se créer un compte sur Pix App avec sa propre adresse mail
- Se déconnecter de Pix App
- Se connecter à la base de données de la RA
- Jouer les requêtes suivantes :
```
select * from users where "email"='votre.email@pix.fr';
select * from "user-logins" where "userId"='votreUserId';
UPDATE "user-logins" SET "lastLoggedAt" = '2020/01/01' where id=votreUserLoginsId;
```
- Se connecter à Pix App
- Aller consulter ses mails pour retrouver pour y trouver le mail envoyé par Pix qui propose à l'utilisateur de réinitialiser son mot de passe
- Cliquer sur ce lien, modifier https://app.pix.fr en https://app-pr11753.review.pix.fr/ 
- Constater que le paramètre email=votreEmail@pix.fr est présent dans l'url
- Constater que votre email a été automatiquement reporté dans le champ concerné