### PR TITLE
[TECH] modification des robots.txt pour ne pas indexer les environnements hors prod

### DIFF
--- a/certif/public/robots.horsProd.txt
+++ b/certif/public/robots.horsProd.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -79,6 +79,10 @@ server {
 
   root /app/dist/;
 
+  location /robots.txt {
+    try_files <%= ENV['APP'] == 'pix-certif-production' ? '/robots.txt' : '/robots.horsProd.txt' %> =404;
+  }
+
   location = /maintenance_page.html {
     # maintenance page is at the root of the project
     root /app/;

--- a/junior/public/robots.horsProd.txt
+++ b/junior/public/robots.horsProd.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -56,6 +56,10 @@ server {
 
   root /app/dist/;
 
+  location /robots.txt {
+    try_files <%= ENV['APP'] == 'pix-junior-production' ? '/robots.txt' : '/robots.horsProd.txt' %> =404;
+  }
+
   location = /maintenance_page.html {
     # maintenance page is at the root of the project
     root /app/;

--- a/orga/public/robots.horsProd.txt
+++ b/orga/public/robots.horsProd.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -79,6 +79,10 @@ server {
 
   root /app/dist/;
 
+  location /robots.txt {
+    try_files <%= ENV['APP'] == 'pix-orga-production' ? '/robots.txt' : '/robots.horsProd.txt' %> =404;
+  }
+
   location = /maintenance_page.html {
     # maintenance page is at the root of the project
     root /app/;


### PR DESCRIPTION
## :pancakes: Problème
Les applications Pix sont référencées sur les moteurs de recherche sur tous les environnements alors que l'on souhaiterait juste indexer la production.

## :bacon: Proposition
Modifier le robots.txt en fonction de l'environnement

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
