### PR TITLE
[TECH] Déplacer le challenge-picker spécifique à la certif (PIX-13739).

### DIFF
--- a/api/src/certification/evaluation/domain/services/pick-challenge-service.js
+++ b/api/src/certification/evaluation/domain/services/pick-challenge-service.js
@@ -1,0 +1,16 @@
+import { config } from '../../../../shared/config.js';
+import { random } from '../../../../shared/infrastructure/utils/random.js';
+
+function getChallengePicker(probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge) {
+  return ({ possibleChallenges }) => {
+    const challengeIndex = random.binaryTreeRandom(probabilityToPickChallenge, possibleChallenges.length);
+
+    return possibleChallenges[challengeIndex];
+  };
+}
+
+const pickChallengeService = {
+  getChallengePicker,
+};
+
+export default pickChallengeService;

--- a/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/get-next-challenge.js
@@ -5,7 +5,7 @@
  * @typedef {import('../../../session-management/domain/usecases/index.js').CertificationCourseRepository} CertificationCourseRepository
  * @typedef {import('../../../session-management/domain/usecases/index.js').ChallengeRepository} ChallengeRepository
  * @typedef {import('../../../session-management/domain/usecases/index.js').FlashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
- * @typedef {import('../../../session-management/domain/usecases/index.js').PickChallengeService} PickChallengeService
+ * @typedef {import('../../../evaluation/domain/usecases/index.js').PickChallengeService} PickChallengeService
  * @typedef {import('../../../session-management/domain/usecases/index.js').FlashAlgorithmService} FlashAlgorithmService
  * @typedef {import('../../../session-management/domain/usecases/index.js').CertificationCandidateRepository} CertificationCandidateRepository
  */
@@ -106,7 +106,7 @@ const getNextChallenge = async function ({
     throw new AssessmentEndedError();
   }
 
-  const challenge = pickChallengeService.chooseNextChallenge()({ possibleChallenges });
+  const challenge = pickChallengeService.getChallengePicker()({ possibleChallenges });
 
   const certificationChallenge = new CertificationChallenge({
     associatedSkillName: challenge.skill.name,

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { pickChallengeService } from '../../../../evaluation/domain/services/pick-challenge-service.js';
 import * as languageService from '../../../../shared/domain/services/language-service.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -31,6 +30,7 @@ import * as certificationCandidateRepository from '../../infrastructure/reposito
 import * as certificationCompanionAlertRepository from '../../infrastructure/repositories/certification-companion-alert-repository.js';
 import * as challengeCalibrationRepository from '../../infrastructure/repositories/challenge-calibration-repository.js';
 import * as certificationChallengesService from '../services/certification-challenges-service.js';
+import pickChallengeService from '../services/pick-challenge-service.js';
 /**
  * @typedef {certificationCompanionAlertRepository} CertificationCompanionAlertRepository
  * @typedef {certificationChallengeRepository} CertificationChallengeRepository

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -2,8 +2,8 @@ import { Readable } from 'node:stream';
 
 import _ from 'lodash';
 
-import { pickChallengeService } from '../../../evaluation/domain/services/pick-challenge-service.js';
 import { random } from '../../../shared/infrastructure/utils/random.js';
+import pickChallengeService from '../../evaluation/domain/services/pick-challenge-service.js';
 import { pickAnswerStatusService } from '../../shared/domain/services/pick-answer-status-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import { scenarioSimulatorBatchSerializer } from '../infrastructure/serializers/scenario-simulator-batch-serializer.js';
@@ -34,7 +34,7 @@ async function simulateFlashAssessmentScenario(
     const iterations = _.range(0, numberOfIterations);
 
     for (const index of iterations) {
-      const pickChallenge = dependencies.pickChallengeService.chooseNextChallenge(challengePickProbability);
+      const pickChallenge = dependencies.pickChallengeService.getChallengePicker(challengePickProbability);
 
       const usecaseParams = _.omitBy(
         {

--- a/api/src/certification/scoring/domain/services/scoring-degradation-service.js
+++ b/api/src/certification/scoring/domain/services/scoring-degradation-service.js
@@ -1,5 +1,5 @@
-import { pickChallengeService } from '../../../../evaluation/domain/services/pick-challenge-service.js';
 import { AnswerStatus, AssessmentSimulator } from '../../../../shared/domain/models/index.js';
+import pickChallengeService from '../../../evaluation/domain/services/pick-challenge-service.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../../../flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js';
 import { pickAnswerStatusService } from '../../../shared/domain/services/pick-answer-status-service.js';
 
@@ -18,14 +18,14 @@ export const downgradeCapacity = ({
   const answerStatusArray = Array.from({ length: numberOfUnansweredChallenges }, () => AnswerStatus.SKIPPED);
 
   const pickAnswerStatus = pickAnswerStatusService.pickAnswerStatusFromArray(answerStatusArray);
-  const pickChallenge = pickChallengeService.chooseNextChallenge(
+  const challengePicker = pickChallengeService.getChallengePicker(
     PROBABILITY_TO_PICK_THE_MOST_USEFUL_CHALLENGE_FOR_CANDIDATE_EVALUATION,
   );
 
   const singleMeasureStrategy = new AssessmentSimulatorSingleMeasureStrategy({
     algorithm,
     challenges: allChallenges,
-    pickChallenge,
+    pickChallenge: challengePicker,
     pickAnswerStatus,
     initialCapacity: capacity,
   });

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -2,7 +2,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { pickChallengeService } from '../../../../../src/evaluation/domain/services/pick-challenge-service.js';
 import * as flashAlgorithmService from '../../../../certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
@@ -107,7 +106,6 @@ import * as sessionPublicationService from '../services/session-publication-serv
  * @typedef {placementProfileService} PlacementProfileService
  * @typedef {certificationCpfService} CertificationCpfService
  * @typedef {mailService} MailService
- * @typedef {pickChallengeService} PickChallengeService
  * @typedef {flashAlgorithmService} FlashAlgorithmService
  * @typedef {sessionPublicationService} SessionPublicationService
  * @typedef {flashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
@@ -137,7 +135,6 @@ const dependencies = {
   certificationIssueReportRepository,
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
-  pickChallengeService,
   sessionPublicationService,
   sharedSessionRepository,
   userRepository,

--- a/api/src/evaluation/domain/services/pick-challenge-service.js
+++ b/api/src/evaluation/domain/services/pick-challenge-service.js
@@ -1,7 +1,5 @@
 import hashInt from 'hash-int';
 
-import { config } from '../../../../src/shared/config.js';
-import { random } from '../../../shared/infrastructure/utils/random.js';
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
 
@@ -16,15 +14,7 @@ const pickChallenge = ({ skills, randomSeed, locale }) => {
   return pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
 };
 
-const chooseNextChallenge =
-  (probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge) =>
-  ({ possibleChallenges }) => {
-    const challengeIndex = random.binaryTreeRandom(probabilityToPickChallenge, possibleChallenges.length);
-
-    return possibleChallenges[challengeIndex];
-  };
-
-export const pickChallengeService = { pickChallenge, chooseNextChallenge };
+export const pickChallengeService = { pickChallenge };
 
 const pickLocaleChallengeAtIndex = (challenges, locale, index) => {
   const localeChallenges = challenges.filter((challenge) => challenge.locales.includes(locale));

--- a/api/tests/certification/evaluation/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/pick-challenge-service_test.js
@@ -1,0 +1,28 @@
+import pickChallengeService from '../../../../../../src/certification/evaluation/domain/services/pick-challenge-service.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Evaluation | Services | PickChallengeService', function () {
+  describe('#getChallengePicker', function () {
+    context('when given a 100% chance to pick the most discriminating challenge', function () {
+      it('should return the most discriminating challenge', function () {
+        // given
+        const mostDiscriminatingChallenge = domainBuilder.buildChallenge({ discriminant: 5, difficulty: 1 });
+        const otherChallenge = domainBuilder.buildChallenge({ discriminant: 2.5, difficulty: 1 });
+        const lessDiscriminatingChallenge = domainBuilder.buildChallenge({ discriminant: 1, difficulty: 1 });
+        const probabilityToPickMostDiscriminatingChallenge = 100;
+
+        // When provided to the below tested function, and thanks to Fisher–Snedecor distribution used by the algorithm to select upcoming questions,
+        // possible challenges are already ordered (in descending order) by the amount of necessary "information" (in which the discriminant plays an important role)
+        // to evaluate the candidate.
+        const possibleChallenges = [mostDiscriminatingChallenge, otherChallenge, lessDiscriminatingChallenge];
+
+        // when
+        const pickChallenge = pickChallengeService.getChallengePicker(probabilityToPickMostDiscriminatingChallenge);
+        const challenge = pickChallenge({ possibleChallenges });
+
+        // then
+        expect(challenge).to.deep.equal(mostDiscriminatingChallenge);
+      });
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -44,7 +44,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         getNextChallengeByCourseIdForV3: sinon.stub(),
       };
       pickChallengeService = {
-        chooseNextChallenge: sinon.stub(),
+        getChallengePicker: sinon.stub(),
       };
       flashAlgorithmService = {
         getPossibleNextChallenges: sinon.stub(),
@@ -113,13 +113,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           })
           .returns([nextChallengeToAnswer]);
 
-        const chooseNextChallengeImpl = sinon.stub();
-        chooseNextChallengeImpl
+        const getChallengePickerImpl = sinon.stub();
+        getChallengePickerImpl
           .withArgs({
             possibleChallenges: [nextChallengeToAnswer],
           })
           .returns(nextChallengeToAnswer);
-        pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+        pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
         // when
         const challenge = await getNextChallenge({
@@ -202,13 +202,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             })
             .returns([nextChallengeToAnswer]);
 
-          const chooseNextChallengeImpl = sinon.stub();
-          chooseNextChallengeImpl
+          const getChallengePickerImpl = sinon.stub();
+          getChallengePickerImpl
             .withArgs({
               possibleChallenges: [nextChallengeToAnswer],
             })
             .returns(nextChallengeToAnswer);
-          pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+          pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
           const candidateNeedingAccessibilityAdjustment = domainBuilder.buildCertificationCandidateForSupervising({
             id: 'candidateNeedingAccessibilityAdjustmentId',
@@ -359,13 +359,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           })
           .returns([nextChallengeToAnswer]);
 
-        const chooseNextChallengeImpl = sinon.stub();
-        chooseNextChallengeImpl
+        const getChallengePickerImpl = sinon.stub();
+        getChallengePickerImpl
           .withArgs({
             possibleChallenges: [nextChallengeToAnswer],
           })
           .returns(nextChallengeToAnswer);
-        pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+        pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
         // when
         const challenge = await getNextChallenge({
@@ -451,13 +451,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(assessment.certificationCourseId, [])
           .resolves(nonAnsweredCertificationChallenge);
 
-        const chooseNextChallengeImpl = sinon.stub();
-        chooseNextChallengeImpl
+        const getChallengePickerImpl = sinon.stub();
+        getChallengePickerImpl
           .withArgs({
             possibleChallenges: [nextChallenge],
           })
           .returns(nextChallenge);
-        pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+        pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
         // when
         const challenge = await getNextChallenge({
@@ -551,13 +551,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           .withArgs(assessment.certificationCourseId, [])
           .resolves(nonAnsweredCertificationChallenge);
 
-        const chooseNextChallengeImpl = sinon.stub();
-        chooseNextChallengeImpl
+        const getChallengePickerImpl = sinon.stub();
+        getChallengePickerImpl
           .withArgs({
             possibleChallenges: [challengeWithOtherSkill],
           })
           .returns(challengeWithOtherSkill);
-        pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+        pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
         // when
         const challenge = await getNextChallenge({
@@ -707,13 +707,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               })
               .returns([nextChallengeToAnswer]);
 
-            const chooseNextChallengeImpl = sinon.stub();
-            chooseNextChallengeImpl
+            const getChallengePickerImpl = sinon.stub();
+            getChallengePickerImpl
               .withArgs({
                 possibleChallenges: [nextChallengeToAnswer],
               })
               .returns(nextChallengeToAnswer);
-            pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
+            pickChallengeService.getChallengePicker.withArgs().returns(getChallengePickerImpl);
 
             // when
             const challenge = await getNextChallenge({

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -1,7 +1,7 @@
+import pickChallengeService from '../../../../../src/certification/evaluation/domain/services/pick-challenge-service.js';
 import * as moduleUnderTest from '../../../../../src/certification/flash-certification/application/scenario-simulator-route.js';
 import { usecases } from '../../../../../src/certification/flash-certification/domain/usecases/index.js';
 import { pickAnswerStatusService } from '../../../../../src/certification/shared/domain/services/pick-answer-status-service.js';
-import { pickChallengeService } from '../../../../../src/evaluation/domain/services/pick-challenge-service.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { domainBuilder, expect, HttpTestServer, parseJsonStream, sinon } from '../../../../test-helper.js';
 
@@ -19,7 +19,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
     sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
     sinon.stub(pickAnswerStatusService, 'pickAnswerStatusFromArray');
     sinon.stub(pickAnswerStatusService, 'pickAnswerStatusForCapacity');
-    sinon.stub(pickChallengeService, 'chooseNextChallenge');
+    sinon.stub(pickChallengeService, 'getChallengePicker');
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -50,7 +50,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
           const challengePickProbability = 40;
 
           const pickChallengeImplementation = sinon.stub();
-          pickChallengeService.chooseNextChallenge
+          pickChallengeService.getChallengePicker
             .withArgs(challengePickProbability)
             .returns(pickChallengeImplementation);
           const pickAnswerStatusForCapacityImplementation = sinon.stub();
@@ -112,7 +112,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
             const capacity = -3.1;
 
             const pickChallengeImplementation = sinon.stub();
-            pickChallengeService.chooseNextChallenge.returns(pickChallengeImplementation);
+            pickChallengeService.getChallengePicker.returns(pickChallengeImplementation);
             const pickAnswerStatusFromCapacityImplementation = sinon.stub();
             pickAnswerStatusService.pickAnswerStatusForCapacity
               .withArgs(capacity)
@@ -168,7 +168,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
             const capacity = -3.1;
 
             const pickChallengeImplementation = sinon.stub();
-            pickChallengeService.chooseNextChallenge.returns(pickChallengeImplementation);
+            pickChallengeService.getChallengePicker.returns(pickChallengeImplementation);
             const pickAnswerStatusFromCapacityImplementation = sinon.stub();
             pickAnswerStatusService.pickAnswerStatusForCapacity
               .withArgs(capacity)
@@ -225,7 +225,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
             const capacity = -3.1;
 
             const pickChallengeImplementation = sinon.stub();
-            pickChallengeService.chooseNextChallenge.returns(pickChallengeImplementation);
+            pickChallengeService.getChallengePicker.returns(pickChallengeImplementation);
             const pickAnswerStatusFromCapacityImplementation = sinon.stub();
             pickAnswerStatusService.pickAnswerStatusForCapacity
               .withArgs(capacity)

--- a/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
@@ -140,29 +140,4 @@ describe('Unit | Service | PickChallengeService', function () {
       });
     });
   });
-
-  describe('#chooseNextChallenge', function () {
-    context('when given a 100% chance to pick the most discriminating challenge', function () {
-      it('should return the most discriminating challenge', function () {
-        // given
-        const mostDiscriminatingChallenge = domainBuilder.buildChallenge({ discriminant: 5, difficulty: 1 });
-        const otherChallenge = domainBuilder.buildChallenge({ discriminant: 2.5, difficulty: 1 });
-        const lessDiscriminatingChallenge = domainBuilder.buildChallenge({ discriminant: 1, difficulty: 1 });
-        const probabilityToPickMostDiscriminatingChallenge = 100;
-
-        // When provided to the below tested function, and thanks to Fisher–Snedecor distribution used by the algorithm to select upcoming questions,
-        // possible challenges are already ordered (in descending order) by the amount of necessary "information" (in which the discriminant plays an important role)
-        // to evaluate the candidate.
-        const possibleChallenges = [mostDiscriminatingChallenge, otherChallenge, lessDiscriminatingChallenge];
-
-        // when
-        const chosenChallenge = pickChallengeService.chooseNextChallenge(probabilityToPickMostDiscriminatingChallenge)({
-          possibleChallenges,
-        });
-
-        // then
-        expect(chosenChallenge).to.deep.equal(mostDiscriminatingChallenge);
-      });
-    });
-  });
 });


### PR DESCRIPTION
## 🌸 Problème

Il existant un challenge picker spécifique à la certif dans le scope `evaluation`.

## 🌳 Proposition

- Déplacer le service dans le scope `certification`
- Renommer sa méthode `chooseNextChallenge` en `getChallengePicker`.

## 🤧 Pour tester

Tests verts
