### PR TITLE
[TECH] :truck: Déplace le service d'obscurcissement vers `src/shared`

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -39,6 +39,7 @@ import * as schoolRepository from '../../../src/school/infrastructure/repositori
 import { config } from '../../../src/shared/config.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
 import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
+import * as obfuscationService from '../../../src/shared/domain/services/obfuscation-service.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import * as userService from '../../../src/shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../src/shared/domain/validators/password-validator.js';
@@ -65,7 +66,6 @@ import { organizationInvitationService } from '../../../src/team/domain/services
 import { certificationCenterMembershipRepository } from '../../../src/team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../src/team/infrastructure/repositories/membership.repository.js';
 import { organizationInvitationRepository } from '../../../src/team/infrastructure/repositories/organization-invitation.repository.js';
-import * as obfuscationService from '../../domain/services/obfuscation-service.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import { certificationCompletedJobRepository } from '../../infrastructure/repositories/jobs/certification-completed-job-repository.js';
 import * as organizationMemberIdentityRepository from '../../infrastructure/repositories/organization-member-identity-repository.js';

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -1,11 +1,10 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as obfuscationService from '../../../../../lib/domain/services/obfuscation-service.js';
 import * as userReconciliationService from '../../../../../lib/domain/services/user-reconciliation-service.js';
-import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
+import * as obfuscationService from '../../../../shared/domain/services/obfuscation-service.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { logErrorWithCorrelationIds } from '../../../../shared/infrastructure/monitoring-tools.js';
 import * as libOrganizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
@@ -14,6 +13,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import * as membershipRepository from '../../../../team/infrastructure/repositories/membership.repository.js';
+import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/registration-organization-learner-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -33,7 +33,7 @@ import { importStorage } from '../../infrastructure/storage/import-storage.js';
 
 /**
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} CampaignParticipationRepository
- * @typedef {import ('../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
+ * @typedef {import ('../../../campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
  * @typedef {import ('../../infrastructure/repositories/jobs/import-organization-learners-job-repository.js')} ImportOrganizationLearnersJobRepository
  * @typedef {import ('../../infrastructure/storage/import-storage.js')} ImportStorage
  * @typedef {import ('../../infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js')} ImportSupOrganizationLearnersJobRepository
@@ -42,7 +42,7 @@ import { importStorage } from '../../infrastructure/storage/import-storage.js';
  * @typedef {import ('../../../../shared/infrastructure/monitoring-tools.js')} LogErrorWithCorrelationIds
  * @typedef {import ('../../../../shared/infrastructure/utils/logger.js')} loggger
  * @typedef {import ('../../../../team/infrastructure/repositories/membership-repository.js')} MembershipRepository
- * @typedef {import ('../../../../../lib/domain/services/obfuscation-service.js')} obfuscationService
+ * @typedef {import ('../../../../shared/domain/services/obfuscation-service.js')} obfuscationService
  * @typedef {import ('../../../../organizational-entities/application/api/organization-features-api.js')} OrganizationFeatureApi
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} OrganizationFeatureRepository
  * @typedef {import ('../../infrastructure/repositories/organization-import-repository.js')} OrganizationImportRepository

--- a/api/src/shared/domain/services/obfuscation-service.js
+++ b/api/src/shared/domain/services/obfuscation-service.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../src/identity-access-management/domain/constants/identity-providers.js';
-import * as authenticationMethodRepository from '../../../src/identity-access-management/infrastructure/repositories/authentication-method.repository.js';
-import { NotFoundError } from '../../../src/shared/domain/errors.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../identity-access-management/domain/constants/identity-providers.js';
+import * as authenticationMethodRepository from '../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
+import { NotFoundError } from '../../domain/errors.js';
 
 const CONNEXION_TYPES = {
   username: 'username',

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -1,7 +1,6 @@
 import lodash from 'lodash';
 const { pick } = lodash;
 
-import * as obfuscationService from '../../../../lib/domain/services/obfuscation-service.js';
 import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import { createAndReconcileUserToOrganizationLearner } from '../../../../lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
@@ -17,6 +16,7 @@ import {
 import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
 import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
 import * as mailService from '../../../../src/shared/domain/services/mail-service.js';
+import * as obfuscationService from '../../../../src/shared/domain/services/obfuscation-service.js';
 import * as userService from '../../../../src/shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../../src/shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../../src/shared/domain/validators/user-validator.js';

--- a/api/tests/shared/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/shared/unit/domain/services/obfuscation-service_test.js
@@ -1,8 +1,8 @@
-import * as obfuscationService from '../../../../lib/domain/services/obfuscation-service.js';
-import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
-import { User } from '../../../../src/identity-access-management/domain/models/User.js';
-import { NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import * as obfuscationService from '../../../../../src/shared/domain/services/obfuscation-service.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Service | user-authentication-method-obfuscation-service', function () {
   let authenticationMethodRepository;


### PR DESCRIPTION
## :pancakes: Problème

Le service d'obscurcissement est encore dans `lib/`. Il semble utilisé pour la réconciliation d'utilisateur (dans le context `identify-management` et dans `prescription`.

## :bacon: Proposition

Déplacee le service d'obscurcissement vers `src/shared`

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
