### PR TITLE
[TECH] :hammer: création d'un script pour compléter un `assessment` qui ne l'a pas été... (pix-17108)

### DIFF
--- a/api/scripts/certification/complete-assessment.js
+++ b/api/scripts/certification/complete-assessment.js
@@ -1,0 +1,41 @@
+import 'dotenv/config';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { usecases } from '../../lib/domain/usecases/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { LOCALE } from '../../src/shared/domain/constants.js';
+import { Assessment } from '../../src/shared/domain/models/Assessment.js';
+
+const { FRENCH_FRANCE } = LOCALE;
+
+export class CompleteAssessment extends Script {
+  constructor() {
+    super({
+      description: 'Complete given assessment',
+      permanent: false,
+      options: {
+        assessmentId: {
+          type: 'integer',
+          describe: 'Id of the assessment to be completed',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, completeAssessment = usecases.completeAssessment }) {
+    const { assessmentId } = options;
+    this.logger = logger;
+
+    const locale = FRENCH_FRANCE;
+    await knex('assessments').where({ id: assessmentId }).update({ state: Assessment.states.STARTED });
+    const assessment = await completeAssessment({ assessmentId, locale });
+
+    this.logger.info(`AssessmentId ${assessment.id}`);
+
+    return 0;
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CompleteAssessment);

--- a/api/tests/integration/scripts/certification/complete-assessment_test.js
+++ b/api/tests/integration/scripts/certification/complete-assessment_test.js
@@ -1,0 +1,148 @@
+import { CompleteAssessment } from '../../../../scripts/certification/complete-assessment.js';
+import { CertificationCompletedJobController } from '../../../../src/certification/evaluation/application/jobs/certification-completed-job-controller.js';
+import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const { FRENCH_FRANCE } = LOCALE;
+const locale = FRENCH_FRANCE;
+
+describe('Integration | Scripts | Certification | complete assessment', function () {
+  let assessment, certificationCourse, completeAssessmentScript, logger;
+
+  beforeEach(async function () {
+    databaseBuilder.factory.learningContent.buildArea({ id: 'recArea0', code: 'area0' });
+    databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'recCompetence0',
+      index: '1.1',
+      areaId: 'recArea0',
+      origin: 'Pix',
+    });
+
+    const configUser = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdAt: new Date('2024-09-23'),
+      createdByUserId: configUser.id,
+      configuration: [
+        {
+          competence: '1.1',
+          values: [
+            {
+              bounds: {
+                max: 0,
+                min: -5,
+              },
+              competenceLevel: 0,
+            },
+            {
+              bounds: {
+                max: 5,
+                min: 0,
+              },
+              competenceLevel: 1,
+            },
+          ],
+        },
+      ],
+    });
+    databaseBuilder.factory.buildScoringConfiguration({
+      createdAt: new Date('2024-09-23'),
+      createdByUserId: configUser.id,
+    });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+      createdAt: new Date('2024-09-23'),
+      createdByUserId: configUser.id,
+    });
+
+    const session = databaseBuilder.factory.buildSession({ version: 3 });
+    const user = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId: session.id,
+      userId: user.id,
+    });
+    certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+      createdAt: new Date('2024-10-23'),
+      sessionId: session.id,
+      userId: user.id,
+      completedAt: null,
+      isPublished: false,
+      isCancelled: false,
+      abortReason: null,
+      version: 3,
+      isRejectedForFraud: false,
+      endedAt: null,
+    });
+    assessment = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: certificationCourse.id,
+      userId: user.id,
+      type: 'CERTIFICATION',
+      state: 'completed',
+      method: 'CERTIFICATION_DETERMINED',
+    });
+
+    await databaseBuilder.commit();
+
+    logger = { info: sinon.stub() };
+    completeAssessmentScript = new CompleteAssessment();
+  });
+
+  it('calls completedAssessment usecase', async function () {
+    // given
+    const completedAssessmentUsecase = sinon.stub().resolves(assessment);
+
+    // when
+    await completeAssessmentScript.handle({
+      options: { assessmentId: assessment.id },
+      logger,
+      completeAssessment: completedAssessmentUsecase,
+    });
+
+    // then
+    expect(completedAssessmentUsecase).to.have.been.called;
+  });
+
+  it('calls CertificationCompletedJob', async function () {
+    // when
+    await completeAssessmentScript.handle({
+      options: { assessmentId: assessment.id },
+      logger,
+    });
+
+    // then
+    await expect('CertificationCompletedJob').to.have.been.performed.withJobPayload({
+      assessmentId: assessment.id,
+      userId: assessment.userId,
+      certificationCourseId: assessment.certificationCourseId,
+      locale,
+    });
+  });
+
+  it('creates an AssessmentResult', async function () {
+    // given
+    await completeAssessmentScript.handle({
+      options: { assessmentId: assessment.id },
+      logger,
+    });
+
+    // when
+    const certificationCompletedJobController = new CertificationCompletedJobController();
+    await certificationCompletedJobController.handle({
+      data: {
+        assessmentId: assessment.id,
+        locale,
+      },
+    });
+
+    // then
+    const { count: assessmentResultCount } = await knex('assessment-results')
+      .where({ assessmentId: assessment.id })
+      .count()
+      .first();
+
+    expect(assessmentResultCount).to.equal(1);
+
+    const certificationCourseAfterUpdate = await knex('certification-courses')
+      .where({ id: certificationCourse.id })
+      .first();
+    expect(certificationCourseAfterUpdate.completedAt).to.not.be.null;
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Nous avons un `assessment` qui n'est pas complété malgré que le candidat ait répondu à l'intégralité des 32 questions de son test dans la BDD de production. Ce test dans un état anormal empêche la publication de la session dont il fait partie.

## 🌳 Proposition

Faire passer un script pour compléter l'`assessment` en question.

## 🐝 Remarques

Ce script utilise le usecase `CompleteAssessment` pour être sûr de ne rien oublier et de ne pas mettre les données dans un drôle d'état.

Nous n'utilisons pas la propriété `dryRun` du script afin de ne pas avoir de comportement étrange lors de rollbacks puisque le usecase génère plusieurs évènements.

## 🤧 Pour tester

Pour reproduire de la façon la plus fidèle possible le problème de production :

- Créer une session V3 et y ajouter un candidat
- Terminer le test en levant une live-alert (et la valider côté surveillant) afin d'avoir 33 questions et 32 réponses

 Une fois le test terminé, en BDD :

- supprimer les `certification-challenge-capacities` créés lors de la complétion du test
- supprimer le `certification-course-last-assessment-result` créé lors de la complétion du test
- supprimer les `competences-marks` créés pour votre test
- supprimer l' `assessment-result` créé lors de la complétion du test
- vérifier que le `state` de votre `assessment` soit à `completed`
- Mettre les champs `completedAt` et `endedAt` de votre `certification-course` à `null`

De retour dans pix-certif: 
- Finaliser la session

Dans pix-admin : 
- vérifier que votre certification est au statut `Démarrée`
- vérifier que la session n'est pas publiable

Dans le conteneur de l'api, lancer le script avec la commande : 

```js
LOG_LEVEL=info node scripts/certification/complete-assessment.js --assessmentId=<MON_ASSESSMENT_ID>
```

Une fois l'exécution du script terminée, vous devriez : 
- Avoir généré un nouvel `assessment-result`
- avoir généré des nouveaux `competence-marks`
- Avoir généré de nouvelles `certification-challenge-capacities`
- Avoir le statut de votre certification passé à `completed`
- être en mesure de publier la session