### PR TITLE
[TECH] Migrer les feedback générique de QCU vers du spécifique (PIX-17114)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -81,21 +81,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Liège"
+                      "content": "Liège",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Marseille"
+                      "content": "Marseille",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
                     },
                     {
                       "id": "3",
-                      "content": "Toulouse"
+                      "content": "Toulouse",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">✨</span></span>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">✨</span></span>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                  },
                   "solution": "3"
                 }
               ]
@@ -109,21 +108,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "la marque de son ordinateur"
+                      "content": "la marque de son ordinateur",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
                     },
                     {
                       "id": "2",
-                      "content": "son adresse IP"
+                      "content": "son adresse IP",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse !<span aria-hidden=\"true\">✨</span></span>"
                     },
                     {
                       "id": "3",
-                      "content": "son historique de navigation"
+                      "content": "son historique de navigation",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse !<span aria-hidden=\"true\">✨</span></span>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -217,17 +215,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -241,17 +237,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Qui dit même point d'accès internet dit même adresse IP publique.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -265,17 +259,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -289,17 +281,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! <span aria-hidden=\"true\">🎉</span></span><p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -427,17 +417,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "l'adresse IP privée"
+                      "content": "l'adresse IP privée",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Ces échanges se font sur le réseau <strong>local</strong> de Mélanie</p>"
                     },
                     {
                       "id": "2",
-                      "content": "l'adresse IP publique"
+                      "content": "l'adresse IP publique",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP publique permet les échanges entre la box internet de Mélanie et les sites qu'elle visite.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Ces échanges se font sur le réseau <strong>local</strong> de Mélanie</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP publique permet les échanges entre la box internet de Mélanie et les sites qu'elle visite.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -451,17 +439,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "l'adresse IP privée"
+                      "content": "l'adresse IP privée",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Cela permet de bien distinguer chacun des appareils de Mélanie</p>"
                     },
                     {
                       "id": "2",
-                      "content": "l'adresse IP publique"
+                      "content": "l'adresse IP publique",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP publique est spécifique à la box internet. Chaque appareil qui y est connecté a sa propre adresse IP privée.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Cela permet de bien distinguer chacun des appareils de Mélanie</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP publique est spécifique à la box internet. Chaque appareil qui y est connecté a sa propre adresse IP privée.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -475,17 +461,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "l'adresse IP privée"
+                      "content": "l'adresse IP privée",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP <strong>privée</strong> (locale) de Mélanie est visible uniquement par les appareils de son réseau local.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "l'adresse IP publique"
+                      "content": "l'adresse IP publique",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Cette adresse est <strong>publique</strong> donc <strong>visible</strong>.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Cette adresse est <strong>publique</strong> donc <strong>visible</strong>.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L'adresse IP <strong>privée</strong> (locale) de Mélanie est visible uniquement par les appareils de son réseau local.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -508,17 +492,15 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "oui"
+                "content": "oui",
+                "feedback": "<p> Pour vérifier votre réponse, suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a>.</p>"
               },
               {
                 "id": "2",
-                "content": "non"
+                "content": "non",
+                "feedback": "<p> Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<p> Pour vérifier votre réponse, suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a>.</p>",
-              "invalid": "<p> Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
-            },
             "solution": "1"
           }
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -246,17 +246,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -270,17 +268,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -294,17 +290,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -369,21 +363,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "Bienvenue"
+                "content": "Bienvenue",
+                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
               },
               {
                 "id": "2",
-                "content": "Bonjour"
+                "content": "Bonjour",
+                "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Vous avez bien remonté la page</p>"
               },
               {
                 "id": "3",
-                "content": "Nous"
+                "content": "Nous",
+                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Vous avez bien remonté la page</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
-            },
             "solution": "2"
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -280,17 +280,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&#8239;! <span aria-hidden=\"true\">🎉</span></span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;! <span aria-hidden=\"true\">🎉</span></span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -304,17 +302,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -328,17 +324,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;🎉</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;🎉</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse</span><p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -352,17 +346,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<p class=\"feedback__state\">Mauvaise réponse</p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<p class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<p class=\"feedback__state\">Bonne réponse&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>",
-                    "invalid": "<p class=\"feedback__state\">Mauvaise réponse</p><p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
-                  },
                   "solution": "2"
                 }
               ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -74,21 +74,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "<p>ChatGPT n'a pas compris la demande de l'utilisateur.</p>"
+                "content": "<p>ChatGPT n'a pas compris la demande de l'utilisateur.</p>",
+                "feedback": "<p><span class=\"feedback__state\">Incorrect&nbsp;!</span></p>\n<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
               },
               {
                 "id": "2",
-                "content": "<p>ChatGPT n’est pas capable de faire des jeux de mots drôles.</p>"
+                "content": "<p>ChatGPT n’est pas capable de faire des jeux de mots drôles.</p>",
+                "feedback": "<p><span class=\"feedback__state\">Incorrect&nbsp;!</span></p>\n<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
               },
               {
                 "id": "3",
-                "content": "ChatGPT n'a pas raté son jeu de mots : il est réussi mais en anglais."
+                "content": "ChatGPT n'a pas raté son jeu de mots : il est réussi mais en anglais.",
+                "feedback": "<p><span class=\"feedback__state\">Correct&nbsp;!</span></p>\n<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<p><span class=\"feedback__state\">Correct&nbsp;!</span></p>\n<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>",
-              "invalid": "<p><span class=\"feedback__state\">Incorrect&nbsp;!</span></p>\n<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
-            },
             "solution": "3"
           }
         }
@@ -201,21 +200,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Le LLM a été programmé en majorité par des Français."
+                      "content": "Le LLM a été programmé en majorité par des Français.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&nbsp;! </span> <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Le LLM a été entraîné avec des données où le Québec est sous-représenté."
+                      "content": "Le LLM a été entraîné avec des données où le Québec est sous-représenté.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Un prompt en langue française amène le LLM à répondre en français. Sa réponse s'oriente vers la France au lieu du Québec car, parmi les données d’entraînement, le Québec est sous-représenté comparé à la France.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "Le LLM a été paramétré pour privilégier des pays européens."
+                      "content": "Le LLM a été paramétré pour privilégier des pays européens.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&nbsp;! </span> <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Un prompt en langue française amène le LLM à répondre en français. Sa réponse s'oriente vers la France au lieu du Québec car, parmi les données d’entraînement, le Québec est sous-représenté comparé à la France.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse&nbsp;! </span> <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -241,21 +239,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Le LLM a été programmé pour favoriser les personnages masculins."
+                      "content": "Le LLM a été programmé pour favoriser les personnages masculins.",
+                      "feedback": "<span class=\"feedback__state\">Incorrect&nbsp;!</span><p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Le LLM a été entraîné avec des données où les pompiers masculins sont surreprésentés."
+                      "content": "Le LLM a été entraîné avec des données où les pompiers masculins sont surreprésentés.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés. Ici, il s'agit d'un stéréotype de genre associé à cette profession.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "Le LLM s'est basé sur le genre de l'auteure du prompt, Erica."
+                      "content": "Le LLM s'est basé sur le genre de l'auteure du prompt, Erica.",
+                      "feedback": "<span class=\"feedback__state\">Incorrect&nbsp;!</span><p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés. Ici, il s'agit d'un stéréotype de genre associé à cette profession.</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect&nbsp;!</span><p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -281,21 +278,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Le LLM a été programmé pour que les extraterrestres soient considérés comme existants."
+                      "content": "Le LLM a été programmé pour que les extraterrestres soient considérés comme existants.",
+                      "feedback": "<span class=\"feedback__state\">Incorrect&nbsp;! </span><p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Le LLM a été entraîné avec de trop nombreuses histoires de science-fiction."
+                      "content": "Le LLM a été entraîné avec de trop nombreuses histoires de science-fiction.",
+                      "feedback": "<span class=\"feedback__state\">Incorrect&nbsp;! </span><p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "Le LLM s'est basé sur la croyance de Stéphane qui est présente dans son prompt."
+                      "content": "Le LLM s'est basé sur la croyance de Stéphane qui est présente dans son prompt.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Le LLM n'est pas le seul à comporter des biais. Les utilisateurs peuvent transmettre leurs biais via leur prompt.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Le LLM n'est pas le seul à comporter des biais. Les utilisateurs peuvent transmettre leurs biais via leur prompt.</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect&nbsp;! </span><p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
-                  },
                   "solution": "3"
                 }
               ]
@@ -354,17 +350,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Soumettez à nouveau un prompt à deux LLM pour observer les variations dans leurs réponses.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Des différences seront systématiquement présentes dans leurs réponses. C'est aussi vrai quand on soumet un prompt identique à un seul et même LLM.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Des différences seront systématiquement présentes dans leurs réponses. C'est aussi vrai quand on soumet un prompt identique à un seul et même LLM.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Soumettez à nouveau un prompt à deux LLM pour observer les variations dans leurs réponses.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -378,17 +372,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>La provenance d'un LLM est d'ailleurs un paramètre qui peut influencer les résultats qu'il fournit.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Sur Compar:IA , donnez votre avis sur les résultats pour révéler les LLM. Vous verrez que des modèles de différents pays sont disponibles.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>La provenance d'un LLM est d'ailleurs un paramètre qui peut influencer les résultats qu'il fournit.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Sur Compar:IA , donnez votre avis sur les résultats pour révéler les LLM. Vous verrez que des modèles de différents pays sont disponibles.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -402,17 +394,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -476,17 +466,15 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "oui"
+                "content": "oui",
+                "feedback": "<span class=\"feedback__state\">Bravo&nbsp;! <span aria-hidden=\"true\">💫</span></span>"
               },
               {
                 "id": "2",
-                "content": "non"
+                "content": "non",
+                "feedback": "<p>Avez-vous utilisé les indices ci-dessous ? Les LLM s'améliorent de jour en jour pour palier à ces résultats biaisés. Ce défi sera donc de plus en plus dur à relever.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Bravo&nbsp;! <span aria-hidden=\"true\">💫</span></span>",
-              "invalid": "<p>Avez-vous utilisé les indices ci-dessous ? Les LLM s'améliorent de jour en jour pour palier à ces résultats biaisés. Ce défi sera donc de plus en plus dur à relever.</p>"
-            },
             "solution": "1"
           }
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -76,17 +76,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "plutôt vrai"
+                      "content": "plutôt vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p>C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "plutôt faux"
+                      "content": "plutôt faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est pourtant vrai. C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p>C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est pourtant vrai. C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -107,17 +105,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "plutôt vrai"
+                      "content": "plutôt vrai",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span><p> Attention, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "plutôt faux"
+                      "content": "plutôt faux",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est une fake news. C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est une fake news. C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span><p> Attention, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -138,17 +134,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "plutôt vrai"
+                      "content": "plutôt vrai",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "plutôt faux"
+                      "content": "plutôt faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Et pourtant, c'est vrai. C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Et pourtant, c'est vrai. C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -210,25 +204,25 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "une opinion"
+                      "content": "une opinion",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "une rumeur"
+                      "content": "une rumeur",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "une anecdote"
+                      "content": "une anecdote",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "4",
-                      "content": "une information"
+                      "content": "une information",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -242,25 +236,25 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "une opinion"
+                      "content": "une opinion",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "une rumeur"
+                      "content": "une rumeur",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "une anecdote"
+                      "content": "une anecdote",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens.</p>"
                     },
                     {
                       "id": "4",
-                      "content": "une information"
+                      "content": "une information",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
-                  },
                   "solution": "3"
                 }
               ]
@@ -274,25 +268,25 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "une opinion"
+                      "content": "une opinion",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "une rumeur"
+                      "content": "une rumeur",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "une anecdote"
+                      "content": "une anecdote",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "4",
-                      "content": "une information"
+                      "content": "une information",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -306,25 +300,25 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "une opinion"
+                      "content": "une opinion",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "une rumeur"
+                      "content": "une rumeur",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "une anecdote"
+                      "content": "une anecdote",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
                     },
                     {
                       "id": "4",
-                      "content": "une information"
+                      "content": "une information",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est un fait qui est vérifiable via plusieurs sources. C'est bien une information.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> C'est un fait qui est vérifiable via plusieurs sources. C'est bien une information.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
-                  },
                   "solution": "4"
                 }
               ]
@@ -456,21 +450,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre."
+                      "content": "L’auteur de la publication n'est pas neutre.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p>Ce vendeur n'est pas neutre. Il exagère la réalité pour essayer d'augmenter ses ventes. </p>"
                     },
                     {
                       "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes."
+                      "content": "Les dates de la publication et de la source sont incohérentes.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "La source d’information est absente de la publication."
+                      "content": "La source d’information est absente de la publication.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p>Ce vendeur n'est pas neutre. Il exagère la réalité pour essayer d'augmenter ses ventes. </p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -491,21 +484,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre."
+                      "content": "L’auteur de la publication n'est pas neutre.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
                     },
                     {
                       "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes."
+                      "content": "Les dates de la publication et de la source sont incohérentes.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
                     },
                     {
                       "id": "3",
-                      "content": "La source d’information est absente de la publication."
+                      "content": "La source d’information est absente de la publication.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
-                  },
                   "solution": "3"
                 }
               ]
@@ -531,21 +523,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre."
+                      "content": "L’auteur de la publication n'est pas neutre.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes."
+                      "content": "Les dates de la publication et de la source sont incohérentes.",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "La source d’information est absente de la publication."
+                      "content": "La source d’information est absente de la publication.",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse ! 🎉</span><p> La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
-                  },
                   "solution": "2"
                 }
               ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -301,17 +301,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -325,17 +323,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -349,17 +345,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "Vrai"
+                      "content": "Vrai",
+                      "feedback": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>"
                     },
                     {
                       "id": "2",
-                      "content": "Faux"
+                      "content": "Faux",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse&#8239;!</span>"
-                  },
                   "solution": "1"
                 }
               ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -409,17 +409,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "vrai"
+                      "content": "vrai",
+                      "feedback": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Cette souris filaire (qui se branche avec un fil) se branche à un port USB.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "faux"
+                      "content": "faux",
+                      "feedback": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était vrai. Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Cette souris filaire (qui se branche avec un fil) se branche à un port USB.</p>",
-                    "invalid": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était vrai. Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -440,17 +438,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "vrai"
+                      "content": "vrai",
+                      "feedback": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était faux. Regardez bien l’extrémité du fil de ce casque audio : il est rond. Il ne se branche pas à un port USB, mais à un port jack.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "faux"
+                      "content": "faux",
+                      "feedback": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>",
-                    "invalid": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était faux. Regardez bien l’extrémité du fil de ce casque audio : il est rond. Il ne se branche pas à un port USB, mais à un port jack.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -471,17 +467,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "vrai"
+                      "content": "vrai",
+                      "feedback": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Ce symbole peut changer un peu sur des ports USB plus récents.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "faux"
+                      "content": "faux",
+                      "feedback": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était vraa. Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<p><span class=\"feedback__state\">Bonne réponse !</span></p><p> Ce symbole peut changer un peu sur des ports USB plus récents.</p>",
-                    "invalid": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p>C'était vraa. Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -593,17 +587,15 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "oui"
+                "content": "oui",
+                "feedback": "<p>Bravo ! <br>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>"
               },
               {
                 "id": "2",
-                "content": "non"
+                "content": "non",
+                "feedback": "<p>Vous pouvez remonter la page et vous&nbsp;aider des schémas présentés, ou demander de l'aide à quelqu'un si c'est possible.<br>Selon l'âge et la marque de votre ordinateur, les ports de connexion de votre ordinateur peuvent varier.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<p>Bravo ! <br>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>",
-              "invalid": "<p>Vous pouvez remonter la page et vous&nbsp;aider des schémas présentés, ou demander de l'aide à quelqu'un si c'est possible.<br>Selon l'âge et la marque de votre ordinateur, les ports de connexion de votre ordinateur peuvent varier.</p>"
-            },
             "solution": "1"
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -588,7 +588,7 @@
               {
                 "id": "1",
                 "content": "oui",
-                "feedback": "<p>Bravo ! <br>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>"
+                "feedback": "<span class=\"feedback__state\">Bravo !</span><p>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>"
               },
               {
                 "id": "2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -237,25 +237,25 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "100"
+                "content": "100",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
               },
               {
                 "id": "2",
-                "content": "250"
+                "content": "250",
+                "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
               },
               {
                 "id": "3",
-                "content": "400"
+                "content": "400",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
               },
               {
                 "id": "4",
-                "content": "700"
+                "content": "700",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>",
-              "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
-            },
             "solution": "2"
           }
         }
@@ -275,21 +275,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "les publicités"
+                "content": "les publicités",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
               },
               {
                 "id": "2",
-                "content": "les abonnements payants"
+                "content": "les abonnements payants",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
               },
               {
                 "id": "3",
-                "content": "les dons"
+                "content": "les dons",
+                "feedback": "<span class=\"feedback__state\">Oui, c'est correct.</span><p> Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Oui, c'est correct.</span><p> Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>",
-              "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
-            },
             "solution": "3"
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -89,17 +89,15 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "plutôt oui"
+                      "content": "plutôt oui",
+                      "feedback": "<p>Oui. Cette information a été vérifiée par des journalistes. Elle a de grandes chances d'être vraie.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "plutôt non"
+                      "content": "plutôt non",
+                      "feedback": "<p>Cette information a de grandes chances d'être vraie.<br> Elle provient d'un article du journal « FranceInfo ». Cette information a été vérifiée par des journalistes.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<p>Oui. Cette information a été vérifiée par des journalistes. Elle a de grandes chances d'être vraie.</p>",
-                    "invalid": "<p>Cette information a de grandes chances d'être vraie.<br> Elle provient d'un article du journal « FranceInfo ». Cette information a été vérifiée par des journalistes.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -169,21 +167,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "C'est le jour de l'événement qui a mené à cette information."
+                "content": "C'est le jour de l'événement qui a mené à cette information.",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
               },
               {
                 "id": "2",
-                "content": "C'est le réseau social où est publiée cette information."
+                "content": "C'est le réseau social où est publiée cette information.",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
               },
               {
                 "id": "3",
-                "content": "C'est la personne à l'origine de cette information."
+                "content": "C'est la personne à l'origine de cette information.",
+                "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> La source d'une information est la personne <strong>témoin</strong> de l'information.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> La source d'une information est la personne <strong>témoin</strong> de l'information.</p>",
-              "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
-            },
             "solution": "3"
           }
         }
@@ -230,21 +227,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "le journaliste Dupont"
+                "content": "le journaliste Dupont",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
               },
               {
                 "id": "2",
-                "content": "la professeure Saturne"
+                "content": "la professeure Saturne",
+                "feedback": "<span class=\"feedback__state\">Oui,c'est correct.</span><p> la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>"
               },
               {
                 "id": "3",
-                "content": "Madame Sarah"
+                "content": "Madame Sarah",
+                "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Oui,c'est correct.</span><p> la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>",
-              "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
-            },
             "solution": "2"
           }
         }
@@ -345,21 +341,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "fiable"
+                      "content": "fiable",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "humoristique"
+                      "content": "humoristique",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "contestable"
+                      "content": "contestable",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
-                  },
                   "solution": "2"
                 }
               ]
@@ -380,21 +375,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "fiable"
+                      "content": "fiable",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "humoristique"
+                      "content": "humoristique",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "contestable"
+                      "content": "contestable",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
-                  },
                   "solution": "1"
                 }
               ]
@@ -415,21 +409,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "fiable"
+                      "content": "fiable",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
                     },
                     {
                       "id": "2",
-                      "content": "humoristique"
+                      "content": "humoristique",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
                     },
                     {
                       "id": "3",
-                      "content": "contestable"
+                      "content": "contestable",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
-                  },
                   "solution": "3"
                 }
               ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -229,17 +229,15 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "<p>oui</p>"
+                "content": "<p>oui</p>",
+                "feedback": "<p>Comme vous avez pu le constater, les réponses des deux systèmes d’intelligence artificielle générative ont adopté les contraintes de forme que nous lui avons données dans le prompt. Impressionnant, non ? <span aria-hidden=\"true\">🤯 </span><br></p>"
               },
               {
                 "id": "2",
-                "content": "<p>non</p>"
+                "content": "<p>non</p>",
+                "feedback": "<p>Et si vous essayiez à nouveau ? Avec un simple copier / coller du prompt à la première étape vous devriez pouvoir générer un joli poème !</p>"
               }
             ],
-            "feedbacks": {
-              "valid": "<p>Comme vous avez pu le constater, les réponses des deux systèmes d’intelligence artificielle générative ont adopté les contraintes de forme que nous lui avons données dans le prompt. Impressionnant, non ? <span aria-hidden=\"true\">🤯 </span><br></p>",
-              "invalid": "<p>Et si vous essayiez à nouveau ? Avec un simple copier / coller du prompt à la première étape vous devriez pouvoir générer un joli poème !</p>"
-            },
             "solution": "1"
           }
         }
@@ -426,17 +424,15 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "<p>oui</p>"
+                "content": "<p>oui</p>",
+                "feedback": "<span class=\"feedback__state\">Bravo !</span><span aria-hidden=\"true\">🎉</span><p>N'hésitez pas à vous amuser avec de nouvelles requêtes.</p>"
               },
               {
                 "id": "2",
-                "content": "<p>non</p>"
+                "content": "<p>non</p>",
+                "feedback": "<span class=\"feedback__state\">N'hésitez pas à retenter avec d'autres modèles, certains sont très bien préparés à ce type de manœuvres ... </span>"
               }
             ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Bravo !</span><span aria-hidden=\"true\">🎉</span><p>N'hésitez pas à vous amuser avec de nouvelles requêtes.</p>",
-              "invalid": "<span class=\"feedback__state\">N'hésitez pas à retenter avec d'autres modèles, certains sont très bien préparés à ce type de manœuvres ... </span>"
-            },
             "solution": "1"
           }
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -447,21 +447,20 @@
                   "proposals": [
                     {
                       "id": "1",
-                      "content": "<p>Vous allez voir, c'est facile !</p>"
+                      "content": "<p>Vous allez voir, c'est facile !</p>",
+                      "feedback": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span> <p>Vous avez lancé la vidéo et trouvé la bonne réponse</p>"
                     },
                     {
                       "id": "2",
-                      "content": "Vous verrez, c'est plié !"
+                      "content": "Vous verrez, c'est plié !",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
                     },
                     {
                       "id": "3",
-                      "content": "Vous pensiez que c'était simple ?"
+                      "content": "Vous pensiez que c'était simple ?",
+                      "feedback": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
                     }
                   ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Bonne réponse&nbsp;! 🎉</span> <p>Vous avez lancé la vidéo et trouvé la bonne réponse</p>",
-                    "invalid": "<span class=\"feedback__state\">Mauvaise réponse.</span><p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
-                  },
                   "solution": "1"
                 },
                 {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -313,21 +313,20 @@
             "proposals": [
               {
                 "id": "1",
-                "content": "<p>4</p>"
+                "content": "<p>4</p>",
+                "feedback": "<p><span class=\"feedback__state\">Bonne réponse.</span></p><p>Il y a bien 4 photos dans le dossier «&nbsp;80 ans Mamie&nbsp;». Bravo ! Vous avez fait 4 doubles-clics et réussi à naviguer dans un explorateur de fichiers.</p>"
               },
               {
                 "id": "2",
-                "content": "<p>5</p>"
+                "content": "<p>5</p>",
+                "feedback": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
               },
               {
                 "id": "3",
-                "content": "<p>6</p>"
+                "content": "<p>6</p>",
+                "feedback": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
               }
             ],
-            "feedbacks": {
-              "valid": "<p><span class=\"feedback__state\">Bonne réponse.</span></p><p>Il y a bien 4 photos dans le dossier «&nbsp;80 ans Mamie&nbsp;». Bravo ! Vous avez fait 4 doubles-clics et réussi à naviguer dans un explorateur de fichiers.</p>",
-              "invalid": "<p><span class=\"feedback__state\">Mauvaise réponse.</span></p><p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
-            },
             "solution": "1"
           }
         }


### PR DESCRIPTION
## 🌸 Problème

Pour préparer le fait de ne plus pouvoir mettre des feedbacks génériques côté QCU, il faut migrer les modules existants.


## 🌳 Proposition

Migrer les feedback génériques QCU en spécifiques

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Vérifier que cela fonctionne toujours 😄 
