### PR TITLE
[BUGFIX] La notification de levelup apparaître parfois lors d'une évaluation de compétence alors que le levelup n'est pas justifié (PIX-17085)

### DIFF
--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -128,10 +128,16 @@ async function computeLevelUpInformation({
   const knowledgeElementsForCompetenceBefore = knowledgeElementsBefore.filter(
     (knowledgeElement) => knowledgeElement.competenceId === competenceId,
   );
+  const knowledgeElementsAddedForCompetence = knowledgeElementsAdded.filter(
+    (knowledgeElement) => knowledgeElement.competenceId === competenceId,
+  );
   const knowledgeElementsForCompetenceAfter = [
-    ...knowledgeElementsAdded.filter((knowledgeElement) => knowledgeElement.competenceId === competenceId),
+    ...knowledgeElementsAddedForCompetence,
     ...knowledgeElementsForCompetenceBefore,
   ];
+  const uniqKnowledgeElementsForCompetenceAfter = knowledgeElementsForCompetenceAfter.filter(
+    (ke, index) => knowledgeElementsForCompetenceAfter.findIndex(({ skillId }) => skillId === ke.skillId) === index,
+  );
   return scorecardService.computeLevelUpInformation({
     answer: answerSaved,
     userId,
@@ -139,7 +145,7 @@ async function computeLevelUpInformation({
     competence,
     competenceEvaluationForCompetence,
     knowledgeElementsForCompetenceBefore,
-    knowledgeElementsForCompetenceAfter,
+    knowledgeElementsForCompetenceAfter: uniqKnowledgeElementsForCompetenceAfter,
   });
 }
 

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -1,0 +1,124 @@
+import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
+import { CompetenceEvaluation } from '../../../../../src/evaluation/domain/models/CompetenceEvaluation.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.js';
+import { AnswerStatus, Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Evaluation | Integration | Usecase | Save and correct answer for competence evaluation', function () {
+  const skillIds = ['monAcquisA_Id', 'monAcquisB_Id', 'monAcquisC_Id'];
+
+  it('should correct answer and save both answer and knowledge-elements', async function () {
+    // given
+    const locale = 'fr';
+    const competenceId = 'maCompetenceId';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const assessmentDB = databaseBuilder.factory.buildAssessment({
+      userId,
+      competenceId,
+      type: Assessment.types.COMPETENCE_EVALUATION,
+    });
+    databaseBuilder.factory.buildCompetenceEvaluation({
+      userId,
+      assessmentId: assessmentDB.id,
+      competenceId,
+      status: CompetenceEvaluation.statuses.STARTED,
+    });
+    databaseBuilder.factory.learningContent.buildArea({
+      id: 'monAreaId',
+    });
+    databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'maCompetenceId',
+      areaId: 'monAreaId',
+      name_i18n: {
+        fr: 'nom de la compétence',
+      },
+    });
+    databaseBuilder.factory.learningContent.buildChallenge({
+      id: 'monEpreuveId',
+      skillId: skillIds[2],
+      competenceId: 'maCompetenceId',
+      locales: [locale],
+      status: 'validé',
+      solution: 'correct',
+      proposals: '${a}',
+      type: 'QROC',
+    });
+    skillIds.map((id, index) =>
+      databaseBuilder.factory.learningContent.buildSkill({
+        id,
+        competenceId: 'maCompetenceId',
+        pixValue: PIX_COUNT_BY_LEVEL,
+        status: 'actif',
+        tubeId: 'monTubeId',
+        level: index + 1,
+      }),
+    );
+    const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+    const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+    databaseBuilder.factory.buildKnowledgeElement({
+      skillId: skillIds[0],
+      earnedPix: PIX_COUNT_BY_LEVEL,
+      userId,
+      assessmentId: someOtherAssessmentId,
+      answerId: someAnswerId,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      source: KnowledgeElement.SourceType.DIRECT,
+      competenceId: 'maCompetenceId',
+      createdAt: new Date('2020-01-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const assessment = domainBuilder.buildAssessment(assessmentDB);
+    const answer = new Answer({
+      value: 'correct',
+      challengeId: 'monEpreuveId',
+      assessmentId: assessment.id,
+    });
+    const savedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCompetenceEvaluation({
+      answer,
+      userId,
+      assessment,
+      locale,
+      forceOKAnswer: false,
+    });
+
+    // then
+    const keData = await knex('knowledge-elements')
+      .select(['source', 'status', 'skillId'])
+      .where({ userId })
+      .orderBy('skillId', 'createdAt');
+    sinon.assert.match(keData[0], {
+      source: KnowledgeElement.SourceType.DIRECT,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[0],
+    });
+    sinon.assert.match(keData[1], {
+      source: KnowledgeElement.SourceType.INFERRED,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[0],
+    });
+    sinon.assert.match(keData[2], {
+      source: KnowledgeElement.SourceType.INFERRED,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[1],
+    });
+    sinon.assert.match(keData[3], {
+      source: KnowledgeElement.SourceType.DIRECT,
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: skillIds[2],
+    });
+    expect(keData.length).to.equal(4);
+    sinon.assert.match(savedAnswer, {
+      id: sinon.match.number,
+      result: AnswerStatus.OK,
+      levelup: {
+        id: savedAnswer.id,
+        competenceName: 'nom de la compétence',
+        level: 3,
+      },
+    });
+    expect(savedAnswer).to.be.instanceOf(Answer);
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

Pour reproduire (parfois).
Se positionner librement sur une compétence (sans bouton magique sinon pas de notif ! 😉 )
Lors de l'apparition d'une notif de levelup, retourner sur la page de profil et, parfois, constater qu'en fait on n'a pas level up sur la compétence.

## :bacon: Proposition
Le bug avait été tué dans l'oeuf lors des campagnes d'évaluation, mais on a oublié de corriger le problème côté évaluation de compétence.
Le bug exactement c'est :
J'ai un KE validé en direct portant sur l'acquis @bonbon1 qui me rapporte 1 pix.
Je réponds correctement à une épreuve portant sur @bonbon2.
Cela génère, en toute logique :
- 1 KE validé en direct sur @bonbon2 (me rapportant 2 pix par exemple)
- 1 KE validé en inférence sur @bonbon1 (me rapportant à nouveau 1 pix)

Lors du calcul du levelup, on compte le score rapporté en pix des deux KEs portant sur l'acquis @bonbon1 au lieu de ne le compter qu'une seule fois.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Essayer de retomber sur un état où le levelup est mensonger. A priori ça n'est plus possible !
