### PR TITLE
[FEATURE] Gérer la traduction pour le certificat V3 (PIX-17120).

### DIFF
--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -4,7 +4,7 @@ import * as url from 'node:url';
 import dayjs from 'dayjs';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-const generateV3AttestationTemplate = (pdf, data) => {
+const generateV3AttestationTemplate = ({ pdf, data, translate, globalCertificationLevel }) => {
   // Global
   pdf.image(path.resolve(__dirname, 'background.jpg'), 0, 0, {
     width: pdf.page.width,
@@ -25,16 +25,29 @@ const generateV3AttestationTemplate = (pdf, data) => {
   );
 
   // Main content
-  pdf.font('Nunito-Bold').fontSize(45).fillColor('#253858').text('Certification Pix', 82, 150, { width: 380 });
+  pdf
+    .font('Nunito-Bold')
+    .fontSize(45)
+    .fillColor('#253858')
+    .text(translate('certification.attestation.v3.main-content.title'), 82, 150, { width: 380 });
   pdf
     .font('Roboto-Regular')
     .fontSize(11)
-    .text(`Centre de certification : ${data.certificationCenter}`, {
-      width: 380,
-      lineGap: 2,
-    })
+    .text(
+      translate('certification.attestation.v3.main-content.certification-center', {
+        certificationCenter: data.certificationCenter,
+      }),
+      {
+        width: 380,
+        lineGap: 2,
+      },
+    )
     .moveDown(0.5);
-  pdf.font('Roboto-Regular').fontSize(11).text('délivrée à', 82, 249).moveDown(0.5);
+  pdf
+    .font('Roboto-Regular')
+    .fontSize(11)
+    .text(translate('certification.attestation.v3.main-content.delivered-at.label'), 82, 249)
+    .moveDown(0.5);
   pdf
     .font('Nunito-Bold')
     .fontSize(25)
@@ -44,21 +57,39 @@ const generateV3AttestationTemplate = (pdf, data) => {
   const birthdate = dayjs(data.birthdate).format('DD/MM/YYYY');
   const deliveredAt = dayjs(data.deliveredAt).format('DD/MM/YYYY');
 
-  pdf.font('Roboto-Regular').fontSize(11).text(`né(e) le : ${birthdate} à ${data.birthplace}`);
-  pdf.font('Roboto-Regular').fontSize(11).text(`le ${deliveredAt}`, 82, 364);
-  pdf.font('Roboto-Regular').fontSize(11).fillColor('#6b778b').text('Benjamin Marteau, directeur du GIP Pix', 82, 438);
+  pdf
+    .font('Roboto-Regular')
+    .fontSize(11)
+    .text(
+      translate('certification.attestation.v3.main-content.birth', {
+        birthdate,
+        birthplace: data.birthplace,
+      }).replaceAll('&#x2F;', '/'),
+    );
+  pdf.font('Roboto-Regular').fontSize(11).text(
+    translate('certification.attestation.v3.main-content.delivered-at.date', {
+      deliveredAt,
+    }).replaceAll('&#x2F;', '/'),
+    82,
+    364,
+  );
+  pdf
+    .font('Roboto-Regular')
+    .fontSize(11)
+    .fillColor('#6b778b')
+    .text(translate('certification.attestation.v3.main-content.signature'), 82, 438);
 
   // QR code content
   pdf.font('Roboto-Medium').fontSize(11).fillColor('#5e6c84').text(data.verificationCode, 142, 467).moveDown(0.25);
   pdf
     .font('Roboto-Regular')
     .fontSize(8.25)
-    .text('Pour vérifier l’authenticité de cette attestation, utilisez ce code sur ', {
+    .text(translate('certification.attestation.v3.qr-code-content.explanation'), {
       continued: true,
       width: 137,
     })
-    .text('app.pix.fr/verification-certificat', {
-      link: 'http://www.example.com',
+    .text(translate('certification.attestation.v3.qr-code-content.link.label'), {
+      link: translate('certification.attestation.v3.qr-code-content.link.url'),
     });
 
   // Score content
@@ -75,39 +106,48 @@ const generateV3AttestationTemplate = (pdf, data) => {
     width: 84,
     align: 'center',
   });
-  pdf.font('Roboto-Regular').fontSize(11).fillColor('#6b778b').text('Niveau global', 550, 195, {
-    width: 205,
-    align: 'center',
-  });
-  const level = 'Intermédiaire 1';
-  pdf.roundedRect(650 - (pdf.widthOfString(level) * 2) / 2, 212, pdf.widthOfString(level) * 2, 24, 24).fill('#6712FF');
+  pdf
+    .font('Roboto-Regular')
+    .fontSize(11)
+    .fillColor('#6b778b')
+    .text(translate('certification.attestation.v3.score-content.global-level'), 550, 195, {
+      width: 205,
+      align: 'center',
+    });
+
+  const globalLevelLabel = globalCertificationLevel.getLevelLabel(translate);
+  pdf
+    .roundedRect(
+      650 - (pdf.widthOfString(globalLevelLabel) * 2) / 2,
+      212,
+      pdf.widthOfString(globalLevelLabel) * 2,
+      24,
+      24,
+    )
+    .fill('#6712FF');
   pdf
     .font('Nunito-Bold')
     .fontSize(14)
     .fillColor('#FFFFFF')
-    .text(level, 650 - (pdf.widthOfString(level) * 2) / 2, 214, {
-      width: pdf.widthOfString(level) * 2,
+    .text(globalLevelLabel, 650 - (pdf.widthOfString(globalLevelLabel) * 2) / 2, 214, {
+      width: pdf.widthOfString(globalLevelLabel) * 2,
       align: 'center',
     });
   pdf
     .font('Nunito-Bold')
     .fontSize(11)
     .fillColor('#253858')
-    .text('Votre niveau signifie que :', 530, 250, {
+    .text(translate('certification.attestation.v3.score-content.level-explanation'), 530, 250, {
       width: 250,
     })
     .moveDown(0.5)
     .font('Roboto-Medium')
     .fontSize(9.5)
-    .text(
-      'Vous avez des pratiques numériques avancées et disposez  de connaissances solides qui vous permettent de faire  face seul(e) à des situations nouvelles. Vous pouvez venir  en aide à d’autres personnes.',
-    )
+    .text('globalCertificationLevel.getSummaryLabel(translate)')
     .moveDown(0.5)
     .font('Roboto-Regular')
     .fontSize(9.5)
-    .text(
-      'Vous êtes capable de recourir à des outils spécialisés pour rechercher de l’information de façon fiable, gérer des ré- seaux sociaux, éditer des images et des vidéos. Vous savez  produire des analyses de données et des représentations  graphiques adaptées. Vous savez mettre en place un environnement numérique (installation et paramétrage). Vous  connaissez les enjeux autour du traçage et de la collecte de  données. Vous comprenez les impacts environnementaux  et sociétaux des usages numériques et savez adapter vos  pratiques',
-    );
+    .text('globalCertificationLevel.getDescriptionLabel(translate)');
 };
 
 export default generateV3AttestationTemplate;

--- a/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
@@ -1,5 +1,7 @@
 import PDFDocument from 'pdfkit';
 
+import { GlobalCertificationLevel } from '../../../../shared/domain/models/GlobalCertificationLevel.js';
+import { findIntervalIndexFromScore } from '../../../domain/services/find-interval-index-from-score.js';
 import generateV3AttestationTemplate from './templates/v3-attestation.js';
 
 const generate = ({ certificates, i18n }) => {
@@ -19,7 +21,20 @@ const generate = ({ certificates, i18n }) => {
     if (index > 0) {
       doc.addPage();
     }
-    generateV3AttestationTemplate(doc, certificate);
+
+    // En attendant PIX-17106
+    const globalCertificationLevel = new GlobalCertificationLevel({
+      meshLevel: findIntervalIndexFromScore({
+        score: certificate.pixScore,
+      }),
+    });
+
+    generateV3AttestationTemplate({
+      pdf: doc,
+      data: certificate,
+      translate: i18n.__,
+      globalCertificationLevel,
+    });
   });
 
   doc.end();

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -144,6 +144,31 @@
     "yes-or-empty": "(\"yes\" or leave blank)"
   },
   "certification": {
+    "attestation": {
+      "v3": {
+        "main-content": {
+            "birth": "Born on: {birthdate} in {birthplace}",
+          "certification-center": "Certification centre : {certificationCenter}",
+          "delivered-at": {
+            "date": "date of issue: {deliveredAt}",
+            "label": "delivered to"
+          },
+          "signature": "Benjamin Marteau, GIP Pix's Director",
+          "title": "Pix Certification"
+        },
+        "qr-code-content": {
+          "explanation": "To verify the authenticity of this certificate, enter this code on ",
+          "link": {
+            "label": "app.pix.org/verification-certificat",
+            "url": "https://app.pix.org/verification-certificat"
+          }
+        },
+        "score-content": {
+          "global-level": "Global level",
+          "level-explanation": "Your level means:"
+        }
+      }
+    },
     "global": {
       "meshlevel": {
         "1": "Beginner 1",

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -12,6 +12,31 @@
     }
   },
   "certification": {
+    "attestation": {
+      "v3": {
+        "main-content": {
+          "birth": "né(e) le : {birthdate} à {birthplace}",
+          "certification-center": "Centre de certification : {certificationCenter}",
+          "delivered-at": {
+            "date": "le {deliveredAt}",
+            "label": "délivrée à"
+          },
+          "signature": "Benjamin Marteau, directeur du GIP Pix",
+          "title": "Certification Pix"
+        },
+        "qr-code-content": {
+          "explanation": "Pour vérifier l’authenticité de cette attestation, utilisez ce code sur ",
+          "link": {
+            "label": "app.pix.fr/verification-certificat",
+            "url": "https://app.pix.fr/verification-certificat"
+          }
+        },
+        "score-content": {
+          "global-level": "Niveau global",
+          "level-explanation": "Votre niveau signifie que :"
+        }
+      }
+    },
     "global": {
       "meshlevel": {
         "1": "Beginner 1",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -155,6 +155,31 @@
     "yes-or-empty": "(\"oui\" ou laisser vide)"
   },
   "certification": {
+    "attestation": {
+      "v3": {
+        "main-content": {
+          "birth": "né(e) le : {birthdate} à {birthplace}",
+          "certification-center": "Centre de certification : {certificationCenter}",
+          "delivered-at": {
+            "date": "le {deliveredAt}",
+            "label": "délivrée à"
+          },
+          "signature": "Benjamin Marteau, directeur du GIP Pix",
+          "title": "Certification Pix"
+        },
+        "qr-code-content": {
+          "explanation": "Pour vérifier l’authenticité de cette attestation, utilisez ce code sur ",
+          "link": {
+            "label": "app.pix.fr/verification-certificat",
+            "url": "https://app.pix.fr/verification-certificat"
+          }
+        },
+        "score-content": {
+          "global-level": "Niveau global",
+          "level-explanation": "Votre niveau signifie que :"
+        }
+      }
+    },
     "global": {
       "meshlevel": {
         "1": "Novice 1",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -12,6 +12,31 @@
     }
   },
   "certification": {
+    "attestation": {
+      "v3": {
+        "main-content": {
+          "birth": "né(e) le : {birthdate} à {birthplace}",
+          "certification-center": "Centre de certification : {certificationCenter}",
+          "delivered-at": {
+            "date": "le {deliveredAt}",
+            "label": "délivrée à"
+          },
+          "signature": "Benjamin Marteau, directeur du GIP Pix",
+          "title": "Certification Pix"
+        },
+        "qr-code-content": {
+          "explanation": "Pour vérifier l’authenticité de cette attestation, utilisez ce code sur ",
+          "link": {
+            "label": "app.pix.fr/verification-certificat",
+            "url": "https://app.pix.fr/verification-certificat"
+          }
+        },
+        "score-content": {
+          "global-level": "Niveau global",
+          "level-explanation": "Votre niveau signifie que :"
+        }
+      }
+    },
     "global": {
       "meshlevel": {
         "1": "Beginner 1",


### PR DESCRIPTION
## 🌸 Problème

Aujourd'hui, nous n'avons pas encore de vrai certificat v3 téléchargeable. Nous avons initié un pdfkit pour ce nouveau certificat PDF mais les informations sont encore en dur. Or nous souhaitons rendre ce certificat traduisible.

## 🌳 Proposition

Appliquer des clés de trad sur le certificat

## 🐝 Remarques

Deux fonctions sont volontairement placées dans des string en attendant la PR prochaine

## 🤧 Pour tester

- Passer une certif v3 et télécharger le certificat
