### PR TITLE
[TECH] ajoute un script pour créer les knowledge-element-snapshot perdus (pix-17101)

### DIFF
--- a/api/src/prescription/scripts/add-missing-knowledge-element-snapshots.js
+++ b/api/src/prescription/scripts/add-missing-knowledge-element-snapshots.js
@@ -1,0 +1,102 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { commaSeparatedNumberParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import * as knowledgeElementRepository from '../../shared/infrastructure/repositories/knowledge-element-repository.js';
+import * as campaignRepository from '../campaign/infrastructure/repositories/campaign-repository.js';
+import * as knowledgeElementSnapshotRepository from '../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
+import { KnowledgeElementCollection } from '../shared/domain/models/KnowledgeElementCollection.js';
+
+const LOG_CONTEXT = 'add-missing-knowledge-element-snapshots';
+
+class AddMissingKnowledgeElementSnapshots extends Script {
+  constructor() {
+    super({
+      description: 'Script to add delete knowledge-element-snapshots from same participation',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'execute script without commit',
+          demandOption: false,
+          default: true,
+        },
+        campaignParticipationIds: {
+          type: 'string',
+          describe: 'a list of comma separated campaign participation ids',
+          demandOption: true,
+          coerce: commaSeparatedNumberParser(),
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info(`${LOG_CONTEXT} | START`);
+    logger.info(`${LOG_CONTEXT} | dryRun ${options.dryRun}`);
+
+    const trx = await knex.transaction();
+    let nbSnapshotsCreated = 0;
+    for (const campaignParticipationId of options.campaignParticipationIds) {
+      const campaign = await campaignRepository.getByCampaignParticipationId(campaignParticipationId);
+      if (campaign === null) {
+        logger.error(`${LOG_CONTEXT} | Skip campaign participation ${campaignParticipationId}, campaign not found`);
+        continue;
+      }
+      if (campaign.isExam) {
+        logger.error(`${LOG_CONTEXT} | Skip campaign participation ${campaignParticipationId}, campaign to exam`);
+        continue;
+      }
+      const participation = await trx('campaign-participations')
+        .select(['userId', 'sharedAt'])
+        .where({ id: campaignParticipationId })
+        .first();
+
+      const existingSnapshots = await trx('knowledge-element-snapshots')
+        .count({ count: 1 })
+        .where({ campaignParticipationId })
+        .first();
+
+      if (existingSnapshots.count !== 0) {
+        logger.error(
+          `${LOG_CONTEXT} | We are skipping this campaignParticipation ${campaignParticipationId} because a snapshot already exists for it.`,
+        );
+        continue;
+      }
+
+      const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
+        userId: participation.userId,
+        limitDate: participation.sharedAt,
+      });
+      await knowledgeElementSnapshotRepository.save({
+        userId: participation.userId,
+        snappedAt: participation.sharedAt,
+        snapshot: new KnowledgeElementCollection(knowledgeElements).toSnapshot(),
+        campaignParticipationId,
+      });
+      nbSnapshotsCreated++;
+    }
+    logger.info(
+      `${LOG_CONTEXT} | Created ${nbSnapshotsCreated} snapshots. Skipped ${options.campaignParticipationIds.length - nbSnapshotsCreated} participations`,
+    );
+
+    try {
+      if (options.dryRun) {
+        logger.info(`${LOG_CONTEXT} | rollback | Mode dry run`);
+        await trx.rollback();
+      } else {
+        logger.info(`${LOG_CONTEXT} | commit`);
+        await trx.commit();
+      }
+    } catch (err) {
+      logger.error(`${LOG_CONTEXT} | FAIL | Reason : ${err}`);
+      await trx.rollback();
+    } finally {
+      logger.info(`${LOG_CONTEXT} | END`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AddMissingKnowledgeElementSnapshots);
+
+export { AddMissingKnowledgeElementSnapshots };

--- a/api/tests/prescription/scripts/add-missing-knowledge-element-snapshots_test.js
+++ b/api/tests/prescription/scripts/add-missing-knowledge-element-snapshots_test.js
@@ -1,0 +1,148 @@
+import { AddMissingKnowledgeElementSnapshots } from '../../../src/prescription/scripts/add-missing-knowledge-element-snapshots.js';
+import { CampaignTypes } from '../../../src/prescription/shared/domain/constants.js';
+import { databaseBuilder, expect, knex, sinon } from '../../test-helper.js';
+
+describe('Integration | Prescription | Scripts | add-missing-knowledge-element-snapshots', function () {
+  let script;
+  let loggerStub;
+
+  before(async function () {
+    script = new AddMissingKnowledgeElementSnapshots();
+    loggerStub = { info: sinon.stub(), error: sinon.stub(), warning: sinon.stub() };
+  });
+
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const { options } = script.metaInfo;
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'execute script without commit',
+        demandOption: false,
+        default: true,
+      });
+      expect(options.campaignParticipationIds).to.deep.include({
+        type: 'string',
+        describe: 'a list of comma separated campaign participation ids',
+        demandOption: true,
+      });
+    });
+  });
+
+  describe('#handle', function () {
+    it("should create ke-snapshot for participation when they don't exists", async function () {
+      //given
+      const createdAt1 = new Date('2023-01-02T09:50:00Z');
+      const sharedAt1 = new Date('2023-01-02T10:00:00Z');
+      const createdAt2 = new Date('2023-01-03T10:00:00Z');
+      const sharedAt2 = new Date('2023-01-03T10:00:00Z');
+
+      const user = databaseBuilder.factory.buildUser();
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        createdAt: createdAt1,
+        sharedAt: sharedAt1,
+      });
+      const participationWithsnapshot = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        createdAt: createdAt2,
+        sharedAt: sharedAt2,
+      });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId: user.id,
+        snappedAt: sharedAt2,
+        campaignParticipationId: participationWithsnapshot.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { campaignParticipationIds: [participation.id, participationWithsnapshot.id], dryRun: false },
+        logger: loggerStub,
+      });
+
+      // then
+      const result = await knex('knowledge-element-snapshots')
+        .orderBy('snappedAt', 'asc')
+        .pluck('campaignParticipationId');
+
+      expect(result).to.deep.equal([participation.id, participationWithsnapshot.id]);
+      expect(loggerStub.error).calledWithExactly(
+        `add-remove-knowledge-element-snapshot | We are skipping this campaignParticipation ${participationWithsnapshot.id} because a snapshot already exists for it.`,
+      );
+      expect(loggerStub.info).calledWithExactly(
+        'add-remove-knowledge-element-snapshot | Created 1 snapshots. Skipped 1 participations',
+      );
+    });
+    context('when campaign participation does not exist', function () {
+      it('should skip participation and log an error', async function () {
+        // when
+        await script.handle({
+          options: { campaignParticipationIds: ['123'], dryRun: false },
+          logger: loggerStub,
+        });
+        expect(loggerStub.error).calledWithExactly(
+          'add-remove-knowledge-element-snapshot | Skip campaign participation 123, campaign not found',
+        );
+      });
+    });
+    context('when campaign is of type exam', function () {
+      it('should skip participation and log an error', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.EXAM });
+        const participation = databaseBuilder.factory.buildCampaignParticipation({
+          userId: user.id,
+          campaignId: campaign.id,
+          createdAt: new Date('2023-01-02T09:50:00Z'),
+          sharedAt: new Date('2023-01-02T10:50:00Z'),
+        });
+        await databaseBuilder.commit();
+        // when
+        await script.handle({
+          options: { campaignParticipationIds: [participation.id], dryRun: false },
+          logger: loggerStub,
+        });
+        expect(loggerStub.error).calledWithExactly(
+          `add-remove-knowledge-element-snapshot | Skip campaign participation ${participation.id}, campaign to exam`,
+        );
+      });
+    });
+    context('when there is knowledge-element after participation sharing date', function () {
+      it('should save the knowledge elements before sharing date', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const campaign = databaseBuilder.factory.buildCampaign();
+        const participation = databaseBuilder.factory.buildCampaignParticipation({
+          userId: user.id,
+          campaignId: campaign.id,
+          createdAt: new Date('2023-01-02T09:50:00Z'),
+          sharedAt: new Date('2023-01-02T10:50:00Z'),
+        });
+        const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+          userId: user.id,
+          createdAt: new Date('2023-01-01T10:50:00Z'),
+          skillId: 'skillId1',
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId: user.id,
+          createdAt: new Date('2023-01-03T10:50:00Z'),
+          skillId: 'skillId1',
+        });
+
+        await databaseBuilder.commit();
+        // when
+        await script.handle({
+          options: { campaignParticipationIds: [participation.id], dryRun: false },
+          logger: loggerStub,
+        });
+        const result = await knex('knowledge-element-snapshots')
+          .where({ campaignParticipationId: participation.id })
+          .first();
+
+        expect(result.snapshot).lengthOf(1);
+        expect(result.snapshot[0].skillId).equal(ke1.skillId);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Suite à des incidents de prod et un bug dans l'utilisation des transactions, certaines données ont partiellement été écrites au moment du partage de résultat. Le statut de la campagne a été mis à jour mais le snapshot associé n'a pas été créé. 

## 🌳 Proposition

On a corrigé l'utilisation de transaction. Il faut maintenant rattraper les données et créer les snapshot

## 🐝 Remarques

ras

## 🤧 Pour tester

- partager une participation
- se connecter sur le posgres et supprimer le snapshot associé
- lancer le script
- voir le snapshot contient les bon ke