### PR TITLE
[BUGFIX] Enregistrer la route `/api/application/token` sur MaDDo

### DIFF
--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -4,8 +4,8 @@ import { parse } from 'neoqs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
-import * as authenticationRoutes from './lib/application/authentication/index.js';
 import { authentication } from './lib/infrastructure/authentication.js';
+import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import * as replicationRoutes from './src/maddo/application/replications-routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
@@ -179,7 +179,13 @@ const setupAuthentication = function (server) {
 };
 
 const setupRoutesAndPlugins = async function (server) {
-  await server.register([...plugins, healthcheckRoutes, authenticationRoutes, replicationRoutes]);
+  const routes = [healthcheckRoutes, ...identityAccessManagementRoutes, replicationRoutes];
+  const routesWithOptions = routes.map((route) => ({
+    plugin: route,
+    options: { tags: ['maddo'] },
+  }));
+
+  await server.register([...plugins, ...routesWithOptions]);
 };
 
 const setupOpenApiSpecification = async function (server) {

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -9,20 +9,30 @@ import { tokenRoutes } from './token/token.route.js';
 import { userAdminRoutes } from './user/user.admin.route.js';
 import { userRoutes } from './user/user.route.js';
 
-const register = async function (server) {
-  server.route([
-    ...accountRecoveryRoutes,
-    ...anonymizationAdminRoutes,
-    ...ltiRoutes,
-    ...oidcProviderAdminRoutes,
-    ...oidcProviderRoutes,
-    ...passwordRoutes,
-    ...samlRoutes,
-    ...tokenRoutes,
-    ...userAdminRoutes,
-    ...userRoutes,
-  ]);
-};
+const allRoutes = [
+  ...accountRecoveryRoutes,
+  ...anonymizationAdminRoutes,
+  ...ltiRoutes,
+  ...oidcProviderAdminRoutes,
+  ...oidcProviderRoutes,
+  ...passwordRoutes,
+  ...samlRoutes,
+  ...tokenRoutes,
+  ...userAdminRoutes,
+  ...userRoutes,
+];
+
+function register(server, { routes = allRoutes, tags }) {
+  if (!tags) {
+    server.route(routes);
+    return;
+  }
+
+  const filteredRoutes = routes.filter((route) =>
+    (route.config ?? route.options).tags.some((tag) => tags.includes(tag)),
+  );
+  server.route(filteredRoutes);
+}
 
 const name = 'identity-access-management-api';
 

--- a/api/src/identity-access-management/application/token/token.route.js
+++ b/api/src/identity-access-management/application/token/token.route.js
@@ -46,7 +46,7 @@ export const tokenRoutes = [
         },
       },
       handler: tokenController.authenticateApplication,
-      tags: ['api', 'authorization-server', 'parcoursup'],
+      tags: ['api', 'authorization-server', 'parcoursup', 'maddo'],
     },
   },
   {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -7,17 +7,25 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   let application2;
 
   beforeEach(async function () {
+    const createdAt = new Date();
+    // To avoid flackyness on date comparison, we set createdAt in the past
+    createdAt.setMinutes(-1);
+
     application2 = databaseBuilder.factory.buildClientApplication({
       name: 'appli2',
       clientId: 'clientId-appli2',
       clientSecret: 'secret-app2',
       scopes: ['scope3', 'scope4', 'scope5'],
+      createdAt,
+      updatedAt: createdAt,
     });
     application1 = databaseBuilder.factory.buildClientApplication({
       name: 'appli1',
       clientId: 'clientId-appli1',
       clientSecret: 'secret-app1',
       scopes: ['scope1', 'scope2'],
+      createdAt,
+      updatedAt: createdAt,
     });
 
     await databaseBuilder.commit();

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -137,9 +137,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           .from('client_applications')
           .where({ clientId })
           .first();
-        expect(updatedAt).to.be.greaterThan(createdAt);
+
         expect(scopes).to.have.lengthOf(4);
         expect(scopes).to.have.members(['scope1', 'scope2', 'newScope1', 'newScope2']);
+        expect(updatedAt).to.be.greaterThan(createdAt);
       });
     });
 
@@ -175,9 +176,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
           .from('client_applications')
           .where({ clientId })
           .first();
-        expect(updatedAt).to.be.greaterThan(createdAt);
+
         expect(scopes).to.have.lengthOf(1);
         expect(scopes).to.deep.equal(['scope4']);
+        expect(updatedAt).to.be.greaterThan(createdAt);
       });
     });
 

--- a/api/tests/identity-access-management/unit/application/routes.test.js
+++ b/api/tests/identity-access-management/unit/application/routes.test.js
@@ -1,0 +1,51 @@
+import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Application | Routes', function () {
+  let routes;
+  let server;
+
+  beforeEach(function () {
+    routes = [
+      { config: { tags: ['tag1', 'tag2'] } },
+      { config: { tags: ['tag3'] } },
+      { options: { tags: ['tag3'] } },
+      { options: { tags: ['tag4'] } },
+      { options: { tags: ['tag2', 'tag5'] } },
+    ];
+
+    server = {
+      route: sinon.stub(),
+    };
+  });
+
+  context('when no tags are given', function () {
+    it('registers all routes', function () {
+      // given
+      const options = { routes, tags: undefined };
+
+      // when
+      identityAccessManagementRoutes[0].register(server, options);
+
+      // then
+      expect(server.route).to.have.been.calledOnceWith(routes);
+    });
+  });
+
+  context('when tags are given', function () {
+    it('registers routes having at least one of the tags', function () {
+      // given
+      const options = { routes, tags: ['tag2', 'tag4'] };
+
+      // when
+      identityAccessManagementRoutes[0].register(server, options);
+
+      // then
+      expect(server.route).to.have.been.calledOnceWith([
+        { config: { tags: ['tag1', 'tag2'] } },
+        { options: { tags: ['tag4'] } },
+        { options: { tags: ['tag2', 'tag5'] } },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Suite au déplacement de la route `/api/application/token` dans src, celle-ci n’est plus enregistrée sur l’API MaDDo.

## 🌳 Proposition

Enregistrer la route `/api/application/token` sur l’API MaDDo.

## 🐝 Remarques

On utilise les tags pour filtrer les routes enregistrées par la fonction `register` des routes IAM.

D'après l'API de Hapi les tags sont disponibles dans `route.config` ou `route.option` et il faut donc pouvoir gérer ces 2 cas.

## 🤧 Pour tester

Vérifier que la méthode POST `/api/application/token` répond autre chose que 404 sur l’API MaDDo.

Vérifier que toutes les routes IAM sont présentes sur l’API Pix.