### PR TITLE
[BUGFIX] Pix Junior - Affichage des puces sur la liste des objectifs d'une mission (PIX-16943)

### DIFF
--- a/junior/app/styles/pages/identified/missions/mission.scss
+++ b/junior/app/styles/pages/identified/missions/mission.scss
@@ -57,21 +57,22 @@
       text-decoration: underline;
     }
 
-    ul {
-      margin-left: 30px;
-      list-style-type: disc;
-    }
-
     .details-list {
-
-      li {
-        display: flex;
-        align-items: flex-start;
-      }
+      margin-left: 30px;
 
       img {
         width: 21px;
         margin: 4px;
+      }
+
+      &--with-bullet {
+        display: list-item;
+        list-style-type: disc;
+      }
+
+      &--with-image {
+        display: flex;
+        align-items: flex-start;
       }
 
       &__title {


### PR DESCRIPTION
## 🌸 Problème

Il n'y a plus de puces sur la liste des objectifs d'une mission.

<img width="824" alt="Capture d’écran 2025-03-24 à 11 12 27" src="https://github.com/user-attachments/assets/7dd16432-61c6-445a-98c8-905959ecac7a" />


## 🌳 Proposition

Repositionner des puces sur cette liste pour avoir l'affichage suivant : 

## 🤧 Pour tester

Afficher la page de détail d'une mission.
-> Des puces précèdent les objectifs

Afficher la page de résultat d'une mission.
-> Il n'y a pas de puces mais des pictogrammes indiquant si les objectifs ont été, ou non, atteints.