### PR TITLE
[FEATURE] Anonymisation (par généralisation) sur les dernières dates de connexion (PIX-16635)

### DIFF
--- a/api/db/database-builder/factory/build-last-user-application-connection.js
+++ b/api/db/database-builder/factory/build-last-user-application-connection.js
@@ -1,0 +1,25 @@
+import { databaseBuffer } from '../database-buffer.js';
+import { buildUser } from './build-user.js';
+
+function buildLastUserApplicationConnection({
+  id = databaseBuffer.getNextId(),
+  userId,
+  application,
+  lastLoggedAt = new Date(),
+} = {}) {
+  if (!userId) {
+    userId = buildUser().id;
+  }
+
+  const values = {
+    id,
+    userId,
+    application,
+    lastLoggedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'last-user-application-connections',
+    values,
+  });
+}
+export { buildLastUserApplicationConnection };

--- a/api/src/identity-access-management/domain/models/LastUserApplicationConnection.js
+++ b/api/src/identity-access-management/domain/models/LastUserApplicationConnection.js
@@ -1,0 +1,21 @@
+import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/date-utils.js';
+
+export class LastUserApplicationConnection {
+  constructor({ id, userId, application, lastLoggedAt }) {
+    this.id = id;
+    this.userId = userId;
+    this.application = application;
+    this.lastLoggedAt = lastLoggedAt;
+  }
+
+  anonymize() {
+    const generalizedLastLoggedAt = anonymizeGeneralizeDate(this.lastLoggedAt);
+
+    return new LastUserApplicationConnection({
+      id: this.id,
+      userId: this.userId,
+      application: this.application,
+      lastLoggedAt: generalizedLastLoggedAt,
+    });
+  }
+}

--- a/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
@@ -1,10 +1,10 @@
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { LastUserApplicationConnection } from '../../domain/models/LastUserApplicationConnection.js';
 const TABLE_NAME = 'last-user-application-connections';
 
 async function upsert({ userId, application, lastLoggedAt }) {
-  return knex(TABLE_NAME)
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(TABLE_NAME)
     .insert({ userId, application, lastLoggedAt })
     .onConflict(['userId', 'application'])
     .merge({ lastLoggedAt });

--- a/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js
@@ -1,4 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { LastUserApplicationConnection } from '../../domain/models/LastUserApplicationConnection.js';
 const TABLE_NAME = 'last-user-application-connections';
 
 async function upsert({ userId, application, lastLoggedAt }) {
@@ -8,4 +10,20 @@ async function upsert({ userId, application, lastLoggedAt }) {
     .merge({ lastLoggedAt });
 }
 
-export const lastUserApplicationConnectionsRepository = { upsert };
+async function findByUserId(userId) {
+  const knexConn = DomainTransaction.getConnection();
+  const lastUserApplicationConnections = await knexConn(TABLE_NAME).where({ userId });
+
+  return lastUserApplicationConnections.map(_toDomain);
+}
+
+export const lastUserApplicationConnectionsRepository = { upsert, findByUserId };
+
+function _toDomain(lastUserApplicationConnection) {
+  return new LastUserApplicationConnection({
+    id: lastUserApplicationConnection.id,
+    userId: lastUserApplicationConnection.userId,
+    application: lastUserApplicationConnection.application,
+    lastLoggedAt: lastUserApplicationConnection.lastLoggedAt,
+  });
+}

--- a/api/src/privacy/domain/usecases/anonymize-user.usecase.js
+++ b/api/src/privacy/domain/usecases/anonymize-user.usecase.js
@@ -58,11 +58,11 @@ const anonymizeUser = withTransaction(async function ({
 
   await _anonymizeMemberships({ membershipRepository, userId, updatedByUserId: anonymizedByUserId });
 
-  await _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId);
-
   await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
   await _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId);
+
+  await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
   await _anonymizeUserLogin({ userId, userLoginRepository });
 
@@ -116,20 +116,6 @@ async function _anonymizeLastUserApplicationConnections(lastUserApplicationConne
   for (const lastUserApplicationConnection of lastUserApplicationConnections) {
     const anonymized = lastUserApplicationConnection.anonymize();
     await lastUserApplicationConnectionsRepository.upsert(anonymized);
-  }
-}
-
-async function _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId) {
-  const userCertificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
-
-  for (const certificationCenterMembership of userCertificationCenterMemberships) {
-    const anonymizedCertificationCenterMembershipLastAccessedAt = anonymizeGeneralizeDate(
-      certificationCenterMembership.lastAccessedAt,
-    );
-    await certificationCenterMembershipRepository.updateLastAccessedAt({
-      certificationCenterMembershipId: certificationCenterMembership.id,
-      lastAccessedAt: anonymizedCertificationCenterMembershipLastAccessedAt,
-    });
   }
 }
 

--- a/api/src/privacy/domain/usecases/anonymize-user.usecase.js
+++ b/api/src/privacy/domain/usecases/anonymize-user.usecase.js
@@ -62,6 +62,8 @@ const anonymizeUser = withTransaction(async function ({
 
   await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
+  await _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId);
+
   await _anonymizeUserLogin({ userId, userLoginRepository });
 
   await _anonymizeUser({ user, anonymizedByUserId, userRepository });
@@ -114,6 +116,20 @@ async function _anonymizeLastUserApplicationConnections(lastUserApplicationConne
   for (const lastUserApplicationConnection of lastUserApplicationConnections) {
     const anonymized = lastUserApplicationConnection.anonymize();
     await lastUserApplicationConnectionsRepository.upsert(anonymized);
+  }
+}
+
+async function _anonymizeCertificationCenterMembershipsLastAccessedAt(certificationCenterMembershipRepository, userId) {
+  const userCertificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
+
+  for (const certificationCenterMembership of userCertificationCenterMemberships) {
+    const anonymizedCertificationCenterMembershipLastAccessedAt = anonymizeGeneralizeDate(
+      certificationCenterMembership.lastAccessedAt,
+    );
+    await certificationCenterMembershipRepository.updateLastAccessedAt({
+      certificationCenterMembershipId: certificationCenterMembership.id,
+      lastAccessedAt: anonymizedCertificationCenterMembershipLastAccessedAt,
+    });
   }
 }
 

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import * as authenticationMethodRepository from '../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { userAnonymizedEventLoggingJobRepository } from '../../../identity-access-management/infrastructure/repositories/jobs/user-anonymized-event-logging-job-repository.js';
+import { lastUserApplicationConnectionsRepository } from '../../../identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js';
 import { refreshTokenRepository } from '../../../identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import { resetPasswordDemandRepository } from '../../../identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
@@ -24,6 +25,7 @@ const repositories = {
   certificationCenterMembershipRepository,
   learnersApiRepository,
   membershipRepository,
+  lastUserApplicationConnectionsRepository,
   organizationLearnerRepository,
   refreshTokenRepository,
   resetPasswordDemandRepository,

--- a/api/src/shared/infrastructure/utils/date-utils.js
+++ b/api/src/shared/infrastructure/utils/date-utils.js
@@ -38,6 +38,8 @@ function formatDate(params, outputFormat) {
  * @returns {Date} a new Date object
  */
 function anonymizeGeneralizeDate(date) {
+  if (!date) return null;
+
   const newDate = new Date(date);
   newDate.setUTCDate(1);
   newDate.setUTCHours(0, 0, 0, 0);

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/last-user-application-connections.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/last-user-application-connections.repository.test.js
@@ -70,4 +70,47 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
     });
   });
+
+  describe('#findByUserId', function () {
+    it('returns the last user application connections', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const lastLoggedAt = new Date();
+
+      await databaseBuilder.factory.buildLastUserApplicationConnection({
+        id: 1,
+        userId,
+        application: 'orga',
+        lastLoggedAt,
+      });
+
+      await databaseBuilder.factory.buildLastUserApplicationConnection({
+        id: 2,
+        userId,
+        application: 'admin',
+        lastLoggedAt,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const lastUserApplicationConnections = await lastUserApplicationConnectionsRepository.findByUserId(userId);
+
+      // then
+      expect(lastUserApplicationConnections).to.have.deep.members([
+        {
+          id: 1,
+          userId,
+          application: 'orga',
+          lastLoggedAt,
+        },
+        {
+          id: 2,
+          userId,
+          application: 'admin',
+          lastLoggedAt,
+        },
+      ]);
+    });
+  });
 });

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -43,7 +43,10 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     const userId = user.id;
     const anonymizedByUserId = admin.id;
 
-    databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      userId,
+      lastAccessedAt: new Date('2023-03-23T23:23:23Z'),
+    });
 
     const managingStudentsOrga = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
     databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId: managingStudentsOrga.id });
@@ -102,6 +105,7 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
       .where({ userId })
       .whereNotNull('disabledAt');
     expect(disabledCertificationCenterMemberships).to.have.lengthOf(1);
+    expect(disabledCertificationCenterMemberships[0].lastAccessedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
 
     const organizationLearners = await knex('organization-learners').where({ userId });
     expect(organizationLearners).to.have.lengthOf(0);

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -25,12 +25,17 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     disables all user’s organization memberships,
     disables all user’s certification center memberships,
     disables all user’s student prescriptions,
-    anonymizes user login info
+    anonymizes user login info,
     and anonymizes user`, async function () {
     // given
-    const user = databaseBuilder.factory.buildUser.withMembership({
+    const user = databaseBuilder.factory.buildUser({
       createdAt: new Date('2012-12-12T12:12:12Z'),
       updatedAt: new Date('2023-03-23T23:23:23Z'),
+    });
+
+    databaseBuilder.factory.buildMembership({
+      userId: user.id,
+      lastAccessedAt: new Date('2023-03-23T23:23:23Z'),
     });
 
     const admin = databaseBuilder.factory.buildUser.withRole();
@@ -87,6 +92,7 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     expect(enabledMemberships).to.have.lengthOf(0);
     const disabledMemberships = await knex('memberships').where({ userId }).whereNotNull('disabledAt');
     expect(disabledMemberships).to.have.lengthOf(1);
+    expect(disabledMemberships[0].lastAccessedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
 
     const enabledCertificationCenterMemberships = await knex('certification-center-memberships')
       .where({ userId })

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -26,6 +26,9 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     disables all user’s certification center memberships,
     disables all user’s student prescriptions,
     anonymizes user login info,
+    anonymizes last user application connections lastLoggedAt,
+    anonymizes membership lastAccessedAt,
+    anonymizes certification center membership lastAccessedAt,
     and anonymizes user`, async function () {
     // given
     const user = databaseBuilder.factory.buildUser({
@@ -46,6 +49,12 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     databaseBuilder.factory.buildCertificationCenterMembership({
       userId,
       lastAccessedAt: new Date('2023-03-23T23:23:23Z'),
+    });
+
+    databaseBuilder.factory.buildLastUserApplicationConnection({
+      userId,
+      application: 'orga',
+      lastLoggedAt: new Date('2023-03-23T23:23:23Z'),
     });
 
     const managingStudentsOrga = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
@@ -130,6 +139,9 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     expect(anonymizedUser.lastTermsOfServiceValidatedAt).to.be.null;
     expect(anonymizedUser.lastPixCertifTermsOfServiceValidatedAt).to.be.null;
     expect(anonymizedUser.lastDataProtectionPolicySeenAt).to.be.null;
+
+    const lastUserApplicationConnection = await knex('last-user-application-connections').where({ userId }).first();
+    expect(lastUserApplicationConnection.lastLoggedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
   });
 
   context('when anonymizedByUserId does not exist', function () {

--- a/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/membership.repository.test.js
@@ -907,4 +907,25 @@ describe('Integration | Team | Infrastructure | Repository | membership-reposito
       expect(updatedMembership.updatedAt).to.deep.equal(now);
     });
   });
+
+  describe('#findByUserId', function () {
+    it('returns all the memberships for a given user ID', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const membership1 = databaseBuilder.factory.buildMembership({ userId, organizationId: organization1.id });
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      const membership2 = databaseBuilder.factory.buildMembership({ userId, organizationId: organization2.id });
+
+      await databaseBuilder.commit();
+
+      // when
+      const memberships = await membershipRepository.findByUserId(userId);
+
+      // then
+      expect(memberships).to.have.lengthOf(2);
+      expect(memberships[0].id).to.equal(membership1.id);
+      expect(memberships[1].id).to.equal(membership2.id);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/utils/date-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/date-utils_test.js
@@ -161,5 +161,18 @@ describe('Unit | Utils | date-utils', function () {
       expect(anonymizedGeneralizedDate).to.not.equal(someDate);
       expect(anonymizedGeneralizedDate.toISOString()).to.equal('2019-03-01T00:00:00.000Z');
     });
+
+    context('when date is null', function () {
+      it('returns null', function () {
+        // given
+        const aNullDate = null;
+
+        // when
+        const anonymizedGeneralizedDate = anonymizeGeneralizeDate(aNullDate);
+
+        // then
+        expect(anonymizedGeneralizedDate).to.be.null;
+      });
+    });
   });
 });


### PR DESCRIPTION
## :pancakes: Problème

Quand un utilisateur est anonymisé, il est nécessaire d'également généraliser ses dates de dernière connexion

## :bacon: Proposition

Dans le use case `api/src/privacy/domain/usecases/anonymize-user.usecase.js` généraliser les dates:

- lastAccessedAt de la table memberships 

- lastAccessedAt de la table certification-center-memberships 

- lastLoggedAt de la table last_user_application_connections



## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

- Dans pix-orga 
  - Se connecter avec admin-orga@example.net
  - aller sur la page de plusieurs orga

- Dans pix-certif
  - Se connecter avec james-paledroits@example.net
  - aller sur la page de plusieurs centre de certif

- Dans pix-admin
  - anonymiser ses deux utilisateurs
  - Vérifier que les éléments suivant ont été anonymisé:
    - lastAccessedAt de la table memberships 
    - lastAccessedAt de la table certification-center-memberships 
    - lastLoggedAt de la table last_user_application_connections
