### PR TITLE
[BUGFIX] Réparer un flaky Tubes Selection sur l'admin

### DIFF
--- a/admin/tests/integration/components/common/tubes-selection-test.gjs
+++ b/admin/tests/integration/components/common/tubes-selection-test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, waitFor } from '@1024pix/ember-testing-library';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import TubesSelection from 'pix-admin/components/common/tubes-selection';
@@ -166,7 +166,12 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
       assert.dom(screen.getByText('Importer un fichier JSON')).exists();
     });
 
-    module('when import succeeds', function () {
+    module('when import succeeds', function (hooks) {
+      let notificationSuccessStub;
+      hooks.beforeEach(function () {
+        const notificationService = this.owner.lookup('service:pixToast');
+        notificationSuccessStub = sinon.stub(notificationService, 'sendSuccessNotification');
+      });
       test('it should update areas and skills list', async function (assert) {
         // given
         const jsonFileContent = [
@@ -189,9 +194,10 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
           files: [new File(jsonFileContent, 'file-to-upload.json')],
         });
 
+        await waitFor(() => notificationSuccessStub.calledOnce);
         // then
-        assert.dom(await screen.findByRole('textbox')).hasAttribute('placeholder', 'Pix plus');
-        assert.dom(await screen.findByText('2/3 sujet(s) sélectionné(s)')).exists();
+        assert.dom(screen.getByRole('textbox')).hasAttribute('placeholder', 'Pix plus');
+        assert.dom(screen.getByText('2/3 sujet(s) sélectionné(s)')).exists();
       });
     });
   });


### PR DESCRIPTION
## :pancakes: Problème

Le test #import tubes preselection or target profile export > when import succeeds > it should update areas and skills list de TubesSelection.

## :bacon: Proposition
On attend l'appel au service PixToast (notification après le succès de l'import JSON) pour vérifier l'affichage des autres messages.

## 🧃 Remarques
Le flaky avait déjà fait l'objet d'une tentative de [réparation ](https://github.com/1024pix/pix/pull/11615#discussion_r1987307787)

## :yum: Pour tester
Pas de func à faire, tech only