### PR TITLE
[FEATURE] Interdire les feedbacks globaux dans les QCU (PIX-17119)

### DIFF
--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -3,24 +3,19 @@ import Joi from 'joi';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { ModuleInstantiationError } from '../../errors.js';
-import { Feedbacks } from '../Feedbacks.js';
 import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
 import { ValidatorQCU } from '../validator/ValidatorQCU.js';
 import { QCU } from './QCU.js';
 
 class QCUForAnswerVerification extends QCU {
   userResponse;
-  constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
+  constructor({ id, instruction, locales, proposals, solution, validator }) {
     super({ id, instruction, locales, proposals });
 
     assertNotNullOrUndefined(solution, 'The solution is required for a verification QCU');
     this.#assertSolutionIsAnExistingProposal(solution, proposals);
 
     this.solution = { value: solution };
-
-    if (feedbacks) {
-      this.feedbacks = new Feedbacks(feedbacks);
-    }
 
     if (validator) {
       this.validator = validator;
@@ -46,7 +41,7 @@ class QCUForAnswerVerification extends QCU {
 
     return new QcuCorrectionResponse({
       status: validation.result,
-      feedback: this.#getFeedback(validation),
+      feedback: this.#getFeedback(),
       solution: this.solution.value,
     });
   }
@@ -71,13 +66,8 @@ class QCUForAnswerVerification extends QCU {
     }
   }
 
-  #getFeedback(validation) {
-    const specificFeedback = this.#getSpecificFeedbackByProposalId(this.userResponse);
-    if (specificFeedback) {
-      return specificFeedback;
-    }
-
-    return validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid;
+  #getFeedback() {
+    return this.#getSpecificFeedbackByProposalId(this.userResponse);
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js
@@ -8,11 +8,8 @@ export function getQcuSample(nbOfProposals = 3) {
     proposals: Array.from(Array(nbOfProposals)).map((_, i) => ({
       id: `${i + 1}`,
       content: `Proposition ${i + 1}`,
+      feedback: `<p>Correct ! ${i + 1}</p>`,
     })),
-    feedbacks: {
-      valid: '<p>Correct !</p>',
-      invalid: '<p>Incorrect !</p>',
-    },
     solution: '1',
   };
 }

--- a/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
+++ b/api/src/devcomp/infrastructure/factories/element-for-verification-factory.js
@@ -50,7 +50,6 @@ export class ElementForVerificationFactory {
           feedback: proposal.feedback,
         });
       }),
-      feedbacks: element.feedbacks,
       solution: element.solution,
     });
   }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-schema.js
@@ -10,33 +10,10 @@ const qcuElementSchema = Joi.object({
     .items({
       id: proposalIdSchema.required(),
       content: htmlSchema.required(),
-      feedback: htmlSchema,
+      feedback: htmlSchema.required(),
     })
     .required(),
-  feedbacks: Joi.object({
-    valid: htmlSchema,
-    invalid: htmlSchema,
-  }),
   solution: proposalIdSchema.required(),
-}).external(async (qcuElement, helpers) => {
-  const hasGlobalFeedbacks = qcuElement.feedbacks !== undefined;
-  const hasSpecificFeedbacks = qcuElement.proposals.some((proposal) => proposal.feedback !== undefined);
-  if (hasGlobalFeedbacks && hasSpecificFeedbacks) {
-    return helpers.error('Un QCU ne peut pas avoir à la fois des feedbacks spécifiques et globales');
-  }
-  if (hasSpecificFeedbacks) {
-    const someProposalsDoNotHaveSpecificFeedback = qcuElement.proposals.some(
-      (proposal) => proposal.feedback === undefined,
-    );
-    if (someProposalsDoNotHaveSpecificFeedback) {
-      return helpers.error('Dans ce QCU, au moins une proposition ne possède pas de feedback spécifique');
-    }
-  }
-  if (!hasGlobalFeedbacks && !hasSpecificFeedbacks) {
-    return helpers.error("Dans ce QCU, il n'y a ni feedbacks spécifiques, ni feedbacks globales");
-  }
-
-  return qcuElement;
 });
 
 export { qcuElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
@@ -120,8 +120,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
       // given
       const feedbacks = { valid: 'valid', invalid: 'invalid' };
       const proposals = [
-        { id: '1', content: 'toto' },
-        { id: '2', content: 'foo' },
+        { id: '1', content: 'toto', feedback: 'valid' },
+        { id: '2', content: 'foo', feedback: 'invalid' },
       ];
 
       const elementData = {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -646,12 +646,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                         feedback: "Faux n'est pas la bonne réponse.",
                       },
                     ],
-                    feedbacks: {
-                      valid:
-                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                      invalid:
-                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                    },
+
                     solution: '1',
                   },
                 },
@@ -1277,11 +1272,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                               feedback: "Faux n'est pas la bonne réponse.",
                             },
                           ],
-                          feedbacks: {
-                            valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                            invalid:
-                              '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
-                          },
                           solution: '1',
                         },
                       ],


### PR DESCRIPTION
## 🌸 Problème

Les feedbacks globaux ne sont pour le moment pas interdit dans les QCU (on ne veut faire que du spécifique maintenant)

## 🌳 Proposition

Interdire cet utilisation côté API.

## 🐝 Remarques

La PR https://github.com/1024pix/pix/pull/11768 doit être mergée avant pour que la CI passe !

## 🤧 Pour tester

- CI au vert 
