### PR TITLE
[FEATURE] MaDDo - Ajout d'une route listant les organisations autorisées pour un client

### DIFF
--- a/api/db/database-builder/factory/build-client-application.js
+++ b/api/db/database-builder/factory/build-client-application.js
@@ -11,6 +11,7 @@ export function buildClientApplication({
   clientId = 'client-id',
   clientSecret = 'super-secret',
   scopes = ['scope1', 'scope2'],
+  jurisdiction = { rules: [{ name: 'tags', value: ['MEDNUM'] }] },
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'client_applications',
@@ -20,6 +21,7 @@ export function buildClientApplication({
       clientId,
       clientSecret: _getHashedSecret(clientSecret),
       scopes,
+      jurisdiction,
     },
   });
 }

--- a/api/db/database-builder/factory/build-client-application.js
+++ b/api/db/database-builder/factory/build-client-application.js
@@ -12,6 +12,8 @@ export function buildClientApplication({
   clientSecret = 'super-secret',
   scopes = ['scope1', 'scope2'],
   jurisdiction = { rules: [{ name: 'tags', value: ['MEDNUM'] }] },
+  createdAt = new Date(),
+  updatedAt = new Date(),
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'client_applications',
@@ -22,6 +24,8 @@ export function buildClientApplication({
       clientSecret: _getHashedSecret(clientSecret),
       scopes,
       jurisdiction,
+      createdAt,
+      updatedAt,
     },
   });
 }

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -1,5 +1,5 @@
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import { PIX_PUBLIC_TARGET_PROFILE_ID, REAL_PIX_SUPER_ADMIN_ID } from './constants.js';
+import { COLLEGE_TAG, PIX_PUBLIC_TARGET_PROFILE_ID, REAL_PIX_SUPER_ADMIN_ID } from './constants.js';
 import { acceptPixOrgaTermsOfService, createPixOrgaTermsOfService } from './tooling/legal-documents.js';
 import { createTargetProfile } from './tooling/target-profile-tooling.js';
 
@@ -92,6 +92,13 @@ function createClientApplications(databaseBuilder) {
     clientId: 'parcoursup',
     clientSecret: 'parcoursup-secret-de-trente-deux-caracteres',
     scopes: ['parcoursup'],
+  });
+  databaseBuilder.factory.buildClientApplication({
+    name: 'multi-organizations-client-application',
+    clientId: 'maddo-client',
+    clientSecret: 'maddo-secret',
+    scopes: ['meta'],
+    jurisdiction: { rules: [{ name: 'tags', value: [COLLEGE_TAG.name] }] },
   });
 }
 

--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -1,6 +1,7 @@
 import { ATTESTATIONS } from '../../../../src/profile/domain/constants.js';
 import {
   AGRICULTURE_TAG,
+  COLLEGE_TAG,
   FEATURE_ATTESTATIONS_MANAGEMENT_ID,
   FEATURE_CAMPAIGN_WITHOUT_USER_PROFILE_ID,
   FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID,
@@ -51,6 +52,7 @@ async function _createScoOrganization(databaseBuilder) {
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
       { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID, params: JSON.stringify([ATTESTATIONS.SIXTH_GRADE]) },
     ],
+    tagIds: [COLLEGE_TAG.id],
   });
 
   await organization.createOrganization({

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -6,6 +6,7 @@ import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
+import * as organizationRoutes from './src/maddo/application/organizations-routes.js';
 import * as replicationRoutes from './src/maddo/application/replications-routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
@@ -179,7 +180,7 @@ const setupAuthentication = function (server) {
 };
 
 const setupRoutesAndPlugins = async function (server) {
-  const routes = [healthcheckRoutes, ...identityAccessManagementRoutes, replicationRoutes];
+  const routes = [healthcheckRoutes, ...identityAccessManagementRoutes, replicationRoutes, organizationRoutes];
   const routesWithOptions = routes.map((route) => ({
     plugin: route,
     options: { tags: ['maddo'] },

--- a/api/src/identity-access-management/domain/models/ClientApplication.js
+++ b/api/src/identity-access-management/domain/models/ClientApplication.js
@@ -1,9 +1,10 @@
 export class ClientApplication {
-  constructor({ id, name, clientId, clientSecret, scopes }) {
+  constructor({ id, name, clientId, clientSecret, scopes, jurisdiction }) {
     this.id = id;
     this.name = name;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.scopes = scopes;
+    this.jurisdiction = jurisdiction;
   }
 }

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,0 +1,6 @@
+import { usecases } from '../domain/usecases/index.js';
+
+export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
+  const organizations = await dependencies.findOrganizations({ organizationIds: request.pre.organizationIds });
+  return h.response(organizations).code(200);
+}

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -1,0 +1,21 @@
+import { getOrganizations } from './organizations-controller.js';
+import { organizationPreHandler } from './pre-handlers.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/organizations',
+      config: {
+        auth: { access: { scope: 'meta' } },
+        pre: [organizationPreHandler],
+        handler: getOrganizations,
+        notes: ["- Retourne la liste des organizations auxquelles l'application client a droit"],
+        tags: ['api', 'meta'],
+      },
+    },
+  ]);
+};
+
+const name = 'maddo-meta-api';
+export { name, register };

--- a/api/src/maddo/application/pre-handlers.js
+++ b/api/src/maddo/application/pre-handlers.js
@@ -1,0 +1,12 @@
+import { usecases } from '../domain/usecases/index.js';
+
+export const organizationPreHandler = {
+  assign: 'organizationIds',
+  method: async function (
+    request,
+    _,
+    dependencies = { findOrganizationIdsByClientApplication: usecases.findOrganizationIdsByClientApplication },
+  ) {
+    return dependencies.findOrganizationIdsByClientApplication({ clientId: request.auth.credentials.client_id });
+  },
+};

--- a/api/src/maddo/application/replications-routes.js
+++ b/api/src/maddo/application/replications-routes.js
@@ -25,5 +25,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'admin-campaign-participation-api';
+const name = 'maddo-replications-api';
 export { name, register };

--- a/api/src/maddo/domain/models/Organization.js
+++ b/api/src/maddo/domain/models/Organization.js
@@ -1,0 +1,6 @@
+export class Organization {
+  constructor({ id, name }) {
+    this.id = id;
+    this.name = name;
+  }
+}

--- a/api/src/maddo/domain/usecases/find-organization-ids-by-client-application.js
+++ b/api/src/maddo/domain/usecases/find-organization-ids-by-client-application.js
@@ -1,0 +1,17 @@
+import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
+
+export async function findOrganizationIdsByClientApplication({
+  clientId,
+  clientApplicationRepository,
+  organizationRepository,
+}) {
+  const jurisdiction = await clientApplicationRepository.getJurisdiction(clientId);
+
+  const tagsRules = jurisdiction.rules.filter((rule) => rule.name === 'tags');
+
+  const rulesOrganizationIds = await PromiseUtils.mapSeries(tagsRules, (rule) =>
+    organizationRepository.findIdsByTagNames(rule.value),
+  );
+
+  return Array.from(new Set(rulesOrganizationIds.flat()));
+}

--- a/api/src/maddo/domain/usecases/find-organizations.js
+++ b/api/src/maddo/domain/usecases/find-organizations.js
@@ -1,0 +1,3 @@
+export async function findOrganizations({ organizationIds, organizationRepository }) {
+  return organizationRepository.findByIds(organizationIds);
+}

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -1,0 +1,22 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
+import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const dependencies = {
+  clientApplicationRepository,
+  organizationRepository,
+};
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/src/maddo/infrastructure/repositories/client-application-repository.js
+++ b/api/src/maddo/infrastructure/repositories/client-application-repository.js
@@ -1,0 +1,6 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+
+export async function getJurisdiction(clientId) {
+  const clientApplication = await knex('client_applications').select('jurisdiction').where({ clientId }).first();
+  return clientApplication.jurisdiction;
+}

--- a/api/src/maddo/infrastructure/repositories/organization-repository.js
+++ b/api/src/maddo/infrastructure/repositories/organization-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import { Organization } from '../../domain/models/Organization.js';
 
 export async function findIdsByTagNames(tagNames) {
   return knex
@@ -9,4 +10,17 @@ export async function findIdsByTagNames(tagNames) {
     .groupBy('organization-tags.organizationId')
     .havingRaw('count(*) = ?', [tagNames.length])
     .orderBy('organization-tags.organizationId');
+}
+
+export async function findByIds(organizationIds) {
+  const rawOrganizations = await knex
+    .select('id', 'name')
+    .from('organizations')
+    .whereIn('id', organizationIds)
+    .orderBy('id');
+  return rawOrganizations.map(toDomain);
+}
+
+function toDomain(rawOrganization) {
+  return new Organization(rawOrganization);
 }

--- a/api/src/maddo/infrastructure/repositories/organization-repository.js
+++ b/api/src/maddo/infrastructure/repositories/organization-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+
+export async function findIdsByTagNames(tagNames) {
+  return knex
+    .pluck('organization-tags.organizationId')
+    .from('organization-tags')
+    .join('tags', 'tags.id', 'organization-tags.tagId')
+    .whereIn('tags.name', tagNames)
+    .groupBy('organization-tags.organizationId')
+    .havingRaw('count(*) = ?', [tagNames.length])
+    .orderBy('organization-tags.organizationId');
+}

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -7,9 +7,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   let application2;
 
   beforeEach(async function () {
-    const createdAt = new Date();
-    // To avoid flackyness on date comparison, we set createdAt in the past
-    createdAt.setMinutes(-1);
+    const createdAt = new Date('2025-03-26T13:18:20Z');
 
     application2 = databaseBuilder.factory.buildClientApplication({
       name: 'appli2',

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -1,0 +1,54 @@
+import { Organization } from '../../../../src/maddo/domain/models/Organization.js';
+import {
+  createMaddoServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from '../../../test-helper.js';
+
+describe('Acceptance | Maddo | Route | Organizations', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createMaddoServer();
+  });
+
+  describe('GET /api/organizations', function () {
+    it('returns the list of all organizations of the client jurisdiction with an HTTP status code 200', async function () {
+      // given
+      const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+      const orgaAlsoInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-also-in-jurisdiction' });
+      databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
+
+      const tag = databaseBuilder.factory.buildTag();
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaAlsoInJurisdiction.id, tagId: tag.id });
+
+      const clientId = 'client';
+      databaseBuilder.factory.buildClientApplication({
+        clientId: 'client',
+        jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/organizations',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'meta'),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal([
+        new Organization({ id: orgaInJurisdiction.id, name: orgaInJurisdiction.name }),
+        new Organization({ id: orgaAlsoInJurisdiction.id, name: orgaAlsoInJurisdiction.name }),
+      ]);
+    });
+  });
+});

--- a/api/tests/maddo/application/unit/pre-handlers_test.js
+++ b/api/tests/maddo/application/unit/pre-handlers_test.js
@@ -1,0 +1,28 @@
+import { organizationPreHandler } from '../../../../src/maddo/application/pre-handlers.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Maddo | Application | pre handlers', function () {
+  describe('#organizationPreHandler', function () {
+    it('returns allowed organizations ids for authentified client application', async function () {
+      // given
+      const request = {
+        auth: {
+          credentials: {
+            client_id: 'client_id',
+          },
+        },
+      };
+
+      const findOrganizationIdsByClientApplication = sinon.stub();
+      findOrganizationIdsByClientApplication.withArgs({ clientId: 'client_id' }).resolves(['orga1', 'orga2']);
+
+      // when
+      const organizationIds = await organizationPreHandler.method(request, hFake, {
+        findOrganizationIdsByClientApplication,
+      });
+
+      // then
+      expect(organizationIds).to.deep.equal(['orga1', 'orga2']);
+    });
+  });
+});

--- a/api/tests/maddo/domain/unit/usecases/find-organization-ids-by-client-application_test.js
+++ b/api/tests/maddo/domain/unit/usecases/find-organization-ids-by-client-application_test.js
@@ -1,0 +1,112 @@
+import { findOrganizationIdsByClientApplication } from '../../../../../src/maddo/domain/usecases/find-organization-ids-by-client-application.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Maddo | Domain | Usecase | Find organization ids by client application', function () {
+  context('when client application’s jurisdiction has only one tags rule', function () {
+    it('returns the list of organisation ids of given client application jurisdiction', async function () {
+      // given
+      const expectedOrganizationIds = ['orga1', 'orga2'];
+      const clientId = Symbol('clientId');
+      const tagNames = Symbol('tagNames');
+      const jurisdiction = {
+        rules: [{ name: 'tags', value: tagNames }],
+      };
+
+      const clientApplicationRepository = {
+        getJurisdiction: sinon.stub(),
+      };
+      clientApplicationRepository.getJurisdiction.withArgs(clientId).resolves(jurisdiction);
+
+      const organizationRepository = {
+        findIdsByTagNames: sinon.stub(),
+      };
+      organizationRepository.findIdsByTagNames.withArgs(tagNames).resolves(expectedOrganizationIds);
+
+      // when
+      const organizationIds = await findOrganizationIdsByClientApplication({
+        clientId,
+        clientApplicationRepository,
+        organizationRepository,
+      });
+
+      // then
+      expect(organizationIds).to.deep.equal(expectedOrganizationIds);
+      expect(organizationRepository.findIdsByTagNames).to.have.been.calledOnce;
+    });
+  });
+
+  context('when client application’s jurisdiction has several tags rules', function () {
+    it('returns the list of organisation ids of given client application jurisdiction', async function () {
+      // given
+      const organizationIdsForTagNames1 = ['orga1', 'orga2'];
+      const organizationIdsForTagNames2 = ['orga1', 'orga3'];
+      const clientId = Symbol('clientId');
+      const tagNames1 = Symbol('tagNames1');
+      const tagNames2 = Symbol('tagNames2');
+      const jurisdiction = {
+        rules: [
+          { name: 'tags', value: tagNames1 },
+          { name: 'tags', value: tagNames2 },
+        ],
+      };
+
+      const clientApplicationRepository = {
+        getJurisdiction: sinon.stub(),
+      };
+      clientApplicationRepository.getJurisdiction.withArgs(clientId).resolves(jurisdiction);
+
+      const organizationRepository = {
+        findIdsByTagNames: sinon.stub(),
+      };
+      organizationRepository.findIdsByTagNames.withArgs(tagNames1).resolves(organizationIdsForTagNames1);
+      organizationRepository.findIdsByTagNames.withArgs(tagNames2).resolves(organizationIdsForTagNames2);
+
+      // when
+      const organizationIds = await findOrganizationIdsByClientApplication({
+        clientId,
+        clientApplicationRepository,
+        organizationRepository,
+      });
+
+      // then
+      expect(organizationIds).to.deep.equal(['orga1', 'orga2', 'orga3']);
+      expect(organizationRepository.findIdsByTagNames).to.have.been.calledTwice;
+    });
+  });
+
+  context('when client application’s jurisdiction has unknown rules', function () {
+    it('discards unknown rules', async function () {
+      // given
+      const organizationIdsForTagNames1 = ['orga1', 'orga2'];
+      const clientId = Symbol('clientId');
+      const tagNames1 = Symbol('tagNames1');
+      const jurisdiction = {
+        rules: [
+          { name: 'tags', value: tagNames1 },
+          { name: 'organizationIds', value: ['orga1', 'orga3'] },
+        ],
+      };
+
+      const clientApplicationRepository = {
+        getJurisdiction: sinon.stub(),
+      };
+      clientApplicationRepository.getJurisdiction.withArgs(clientId).resolves(jurisdiction);
+
+      const organizationRepository = {
+        findIdsByTagNames: sinon.stub(),
+      };
+      organizationRepository.findIdsByTagNames.withArgs(tagNames1).resolves(organizationIdsForTagNames1);
+
+      // when
+      const organizationIds = await findOrganizationIdsByClientApplication({
+        clientId,
+        clientApplicationRepository,
+        organizationRepository,
+      });
+
+      // then
+      expect(organizationIds).to.deep.equal(organizationIdsForTagNames1);
+      expect(organizationRepository.findIdsByTagNames).to.have.been.calledOnce;
+    });
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/client-application-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/client-application-repository_test.js
@@ -1,0 +1,19 @@
+import { getJurisdiction } from '../../../../../src/maddo/infrastructure/repositories/client-application-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | client application', function () {
+  describe('#getJurisdiction', function () {
+    it('returns jurisdiction of given clientId', async function () {
+      // given
+      const expectedJurisdiction = { rules: [{ name: 'tags', value: ['MEDNUM'] }] };
+      const { clientId } = databaseBuilder.factory.buildClientApplication({ jurisdiction: expectedJurisdiction });
+      await databaseBuilder.commit();
+
+      // when
+      const jurisdiction = await getJurisdiction(clientId);
+
+      // then
+      expect(jurisdiction).to.deep.equal(expectedJurisdiction);
+    });
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
@@ -1,4 +1,8 @@
-import { findIdsByTagNames } from '../../../../../src/maddo/infrastructure/repositories/organization-repository.js';
+import { Organization } from '../../../../../src/maddo/domain/models/Organization.js';
+import {
+  findByIds,
+  findIdsByTagNames,
+} from '../../../../../src/maddo/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | organization', function () {
@@ -33,6 +37,28 @@ describe('Maddo | Infrastructure | Repositories | Integration | organization', f
 
       // then
       expect(ids).to.deep.equal([organizationId1, organizationId5]);
+    });
+  });
+
+  describe('#findByIds', function () {
+    it('find organizations for given ids', async function () {
+      //given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      //when
+      const organizations = await findByIds([organization1.id, organization2.id]);
+
+      //then
+      expect(organizations).to.deep.equal([
+        new Organization({ id: organization1.id, name: organization1.name }),
+        new Organization({
+          id: organization2.id,
+          name: organization2.name,
+        }),
+      ]);
     });
   });
 });

--- a/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
@@ -1,0 +1,38 @@
+import { findIdsByTagNames } from '../../../../../src/maddo/infrastructure/repositories/organization-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | organization', function () {
+  describe('#findIdsByTagNames', function () {
+    it('lists organizations ids belonging to all given tag names', async function () {
+      // given
+      const { id: organizationId1 } = databaseBuilder.factory.buildOrganization();
+      const { id: organizationId2 } = databaseBuilder.factory.buildOrganization();
+      const { id: organizationId3 } = databaseBuilder.factory.buildOrganization();
+      const { id: organizationId4 } = databaseBuilder.factory.buildOrganization();
+      const { id: organizationId5 } = databaseBuilder.factory.buildOrganization();
+
+      const { id: tagId1 } = databaseBuilder.factory.buildTag({ name: 'tag1' });
+      const { id: tagId2 } = databaseBuilder.factory.buildTag({ name: 'tag2' });
+      const { id: tagId3 } = databaseBuilder.factory.buildTag({ name: 'tag3' });
+
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId1, tagId: tagId1 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId1, tagId: tagId3 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId2, tagId: tagId2 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId3, tagId: tagId1 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId4, tagId: tagId3 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId5, tagId: tagId1 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId5, tagId: tagId2 });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organizationId5, tagId: tagId3 });
+
+      await databaseBuilder.commit();
+
+      const tagNames = ['tag1', 'tag3'];
+
+      // when
+      const ids = await findIdsByTagNames(tagNames);
+
+      // then
+      expect(ids).to.deep.equal([organizationId1, organizationId5]);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-client-application.js
+++ b/api/tests/tooling/domain-builder/factory/build-client-application.js
@@ -6,6 +6,12 @@ export function buildClientApplication({
   clientId = 'client-id',
   clientSecret = 'super-secret',
   scopes = ['scope1', 'scope2'],
+  jurisdiction = [
+    {
+      rule: 'tags',
+      value: ['MEDNUM'],
+    },
+  ],
 } = {}) {
-  return new ClientApplication({ id, name, clientId, clientSecret, scopes });
+  return new ClientApplication({ id, name, clientId, clientSecret, scopes, jurisdiction });
 }


### PR DESCRIPTION
## 🌸 Problème

Pix souhaite mettre à disposition de partenaires identifiés les données relatives à leurs organisations. Il n'existe actuellement pas d'API pour cela.

## 🌳 Proposition

Ajouter la notion de juridiction des applications clientes.
Les juridictions sont des ensembles de règles indiquant les organisations autorisées pour une application cliente.
Dans un premier temps, la seule règle possible est de la forme :
```
rules: [{ name: 'tags', value: [<liste de noms de tags>] }]
```
On a choisi de se baser sur les noms de tags pour plus de facilité et de lisibilité.

Mettre en place une route `/api/organizations` accessible via un token d'application cliente dont le scope est `meta`.
Cette route retourne les données de l'ensemble des organisations autorisées par les règles de juridiction de l'application cliente.


## 🐝 Remarques

Les seules données d'organisation actuellement retournées sont les ids et noms.


## 🤧 Pour tester

Récupérer un token avec 
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11779.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta' | jq -r .access_token)
```

Appeler la route `/api/organizations` avec ce token.

```
curl https://pix-api-maddo-review-pr11779.osc-fr1.scalingo.io/api/organizations -H "Authorization: Bearer $ACCESS_TOKEN"
```

Cette route doit répondre

```
[{"id":1003,"name":"SCO Classic"},{"id":7200,"name":"Orga SCO Managing team Certification"},{"id":7202,"name":"Orga not managing student team Certification"},{"id":7203,"name":"Orga team Certification"}]
```