### PR TITLE
[FEATURE] Pix Table sur Pix Admin : Profil Cibles / Contenus formatifs (PIX-17155).

### DIFF
--- a/admin/app/components/administration/certification/scoring-simulator.gjs
+++ b/admin/app/components/administration/certification/scoring-simulator.gjs
@@ -120,7 +120,7 @@ export default class ScoringSimulator extends Component {
 
     {{#if this.simulatorReport.data.attributes.competences}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "pages.administration.certification.scoring-simulator.table.label"}}
         @data={{this.simulatorReport.data.attributes.competences}}
       >

--- a/admin/app/components/campaigns/participations-section.gjs
+++ b/admin/app/components/campaigns/participations-section.gjs
@@ -16,7 +16,7 @@ export default class ParticipationsSection extends Component {
         Attention toute modification sur une participation nécessite un accord écrit du prescripteur.
       </p>
 
-      <PixTable @data={{@participations}} @caption="Liste des participations" class="table">
+      <PixTable @variant="admin" @data={{@participations}} @caption="Liste des participations" class="table">
         <:columns as |participation context|>
           <ParticipationRow
             @participation={{participation}}

--- a/admin/app/components/certification-centers/invitations.gjs
+++ b/admin/app/components/certification-centers/invitations.gjs
@@ -22,7 +22,7 @@ export default class CertificationCenterInvitations extends Component {
 
       {{#if this.sortedCertificationCenterInvitations}}
         <PixTable
-          @variant="primary"
+          @variant="admin"
           @caption={{t "components.certification-centers.invitations.table.caption"}}
           @data={{this.sortedCertificationCenterInvitations}}
         >

--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -33,7 +33,7 @@ export default class CertificationCenterListItems extends Component {
 
       {{#if @certificationCenters}}
         <PixTable
-          @variant="primary"
+          @variant="admin"
           @caption={{t "components.certification-centers.list-items.table.caption"}}
           @data={{@certificationCenters}}
         >

--- a/admin/app/components/certification-centers/memberships-section.gjs
+++ b/admin/app/components/certification-centers/memberships-section.gjs
@@ -11,7 +11,7 @@ import MembershipItem from './membership-item';
 
     {{#if @certificationCenterMemberships}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "components.memberships-section.table.caption"}}
         @data={{@certificationCenterMemberships}}
       >

--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -309,7 +309,7 @@ export default class DetailsV3 extends Component {
         {{t "pages.certifications.certification.details.v3.questions-list.title"}}
       </h2>
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "pages.certifications.certification.details.v3.questions-list.caption"}}
         @data={{@details.certificationChallengesForAdministration}}
       >

--- a/admin/app/components/certifications/competence-list.gjs
+++ b/admin/app/components/certifications/competence-list.gjs
@@ -85,7 +85,7 @@ export default class CertificationCompetenceList extends Component {
       {{/each}}
     {{else}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "pages.certifications.certification.result.table.label"}}
         @data={{@competences}}
       >

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
@@ -42,7 +42,7 @@ export default class List extends Component {
             {{t "common.forms.mandatory-fields" htmlSafe=true}}
           </p>
 
-          <PixTable @variant="primary" @data={{@options}} @caption="Liste des résultats thématiques">
+          <PixTable @variant="admin" @data={{@options}} @caption="Liste des résultats thématiques">
             <:columns as |row option|>
               <PixTableColumn @context={{option}}>
                 <:header>

--- a/admin/app/components/complementary-certifications/list.gjs
+++ b/admin/app/components/complementary-certifications/list.gjs
@@ -11,6 +11,7 @@ export default class List extends Component {
 
   <template>
     <PixTable
+      @variant="admin"
       @data={{this.sortedComplementaryCertifications}}
       @caption={{t "components.complementary-certifications.list.caption"}}
     >

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
@@ -20,6 +20,7 @@ export default class BadgesList extends Component {
         {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
       </h2>
       <PixTable
+        @variant="admin"
         @data={{this.currentTargetProfileBadges}}
         @caption={{t "components.complementary-certifications.target-profiles.badges-list.caption"}}
       >

--- a/admin/app/components/complementary-certifications/target-profiles/history.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/history.gjs
@@ -10,6 +10,7 @@ import { t } from 'ember-intl';
       {{t "components.complementary-certifications.target-profiles.history-list.title"}}
     </h2>
     <PixTable
+      @variant="admin"
       @data={{@targetProfilesHistory}}
       @caption={{t "components.complementary-certifications.target-profiles.history-list.caption"}}
     >

--- a/admin/app/components/organizations/campaigns-section.gjs
+++ b/admin/app/components/organizations/campaigns-section.gjs
@@ -9,7 +9,7 @@ import CampaignType from '../campaigns/type';
 
 <template>
   <section class="no-background">
-    <PixTable @data={{@campaigns}} @caption="Liste des campagnes de l'organisation" class="table">
+    <PixTable @variant="admin" @data={{@campaigns}} @caption="Liste des campagnes de l'organisation" class="table">
       <:columns as |campaign context|>
         <PixTableColumn @context={{context}}>
           <:header>Code</:header>

--- a/admin/app/components/organizations/children/list.gjs
+++ b/admin/app/components/organizations/children/list.gjs
@@ -5,7 +5,7 @@ import ListItem from './list-item';
 
 <template>
   <PixTable
-    @variant="primary"
+    @variant="admin"
     @caption={{t "components.organizations.children-list.table-name"}}
     @data={{@organizations}}
   >

--- a/admin/app/components/organizations/invitations.gjs
+++ b/admin/app/components/organizations/invitations.gjs
@@ -23,7 +23,7 @@ export default class OrganizationInvitations extends Component {
 
       {{#if this.sortedInvitations}}
         <PixTable
-          @variant="primary"
+          @variant="admin"
           @caption={{t "components.organizations.invitations.table.caption"}}
           @data={{this.sortedInvitations}}
         >

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -83,7 +83,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
 
     {{#if @organizations}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "components.organizations.list-items.table.caption"}}
         @data={{@organizations}}
       >

--- a/admin/app/components/organizations/places/list.gjs
+++ b/admin/app/components/organizations/places/list.gjs
@@ -13,7 +13,7 @@ export default class List extends Component {
 
   <template>
     <PixTable
-      @variant="primary"
+      @variant="admin"
       @caption="Affichage des lots de place disponible triés par ordre anti-chronologique d'activation puis d'expiration"
       @data={{@places}}
     >

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -163,7 +163,7 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
       </header>
       {{#if @targetProfileSummaries}}
         <PixTable
-          @variant="primary"
+          @variant="admin"
           @caption={{t "components.organizations.target-profiles-section.table.caption"}}
           @data={{this.sortedTargetProfileSummaries}}
         >

--- a/admin/app/components/organizations/team-section.gjs
+++ b/admin/app/components/organizations/team-section.gjs
@@ -64,7 +64,7 @@ export default class OrganizationTeamSection extends Component {
 
       {{#if @organizationMemberships}}
         <PixTable
-          @variant="primary"
+          @variant="admin"
           @caption={{t "components.organizations.team-section.table.caption"}}
           @data={{@organizationMemberships}}
         >

--- a/admin/app/components/sessions/certifications/list.gjs
+++ b/admin/app/components/sessions/certifications/list.gjs
@@ -14,7 +14,7 @@ export default class CertificationsHeader extends Component {
   <template>
     {{#if @juryCertificationSummaries}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @data={{this.sortedCertificationJurySummaries}}
         @caption={{t "pages.certifications.table.caption"}}
       >

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -102,51 +102,51 @@ export default class ListItems extends Component {
           type="text"
           value={{this.searchedId}}
           oninput={{fn @triggerFiltering "id"}}
-          placeholder={{t "pages.sessions.list.filters.id.placeholder"}}
-        />
+        >
+          <:label>{{t "pages.sessions.list.filters.id.label"}}</:label>
+        </PixInput>
         <PixInput
           aria-label={{t "pages.sessions.list.filters.certification-name.aria-label"}}
           type="text"
           value={{this.searchedCertificationCenterName}}
           oninput={{fn @triggerFiltering "certificationCenterName"}}
-          placeholder={{t "pages.sessions.table.headers.certification-name"}}
-        />
+        >
+          <:label>{{t "pages.sessions.table.headers.certification-name"}}</:label>
+        </PixInput>
         <PixInput
           aria-label={{t "pages.sessions.list.filters.external-id.aria-label"}}
           type="text"
           value={{this.searchedCertificationCenterExternalId}}
           oninput={{fn @triggerFiltering "certificationCenterExternalId"}}
-          placeholder={{t "pages.sessions.table.headers.external-id"}}
-        />
+        >
+          <:label>{{t "pages.sessions.table.headers.external-id"}}</:label>
+        </PixInput>
         <PixSelect
-          @screenReaderOnly={{true}}
           @options={{this.certificationCenterTypeOptions}}
           @onChange={{this.selectCertificationCenterType}}
           @value={{@certificationCenterType}}
-          @placeholder={{t "pages.sessions.table.headers.type"}}
           @hideDefaultOption={{true}}
+          arial-label={{t "pages.sessions.list.filters.type.aria-label"}}
         >
-          <:label>{{t "pages.sessions.list.filters.type.aria-label"}}</:label>
+          <:label>{{t "pages.sessions.table.headers.type"}}</:label>
         </PixSelect>
         <PixSelect
-          @screenReaderOnly={{true}}
           @options={{this.sessionStatusOptions}}
           @onChange={{this.selectSessionStatus}}
           @value={{@status}}
-          @placeholder={{t "pages.sessions.table.headers.status"}}
           @hideDefaultOption={{true}}
+          aria-label={{t "pages.sessions.list.filters.status.aria-label"}}
         >
-          <:label>{{t "pages.sessions.list.filters.status.aria-label"}}</:label>
+          <:label>{{t "pages.sessions.table.headers.status"}}</:label>
         </PixSelect>
         <PixSelect
-          @screenReaderOnly={{true}}
           @options={{this.sessionVersionOptions}}
           @onChange={{this.selectSessionVersion}}
           @value={{@version}}
-          @placeholder={{t "pages.sessions.list.filters.version.placeholder"}}
           @hideDefaultOption={{true}}
+          aria-label={{t "pages.sessions.list.filters.version.aria-label"}}
         >
-          <:label>{{t "pages.sessions.list.filters.version.aria-label"}}</:label>
+          <:label>{{t "pages.sessions.list.filters.version.label"}}</:label>
         </PixSelect>
       </PixFilterBanner>
 

--- a/admin/app/components/sessions/list-items.gjs
+++ b/admin/app/components/sessions/list-items.gjs
@@ -151,7 +151,7 @@ export default class ListItems extends Component {
       </PixFilterBanner>
 
       {{#if @sessions}}
-        <PixTable @variant="primary" @data={{@sessions}} @caption={{t "pages.sessions.table.caption"}}>
+        <PixTable @variant="admin" @data={{@sessions}} @caption={{t "pages.sessions.table.caption"}}>
           <:columns as |session context|>
             <PixTableColumn @context={{context}}>
               <:header>

--- a/admin/app/components/target-profiles/badges.gjs
+++ b/admin/app/components/target-profiles/badges.gjs
@@ -48,7 +48,12 @@ export default class Badges extends Component {
 
   <template>
     {{#if this.hasBadges}}
-      <PixTable @data={{@badges}} @caption={{t "components.target-profiles.badges.table.caption"}} class="table insights-section__badge-table">
+      <PixTable
+        @variant="admin"
+        @data={{@badges}}
+        @caption={{t "components.target-profiles.badges.table.caption"}}
+        class="table insights-section__badge-table"
+      >
         <:columns as |badge context|>
           <PixTableColumn @context={{context}}>
             <:header>

--- a/admin/app/components/target-profiles/badges.gjs
+++ b/admin/app/components/target-profiles/badges.gjs
@@ -1,6 +1,8 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
@@ -45,89 +47,113 @@ export default class Badges extends Component {
   }
 
   <template>
-    <div class="content-text content-text--small">
-      {{#if this.hasBadges}}
-        <table class="badges-table table-admin">
-          <thead class="badges-table__header">
-            <tr>
-              <th class="badges-table-header__id">ID</th>
-              <th class="badges-table-header__image">Image</th>
-              <th class="badges-table-header__key">Clé</th>
-              <th class="badges-table-header__name">Nom</th>
-              <th class="badges-table-header__message">Message</th>
-              <th class="badges-table-header__parameters">
-                <PixTooltip @isWide={{true}}>
-                  <:triggerElement>
-                    Paramètres
-                    <PixIcon @name="help" />
-                  </:triggerElement>
-                  <:tooltip>
-                    {{t "components.badges.tooltips.parameters" htmlSafe=true}}
-                  </:tooltip>
-                </PixTooltip>
-              </th>
-              <th class="badges-table-header__actions">Actions</th>
-            </tr>
-          </thead>
-          <tbody class="badges-table__body">
-            {{#each @badges as |badge|}}
-              <tr aria-label="Informations du badge {{badge.title}}">
-                <td class="badges-table-body__id">
-                  <LinkTo
-                    @route="authenticated.target-profiles.target-profile.badges.badge"
-                    @model={{badge.id}}
-                    aria-label="Voir le détail du résultat thématique ID {{badge.id}}"
-                  >
-                    {{badge.id}}
-                  </LinkTo>
-                </td>
-                <td class="badges-table-body__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
-                <td class="badges-table-body__key">{{badge.key}}</td>
-                <td class="badges-table-body__title">{{badge.title}}</td>
-                <td class="badges-table-body__message">{{badge.message}}</td>
-                <td class="badges-table-body__parameters">
-                  <PixTag
-                    class={{if badge.isAlwaysVisible "valid" "not-valid"}}
-                    @color={{if badge.isAlwaysVisible "tertiary" "error"}}
-                  >
-                    {{if badge.isAlwaysVisible "En lacune" "Pas en lacune"}}
-                  </PixTag>
-                  <PixTag
-                    class={{if badge.isCertifiable "valid" "not-valid"}}
-                    @color={{if badge.isCertifiable "success" "error"}}
-                  >
-                    {{if badge.isCertifiable "Certifiable" "Pas certifiable"}}
-                  </PixTag>
-                </td>
-                <td class="badges-table-body__actions">
-                  <PixButtonLink
-                    @variant="secondary"
-                    @route="authenticated.target-profiles.target-profile.badges.badge"
-                    @size="small"
-                    @model={{badge.id}}
-                    aria-label="Voir le détail du résultat thématique {{badge.title}}"
-                  >
-                    Voir le détail
-                  </PixButtonLink>
-                  <PixButton
-                    @size="small"
-                    @variant="error"
-                    @triggerAction={{fn this.toggleDisplayConfirm badge.id}}
-                    class="badges-table-actions-delete"
-                    @iconBefore="delete"
-                    aria-label="Supprimer le résultat thématique {{badge.title}}"
-                  >
-                    Supprimer
-                  </PixButton>
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      {{else}}
-        <div class="table__empty">Aucun résultat thématique associé</div>
-      {{/if}}
-    </div>
+    {{#if this.hasBadges}}
+      <PixTable @data={{@badges}} @caption={{t "components.target-profiles.badges.table.caption"}} class="table insights-section__badge-table">
+        <:columns as |badge context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              ID
+            </:header>
+            <:cell>
+              <LinkTo
+                @route="authenticated.target-profiles.target-profile.badges.badge"
+                @model={{badge.id}}
+                aria-label="Voir le détail du résultat thématique ID {{badge.id}}"
+              >
+                {{badge.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="badges-table-body__image">
+            <:header>
+              Image
+            </:header>
+            <:cell>
+              <img src={{badge.imageUrl}} alt={{badge.altMessage}} />
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="break-word">
+            <:header>
+              Clé
+            </:header>
+            <:cell>
+              {{badge.key}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="break-word">
+            <:header>
+              Nom
+            </:header>
+            <:cell>
+              {{badge.title}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="break-word">
+            <:header>
+              Message
+            </:header>
+            <:cell>
+              {{badge.message}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="badges-table-header__parameters">
+            <:header>
+              <PixTooltip @isWide={{true}}>
+                <:triggerElement>
+                  Paramètres
+                  <PixIcon @name="help" />
+                </:triggerElement>
+                <:tooltip>
+                  {{t "components.badges.tooltips.parameters" htmlSafe=true}}
+                </:tooltip>
+              </PixTooltip>
+            </:header>
+            <:cell>
+              <div class="badges-table-body__content">
+                <PixTag class="badges-table-body__tag" @color={{if badge.isAlwaysVisible "tertiary" "error"}}>
+                  <PixIcon @name={{if badge.isAlwaysVisible "check" "close"}} />
+                  {{if badge.isAlwaysVisible "En lacune" "Pas en lacune"}}
+                </PixTag>
+                <PixTag class="badges-table-body__tag" @color={{if badge.isCertifiable "success" "error"}}>
+                  <PixIcon @name={{if badge.isCertifiable "check" "close"}} />
+                  {{if badge.isCertifiable "Certifiable" "Pas certifiable"}}
+                </PixTag>
+              </div>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              Actions
+            </:header>
+            <:cell>
+              <div class="badges-table-body__content">
+                <PixButtonLink
+                  @variant="secondary"
+                  @route="authenticated.target-profiles.target-profile.badges.badge"
+                  @size="small"
+                  @model={{badge.id}}
+                  aria-label="Voir le détail du résultat thématique {{badge.title}}"
+                >
+                  Voir le détail
+                </PixButtonLink>
+                <PixButton
+                  @size="small"
+                  @variant="error"
+                  @triggerAction={{fn this.toggleDisplayConfirm badge.id}}
+                  class="badges-table-actions-delete"
+                  @iconBefore="delete"
+                  aria-label="Supprimer le résultat thématique {{badge.title}}"
+                >
+                  Supprimer
+                </PixButton>
+              </div>
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">Aucun résultat thématique associé</div>
+    {{/if}}
 
     <ConfirmPopup
       @message="Êtes-vous sûr de vouloir supprimer ce résultat thématique ? (Uniquement si le RT n'a pas encore été assigné)"

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -74,7 +74,12 @@ export default class TargetProfileListSummaryItems extends Component {
     </PixFilterBanner>
 
     {{#if @summaries}}
-      <PixTable @data={{@summaries}} @caption={{t "components.target-profiles.list.table.caption"}} class="table">
+      <PixTable
+        @variant="admin"
+        @data={{@summaries}}
+        @caption={{t "components.target-profiles.list.table.caption"}}
+        class="table"
+      >
         <:columns as |summary context|>
           <PixTableColumn @context={{context}}>
             <:header>

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -46,25 +46,22 @@ export default class TargetProfileListSummaryItems extends Component {
         type="text"
         value={{@id}}
         oninput={{fn @triggerFiltering "id"}}
-        placeholder={{t "pages.target-profiles.filters.search-by-id.placeholder"}}
-        @screenReaderOnly={{true}}
+        aria-label={{t "pages.target-profiles.filters.search-by-id.aria-label"}}
       >
-        <:label>{{t "pages.target-profiles.filters.search-by-id.name"}}</:label>
+        <:label>{{t "pages.target-profiles.filters.search-by-id.label"}}</:label>
       </PixInput>
 
       <PixInput
         type="text"
         value={{@internalName}}
-        placeholder={{t "pages.target-profiles.filters.search-by-internal-name.placeholder"}}
+        aria-label={{t "pages.target-profiles.filters.search-by-internal-name.aria-label"}}
         oninput={{fn @triggerFiltering "internalName"}}
-        @screenReaderOnly={{true}}
       >
-        <:label>{{t "pages.target-profiles.filters.search-by-internal-name.name"}}</:label>
+        <:label>{{t "pages.target-profiles.filters.search-by-internal-name.label"}}</:label>
       </PixInput>
 
       <PixMultiSelect
         @id="categories"
-        @screenReaderOnly={{true}}
         @placeholder={{t "common.filters.target-profile.placeholder"}}
         @onChange={{this.triggerCategoriesFiltering}}
         @values={{@categories}}

--- a/admin/app/components/target-profiles/list-summary-items.gjs
+++ b/admin/app/components/target-profiles/list-summary-items.gjs
@@ -2,6 +2,8 @@ import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -74,48 +76,58 @@ export default class TargetProfileListSummaryItems extends Component {
 
     </PixFilterBanner>
 
-    <div class="content-text content-text--small">
-      <div class="table-admin">
-        <table>
-          <thead>
-            <tr>
-              <th class="table__column table__column--id">{{t "common.fields.id"}}</th>
-              <th>{{t "common.fields.internalName"}}</th>
-              <th>{{t "common.fields.target-profile.category.name"}}</th>
-              <th class="col-date">{{t "common.fields.createdAt"}}</th>
-              <th class="col-status">{{t "common.fields.status"}}</th>
-            </tr>
-          </thead>
-
-          {{#if @summaries}}
-            <tbody>
-              {{#each @summaries as |summary|}}
-                <tr aria-label="Profil cible">
-                  <td class="table__column table__column--id">{{summary.id}}</td>
-                  <td>
-                    <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
-                      {{summary.internalName}}
-                    </LinkTo>
-                  </td>
-                  <td class="table__column table__column--id">{{t summary.translationKeyCategory}}</td>
-                  <td class="table__column">{{formatDate summary.createdAt}}</td>
-                  <td class="target-profile-table-column__status">
-                    {{if summary.outdated "Obsolète" "Actif"}}
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          {{/if}}
-        </table>
-
-        {{#unless @summaries}}
-          <div class="table__empty">{{t "common.tables.empty-result"}}</div>
-        {{/unless}}
-      </div>
-    </div>
-
     {{#if @summaries}}
+      <PixTable @data={{@summaries}} @caption={{t "components.target-profiles.list.table.caption"}} class="table">
+        <:columns as |summary context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.id"}}
+            </:header>
+            <:cell>
+              {{summary.id}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.internalName"}}
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
+                {{summary.internalName}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.target-profile.category.name"}}
+            </:header>
+            <:cell>
+              {{t summary.translationKeyCategory}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.createdAt"}}
+            </:header>
+            <:cell>
+              {{formatDate summary.createdAt}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "common.fields.status"}}
+            </:header>
+            <:cell>
+              {{if summary.outdated "Obsolète" "Actif"}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+
       <PixPagination @pagination={{@summaries.meta}} />
+
+    {{else}}
+      <div class="table__empty">{{t "common.tables.empty-result"}}</div>
     {{/if}}
   </template>
 }

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -168,7 +168,7 @@ export default class Organizations extends Component {
         </form>
       </div>
     </section>
-    <section class="page-section">
+    <section class="page-section organizations-list">
       <header class="page-section__header">
         <h2 class="page-section__title">Organisations</h2>
       </header>

--- a/admin/app/components/target-profiles/training-summaries.gjs
+++ b/admin/app/components/target-profiles/training-summaries.gjs
@@ -1,7 +1,7 @@
 import ListSummaryItems from '../trainings/list-summary-items';
 
 <template>
-  <section class="page-section">
+  <section class="page-section page-with-table">
     <header class="page-section__header">
       <h2 class="page-section__title">Contenus Formatifs</h2>
     </header>

--- a/admin/app/components/to-be-published-sessions/list-items.gjs
+++ b/admin/app/components/to-be-published-sessions/list-items.gjs
@@ -40,7 +40,11 @@ export default class ToBePublishedSessionsList extends Component {
   }
   <template>
     {{#if @toBePublishedSessions}}
-      <PixTable @data={{@toBePublishedSessions}} @caption={{t "pages.sessions.table.to-be-published.caption"}}>
+      <PixTable
+        @variant="admin"
+        @data={{@toBePublishedSessions}}
+        @caption={{t "pages.sessions.table.to-be-published.caption"}}
+      >
         <:columns as |row toBePublishedSession|>
           <PixTableColumn @context={{toBePublishedSession}}>
             <:header>

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -1,5 +1,8 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
@@ -12,89 +15,88 @@ export default class TrainingListSummaryItems extends Component {
   searchedInternalTitle = this.args.internalTitle;
 
   <template>
-    <div class="content-text content-text--small">
-      <div class="table-admin">
-        <table>
-          <caption class="screen-reader-only">{{t "pages.trainings.training.list.caption"}}</caption>
-          <thead>
-            <tr>
-              <th class="table__column table__column--id" id="training-id" scope="col">{{t
-                  "pages.trainings.training.list.id"
-                }}</th>
-              <th id="training-internal-title" scope="col">{{t "pages.trainings.training.list.internalTitle"}}</th>
-              <th id="training-prerequisite-threshold" scope="col" class="col-status">{{t
-                  "pages.trainings.training.list.prerequisite"
-                }}</th>
-              <th id="training-goal-threshold" scope="col" class="col-status">{{t
-                  "pages.trainings.training.list.goalThreshold"
-                }}</th>
-              <th id="training-target-profile-count" scope="col" class="col-status">{{t
-                  "pages.trainings.training.list.targetProfileCount"
-                }}</th>
-              <th id="training-state" scope="col" class="col-status">{{t "pages.trainings.training.list.status"}}</th>
-            </tr>
-            {{#if @triggerFiltering}}
-              <tr>
-                <td class="table__column table__column--id">
-                  <PixInput
-                    type="text"
-                    value={{this.searchedId}}
-                    oninput={{fn @triggerFiltering "id"}}
-                    aria-label="Filtrer les contenus formatifs par un id"
-                  />
-                </td>
-                <td>
-                  <PixInput
-                    type="text"
-                    value={{this.searchedInternalTitle}}
-                    oninput={{fn @triggerFiltering "internalTitle"}}
-                    aria-label="Filtrer les contenus formatifs par un titre"
-                  />
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-              </tr>
-            {{/if}}
-          </thead>
-
-          {{#if @summaries}}
-            <tbody>
-              {{#each @summaries as |summary|}}
-                <tr aria-label="Contenu formatif">
-                  <td headers="training-id" class="table__column table__column--id">{{summary.id}}</td>
-                  <td headers="training-internal-title">
-                    <LinkTo @route="authenticated.trainings.training" @model={{summary.id}}>
-                      {{summary.internalTitle}}
-                    </LinkTo>
-                  </td>
-                  <td headers="training-prerequisite-threshold">
-                    {{summary.prerequisiteThreshold}}
-                  </td>
-                  <td headers="training-goal-threshold">
-                    {{summary.goalThreshold}}
-                  </td>
-                  <td headers="training-target-profiles-count">
-                    {{summary.targetProfilesCount}}
-                  </td>
-                  <td headers="training-state">
-                    <StateTag @isDisabled={{summary.isDisabled}} />
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          {{/if}}
-        </table>
-
-        {{#unless @summaries}}
-          <div class="table__empty">{{t "pages.trainings.training.list.noResult"}}</div>
-        {{/unless}}
-      </div>
-    </div>
+    {{#if @triggerFiltering}}
+      <PixFilterBanner @title={{t "common.filters.title"}}>
+        <PixInput
+          type="text"
+          value={{this.searchedId}}
+          oninput={{fn @triggerFiltering "id"}}
+          aria-label="Filtrer les contenus formatifs par un id"
+        >
+          <:label>{{t "pages.trainings.training.list.id"}}</:label>
+        </PixInput>
+        <PixInput
+          type="text"
+          value={{this.searchedInternalTitle}}
+          oninput={{fn @triggerFiltering "internalTitle"}}
+          aria-label="Filtrer les contenus formatifs par un titre"
+        >
+          <:label>{{t "pages.trainings.training.list.internalTitle"}}</:label>
+        </PixInput>
+      </PixFilterBanner>
+    {{/if}}
 
     {{#if @summaries}}
+      <PixTable @data={{@summaries}} @caption={{t "pages.trainings.training.list.caption"}}>
+        <:columns as |summary context|>
+          <PixTableColumn @context={{context}} class="table__column--medium">
+            <:header>
+              {{t "pages.trainings.training.list.id"}}
+            </:header>
+            <:cell>
+              {{summary.id}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="break-word">
+            <:header>
+              {{t "pages.trainings.training.list.internalTitle"}}
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.trainings.training" @model={{summary.id}}>
+                {{summary.internalTitle}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--medium">
+            <:header>
+              {{t "pages.trainings.training.list.prerequisite"}}
+            </:header>
+            <:cell>
+              {{summary.prerequisiteThreshold}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--medium">
+            <:header>
+              {{t "pages.trainings.training.list.goalThreshold"}}
+            </:header>
+            <:cell>
+              {{summary.goalThreshold}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--medium">
+            <:header>
+              {{t "pages.trainings.training.list.targetProfileCount"}}
+            </:header>
+            <:cell>
+              {{summary.targetProfilesCount}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--medium">
+            <:header>
+              {{t "pages.trainings.training.list.status"}}
+            </:header>
+            <:cell>
+              <StateTag @isDisabled={{summary.isDisabled}} />
+            </:cell>
+          </PixTableColumn>
+
+        </:columns>
+      </PixTable>
+
       <PixPagination @pagination={{@summaries.meta.pagination}} />
+
+    {{else}}
+      <div class="table__empty">{{t "pages.trainings.training.list.noResult"}}</div>
     {{/if}}
   </template>
 }

--- a/admin/app/components/trainings/list-summary-items.gjs
+++ b/admin/app/components/trainings/list-summary-items.gjs
@@ -37,7 +37,7 @@ export default class TrainingListSummaryItems extends Component {
     {{/if}}
 
     {{#if @summaries}}
-      <PixTable @data={{@summaries}} @caption={{t "pages.trainings.training.list.caption"}}>
+      <PixTable @variant="admin" @data={{@summaries}} @caption={{t "pages.trainings.training.list.caption"}}>
         <:columns as |summary context|>
           <PixTableColumn @context={{context}} class="table__column--medium">
             <:header>

--- a/admin/app/components/users/campaign-participations.gjs
+++ b/admin/app/components/users/campaign-participations.gjs
@@ -43,7 +43,7 @@ export default class CampaignParticipation extends Component {
 
     {{#if @participations}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @data={{@participations}}
         @caption={{t "components.users.campaign-participations.table.caption"}}
       >

--- a/admin/app/components/users/certification-centers/memberships.gjs
+++ b/admin/app/components/users/certification-centers/memberships.gjs
@@ -16,7 +16,7 @@ export default class Memberships extends Component {
 
     {{#if this.orderedCertificationCenterMemberships}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @data={{this.orderedCertificationCenterMemberships}}
         @caption={{t "components.users.certification-centers.memberships.caption"}}
       >

--- a/admin/app/components/users/list-items.gjs
+++ b/admin/app/components/users/list-items.gjs
@@ -7,7 +7,7 @@ import { t } from 'ember-intl';
 <template>
   {{#if @users}}
     <PixTable
-      @variant="primary"
+      @variant="admin"
       @caption={{t "components.users.list-items.table.caption"}}
       @data={{@users}}
       class="table"

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -19,7 +19,7 @@ export default class OrganizationLearnerInformation extends Component {
 
     {{#if @user.organizationLearners}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @caption={{t "components.users.organization-learner-information.table.caption"}}
         @data={{@user.organizationLearners}}
       >

--- a/admin/app/components/users/user-organization-memberships.gjs
+++ b/admin/app/components/users/user-organization-memberships.gjs
@@ -22,7 +22,7 @@ export default class UserOrganizationMemberships extends Component {
 
     {{#if this.orderedOrganizationMemberships}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @data={{this.orderedOrganizationMemberships}}
         @caption={{t "components.users.organizations.memberships.table.caption"}}
       >

--- a/admin/app/components/users/user-profile.gjs
+++ b/admin/app/components/users/user-profile.gjs
@@ -12,7 +12,7 @@ import { t } from 'ember-intl';
 
   {{#if @profile.scorecards}}
     <PixTable
-      @variant="primary"
+      @variant="admin"
       @data={{@profile.scorecards}}
       @caption="Pix et niveau obtenus en fonction des compétences"
       class="user-profile-table"

--- a/admin/app/components/with-required-action-sessions/list-items.gjs
+++ b/admin/app/components/with-required-action-sessions/list-items.gjs
@@ -5,7 +5,11 @@ import { t } from 'ember-intl';
 
 <template>
   {{#if @withRequiredActionSessions}}
-    <PixTable @data={{@withRequiredActionSessions}} @caption={{t "pages.sessions.table.required-actions.caption"}}>
+    <PixTable
+      @variant="admin"
+      @data={{@withRequiredActionSessions}}
+      @caption={{t "pages.sessions.table.required-actions.caption"}}
+    >
       <:columns as |row withRequiredActionSession|>
         <PixTableColumn @context={{withRequiredActionSession}} class="table__column--medium">
           <:header>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -79,7 +79,6 @@
 @use 'components/target-profiles/badges' as *;
 @use 'components/target-profiles/details' as *;
 @use 'components/target-profiles/insights' as *;
-@use 'components/target-profiles/list-items' as *;
 @use 'components/target-profiles/organizations' as *;
 @use 'components/target-profiles/pdf-modal' as *;
 @use 'components/target-profiles/stage-form' as *;

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -1,28 +1,7 @@
 @use 'pix-design-tokens/typography';
 
-.badges-table {
-  @extend %pix-body-m;
-}
-
 .badges-table-header {
-  &__id {
-    width: 110px;
-  }
-
-  &__key {
-    width: 120px;
-  }
-
-  &__name {
-    width: 250px;
-  }
-
-  &__image {
-    width: 130px;
-  }
-
   &__parameters {
-    width: 175px;
 
     .pix-tooltip {
       display: block;
@@ -39,10 +18,6 @@
       }
     }
   }
-
-  &__actions {
-    width: 180px;
-  }
 }
 
 .badges-table-body {
@@ -51,46 +26,18 @@
       display: block;
       width: 80px;
       height: 80px;
-      margin: 0 auto;
-      object-fit: contain;
-      object-position: center;
     }
   }
 
-  &__key {
-    word-wrap: break-word;
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-1x);
   }
 
-  &__parameters {
-    & > * {
-      width: 100%;
-
-      & + * {
-        margin-top: var(--pix-spacing-2x);
-      }
-    }
-
-    .valid::before,
-    .not-valid::before {
-      margin-right: 0.25ch;
-    }
-
-    .valid::before {
-      content: '✔'
-    }
-
-    .not-valid::before {
-      content: '✘'
-    }
-  }
-
-  &__actions {
-    & > * {
-      width: 100%;
-    }
-
-    & > *:not(:first-child) {
-      margin-top: var(--pix-spacing-2x);
-    }
+  &__tag {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    align-items: center;
   }
 }

--- a/admin/app/styles/components/target-profiles/insights.scss
+++ b/admin/app/styles/components/target-profiles/insights.scss
@@ -21,6 +21,10 @@
       text-decoration: none;
     }
   }
+
+  &__badge-table {
+    overflow: unset;
+  }
 }
 
 .insights__section > .pix-banner-alert {

--- a/admin/app/styles/components/target-profiles/list-items.scss
+++ b/admin/app/styles/components/target-profiles/list-items.scss
@@ -1,7 +1,0 @@
-/* stylelint-disable selector-class-pattern */
-.target-profile-table-column__status {
-
-  p {
-    display: inline;
-  }
-}

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -70,6 +70,12 @@
   }
 }
 
+.page-with-table {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+}
+
 section.no-background {
   padding: 0;
   background-color:transparent;

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -30,11 +30,6 @@
     background-color: rgb(0 0 0 / 3%);
   }
 
-  .col-status,
-  .col-date {
-    width: 10%;
-  }
-
   .pix-input {
     display: flex;
   }

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -20,7 +20,7 @@
 </header>
 
 <main class="page-body">
-  <section class="page-section">
+  <section class="page-section page-with-table">
     <Trainings::ListSummaryItems
       @summaries={{@model}}
       @id={{this.id}}

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -30,7 +30,7 @@
     </header>
     {{#if @model.targetProfileSummaries}}
       <PixTable
-        @variant="primary"
+        @variant="admin"
         @data={{@model.training.sortedTargetProfileSummaries}}
         @caption="Profil cible associé au contenu"
       >

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -28,59 +28,53 @@
           "pages.trainings.training.targetProfiles.tabName"
         }}</h2>
     </header>
-    <div class="content-text content-text--small">
-      <div class="table-admin">
-        {{#if @model.targetProfileSummaries}}
-          <PixTable
-            @variant="primary"
-            @data={{@model.training.sortedTargetProfileSummaries}}
-            @caption="Profil cible associé au contenu"
-          >
-            <:columns as |row context|>
-              <PixTableColumn @context={{context}} class="table__column--wide">
-                <:header>
-                  ID
-                </:header>
-                <:cell>
-                  {{row.id}}
-                </:cell>
-              </PixTableColumn>
-              <PixTableColumn @context={{context}} class="table__column--wide">
-                <:header>
-                  Nom interne du profil cible
-                </:header>
-                <:cell>
-                  <LinkTo @route="authenticated.target-profiles.target-profile" @model={{row.id}}>
-                    {{row.internalName}}
-                  </LinkTo>
-                </:cell>
-              </PixTableColumn>
-              <PixTableColumn @context={{context}} class="table__column--wide">
-                <:header>
-                  Statut
-                </:header>
-                <:cell>
-                  {{if row.outdated "Obsolète" "Actif"}}
-                </:cell>
-              </PixTableColumn>
-              <PixTableColumn @context={{context}} class="table__column--wide">
-                <:header>
-                  Actions
-                </:header>
-                <:cell>
-                  <PixButton @variant="error" @iconBefore="delete" @triggerAction={{fn this.detachTargetProfile row}}>
-                    Détacher
-                  </PixButton>
-                </:cell>
-              </PixTableColumn>
-            </:columns>
-          </PixTable>
-        {{/if}}
-
-        {{#unless @model.targetProfileSummaries}}
-          <div class="table__empty">Aucun profil cible associé à ce contenu formatif</div>
-        {{/unless}}
-      </div>
-    </div>
+    {{#if @model.targetProfileSummaries}}
+      <PixTable
+        @variant="primary"
+        @data={{@model.training.sortedTargetProfileSummaries}}
+        @caption="Profil cible associé au contenu"
+      >
+        <:columns as |row context|>
+          <PixTableColumn @context={{context}} class="table__column--wide">
+            <:header>
+              ID
+            </:header>
+            <:cell>
+              {{row.id}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--wide">
+            <:header>
+              Nom interne du profil cible
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.target-profiles.target-profile" @model={{row.id}}>
+                {{row.internalName}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--wide">
+            <:header>
+              Statut
+            </:header>
+            <:cell>
+              {{if row.outdated "Obsolète" "Actif"}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}} class="table__column--wide">
+            <:header>
+              Actions
+            </:header>
+            <:cell>
+              <PixButton @variant="error" @iconBefore="delete" @triggerAction={{fn this.detachTargetProfile row}}>
+                Détacher
+              </PixButton>
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">Aucun profil cible associé à ce contenu formatif</div>
+    {{/if}}
   </section>
 </div>

--- a/admin/tests/acceptance/authenticated/target-profiles/list-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list-test.js
@@ -111,7 +111,7 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
           // then
           assert
-            .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.name') }))
+            .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.aria-label') }))
             .hasValue('123');
         });
       });

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -174,7 +174,7 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
           await click(
             screen.getByRole('button', {
-              name: 'Filtrer les sessions en sélectionnant un statut',
+              name: t('pages.sessions.table.headers.status'),
             }),
           );
           await screen.findByRole('listbox');
@@ -216,7 +216,7 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
           await click(
             screen.getByRole('button', {
-              name: 'Filtrer les sessions par leur version',
+              name: t('pages.sessions.list.filters.version.label'),
             }),
           );
           await screen.findByRole('listbox');
@@ -239,7 +239,7 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
           await click(
             screen.getByRole('button', {
-              name: 'Filtrer les sessions par leur version',
+              name: t('pages.sessions.list.filters.version.label'),
             }),
           );
           await screen.findByRole('listbox');

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.gjs
@@ -4,7 +4,7 @@ import ListItems from 'pix-admin/components/sessions/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -113,7 +113,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
+          name: t('pages.sessions.table.headers.type'),
         }),
       );
       await screen.findByRole('listbox');
@@ -142,7 +142,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
+          name: t('pages.sessions.table.headers.type'),
         }),
       );
       await screen.findByRole('listbox');
@@ -161,7 +161,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions en sélectionnant un statut',
+          name: t('pages.sessions.table.headers.status'),
         }),
       );
       await screen.findByRole('listbox');
@@ -191,7 +191,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions en sélectionnant un statut',
+          name: t('pages.sessions.table.headers.status'),
         }),
       );
       await screen.findByRole('listbox');
@@ -210,7 +210,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions par leur version',
+          name: t('pages.sessions.list.filters.version.label'),
         }),
       );
       await screen.findByRole('listbox');
@@ -239,7 +239,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // when
       await click(
         screen.getByRole('button', {
-          name: 'Filtrer les sessions par leur version',
+          name: t('pages.sessions.list.filters.version.label'),
         }),
       );
       await screen.findByRole('listbox');

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import ListSummaryItems from 'pix-admin/components/target-profiles/list-summary-items';
 import { module, test } from 'qunit';
 
@@ -10,7 +10,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
   const triggerFiltering = function () {};
   const goToTargetProfilePage = function () {};
 
-  test('it should display header with name, id and status', async function (assert) {
+  test('it should display search inputs (name, id and status)', async function (assert) {
     // when
     const screen = await render(
       <template>
@@ -19,24 +19,13 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
     );
 
     // then
-    assert.ok(screen.getByText(t('common.fields.id')));
-    assert.ok(screen.getByText(t('common.fields.internalName')));
-    assert.ok(screen.getByText(t('common.fields.status')));
-  });
-
-  test('it should display search inputs', async function (assert) {
-    // when
-    const screen = await render(
-      <template>
-        <ListSummaryItems @triggerFiltering={{triggerFiltering}} @goToTargetProfilePage={{goToTargetProfilePage}} />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.name') })).exists();
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-internal-name.name') }))
+      .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-id.aria-label') }))
       .exists();
+    assert
+      .dom(screen.getByRole('textbox', { name: t('pages.target-profiles.filters.search-by-internal-name.aria-label') }))
+      .exists();
+    assert.dom(screen.getByRole('button', { name: t('common.filters.target-profile.label') })).exists();
   });
 
   test('it should display target profile summaries list', async function (assert) {
@@ -59,7 +48,9 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
     );
 
     // then
-    assert.strictEqual(screen.getAllByLabelText('Profil cible').length, 2);
+    const table = screen.getByRole('table', { name: t('components.target-profiles.list.table.caption') });
+    const rows = within(table).getAllByRole('row');
+    assert.strictEqual(rows.length, 3);
   });
 
   test('it should display target profile summaries data', async function (assert) {
@@ -82,8 +73,9 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
     );
 
     // then
-    assert.dom(screen.getByLabelText('Profil cible')).containsText(123);
-    assert.dom(screen.getByLabelText('Profil cible')).containsText('Profile Cible 1');
+    const table = screen.getByRole('table', { name: t('components.target-profiles.list.table.caption') });
+    assert.dom(within(table).getByRole('cell', { name: 123 })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Profile Cible 1' })).exists();
   });
 
   test('it should display target profile status as "Obsolète" when target profile is outdated', async function (assert) {

--- a/admin/tests/integration/components/target-profiles/badges-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badges-test.gjs
@@ -1,10 +1,10 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Badges from 'pix-admin/components/target-profiles/badges';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -42,44 +42,24 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
       // then
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+      const table = screen.getByRole('table', { name: t('components.target-profiles.badges.table.caption') });
+      assert.dom(within(table).getByRole('columnheader', { name: 'ID' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Image' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Clé' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Nom' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Message' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Paramètres' })).exists();
+      assert.dom(within(table).getByRole('columnheader', { name: 'Actions' })).exists();
 
-      assert.dom(screen.getByRole('table')).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Voir le détail du résultat thématique ID 1' })).exists();
 
-      assert.dom(screen.getAllByRole('columnheader')[0]).hasText('ID');
-      assert.dom(screen.getAllByRole('columnheader')[1]).hasText('Image');
-      assert.dom(screen.getAllByRole('columnheader')[2]).hasText('Clé');
-      assert.dom(screen.getAllByRole('columnheader')[3]).hasText('Nom');
-      assert.dom(screen.getAllByRole('columnheader')[4]).hasText('Message');
-      assert.dom(screen.getAllByRole('columnheader')[5]).hasText(/Paramètres/);
-      assert.dom(screen.getAllByRole('columnheader')[6]).hasText('Actions');
-
-      assert.dom(screen.getByRole('row', { name: 'Informations du badge My title' })).exists();
-
-      assert.dom(screen.getAllByRole('cell')[0].children[0]).hasTagName('a');
-      assert
-        .dom(screen.getAllByRole('cell')[0].children[0])
-        .hasAttribute('aria-label', 'Voir le détail du résultat thématique ID 1');
-
-      assert.strictEqual(screen.getAllByRole('cell')[1].children.length, 1);
-      assert.dom(screen.getAllByRole('cell')[1].children[0]).hasTagName('img');
+      assert.dom(within(table).getByRole('img', { name: 'My alt message' })).exists();
       assert.dom(screen.getAllByRole('cell')[1].children[0]).hasAttribute('src', 'data:,');
-      assert.dom(screen.getAllByRole('cell')[1].children[0]).hasAttribute('alt', 'My alt message');
-
-      assert.dom(screen.getAllByRole('cell')[2]).hasText('My key');
-      assert.dom(screen.getAllByRole('cell')[3]).hasText('My title');
-      assert.dom(screen.getAllByRole('cell')[4]).hasText('My message');
-
-      assert.strictEqual(screen.getAllByRole('cell')[5].children.length, 2);
-      assert.dom(screen.getAllByRole('cell')[5].children[0]).hasText('Pas en lacune');
-      assert.dom(screen.getAllByRole('cell')[5].children[1]).hasText('Pas certifiable');
-
-      assert.strictEqual(screen.getAllByRole('cell')[6].children.length, 2);
-      assert
-        .dom(screen.getAllByRole('cell')[6].children[0])
-        .hasAttribute('aria-label', 'Voir le détail du résultat thématique My title');
-      assert
-        .dom(screen.getAllByRole('cell')[6].children[1])
-        .hasAttribute('aria-label', 'Supprimer le résultat thématique My title');
+      assert.dom(within(table).getByRole('cell', { name: 'My key' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'My title' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'My message' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Pas en lacune Pas certifiable' })).exists();
+      assert.dom(within(table).getByRole('button', { name: 'Supprimer le résultat thématique My title' })).exists();
     });
 
     module('when the badge is always visible', function () {
@@ -96,7 +76,8 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
         // then
         assert.dom(screen.queryByText('Pas en lacune')).doesNotExist();
-        assert.dom(screen.getAllByRole('cell')[5].children[0]).hasText('En lacune');
+        const table = screen.getByRole('table', { name: t('components.target-profiles.badges.table.caption') });
+        assert.dom(within(table).getByRole('cell', { name: 'En lacune Pas certifiable' })).exists();
       });
     });
 
@@ -114,7 +95,8 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
         // then
         assert.dom(screen.queryByText('Pas certifiable')).doesNotExist();
-        assert.dom(screen.getAllByRole('cell')[5].children[1]).hasText('Certifiable');
+        const table = screen.getByRole('table', { name: t('components.target-profiles.badges.table.caption') });
+        assert.dom(within(table).getByRole('cell', { name: 'Pas en lacune Certifiable' })).exists();
       });
     });
 
@@ -136,9 +118,9 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
         const screen = await render(<template><Badges @badges={{badges}} /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByRole('row').length, 3);
-        assert.dom(screen.getAllByRole('row')[1]).hasAttribute('aria-label', 'Informations du badge First badge');
-        assert.dom(screen.getAllByRole('row')[2]).hasAttribute('aria-label', 'Informations du badge Second badge');
+        const table = screen.getByRole('table', { name: t('components.target-profiles.badges.table.caption') });
+        const rows = within(table).getAllByRole('row');
+        assert.strictEqual(rows.length, 3);
       });
     });
   });

--- a/admin/tests/integration/components/trainings/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/trainings/list-summary-items-test.gjs
@@ -1,8 +1,8 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import ListSummaryItems from 'pix-admin/components/trainings/list-summary-items';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | list-summary-items', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -34,7 +34,9 @@ module('Integration | Component | list-summary-items', function (hooks) {
     );
 
     // then
-    assert.strictEqual(screen.getAllByLabelText('Contenu formatif').length, 2);
+    const table = screen.getByRole('table', { name: t('pages.trainings.training.list.caption') });
+    const rows = within(table).getAllByRole('row');
+    assert.strictEqual(rows.length, 3);
   });
 
   test('it should display trainings summaries data', async function (assert) {
@@ -54,7 +56,8 @@ module('Integration | Component | list-summary-items', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(id);
-    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(internalTitle);
+    const table = screen.getByRole('table', { name: t('pages.trainings.training.list.caption') });
+    assert.dom(within(table).getByRole('cell', { name: id })).exists();
+    assert.dom(within(table).getByRole('cell', { name: internalTitle })).exists();
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -879,7 +879,7 @@
           },
           "id": {
             "aria-label": "Filtrer les sessions avec un id",
-            "placeholder": "Identifiant"
+            "label": "Identifiant"
           },
           "status": {
             "aria-label": "Filtrer les sessions en sélectionnant un statut"
@@ -889,7 +889,7 @@
           },
           "version": {
             "aria-label": "Filtrer les sessions par leur version",
-            "placeholder": "Version"
+            "label": "Version"
           }
         },
         "required-actions": {
@@ -966,12 +966,12 @@
         "aria-label": "Target profile filters",
         "count": "{count, plural, =0 {0 target profile} =1 {1 target profile} other {{count} target profiles}}",
         "search-by-id": {
-          "name": "Filter target profiles by ID",
-          "placeholder": "Search by ID"
+          "aria-label": "Filter target profiles by ID",
+          "label": "Identifier"
         },
         "search-by-internal-name": {
-          "name": "Filter target profiles by internal name",
-          "placeholder": "Search by internal name"
+          "aria-label": "Filter target profiles by internal name",
+          "label": "Internal name"
         }
       },
       "resettable-checkbox": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -466,6 +466,11 @@
       }
     },
     "target-profiles": {
+      "badges": {
+        "table": {
+          "caption": "Liste des résultats thématiques. Contient l'identifiant, l'image, la clé, le nom, le message et les paramètres (colonne indiquant si le résultat thématique est en lacune ou certifiable). Des actions permettent de supprimer ou bien d'accéder à une page de détails du résultat thématique."
+        }
+      },
       "list": {
         "table": {
           "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -465,6 +465,13 @@
         }
       }
     },
+    "target-profiles": {
+      "list": {
+        "table": {
+          "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."
+        }
+      }
+    },
     "users": {
       "campaign-participations": {
         "table": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -879,7 +879,7 @@
           },
           "id": {
             "aria-label": "Filtrer les sessions avec un id",
-            "placeholder": "Identifiant"
+            "label": "Identifiant"
           },
           "status": {
             "aria-label": "Filtrer les sessions en sélectionnant un statut"
@@ -889,7 +889,7 @@
           },
           "version": {
             "aria-label": "Filtrer les sessions par leur version",
-            "placeholder": "Version"
+            "label": "Version"
           }
         },
         "required-actions": {
@@ -966,12 +966,12 @@
         "aria-label": "Filtres sur les profils cibles",
         "count": "{count, plural, =0 {0 profil cible} =1 {1 profil cible} other {{count} profils cibles}}",
         "search-by-id": {
-          "name": "Filtrer les profils cible par un ID",
-          "placeholder": "Rechercher par ID"
+          "aria-label": "Filtrer les profils cible par un ID",
+          "label": "Identifiant"
         },
         "search-by-internal-name": {
-          "name": "Filtrer les profils cible par le nom interne",
-          "placeholder": "Rechercher par nom interne"
+          "aria-label": "Filtrer les profils cible par le nom interne",
+          "label": "Nom interne"
         }
       },
       "resettable-checkbox": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -466,6 +466,11 @@
       }
     },
     "target-profiles": {
+      "badges": {
+        "table": {
+          "caption": "Liste des résultats thématiques. Contient l'identifiant, l'image, la clé, le nom, le message et les paramètres (colonne indiquant si le résultat thématique est en lacune ou certifiable). Des actions permettent de supprimer ou bien d'accéder à une page de détails du résultat thématique."
+        }
+      },
       "list": {
         "table": {
           "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -465,6 +465,13 @@
         }
       }
     },
+    "target-profiles": {
+      "list": {
+        "table": {
+          "caption": "Liste des profil cibles. Contient l'identifiant, le nom interne, la catégorie, la date de création et le statut."
+        }
+      }
+    },
     "users": {
       "campaign-participations": {
         "table": {


### PR DESCRIPTION
## 🌳 Proposition

On poursuit l'ajout de PixTable

## 🐝 Remarques

Je ne traiterait pas le tableau des paliers. A mon sens il ne faudrait plus créer les paliers via le tableau, mais via un formulaire séparé. @pierrepougetpix 

<img width="1631" alt="Capture d’écran 2025-03-24 à 11 22 02" src="https://github.com/user-attachments/assets/450b3971-bc48-44a3-b8ad-0ca393e7cac0" />


## 🤧 Pour tester


### Liste des profil cibles : https://admin-pr11804.review.pix.fr/target-profiles/list

- Non reg sur les colonnes
- Non reg sur les filtres
- Non reg sur la pagination

<img width="1631" alt="Capture d’écran 2025-03-24 à 11 44 52" src="https://github.com/user-attachments/assets/b194833f-acc8-4799-a4d8-829c695a434a" />

### Liste des résultats thématiques : https://admin-pr11804.review.pix.fr/target-profiles/56/insights

- Non reg sur les colonnes
- Non reg sur les actions
- Non reg sur les états des labels certifiable et lacune

<img width="1631" alt="Capture d’écran 2025-03-24 à 11 40 36" src="https://github.com/user-attachments/assets/114e0abc-35e2-4c68-8565-b519dba91143" />

### Liste des contenus formatifs ⚠️ deux pages ⚠️ 

- https://admin-pr11804.review.pix.fr/target-profiles/8000/training-summaries
 - Non reg sur les colonnes

<img width="1631" alt="Capture d’écran 2025-03-24 à 11 42 37" src="https://github.com/user-attachments/assets/18aabe2c-9fd9-4664-b2db-7ddb84eed1e7" />

- https://admin-pr11804.review.pix.fr/trainings/list
 - Non reg sur les colonnes
 - Non reg sur les filtres

<img width="1444" alt="Capture d’écran 2025-03-24 à 12 36 09" src="https://github.com/user-attachments/assets/69f51c35-c7d0-431e-8635-0765979143ec" />
