### PR TITLE
[BUGFIX] :bug: Corrige le problème de pagination dans la page de liste des sessions de PixAdmin

### DIFF
--- a/api/src/certification/session-management/infrastructure/serializers/jury-session-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-session-serializer.js
@@ -77,7 +77,7 @@ const serialize = function (jurySessions, meta) {
 
 const serializeForPaginatedList = function (jurySessionsForPaginatedList, injectedSerialize = serialize) {
   const { jurySessions, pagination } = jurySessionsForPaginatedList;
-  return injectedSerialize(jurySessions, undefined, pagination);
+  return injectedSerialize(jurySessions, pagination);
 };
 
 export { serialize, serializeForPaginatedList };

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/jury-session-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/jury-session-serializer_test.js
@@ -15,7 +15,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
       serializer.serializeForPaginatedList(parameter, serialize);
 
       // then
-      expect(serialize).to.have.been.calledWithExactly(jurySessions, undefined, pagination);
+      expect(serialize).to.have.been.calledWithExactly(jurySessions, pagination);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

La pagination de la page de liste des sessions de certification est toute cassée !

## 🌳 Proposition

Réparer la pagination.

## 🐝 Remarques

C'est un reusinage intempestif qui s'est glissé dans une PR qui fait complétement autre chose qui est la cause de ce problème... Comme quoi, il faut faire une chose à la fois pour ne pas se tromper :p

## 🤧 Pour tester

Aller sur PixAdmin, page de certification, et constaté que la pagination affiche des chiffres au-dessus de 0. 
Bonus : créer plein de session de certif et s'assurer que ça fonctionne sur plusieurs pages aussi.