### PR TITLE
[FEATURE] ajoute la route pour récupérer les niveaux par sujet et competence (Pix-17023)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -23,6 +23,7 @@ import * as organizationRepository from '../../../../shared/infrastructure/repos
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
+import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
@@ -42,6 +43,7 @@ import { participantResultsSharedRepository } from '../../infrastructure/reposit
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
 import * as poleEmploiSendingRepository from '../../infrastructure/repositories/pole-emploi-sending-repository.js';
+
 /**
  * @typedef { import ('../../../../shared/infrastructure/repositories/area-repository.js')} AreaRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/assessment-repository.js')} AssessmentRepository
@@ -60,7 +62,8 @@ import * as poleEmploiSendingRepository from '../../infrastructure/repositories/
  * @typedef { import ('../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js')} CompareStagesAndAcquiredStages
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/competence-evaluation-repository.js')} CompetenceEvaluationRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/competence-repository.js')} CompetenceRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
+ * @typedef { import ('../../../../shared/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
+ * @typedef { import ('../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js')} KnowledgeElementSnapshotRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/organization-learner-repository.js')} OrganizationLearnerRepository
  * @typedef { import ('../../infrastructure/repositories/participant-result-repository.js')} ParticipantResultRepository
@@ -106,6 +109,7 @@ const dependencies = {
   competenceEvaluationRepository,
   competenceRepository,
   knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
+  knowledgeElementSnapshotRepository,
   learningContentRepository,
   organizationLearnerRepository,
   organizationRepository,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
@@ -1,14 +1,12 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING } from '../../../../../src/shared/infrastructure/constants.js';
 import { CampaignAnalysis } from '../../../campaign/domain/read-models/CampaignAnalysis.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
-import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
-const { SHARED } = CampaignParticipationStatuses;
+import * as campaignParticipationRepository from './campaign-participation-repository.js';
 
 const getCampaignAnalysis = async function (campaignId, campaignLearningContent, tutorials) {
-  const campaignParticipationIds = await _getSharedParticipationsId(campaignId);
+  const campaignParticipationIds = await campaignParticipationRepository.getSharedParticipationIds(campaignId);
   const campaignParticipationIdsChunks = _.chunk(campaignParticipationIds, CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
   const participantCount = campaignParticipationIds.length;
 
@@ -58,11 +56,3 @@ const getCampaignParticipationAnalysis = async function (
 };
 
 export { getCampaignAnalysis, getCampaignParticipationAnalysis };
-
-async function _getSharedParticipationsId(campaignId) {
-  const results = await knex('campaign-participations')
-    .pluck('id')
-    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
-
-  return results;
-}

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -14,7 +14,7 @@ import { KnowledgeElementCollection } from '../../../shared/domain/models/Knowle
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
 
-const { TO_SHARE } = CampaignParticipationStatuses;
+const { TO_SHARE, SHARED } = CampaignParticipationStatuses;
 
 const { pick } = lodash;
 
@@ -244,6 +244,14 @@ function _rowToResult(row) {
   };
 }
 
+async function getSharedParticipationIds(campaignId) {
+  const results = await knex('campaign-participations')
+    .pluck('id')
+    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
+
+  return results;
+}
+
 export {
   batchUpdate,
   findOneByCampaignIdAndUserId,
@@ -253,6 +261,7 @@ export {
   getByCampaignIds,
   getCampaignParticipationsForOrganizationLearner,
   getCodeOfLastParticipationToProfilesCollectionCampaignForUser,
+  getSharedParticipationIds,
   hasAssessmentParticipations,
   isRetrying,
   remove,

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -1,6 +1,7 @@
 import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as campaignAnalysisSerializer from '../../campaign-participation/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as campaignResultLevelsPerTubesAndCompetencesSerializer from '../infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import * as divisionSerializer from '../infrastructure/serializers/jsonapi/division-serializer.js';
 import * as groupSerializer from '../infrastructure/serializers/jsonapi/group-serializer.js';
 import * as presentationStepsSerializer from '../infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
@@ -42,11 +43,25 @@ const getPresentationSteps = async function (
   return dependencies.presentationStepsSerializer.serialize(presentationSteps);
 };
 
+const getLevelPerTubesAndCompetences = async function (
+  request,
+  h,
+  dependencies = { campaignResultLevelsPerTubesAndCompetencesSerializer },
+) {
+  const { campaignId } = request.params;
+  const locale = extractLocaleFromRequest(request);
+  const campaignAnalysis = await usecases.getResultLevelsPerTubesAndCompetences({
+    campaignId,
+    locale,
+  });
+  return dependencies.campaignResultLevelsPerTubesAndCompetencesSerializer.serialize(campaignAnalysis);
+};
 const campaignController = {
   division,
   getAnalysis,
   getGroups,
   getPresentationSteps,
+  getLevelPerTubesAndCompetences,
 };
 
 export { campaignController };

--- a/api/src/prescription/campaign/application/campaign-route.js
+++ b/api/src/prescription/campaign/application/campaign-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { identifiersType as prescriptionIdentifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { campaignController } from './campaign-controller.js';
@@ -54,6 +55,20 @@ const register = async function (server) {
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
             "- Récupération de l'analyse de la campagne par son id",
         ],
+        tags: ['api', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{campaignId}/level_by_tubes_and_competences',
+      config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        handler: campaignController.getLevelPerTubesAndCompetences,
         tags: ['api', 'campaign'],
       },
     },

--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -1,0 +1,100 @@
+import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
+
+class CampaignResultLevelsPerTubesAndCompetences {
+  #difficultyBySkillId;
+  #tubesWithLevels;
+
+  constructor({ campaignId, learningContent, knowledgeElementsByParticipation } = {}) {
+    this.id = campaignId;
+    this.learningContent = learningContent;
+    this.knowledgeElementByParticipation = knowledgeElementsByParticipation;
+    this.knowledgeElementsParticipations = Object.values(knowledgeElementsByParticipation);
+    this.#difficultyBySkillId = learningContent.skills.reduce(
+      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
+      {},
+    );
+    this.#tubesWithLevels = this.#getTubesWithLevels(learningContent.tubes);
+  }
+
+  #getTubesWithLevels(tubes) {
+    const maxTubeLevels = tubes.map((tube) => {
+      const participationsReachedLevels = this.#computeParticipationsReachedLevels(tube);
+
+      const maxLevel = tube.skills.reduce(
+        (maxLevel, skill) => (skill.difficulty > maxLevel ? skill.difficulty : maxLevel),
+        -Infinity,
+      );
+
+      const meanLevel =
+        participationsReachedLevels.reduce((acc, current) => acc + current, 0) / participationsReachedLevels.length;
+
+      return {
+        id: tube.id,
+        competenceId: tube.competenceId,
+        practicalTitle: tube.practicalTitle,
+        practicalDescription: tube.practicalDescription,
+        maxLevel,
+        meanLevel,
+      };
+    });
+    return maxTubeLevels;
+  }
+
+  get campaignLevelsPerTube() {
+    return this.#tubesWithLevels;
+  }
+
+  get campaignLevelsPerCompetence() {
+    const maxCompetenceLevels = this.learningContent.competences.map((competence) => {
+      const averageTubesMaxReachableLevel =
+        this.#tubesWithLevels.reduce((maxLevel, tube) => maxLevel + tube.maxLevel, 0) / this.#tubesWithLevels.length;
+
+      const averageTubesMeanReachedLevel =
+        this.#tubesWithLevels.reduce((meanLevel, tube) => meanLevel + tube.meanLevel, 0) / this.#tubesWithLevels.length;
+
+      return {
+        id: competence.id,
+        index: competence.index,
+        name: competence.name,
+        description: competence.description,
+        maxLevel: averageTubesMaxReachableLevel,
+        meanLevel: averageTubesMeanReachedLevel,
+      };
+    });
+    return maxCompetenceLevels;
+  }
+
+  get campaignMaxReachableLevel() {
+    return (
+      this.campaignLevelsPerTube.reduce((maxLevel, tube) => maxLevel + tube.maxLevel, 0) /
+      this.campaignLevelsPerTube.length
+    );
+  }
+
+  get campaignMeanReachedLevel() {
+    return (
+      this.campaignLevelsPerTube.reduce((meanLevel, tube) => meanLevel + tube.meanLevel, 0) /
+      this.campaignLevelsPerTube.length
+    );
+  }
+
+  #computeParticipationsReachedLevels(tube) {
+    const skillIdsForTube = tube.skills.map((skill) => skill.id);
+    return this.knowledgeElementsParticipations.map((knowledgeElements) =>
+      this.#computeParticipationLevel(skillIdsForTube, knowledgeElements),
+    );
+  }
+
+  #computeParticipationLevel(skillIds, knowledgeElements) {
+    return knowledgeElements
+      .filter((ke) => skillIds.includes(ke.skillId))
+      .reduce((max, knowledgeElement) => {
+        const skillDifficulty = this.#difficultyBySkillId[knowledgeElement.skillId];
+        return knowledgeElement.status === KnowledgeElement.StatusType.VALIDATED && max < skillDifficulty
+          ? skillDifficulty
+          : max;
+      }, 0);
+  }
+}
+
+export { CampaignResultLevelsPerTubesAndCompetences };

--- a/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
+++ b/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
@@ -1,0 +1,24 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../models/CampaignResultLevelsPerTubesAndCompetences.js';
+
+const getResultLevelsPerTubesAndCompetences = async ({
+  campaignId,
+  locale,
+  campaignParticipationRepository,
+  learningContentRepository,
+  knowledgeElementSnapshotRepository,
+}) => {
+  const campaignParticipationIds = await campaignParticipationRepository.getSharedParticipationIds(campaignId);
+
+  const knowledgeElementsByParticipation =
+    await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(campaignParticipationIds);
+
+  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
+
+  return new CampaignResultLevelsPerTubesAndCompetences({
+    campaignId,
+    learningContent,
+    knowledgeElementsByParticipation,
+  });
+};
+
+export { getResultLevelsPerTubesAndCompetences };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
@@ -1,0 +1,26 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (results) {
+  return new Serializer('campaign-result-levels-per-tubes-and-competences', {
+    attributes: [
+      'campaignLevelsPerTube',
+      'campaignLevelsPerCompetence',
+      'campaignMaxReachableLevel',
+      'campaignMeanReachedLevel',
+    ],
+    campaignLevelsPerCompetence: {
+      ref: 'id',
+      includes: true,
+      attributes: ['index', 'name', 'description', 'maxLevel', 'meanLevel'],
+    },
+    campaignLevelsPerTube: {
+      ref: 'id',
+      includes: true,
+      attributes: ['competenceId', 'practicalTitle', 'practicalDescription', 'maxLevel', 'meanLevel'],
+    },
+  }).serialize(results);
+};
+
+export { serialize };

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1427,4 +1427,81 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
     });
   });
+
+  describe('#getSharedParticipationIds', function () {
+    context('no shared participation', function () {
+      it('should return an empty array', async function () {
+        // given
+        const participation = databaseBuilder.factory.buildCampaignParticipation({
+          status: CampaignParticipationStatuses.TO_SHARE,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: participation.campaignId,
+          status: CampaignParticipationStatuses.STARTED,
+        });
+        await databaseBuilder.commit();
+        // given
+        // when
+        const result = await campaignParticipationRepository.getSharedParticipationIds(participation.campaignId);
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+    context('with participation in another campaign', function () {
+      it('should return an empty array', async function () {
+        // given
+        const campaign1 = databaseBuilder.factory.buildCampaign();
+        const campaign2 = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign1.id,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+
+        await databaseBuilder.commit();
+        // given
+        // when
+        const result = await campaignParticipationRepository.getSharedParticipationIds(campaign2.id);
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+    context('with shared participation', function () {
+      it('should return an array', async function () {
+        // given
+        const participation = databaseBuilder.factory.buildCampaignParticipation({
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        await databaseBuilder.commit();
+        // when
+        const result = await campaignParticipationRepository.getSharedParticipationIds(participation.campaignId);
+
+        // then
+        expect(result).lengthOf(1);
+      });
+    });
+    context('with improved participation', function () {
+      it('should return only not improved participation ', async function () {
+        // given
+        const improvedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          status: CampaignParticipationStatuses.SHARED,
+          isImproved: true,
+        });
+        const participation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: improvedParticipation.campaignId,
+          status: CampaignParticipationStatuses.SHARED,
+          userId: improvedParticipation.userId,
+          organizationLearnerId: improvedParticipation.organizationLearnerId,
+        });
+        await databaseBuilder.commit();
+        // when
+        const result = await campaignParticipationRepository.getSharedParticipationIds(participation.campaignId);
+
+        // then
+        expect(result).lengthOf(1);
+        expect(result[0]).equal(participation.id);
+      });
+    });
+  });
 });

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -3,7 +3,6 @@ import { KnowledgeElement, Membership } from '../../../../../src/shared/domain/m
 import {
   createServer,
   databaseBuilder,
-  domainBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
@@ -480,7 +479,7 @@ describe('Acceptance | API | Campaign Route', function () {
   });
 
   describe('GET /api/campaigns/{campaignId}/level_by_tubes_and_competences', function () {
-    let campaign, campaignId, userId;
+    let campaign, userId;
     const options = {
       headers: { authorization: null },
       method: 'GET',

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -1,7 +1,9 @@
-import { Membership } from '../../../../../src/shared/domain/models/index.js';
+import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement, Membership } from '../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
   databaseBuilder,
+  domainBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
   learningContentBuilder,
@@ -474,6 +476,168 @@ describe('Acceptance | API | Campaign Route', function () {
           },
         ],
       });
+    });
+  });
+
+  describe('GET /api/campaigns/{campaignId}/level_by_tubes_and_competences', function () {
+    let campaign, campaignId, userId;
+    const options = {
+      headers: { authorization: null },
+      method: 'GET',
+      url: null,
+    };
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.MEMBER,
+      });
+
+      campaign = databaseBuilder.factory.buildCampaign({
+        name: 'Campagne de Test N°3',
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillWeb1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillWeb2' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillUrl1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillUrl2' });
+
+      const learningContentData = {
+        frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
+        areas: [{ id: 'recArea1', frameworkId: 'frameworkId', competenceIds: ['recCompetence1'] }],
+        competences: [
+          {
+            id: 'recCompetence1',
+            name_i18n: { fr: 'name FR Compétence 1', en: 'name EN Compétence 1' },
+            description_i18n: { fr: 'description FR Compétence 1', en: 'description EN Compétence 1' },
+            index: '1.1',
+            skillIds: ['recSkillWeb1', 'recSkillWeb2', 'recSkillUrl1', 'recSkillUrl2'],
+            areaId: 'recArea1',
+            origin: 'Pix',
+          },
+        ],
+        thematics: [],
+        tubes: [
+          {
+            id: 'recTube1',
+            name: '@tubeWeb1',
+            title: 'Title recTube1',
+            description: 'recTube1 description',
+            practicalTitle_i18n: { fr: 'Tube 1 fr title', en: 'Tube 1 en title' },
+            practicalDescription_i18n: { fr: 'recTube1 fr description', en: 'recTube1 en description' },
+            competenceId: 'recCompetence1',
+            skillIds: ['recSkillWeb1', 'recSkillWeb2'],
+          },
+          {
+            id: 'recTube2',
+            name: '@tubeUrl2',
+            title: 'Title recTube2',
+            description: 'recTube2 description',
+            practicalTitle_i18n: { fr: 'Tube 2 fr title', en: 'Tube 2 en title' },
+            practicalDescription_i18n: { fr: 'recTube2 fr description', en: 'recTube2 en description' },
+            competenceId: 'recCompetence1',
+            skillIds: ['recSkillUrl1', 'recSkillUrl2'],
+          },
+        ],
+        skills: [
+          {
+            id: 'recSkillWeb1',
+            name: '@web1',
+            tubeId: 'recTube1',
+            status: 'actif',
+            level: 1,
+            competenceId: 'recCompetence1',
+          },
+          {
+            id: 'recSkillWeb2',
+            name: '@web2',
+            tubeId: 'recTube1',
+            status: 'actif',
+            level: 2,
+            competenceId: 'recCompetence1',
+          },
+          {
+            id: 'recSkillUrl1',
+            name: '@url1',
+            tubeId: 'recTube2',
+            status: 'actif',
+            level: 3,
+            competenceId: 'recCompetence1',
+          },
+          {
+            id: 'recSkillUrl2',
+            name: '@url2',
+            tubeId: 'recTube2',
+            status: 'actif',
+            level: 4,
+            competenceId: 'recCompetence1',
+          },
+        ],
+        challenges: [],
+      };
+
+      databaseBuilder.factory.learningContent.build(learningContentData);
+
+      const user1 = databaseBuilder.factory.buildUser();
+      const user2 = databaseBuilder.factory.buildUser();
+
+      const participationUser1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId: user1.id,
+      });
+      const participationUser2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId: user2.id,
+      });
+
+      const user1ke1 = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: learningContentData.skills[0].id,
+        userId: participationUser1.userId,
+      });
+      const user1ke2 = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: learningContentData.skills[1].id,
+        userId: participationUser1.userId,
+      });
+
+      const user2ke1 = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: learningContentData.skills[2].id,
+        userId: participationUser2.userId,
+      });
+
+      const user2ke2 = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: learningContentData.skills[3].id,
+        userId: participationUser2.userId,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participationUser1.id,
+        snapshot: new KnowledgeElementCollection([user1ke1, user1ke2]).toSnapshot(),
+      });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participationUser2.id,
+        snapshot: new KnowledgeElementCollection([user2ke1, user2ke2]).toSnapshot(),
+      });
+
+      await databaseBuilder.commit();
+
+      options.headers = generateAuthenticatedUserRequestHeaders({ userId });
+      options.url = `/api/campaigns/${campaign.id}/level_by_tubes_and_competences`;
+    });
+
+    it('should return correct mean and max levels for competences and tubes', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200, response.payload);
+      expect(response.result.data.type).to.deep.equal('campaign-result-levels-per-tubes-and-competences');
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -1,5 +1,5 @@
 import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
-import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { LOCALE } from '../../../../../../src/shared/domain/constants.js';

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -1,0 +1,141 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Prescription Integration | UseCase | get-result-levels-per-tubes-and-competences', function () {
+  let campaignId;
+
+  beforeEach(async function () {
+    const learningContentData = {
+      frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
+      areas: [{ id: 'recArea1', frameworkId: 'frameworkId', competenceIds: ['recCompetence1'] }],
+      competences: [
+        {
+          id: 'recCompetence1',
+          name_i18n: { fr: 'name FR Compétence 1', en: 'name EN Compétence 1' },
+          description_i18n: { fr: 'description FR Compétence 1', en: 'description EN Compétence 1' },
+          index: '1.1',
+          skillIds: ['recSkillWeb1', 'recSkillWeb2', 'recSkillUrl1', 'recSkillUrl2'],
+          areaId: 'recArea1',
+          origin: 'Pix',
+        },
+      ],
+      thematics: [],
+      tubes: [
+        {
+          id: 'recTube1',
+          name: '@tubeWeb1',
+          title: 'Title recTube1',
+          description: 'recTube1 description',
+          practicalTitle_i18n: { fr: 'Tube 1 fr title', en: 'Tube 1 en title' },
+          practicalDescription_i18n: { fr: 'recTube1 fr description', en: 'recTube1 en description' },
+          competenceId: 'recCompetence1',
+          skillIds: ['recSkillWeb1', 'recSkillWeb2'],
+        },
+        {
+          id: 'recTube2',
+          name: '@tubeUrl2',
+          title: 'Title recTube2',
+          description: 'recTube2 description',
+          practicalTitle_i18n: { fr: 'Tube 2 fr title', en: 'Tube 2 en title' },
+          practicalDescription_i18n: { fr: 'recTube2 fr description', en: 'recTube2 en description' },
+          competenceId: 'recCompetence1',
+          skillIds: ['recSkillUrl1', 'recSkillUrl2'],
+        },
+      ],
+      skills: [
+        {
+          id: 'recSkillWeb1',
+          name: '@web1',
+          tubeId: 'recTube1',
+          status: 'actif',
+          level: 1,
+          competenceId: 'recCompetence1',
+        },
+        {
+          id: 'recSkillWeb2',
+          name: '@web2',
+          tubeId: 'recTube1',
+          status: 'actif',
+          level: 2,
+          competenceId: 'recCompetence1',
+        },
+        {
+          id: 'recSkillUrl1',
+          name: '@url1',
+          tubeId: 'recTube2',
+          status: 'actif',
+          level: 3,
+          competenceId: 'recCompetence1',
+        },
+        {
+          id: 'recSkillUrl2',
+          name: '@url2',
+          tubeId: 'recTube2',
+          status: 'actif',
+          level: 4,
+          competenceId: 'recCompetence1',
+        },
+      ],
+      challenges: [],
+    };
+    await databaseBuilder.factory.learningContent.build(learningContentData);
+
+    campaignId = databaseBuilder.factory.buildCampaign({
+      type: CampaignTypes.ASSESSMENT,
+    }).id;
+
+    const firstParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+    const secondParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+    learningContentData.skills.forEach((skill) => {
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: skill.id });
+    });
+
+    const user1ke1 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: learningContentData.skills[0].id,
+      userId: firstParticipation.userId,
+    });
+    const user1ke2 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.INVALIDATED,
+      skillId: learningContentData.skills[1].id,
+      userId: firstParticipation.userId,
+    });
+
+    const user2ke1 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: learningContentData.skills[2].id,
+      userId: secondParticipation.userId,
+    });
+
+    const user2ke2 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: learningContentData.skills[3].id,
+      userId: secondParticipation.userId,
+    });
+
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({
+      campaignParticipationId: firstParticipation.id,
+      snapshot: new KnowledgeElementCollection([user1ke1, user1ke2]).toSnapshot(),
+    });
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({
+      campaignParticipationId: secondParticipation.id,
+      snapshot: new KnowledgeElementCollection([user2ke1, user2ke2]).toSnapshot(),
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should return a CampaignResultLevelsPerTubesAndCompetences', async function () {
+    const result = await usecases.getResultLevelsPerTubesAndCompetences({ campaignId, locale: LOCALE.FRENCH_SPOKEN });
+
+    expect(result).instanceOf(CampaignResultLevelsPerTubesAndCompetences);
+    expect(result.campaignMaxReachableLevel).to.equal(3);
+    expect(result.campaignMeanReachedLevel).to.equal(1.25);
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
@@ -99,4 +99,40 @@ describe('Unit | Application | Controller | Campaign', function () {
       expect(response).to.equal(expectedResults);
     });
   });
+
+  describe('#getLevelPerTubesAndCompetences', function () {
+    const campaignId = 1;
+    const locale = FRENCH_SPOKEN;
+    let campaignResultLevelsPerTubesAndCompetencesSerializerStub;
+
+    beforeEach(function () {
+      sinon.stub(usecases, 'getResultLevelsPerTubesAndCompetences');
+      campaignResultLevelsPerTubesAndCompetencesSerializerStub = {
+        serialize: sinon.stub(),
+      };
+    });
+
+    it('should return expected results', async function () {
+      // given
+      const resultLevels = Symbol('resultLevels');
+      const expectedResults = Symbol('results');
+      usecases.getResultLevelsPerTubesAndCompetences.withArgs({ campaignId, locale }).resolves(resultLevels);
+      campaignResultLevelsPerTubesAndCompetencesSerializerStub.serialize
+        .withArgs(resultLevels)
+        .returns(expectedResults);
+
+      const request = {
+        params: { campaignId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignController.getLevelPerTubesAndCompetences(request, hFake, {
+        campaignResultLevelsPerTubesAndCompetencesSerializer: campaignResultLevelsPerTubesAndCompetencesSerializerStub,
+      });
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-route_test.js
@@ -1,5 +1,6 @@
 import { campaignController } from '../../../../../src/prescription/campaign/application/campaign-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Router | campaign-router ', function () {
@@ -78,6 +79,54 @@ describe('Unit | Application | Router | campaign-router ', function () {
 
       // when
       const response = await httpTestServer.request('GET', '/api/campaigns/wrong_id/analyses');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('GET /api/campaigns/{campaignId}/level_by_tubes_and_competences', function () {
+    it('should return 200', async function () {
+      // given
+      sinon
+        .stub(campaignController, 'getLevelPerTubesAndCompetences')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/level_by_tubes_and_competences');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403', async function () {
+      // given
+      sinon
+        .stub(campaignController, 'getLevelPerTubesAndCompetences')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/level_by_tubes_and_competences');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should return 400', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/wrong_id/level_by_tubes_and_competences');
 
       // then
       expect(response.statusCode).to.equal(400);

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -1,0 +1,173 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', function () {
+  describe('compute', function () {
+    let learningContent, keData;
+
+    beforeEach(function () {
+      const learningContentData = {
+        frameworks: [
+          {
+            id: 'frameworkId',
+            name: 'frameworkName',
+            areas: [
+              {
+                id: 'recArea1',
+                frameworkId: 'frameworkId',
+                competenceIds: ['recCompetence1'],
+                competences: [
+                  {
+                    id: 'recCompetence1',
+                    index: '1.1',
+                    name: 'nom de la competence',
+                    description: 'description de la competence',
+                    areaId: 'recArea1',
+                    origin: 'Pix',
+                    tubes: [
+                      {
+                        id: 'recTube1',
+                        practicalTitle: 'tube1',
+                        practicalDescription: 'tube1 description',
+                        competenceId: 'recCompetence1',
+                        skills: [
+                          {
+                            id: 'recSkillWeb1',
+                            name: '@web1',
+                            status: 'actif',
+                            difficulty: 1,
+                          },
+                          {
+                            id: 'recSkillWeb2',
+                            name: '@web2',
+                            status: 'actif',
+                            difficulty: 2,
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recTube2',
+                        practicalTitle: 'tube2',
+                        practicalDescription: 'tube2 description',
+                        competenceId: 'recCompetence1',
+                        skills: [
+                          {
+                            id: 'recSkillUrl1',
+                            name: '@url1',
+                            status: 'actif',
+                            difficulty: 3,
+                          },
+                          {
+                            id: 'recSkillUrl2',
+                            name: '@url2',
+                            status: 'actif',
+                            difficulty: 4,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      learningContent = domainBuilder.buildLearningContent(learningContentData.frameworks);
+
+      const user1ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillWeb1',
+        userId: 1,
+      });
+      const user1ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: 'recSkillWeb2',
+        userId: 1,
+      });
+
+      const user2ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl1',
+        userId: 2,
+      });
+
+      const user2ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl2',
+        userId: 2,
+      });
+
+      keData = {
+        participationId1: new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
+        participationId2: new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+      };
+    });
+
+    it('should compute the maximum reachable level', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      expect(campaignResult.campaignMaxReachableLevel).equal(3);
+    });
+
+    it('should compute the mean reached level', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      expect(campaignResult.campaignMeanReachedLevel).equal(1.25);
+    });
+
+    it('should get max level per tube', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+
+      expect(campaignResult.campaignLevelsPerTube).deep.equal([
+        {
+          id: 'recTube1',
+          competenceId: 'recCompetence1',
+          practicalTitle: 'tube1',
+          practicalDescription: 'tube1 description',
+          maxLevel: 2,
+          meanLevel: 0.5,
+        },
+        {
+          id: 'recTube2',
+          competenceId: 'recCompetence1',
+          practicalTitle: 'tube2',
+          practicalDescription: 'tube2 description',
+          maxLevel: 4,
+          meanLevel: 2,
+        },
+      ]);
+    });
+
+    it('should get max level per competence', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+
+      expect(campaignResult.campaignLevelsPerCompetence).deep.equal([
+        {
+          id: 'recCompetence1',
+          index: '1.1',
+          name: 'nom de la competence',
+          description: 'description de la competence',
+          maxLevel: 3,
+          meanLevel: 1.25,
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -1,0 +1,190 @@
+import { expect } from 'chai';
+
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
+import { KnowledgeElementCollection } from '../../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-competences-serializer', function () {
+  describe('#serialize', function () {
+    let learningContent, keData;
+
+    beforeEach(function () {
+      const learningContentData = {
+        frameworks: [
+          {
+            id: 'frameworkId',
+            name: 'frameworkName',
+            areas: [
+              {
+                id: 'recArea1',
+                frameworkId: 'frameworkId',
+                competenceIds: ['recCompetence1'],
+                competences: [
+                  {
+                    id: 'recCompetence1',
+                    index: '1.1',
+                    name: 'nom de la competence',
+                    description: 'description de la competence',
+                    areaId: 'recArea1',
+                    origin: 'Pix',
+                    tubes: [
+                      {
+                        id: 'recTube1',
+                        practicalTitle: 'tube1',
+                        practicalDescription: 'tube1 description',
+                        competenceId: 'recCompetence1',
+                        skills: [
+                          {
+                            id: 'recSkillWeb1',
+                            name: '@web1',
+                            status: 'actif',
+                            difficulty: 1,
+                          },
+                          {
+                            id: 'recSkillWeb2',
+                            name: '@web2',
+                            status: 'actif',
+                            difficulty: 2,
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recTube2',
+                        practicalTitle: 'tube2',
+                        practicalDescription: 'tube2 description',
+                        competenceId: 'recCompetence1',
+                        skills: [
+                          {
+                            id: 'recSkillUrl1',
+                            name: '@url1',
+                            status: 'actif',
+                            difficulty: 3,
+                          },
+                          {
+                            id: 'recSkillUrl2',
+                            name: '@url2',
+                            status: 'actif',
+                            difficulty: 4,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      learningContent = domainBuilder.buildLearningContent(learningContentData.frameworks);
+
+      const user1ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillWeb1',
+        userId: 1,
+      });
+      const user1ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: 'recSkillWeb2',
+        userId: 1,
+      });
+
+      const user2ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl1',
+        userId: 2,
+      });
+
+      const user2ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl2',
+        userId: 2,
+      });
+
+      keData = {
+        participationId1: new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
+        participationId2: new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+      };
+    });
+
+    it('should convert CampaignResultLevelPerTubesAndCompentences acquisitions statistics into JSON API data', function () {
+      const campaignId = 1;
+      const model = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      const json = serializer.serialize(model);
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'campaign-result-levels-per-tubes-and-competences',
+          id: `${campaignId}`,
+          attributes: {
+            'campaign-max-reachable-level': 3,
+            'campaign-mean-reached-level': 1.25,
+          },
+          relationships: {
+            'campaign-levels-per-competence': {
+              data: [
+                {
+                  id: 'recCompetence1',
+                  type: 'campaignLevelsPerCompetences',
+                },
+              ],
+            },
+            'campaign-levels-per-tube': {
+              data: [
+                {
+                  id: 'recTube1',
+                  type: 'campaignLevelsPerTubes',
+                },
+                {
+                  id: 'recTube2',
+                  type: 'campaignLevelsPerTubes',
+                },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              'competence-id': 'recCompetence1',
+              'max-level': 2,
+              'mean-level': 0.5,
+              'practical-description': 'tube1 description',
+              'practical-title': 'tube1',
+            },
+            id: 'recTube1',
+            type: 'campaignLevelsPerTubes',
+          },
+          {
+            attributes: {
+              'competence-id': 'recCompetence1',
+              'max-level': 4,
+              'mean-level': 2,
+              'practical-description': 'tube2 description',
+              'practical-title': 'tube2',
+            },
+            id: 'recTube2',
+            type: 'campaignLevelsPerTubes',
+          },
+          {
+            attributes: {
+              description: 'description de la competence',
+              index: '1.1',
+              'max-level': 3,
+              'mean-level': 1.25,
+              name: 'nom de la competence',
+            },
+            id: 'recCompetence1',
+            type: 'campaignLevelsPerCompetences',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème
Dans le cadre de l'épix sur la refonte de la page analyse, on a besoin d'afficher les infos de niveaux atteints / niveaux max atteignable par tubes ou compétences.

## :bacon: Proposition
On ajoute une nouvelle route qui à terme remplacera la route `/api/campaigns/{campaignId}/analyses` et qui renvois les donnée attendu (avec la description de chaque tube et compétences)

## 🧃 Remarques

Valider avec le team data que le calcul des niveaux moyen max et atteints sont ok

## :yum: Pour tester

```
ACCESS_TOKEN=$(curl -s 'https://pix-api-review-pr11758.osc-fr1.scalingo.io/api/token' --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123&scope=pix-orga' | jq -r .access_token);

curl -H "Authorization: Bearer $ACCESS_TOKEN" https://orga-pr11758.review.pix.fr/api/campaigns/xxx/level_by_tubes_and_competences
```