### PR TITLE
[BUGFIX] Ajuster l'affichage de la page de début de campagne (PIX-17090)

### DIFF
--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: var(--pix-spacing-8x);
+  padding: var(--pix-spacing-8x) 0;
 }
 
 .campaign-landing-page__start__image__container {


### PR DESCRIPTION
## :pancakes: Problème

L'affichage des étapes sur la page de début de parcours se fait en 2 lignes sur de plus petites résolutions en format Desktop (< 1300px en width). 

Cela est dû à un padding ajouté sur la PR https://github.com/1024pix/pix/pull/11695 à gauche et à droite du container.

## :bacon: Proposition

On revert cette modification de padding.

## 🧃 Remarques

RAS

## :yum: Pour tester

- Aller sur la page de début de campagnes [/campagnes/EDUSIMPLE](https://app-pr11762.review.pix.fr/campagnes/EDUSIMPLE)
- Se mettre sur une résolution d'écran inférieure à 1300 px (ex: 1280 x 800)
- Vérifier que les blocs d'étapes s'affichent bien en 1 ligne 😸 
