### PR TITLE
[TECH] Ajout de la colonne jurisdiction à la table client_applications (PIX-17137)

### DIFF
--- a/api/db/migrations/20250320145104_add-column-jurisdiction-to-client-applications.js
+++ b/api/db/migrations/20250320145104_add-column-jurisdiction-to-client-applications.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'client_applications';
+const COLUMN_NAME = 'jurisdiction';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .jsonb(COLUMN_NAME)
+      .defaultTo(null)
+      .comment("Juridiction de données de l'application : organisations, centres de certification ou autres.");
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
 ## 🌸 Problème

Pour la mise à disposition de données, il n'est pas possible de limiter le périmètre des données à remonter sur les routes.
Il faudrait faire émerger la notion de juridiction de données pour les partenaires. 

## 🌳 Proposition

Ajouter la colonne jurisdiction à la table client_applications pour porter cette information de juridiction de données sur le partenaire.

## 🤧 Pour tester

Les tests sont verts.

La colonne jurisdiction est présente dans la table client_applications (sinon lancer un `npm run db:migrate`).
Puis faire un `npm run db:rollback:latest`. La colonne jurisdiction a bien disparu.

