### PR TITLE
[FEATURE] Pix Junior - Limitation de la largeur du contenu affiché sur grand écran (PIX-16978)

### DIFF
--- a/junior/app/components/challenge/challenge-layout.gjs
+++ b/junior/app/components/challenge/challenge-layout.gjs
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 
+import WidthLimitedContent from '../width-limited-content';
+
 export default class ChallengeLayout extends Component {
   get className() {
     return this.args.color ?? 'default';
@@ -7,9 +9,7 @@ export default class ChallengeLayout extends Component {
 
   <template>
     <div class="challenge-layout challenge-layout--{{this.className}}">
-      <div class="container">
-        {{yield}}
-      </div>
+      <WidthLimitedContent>{{yield}}</WidthLimitedContent>
     </div>
   </template>
 }

--- a/junior/app/components/challenge/challenge.gjs
+++ b/junior/app/components/challenge/challenge.gjs
@@ -8,7 +8,7 @@ import ENV from 'junior/config/environment';
 
 import Bubble from '../bubble';
 import DelayedElement from '../delayed-element';
-import IdentifiedLearner from '../identified-learner';
+import Header from '../header';
 import RobotDialog from '../robot-dialog';
 import ChallengeContent from './challenge-content';
 import ChallengeLayout from './challenge-layout';
@@ -161,7 +161,7 @@ export default class Challenge extends Component {
   <template>
     {{pageTitle (t "pages.challenge.title")}}
     <ChallengeLayout @color={{this.layoutColor}}>
-      <div class="header_container">
+      <Header>
         <RobotDialog @class={{this.robotMood}}>
           {{#each @challenge.instructions as |instruction index|}}
             <DelayedElement @shouldDisplayIn={{this.bubbleDisplayDelay index}}>
@@ -178,8 +178,7 @@ export default class Challenge extends Component {
             />
           {{/if}}
         </RobotDialog>
-        <IdentifiedLearner />
-      </div>
+      </Header>
       <DelayedElement @shouldDisplayIn={{this.challengeItemDisplayDelay}}>
         <ChallengeContent
           @setAnswerValue={{this.setAnswerValue}}

--- a/junior/app/components/challenge/content/qrocm.gjs
+++ b/junior/app/components/challenge/content/qrocm.gjs
@@ -90,7 +90,7 @@ export default class Qrocm extends Component {
         {{/if}}
         {{#if (eq block.type "select")}}
           <PixSelect
-            class="challenge-content-proposals__response challenge-content-proposals__response--selector"
+            class="challenge-content-proposals__response"
             @value={{get this.answerValues block.input}}
             @screenReaderOnly={{true}}
             @placeholder={{block.placeholder}}
@@ -99,6 +99,7 @@ export default class Qrocm extends Component {
             @onChange={{fn this.onSelectChange block.input}}
             @id="{{block.input}}"
             @isDisabled={{@isDisabled}}
+            @isComputeWidthDisabled={{true}}
           >
             <:label>{{block.ariaLabel}}</:label>
           </PixSelect>

--- a/junior/app/components/header.gjs
+++ b/junior/app/components/header.gjs
@@ -1,0 +1,8 @@
+import IdentifiedLearner from './identified-learner';
+
+<template>
+  <div class="header">
+    {{yield}}
+    <IdentifiedLearner />
+  </div>
+</template>

--- a/junior/app/components/width-limited-content.gjs
+++ b/junior/app/components/width-limited-content.gjs
@@ -1,0 +1,7 @@
+<template>
+  <div class="width-limited-content">
+    <div class="width-limited-content__inner-content">
+      {{yield}}
+    </div>
+  </div>
+</template>

--- a/junior/app/styles/app.scss
+++ b/junior/app/styles/app.scss
@@ -10,7 +10,7 @@
 @use 'globals/fonts' as *;
 
 // Components
-@use 'components/challenge/challenge' as *;
+@use 'components/header' as *;
 @use 'components/challenge/challenge-actions' as *;
 @use 'components/challenge/challenge-embed-simulator' as *;
 @use 'components/challenge/challenge-content' as *;
@@ -27,6 +27,7 @@
 @use 'components/identified-learner' as *;
 @use 'components/oralization-button' as *;
 @use 'components/robot-dialog' as *;
+@use 'components/width-limited-content' as *;
 
 // Pages
 @use 'pages/identified/missions/introduction' as *;

--- a/junior/app/styles/components/challenge/challenge-layout.scss
+++ b/junior/app/styles/components/challenge/challenge-layout.scss
@@ -36,9 +36,4 @@
     background-color: rgba(var(--pix-secondary-500-inline), 10%);
     background-image: url("/images/background-success-result-page.svg");
   }
-
-  .container {
-    width: 100%;
-    max-width: 1440px;
-  }
 }

--- a/junior/app/styles/components/header.scss
+++ b/junior/app/styles/components/header.scss
@@ -1,4 +1,4 @@
-.header_container {
+.header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;

--- a/junior/app/styles/components/width-limited-content.scss
+++ b/junior/app/styles/components/width-limited-content.scss
@@ -1,0 +1,10 @@
+.width-limited-content {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  &__inner-content {
+    width: 100%;
+    max-width: 1440px;
+  }
+}

--- a/junior/app/templates/assessment/results.hbs
+++ b/junior/app/templates/assessment/results.hbs
@@ -1,43 +1,44 @@
 {{page-title (t "pages.missions.end-page.title")}}
 <Challenge::ChallengeLayout @color="{{this.feedbackClassName}}">
-  <div class="mission-page">
-    <div class="header_container">
-      <RobotDialog @class={{this.robotMood}}>
-        {{#each this.robotFeedBackMessage as |message|}}
-          <Bubble @message={{message}} />
-        {{/each}}
-      </RobotDialog>
-      <IdentifiedLearner />
-    </div>
-    <div class="mission-page__body">
-      <MissionCard::CompletedMissionCard
-        @missionLabelStatus={{t "pages.missions.list.status.completed.label"}}
-        @title={{@model.mission.name}}
-        @areaCode={{@model.mission.areaCode}}
-      />
-
-      <div class="mission-page__details">
-        <p class="details-list__title details-list__title--big">{{t this.resultsTitle}}</p>
-        <ul class="details-list">
-          {{#each this.validatedObjectives as |element index|}}
-
-            <li>
-              {{#if (this.isStepSuccessFul index)}}
-                <img src="/images/icons/valid.svg" alt="Valid" />
-              {{else}}
-                <img src="/images/icons/not-valid.svg" alt="Invalid" />
-              {{/if}}
-              <MarkdownToHtml @markdown="{{element}}" class="details-list__item" />
-            </li>
+  <WidthLimitedContent>
+    <div class="mission-page">
+      <Header>
+        <RobotDialog @class={{this.robotMood}}>
+          {{#each this.robotFeedBackMessage as |message|}}
+            <Bubble @message={{message}} />
           {{/each}}
-        </ul>
+        </RobotDialog>
+      </Header>
+      <div class="mission-page__body">
+        <MissionCard::CompletedMissionCard
+          @missionLabelStatus={{t "pages.missions.list.status.completed.label"}}
+          @title={{@model.mission.name}}
+          @areaCode={{@model.mission.areaCode}}
+        />
 
-        <PixButtonLink @route="identified.missions" class="details-action">
-          <p>{{t "pages.missions.end-page.back-to-missions"}}</p>
-          <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
-        </PixButtonLink>
+        <div class="mission-page__details">
+          <p class="details-list__title details-list__title--big">{{t this.resultsTitle}}</p>
+          <ul class="details-list">
+            {{#each this.validatedObjectives as |element index|}}
 
+              <li class="details-list--with-image">
+                {{#if (this.isStepSuccessFul index)}}
+                  <img src="/images/icons/valid.svg" alt="Valid" />
+                {{else}}
+                  <img src="/images/icons/not-valid.svg" alt="Invalid" />
+                {{/if}}
+                <MarkdownToHtml @markdown="{{element}}" class="details-list__item" />
+              </li>
+            {{/each}}
+          </ul>
+
+          <PixButtonLink @route="identified.missions" class="details-action">
+            <p>{{t "pages.missions.end-page.back-to-missions"}}</p>
+            <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
+          </PixButtonLink>
+
+        </div>
       </div>
     </div>
-  </div>
+  </WidthLimitedContent>
 </Challenge::ChallengeLayout>

--- a/junior/app/templates/identified/missions/list.hbs
+++ b/junior/app/templates/identified/missions/list.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "pages.missions.list.title")}}
-<div>
-  <div class="header_container">
+<WidthLimitedContent>
+  <Header>
     <RobotDialog>
       <Bubble @message={{t "pages.missions.list.instruction" prenom=this.model.organizationLearner.firstName}} />
       <Bubble
@@ -11,8 +11,7 @@
         }}
       />
     </RobotDialog>
-    <IdentifiedLearner />
-  </div>
+  </Header>
   <div class="cards">
     {{#each this.orderedMissionList as |mission|}}
       <PixButton @triggerAction={{fn this.goToMission mission.id}} class="card">
@@ -35,4 +34,4 @@
       </PixButton>
     {{/each}}
   </div>
-</div>
+</WidthLimitedContent>

--- a/junior/app/templates/identified/missions/mission/index.hbs
+++ b/junior/app/templates/identified/missions/mission/index.hbs
@@ -1,43 +1,44 @@
 {{page-title (t "pages.missions.start-page.title")}}
-<div class="mission-page">
-  <div class="header_container">
-    <RobotDialog>
-      <Bubble @message={{t "pages.missions.start-page.welcome"}} />
-    </RobotDialog>
-    <IdentifiedLearner />
-  </div>
-  <div class="mission-page__body">
+<WidthLimitedContent>
+  <div class="mission-page">
+    <Header>
+      <RobotDialog>
+        <Bubble @message={{t "pages.missions.start-page.welcome"}} />
+      </RobotDialog>
+    </Header>
+    <div class="mission-page__body">
 
-    <MissionCard::MissionCard
-      @title={{@model.name}}
-      @cardImageUrl={{@model.cardImageUrl}}
-      @areaCode={{@model.areaCode}}
-    />
+      <MissionCard::MissionCard
+        @title={{@model.name}}
+        @cardImageUrl={{@model.cardImageUrl}}
+        @areaCode={{@model.areaCode}}
+      />
 
-    <div class="mission-page__details">
-      <LinkTo @route="identified.missions" class="details-go-back">{{t
-          "pages.missions.start-page.back-to-missions"
-        }}</LinkTo>
-      <p class="details-list__title details-list__title--big">{{t "pages.missions.start-page.purpose-title"}}</p>
-      <ul class="details-list">
-        {{#each this.validatedObjectives as |element|}}
-          <li>
-            <MarkdownToHtml @markdown={{element}} class="details-list__item" />
-          </li>
-        {{/each}}
-      </ul>
+      <div class="mission-page__details">
+        <LinkTo @route="identified.missions" class="details-go-back">{{t
+            "pages.missions.start-page.back-to-missions"
+          }}</LinkTo>
+        <p class="details-list__title details-list__title--big">{{t "pages.missions.start-page.purpose-title"}}</p>
+        <ul class="details-list">
+          {{#each this.validatedObjectives as |element|}}
+            <li class="details-list--with-bullet">
+              <MarkdownToHtml @markdown={{element}} class="details-list__item" />
+            </li>
+          {{/each}}
+        </ul>
 
-      <PixButtonLink
-        @route={{this.routeUrl}}
-        size="large"
-        class="details-action"
-        {{on "click" this.activeLoadingButton}}
-      >
-        <p>{{t "pages.missions.start-page.start-mission"}}</p>
-        <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
-      </PixButtonLink>
+        <PixButtonLink
+          @route={{this.routeUrl}}
+          size="large"
+          class="details-action"
+          {{on "click" this.activeLoadingButton}}
+        >
+          <p>{{t "pages.missions.start-page.start-mission"}}</p>
+          <PixIcon @name="arrowRight" class="details-action__icon" @ariaHidden={{true}} />
+        </PixButtonLink>
 
-      <PixButton class="details-action details-action__loader" @isLoading="true" @ariaHidden={{true}} />
+        <PixButton class="details-action details-action__loader" @isLoading="true" @ariaHidden={{true}} />
+      </div>
     </div>
   </div>
-</div>
+</WidthLimitedContent>

--- a/junior/app/templates/identified/missions/mission/introduction.hbs
+++ b/junior/app/templates/identified/missions/mission/introduction.hbs
@@ -1,35 +1,36 @@
 {{page-title (t "pages.missions.introduction-page.title")}}
 
 <Challenge::ChallengeLayout>
-  <div class="mission-introduction">
-    <div class="header_container">
-      <RobotDialog>
-        <Bubble
-          @message={{t "pages.missions.introduction-page.robot-text.0"}}
-          @oralization={{@model.learnerHasOralizationFeature}}
-        />
+  <WidthLimitedContent>
+    <div class="mission-introduction">
+      <Header>
+        <RobotDialog>
+          <Bubble
+            @message={{t "pages.missions.introduction-page.robot-text.0"}}
+            @oralization={{@model.learnerHasOralizationFeature}}
+          />
 
-        <Bubble
-          @message={{t "pages.missions.introduction-page.robot-text.1"}}
-          @oralization={{@model.learnerHasOralizationFeature}}
-        />
-      </RobotDialog>
-      <IdentifiedLearner />
-    </div>
-    <div class="mission-introduction__container">
-      <div class="mission-introduction__media">
-        <Challenge::Content::ChallengeMedia
-          @src={{@model.mission.introductionMediaUrl}}
-          @alt={{@model.mission.introductionMediaAlt}}
-          @type={{@model.mission.introductionMediaType}}
-        />
+          <Bubble
+            @message={{t "pages.missions.introduction-page.robot-text.1"}}
+            @oralization={{@model.learnerHasOralizationFeature}}
+          />
+        </RobotDialog>
+      </Header>
+      <div class="mission-introduction__container">
+        <div class="mission-introduction__media">
+          <Challenge::Content::ChallengeMedia
+            @src={{@model.mission.introductionMediaUrl}}
+            @alt={{@model.mission.introductionMediaAlt}}
+            @type={{@model.mission.introductionMediaType}}
+          />
+        </div>
+        <div class="mission-introduction__actions">
+          <PixButtonLink @route="identified.missions.mission.resume" size="large" class="details-action">
+            <p>{{t "pages.missions.introduction-page.start-mission"}}</p>
+            <PixIcon @name="arrowRight" class="button-actions__icon" @ariaHidden={{true}} />
+          </PixButtonLink>
+        </div>
       </div>
-      <div class="mission-introduction__actions">
-        <PixButtonLink @route="identified.missions.mission.resume" size="large" class="details-action">
-          <p>{{t "pages.missions.introduction-page.start-mission"}}</p>
-          <PixIcon @name="arrowRight" class="button-actions__icon" @ariaHidden={{true}} />
-        </PixButtonLink>
-      </div>
     </div>
-  </div>
+  </WidthLimitedContent>
 </Challenge::ChallengeLayout>

--- a/junior/app/templates/organization-code.hbs
+++ b/junior/app/templates/organization-code.hbs
@@ -1,37 +1,39 @@
 {{page-title (t "pages.home.page-title")}}
 
-<form onSubmit={{this.goToSchool}} class="school-code">
-  <div class="school-code__welcome-with-bubble">
-    <div class="school-code__rotated-bubble">{{t "pages.home.beta"}}</div>
-    <p class="school-code__welcome">{{t "pages.home.welcome"}}</p>
-  </div>
-  <p class="school-code__instructions">{{t "pages.home.code-instruction"}}</p>
-  <div class="school-code__input">
-    <PixCode
-      @length="9"
-      @requiredLabel={{t "common.forms.mandatory"}}
-      @value={{this.schoolCode}}
-      aria-label={{t "pages.home.code-description"}}
-      {{on "input" this.handleCode}}
-      class="school-code__pix-code"
-    >
-      <:label>{{t "pages.home.code-label"}}</:label>
-    </PixCode>
-  </div>
+<WidthLimitedContent>
+  <form onSubmit={{this.goToSchool}} class="school-code">
+    <div class="school-code__welcome-with-bubble">
+      <div class="school-code__rotated-bubble">{{t "pages.home.beta"}}</div>
+      <p class="school-code__welcome">{{t "pages.home.welcome"}}</p>
+    </div>
+    <p class="school-code__instructions">{{t "pages.home.code-instruction"}}</p>
+    <div class="school-code__input">
+      <PixCode
+        @length="9"
+        @requiredLabel={{t "common.forms.mandatory"}}
+        @value={{this.schoolCode}}
+        aria-label={{t "pages.home.code-description"}}
+        {{on "input" this.handleCode}}
+        class="school-code__pix-code"
+      >
+        <:label>{{t "pages.home.code-label"}}</:label>
+      </PixCode>
+    </div>
 
-  <PixButton class="pix1d-button" @type="submit" @size="large">
-    {{t "pages.home.go-to-school"}}
-  </PixButton>
-  <p>
-    <strong>{{t "pages.home.not-any-code"}}</strong>
-    <PixButtonLink @href="https://pix.fr/enseignement-primaire" target="_blank" @variant="tertiary">
-      {{t "pages.home.ask-to-activate-organization"}}
-    </PixButtonLink>
-  </p>
+    <PixButton class="pix1d-button" @type="submit" @size="large">
+      {{t "pages.home.go-to-school"}}
+    </PixButton>
+    <p>
+      <strong>{{t "pages.home.not-any-code"}}</strong>
+      <PixButtonLink @href="https://pix.fr/enseignement-primaire" target="_blank" @variant="tertiary">
+        {{t "pages.home.ask-to-activate-organization"}}
+      </PixButtonLink>
+    </p>
 
-  <div class="logos">
-    <img src="/images/government-logo.svg" alt={{t "pages.home.government-logo-alt"}} class="logo" />
-    <img src="/images/logo.svg" alt="Pix Junior" class="logo" />
-  </div>
-</form>
+    <div class="logos">
+      <img src="/images/government-logo.svg" alt={{t "pages.home.government-logo-alt"}} class="logo" />
+      <img src="/images/logo.svg" alt="Pix Junior" class="logo" />
+    </div>
+  </form>
+</WidthLimitedContent>
 <Footer />

--- a/junior/app/templates/school/divisions.hbs
+++ b/junior/app/templates/school/divisions.hbs
@@ -2,29 +2,31 @@
   <SchoolCodeError @refreshAction={{this.refreshModel}} />
 {{else}}
   {{page-title (t "pages.school.division-list.page-title")}}
-  <div class="school">
-    <RobotDialog>
-      <Bubble @message={{t "pages.school.division-list.welcome" schoolName=@model.name}} />
-    </RobotDialog>
-    <div class="list">
-      {{#each @model.divisions as |division|}}
-        <LinkTo @route="school.students" @query={{hash division=division}}>
-          <PixTooltip @isInline={{true}}>
-            <:triggerElement>
-              <div class="divisions__item">
-                <p class="item__title">{{division}}</p>
+  <WidthLimitedContent>
+    <div class="school">
+      <RobotDialog>
+        <Bubble @message={{t "pages.school.division-list.welcome" schoolName=@model.name}} />
+      </RobotDialog>
+      <div class="list">
+        {{#each @model.divisions as |division|}}
+          <LinkTo @route="school.students" @query={{hash division=division}}>
+            <PixTooltip @isInline={{true}}>
+              <:triggerElement>
+                <div class="divisions__item">
+                  <p class="item__title">{{division}}</p>
 
-              </div>
-            </:triggerElement>
+                </div>
+              </:triggerElement>
 
-            <:tooltip>
-              {{division}}
-            </:tooltip>
-          </PixTooltip>
-        </LinkTo>
+              <:tooltip>
+                {{division}}
+              </:tooltip>
+            </PixTooltip>
+          </LinkTo>
 
-      {{/each}}
+        {{/each}}
+      </div>
     </div>
-  </div>
-  <Footer />
+    <Footer />
+  </WidthLimitedContent>
 {{/if}}

--- a/junior/app/templates/school/divisions.hbs
+++ b/junior/app/templates/school/divisions.hbs
@@ -27,6 +27,5 @@
         {{/each}}
       </div>
     </div>
-    <Footer />
   </WidthLimitedContent>
 {{/if}}

--- a/junior/app/templates/school/students.hbs
+++ b/junior/app/templates/school/students.hbs
@@ -1,15 +1,16 @@
 {{page-title (t "pages.school.student-list.page-title")}}
-<div class="school">
-
-  <RobotDialog>
-    <Bubble @message={{t "pages.school.student-list.find-name" division=@model.division}} />
-    <Bubble @message={{t "pages.school.student-list.back-to-divisions" backUrl=@model.schoolUrl}} />
-  </RobotDialog>
-  <div class="list">
-    {{#each @model.organizationLearners as |learner|}}
-      <PixButton @triggerAction={{fn this.identifyUser learner}} class="students__item">
-        <p>{{learner.displayName}}</p>
-      </PixButton>
-    {{/each}}
+<WidthLimitedContent>
+  <div class="school">
+    <RobotDialog>
+      <Bubble @message={{t "pages.school.student-list.find-name" division=@model.division}} />
+      <Bubble @message={{t "pages.school.student-list.back-to-divisions" backUrl=@model.schoolUrl}} />
+    </RobotDialog>
+    <div class="list">
+      {{#each @model.organizationLearners as |learner|}}
+        <PixButton @triggerAction={{fn this.identifyUser learner}} class="students__item">
+          <p>{{learner.displayName}}</p>
+        </PixButton>
+      {{/each}}
+    </div>
   </div>
-</div>
+</WidthLimitedContent>

--- a/junior/tests/acceptance/access-school-test.js
+++ b/junior/tests/acceptance/access-school-test.js
@@ -40,22 +40,6 @@ module('Acceptance | School', function (hooks) {
         );
       });
 
-      test('Should display the footer on divisions page ', async function (assert) {
-        this.server.create('school');
-        const screen = await visit('schools/MINIPIXOU');
-        assert.dom(screen.getByLabelText(t('navigation.footer.label'))).exists();
-        assert.dom(screen.getByText(t('navigation.footer.legal-notice'))).exists();
-        assert.dom(screen.getByText(t('navigation.footer.student-data-protection-policy'))).exists();
-        assert.strictEqual(
-          screen.getByRole('link', { name: t('navigation.footer.legal-notice') }).href,
-          t('navigation.footer.legal-notice-url'),
-        );
-        assert.strictEqual(
-          screen.getByRole('link', { name: t('navigation.footer.student-data-protection-policy') }).href,
-          t('navigation.footer.student-data-protection-policy-url'),
-        );
-      });
-
       test('Should not display the footer on students page ', async function (assert) {
         this.server.create('school');
         const screen = await visit('schools/MINIPIXOU/students?division=CM1-A');

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -80,7 +80,7 @@
       "code-label": "Code de l'école",
       "go-to-school": "Je valide le code",
       "government-logo-alt": "République française. Liberté, égalité, fraternité.",
-      "not-any-code": "Vous n'avez pas de code école ?",
+      "not-any-code": "Vous êtes enseignant et vous n'avez pas de code école ?",
       "page-title": "Page d'accueil",
       "welcome": "Bienvenue sur Pix Junior !"
     },


### PR DESCRIPTION
## 🌸 Problème

Les pages ayant peu de contenu donnent une impression de vide sur les grands écrans.

## 🌳 Proposition

Limiter la largeur du contenu sur grand écran et centrer la zone.

## 🐝  Remarques

* Les mentions légales sont également supprimées de la page présentant la liste des classes de l'école.
* Le message à l'intention des enseignants n'ayant pas de code a été précisé : "Vous êtes enseignant et vous n’avez pas de code école ?"
* Le calcul de la taille des menus déroulants a été désactivé. L'épreuve https://junior-pr11803.review.pix.fr/challenges/challengeMJ5QrSLVnX7ZA/preview doit maintenant respecter le ratio 50/50 voulu (en affichage écran comme tablette) : 
<img width="770" alt="Capture d’écran 2025-03-26 à 12 02 49" src="https://github.com/user-attachments/assets/0dd68f09-b2a4-4d11-9236-504bf7e78d3c" />

## 🤧 Pour tester

Afficher toutes les pages de Pix Junior.
* La zone de contenu ne s'étale plus au delà de 1440px (hors mentions légales et utilisateur connecté).
* Les quelques modifications complémentaires en remarques ont bien été appliquées.