### PR TITLE
[FEATURE] Supression des colonnes pixOrgaTermsOfServiceAccepted et lastPixOrgaTermsOfServiceValidatedAt de la table users (PIX-16700)

### DIFF
--- a/api/db/migrations/20250318093202_remove-pix-orga-terms-of-service-in-users-table.js
+++ b/api/db/migrations/20250318093202_remove-pix-orga-terms-of-service-in-users-table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'users';
+const PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME = 'pixOrgaTermsOfServiceAccepted';
+const LAST_PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME = 'lastPixOrgaTermsOfServiceValidatedAt';
+
+const up = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME);
+    table.dropColumn(LAST_PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME);
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME);
+    table.dateTime(LAST_PIX_ORGA_TERMS_OF_SERVICE_ACCEPTED_COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Les colonnes users.pixOrgaTermsOfServiceAccepted et users.lastPixOrgaTermsOfServiceValidatedAt ne sont plus utilisées


## :robot: Proposition
Supprimer ces colonnes

## :rainbow: Remarques
RAS

## :100: Pour tester

exécuter la commande : 
```sh
npm run db:migrate
```

Vérifier en base de données que les deux colonnes sont bien supprimées

Puis faire le rollback

```sh
npm run db:rollback:latest
```
et vérifier que les colonnes sont bien présentes.