### PR TITLE
[FEATURE] Ajouter le PV de fraude sur la page de détails d'une session sur Pix Certif (PIX-17043).

### DIFF
--- a/certif/app/components/sessions/session-details/controls-links.gjs
+++ b/certif/app/components/sessions/session-details/controls-links.gjs
@@ -1,46 +1,65 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-<template>
-  <div class='session-details__controls-links'>
-    <span class='session-details__controls-title'>{{t 'pages.sessions.detail.downloads.label'}}</span>
-    <PixButtonLink
-      href='{{@urlToDownloadSessionIssueReportSheet}}'
-      @variant='secondary'
-      @isBorderVisible={{true}}
-      @size='small'
-      target='_blank'
-      aria-label={{t 'pages.sessions.detail.downloads.incident-report.extra-information'}}
-      rel='noopener noreferrer'
-      download
-    >
-      <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
-      {{t 'pages.sessions.detail.downloads.incident-report.label'}}
-    </PixButtonLink>
-    <PixButton
-      @variant='secondary'
-      @isBorderVisible={{true}}
-      @size='small'
-      aria-label={{t 'pages.sessions.detail.downloads.invigilator-kit.extra-information'}}
-      @triggerAction={{@fetchInvigilatorKit}}
-    >
-      <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
-      {{t 'pages.sessions.detail.downloads.invigilator-kit.label'}}
-    </PixButton>
-    {{#if @shouldDisplayDownloadButton}}
-      <PixButton
-        @triggerAction={{@fetchAttendanceSheet}}
+export default class ControlsLinks extends Component {
+  @service url;
+
+  <template>
+    <div class='session-details__controls-links'>
+      <span class='session-details__controls-title'>{{t 'pages.sessions.detail.downloads.label'}}</span>
+      <PixButtonLink
+        href='{{@urlToDownloadSessionIssueReportSheet}}'
         @variant='secondary'
         @isBorderVisible={{true}}
         @size='small'
         target='_blank'
-        aria-label={{t 'pages.sessions.detail.downloads.attendance-sheet.extra-information'}}
+        aria-label={{t 'pages.sessions.detail.downloads.incident-report.extra-information'}}
+        rel='noopener noreferrer'
+        download
       >
         <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
-        {{t 'pages.sessions.detail.downloads.attendance-sheet.label'}}
+        {{t 'pages.sessions.detail.downloads.incident-report.label'}}
+      </PixButtonLink>
+      <PixButtonLink
+        href={{this.url.fraudReportUrl}}
+        @variant='secondary'
+        @isBorderVisible={{true}}
+        @size='small'
+        target='_blank'
+        aria-label={{t 'pages.sessions.detail.downloads.fraud.extra-information'}}
+        rel='noopener noreferrer'
+        download
+      >
+        <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
+        {{t 'pages.sessions.detail.downloads.fraud.label'}}
+      </PixButtonLink>
+      <PixButton
+        @variant='secondary'
+        @isBorderVisible={{true}}
+        @size='small'
+        aria-label={{t 'pages.sessions.detail.downloads.invigilator-kit.extra-information'}}
+        @triggerAction={{@fetchInvigilatorKit}}
+      >
+        <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
+        {{t 'pages.sessions.detail.downloads.invigilator-kit.label'}}
       </PixButton>
-    {{/if}}
-  </div>
-</template>
+      {{#if @shouldDisplayDownloadButton}}
+        <PixButton
+          @triggerAction={{@fetchAttendanceSheet}}
+          @variant='secondary'
+          @isBorderVisible={{true}}
+          @size='small'
+          target='_blank'
+          aria-label={{t 'pages.sessions.detail.downloads.attendance-sheet.extra-information'}}
+        >
+          <PixIcon @name='download' @plainIcon={{true}} @ariaHidden={{true}} class='session-details__controls-icon' />
+          {{t 'pages.sessions.detail.downloads.attendance-sheet.label'}}
+        </PixButton>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -74,6 +74,10 @@ export default class Url extends Service {
     return 'https://form-eu.123formbuilder.com/41052/form';
   }
 
+  get fraudReportUrl() {
+    return this.intl.t('common.urls.fraud');
+  }
+
   get invigilatorDocumentationUrl() {
     return 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f';
   }

--- a/certif/tests/integration/components/sessions/session-details/controls-links-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/controls-links-test.gjs
@@ -1,0 +1,53 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import SessionDetailsControlsLinks from 'pix-certif/components/sessions/session-details/controls-links';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | sessions | session-details | controls-links', function (hooks) {
+  setupIntlRenderingTest(hooks, 'fr');
+
+  test('it should display links and buttons', async function (assert) {
+    // given
+    // when
+    const screen = await render(
+      <template>
+        <SessionDetailsControlsLinks
+          @urlToDownloadSessionIssueReportSheet='link'
+          @shouldDisplayDownloadButton={{true}}
+        />
+      </template>,
+    );
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('link', {
+          name: `${t('pages.sessions.detail.downloads.fraud.extra-information')}`,
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('button', {
+          name: `${t('pages.sessions.detail.downloads.invigilator-kit.extra-information')}`,
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('link', {
+          name: `${t('pages.sessions.detail.downloads.incident-report.extra-information')}`,
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('button', {
+          name: `${t('pages.sessions.detail.downloads.attendance-sheet.extra-information')}`,
+        }),
+      )
+      .exists();
+  });
+});

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -296,4 +296,17 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');
     });
   });
+
+  module('#fraudReportUrl', function () {
+    test('should return the fraud report url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const fraudReportUrl = service.fraudReportUrl;
+
+      // then
+      assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download');
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -197,6 +197,9 @@
       },
       "candidates": "Candidates",
       "invigilator": "Invigilator"
+    },
+    "urls": {
+      "fraud": "https://cloud.pix.fr/s/9A598pR5ksp6jss/download"
     }
   },
   "navigation": {
@@ -696,6 +699,10 @@
           "attendance-sheet": {
             "extra-information": "Download attendance sheet",
             "label": "Attendance sheet"
+          },
+          "fraud": {
+            "extra-information": "Download fraud report",
+            "label": "Fraud report"
           },
           "incident-report": {
             "extra-information": "Download incident report",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -197,6 +197,9 @@
       },
       "candidates": "Candidats",
       "invigilator": "Surveillant"
+    },
+    "urls": {
+      "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download"
     }
   },
   "navigation": {
@@ -696,6 +699,10 @@
           "attendance-sheet": {
             "extra-information": "Télécharger la feuille d'émargement",
             "label": "Feuille d'émargement"
+          },
+          "fraud": {
+            "extra-information": "Télécharger le PV de fraude",
+            "label": "PV de fraude"
           },
           "incident-report": {
             "extra-information": "Télécharger le PV d'incident",


### PR DESCRIPTION
## 🌸 Problème

Souvent les établissements oublient l'étape de la transmission du PV de fraude car c'est un document qu'ils n'ont pas imprimé/rempli en amont et ils utilisent (seulement) le PV d'incident (qui n'a pas la même valeur juridique).

## 🌳 Proposition

Pour palier à cet oubli, permettre le téléchargement du PV de fraude directement sur Pix Certif, au même endroit que le PV d'incident; le kit surveillant, etc..

## 🤧 Pour tester

- Se co avec certif-pro@example.net
- Aller sur le détails d'une session
- Constater la présence d'un bouton de PV de fraude
- Le télécharger
