### PR TITLE
[BUMP] Remplacement de @1024pix/web-components par @1024pix/epreuves-components

### DIFF
--- a/junior/app/app.js
+++ b/junior/app/app.js
@@ -1,4 +1,4 @@
-import '@1024pix/web-components';
+import '@1024pix/epreuves-components';
 
 import Application from '@ember/application';
 import loadInitializers from 'ember-load-initializers';

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -12,10 +12,10 @@
       "devDependencies": {
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
+        "@1024pix/epreuves-components": "^0.1.0",
         "@1024pix/eslint-plugin": "^2.1.1",
         "@1024pix/pix-ui": "^55.6.0",
         "@1024pix/stylelint-config": "^5.1.28",
-        "@1024pix/web-components": "^0.2.7",
         "@babel/eslint-parser": "^7.26.5",
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@ember/optional-features": "^2.2.0",
@@ -107,6 +107,13 @@
       "engines": {
         "node": "^20 || ^22"
       }
+    },
+    "node_modules/@1024pix/epreuves-components": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.1.0.tgz",
+      "integrity": "sha512-UE8/NHpIM816NSivEa1CKS8KBTtNGTQGn9NmEH1PS43c2wZB90O8yReVqAN9Zdw4N7VdZ3//SvzTRBzbEzVY1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@1024pix/eslint-plugin": {
       "version": "2.1.1",
@@ -912,13 +919,6 @@
       "dependencies": {
         "camelcase": "^4.1.0"
       }
-    },
-    "node_modules/@1024pix/web-components": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@1024pix/web-components/-/web-components-0.2.7.tgz",
-      "integrity": "sha512-wNSshEoSt/kIEyQSlXPLDFWgMlPe4tsEMYXVrgla2jEN/YYcu1OwL92a0ldPdxz2tQRa1p3Pxc2ns+xmYL/Ssw==",
-      "dev": true,
-      "license": "UNLICENSED"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/junior/package.json
+++ b/junior/package.json
@@ -39,10 +39,10 @@
   "devDependencies": {
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
+    "@1024pix/epreuves-components": "^0.1.0",
     "@1024pix/eslint-plugin": "^2.1.1",
     "@1024pix/pix-ui": "^55.6.0",
     "@1024pix/stylelint-config": "^5.1.28",
-    "@1024pix/web-components": "^0.2.7",
     "@babel/eslint-parser": "^7.26.5",
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@ember/optional-features": "^2.2.0",


### PR DESCRIPTION
## 🌸 Problème

On a renommé @1024pix/web-components en @1024pix/epreuves-components.

## 🌳 Proposition

Prendre en compte ce renommage dans junior.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Vérifier que les QCU images s’affichent toujours correctement dans junior.