### PR TITLE
[BUGFIX] Ne plus retourner de 500 sur le reset d'une compétence avec un assessment de type campagne anonymisé (PIX-17092)

### DIFF
--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -128,12 +128,21 @@ class Assessment {
         break;
       }
       case Assessment.types.CAMPAIGN: {
-        this.campaignCode = campaign.code;
-        this.showProgressBar = campaign.isAssessment;
-        this.hasCheckpoints = campaign.isAssessment;
-        this.showLevelup = campaign.isAssessment;
-        this.showQuestionCounter = campaign.isAssessment;
-        this.title = campaign.title;
+        // if campaign participation is anonymized, assessment of type campaign do not have related campaign
+        if (!campaign) {
+          this.showProgressBar = false;
+          this.hasCheckpoints = false;
+          this.showLevelup = false;
+          this.showQuestionCounter = false;
+          this.title = '';
+        } else {
+          this.campaignCode = campaign.code;
+          this.showProgressBar = campaign.isAssessment;
+          this.hasCheckpoints = campaign.isAssessment;
+          this.showLevelup = campaign.isAssessment;
+          this.showQuestionCounter = campaign.isAssessment;
+          this.title = campaign.title;
+        }
         break;
       }
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -60,6 +60,8 @@ describe('Unit | Domain | Models | Assessment', function () {
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         type: Assessment.types.CAMPAIGN,
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        describeInfos: CampaignTypes.ASSESSMENT,
         hasCheckpoints: true,
         showProgressBar: true,
         showLevelup: true,
@@ -71,6 +73,8 @@ describe('Unit | Domain | Models | Assessment', function () {
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         type: Assessment.types.CAMPAIGN,
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        describeInfos: CampaignTypes.EXAM,
         hasCheckpoints: false,
         showProgressBar: false,
         showLevelup: false,
@@ -79,8 +83,20 @@ describe('Unit | Domain | Models | Assessment', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         attributes: { campaign: domainBuilder.buildCampaign({ title: 'Ma Campagne', type: CampaignTypes.EXAM }) },
       },
-    ].forEach(({ type, attributes, showProgressBar, showLevelup, hasCheckpoints, expectedTitle }) => {
-      describe(type, function () {
+      {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        type: Assessment.types.CAMPAIGN,
+        describeInfos: 'Anonymized assessment',
+        hasCheckpoints: false,
+        showProgressBar: false,
+        expectedTitle: '',
+        showLevelup: false,
+        showQuestionCounter: false,
+
+        attributes: { campaign: null },
+      },
+    ].forEach(({ type, describeInfos, attributes, showProgressBar, showLevelup, hasCheckpoints, expectedTitle }) => {
+      describe(`${type} ${describeInfos}`, function () {
         let assessment;
 
         before(function () {


### PR DESCRIPTION
## :pancakes: Problème

Lors du reset d'une compétence sur la dashboard utilisateur Pix, nous récupérons tout les assessments pour les `aborted` . 
Les flags sont computed, si un `Assessment` est de type `Campaign` mais que celui ci a été anonymisé. Nous sommes donc dans l'impossibilité de récupérer la campagne associé. Ce qui engendre une grosse 500

## :bacon: Proposition

Si la campagne n'existe pas sur un assessment de type campagne. définit par défaut tout à false

## 🧃 Remarques

RAS

## :yum: Pour tester

Faire une campagne sur une compténce. ( supprimer cette participation, vérifier que la suppression anonymise bien la campaignParticipationId dans l'assessment)

Aller sur le dashboard de la compétence et faire un reset de card. Vérifier que ça ne pète plus. 
