### PR TITLE
[TECH] Ajout de transactions aux usecases de publication de sessions (PIX-17161).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/publish-session.js
+++ b/api/src/certification/session-management/domain/usecases/publish-session.js
@@ -1,3 +1,5 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
 /**
  * @typedef {import ('../../../../../src/certification/session-management/domain/usecases/index.js').CertificationRepository} CertificationRepository
  * @typedef {import ('../../../../../lib/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
@@ -27,24 +29,26 @@ const publishSession = async function ({
   sessionRepository,
   sessionPublicationService,
 }) {
-  const session = await sessionPublicationService.publishSession({
-    sessionId,
-    publishedAt,
-    certificationRepository,
-    finalizedSessionRepository,
-    sessionRepository,
-    sharedSessionRepository,
-  });
+  return DomainTransaction.execute(async function () {
+    const session = await sessionPublicationService.publishSession({
+      sessionId,
+      publishedAt,
+      certificationRepository,
+      finalizedSessionRepository,
+      sessionRepository,
+      sharedSessionRepository,
+    });
 
-  await sessionPublicationService.manageEmails({
-    i18n,
-    session,
-    publishedAt,
-    certificationCenterRepository,
-    sessionRepository,
-  });
+    await sessionPublicationService.manageEmails({
+      i18n,
+      session,
+      publishedAt,
+      certificationCenterRepository,
+      sessionRepository,
+    });
 
-  return sessionRepository.get({ id: sessionId });
+    return sessionRepository.get({ id: sessionId });
+  });
 };
 
 export { publishSession };

--- a/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
+++ b/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 
 const publishSessionsInBatch = async function ({
@@ -17,21 +18,23 @@ const publishSessionsInBatch = async function ({
   const result = new SessionPublicationBatchResult(batchId);
   for (const sessionId of sessionIds) {
     try {
-      const session = await sessionPublicationService.publishSession({
-        sessionId,
-        publishedAt,
-        certificationRepository,
-        finalizedSessionRepository,
-        sharedSessionRepository,
-        sessionRepository,
-      });
+      await DomainTransaction.execute(async () => {
+        const session = await sessionPublicationService.publishSession({
+          sessionId,
+          publishedAt,
+          certificationRepository,
+          finalizedSessionRepository,
+          sharedSessionRepository,
+          sessionRepository,
+        });
 
-      await sessionPublicationService.manageEmails({
-        i18n,
-        session,
-        publishedAt,
-        certificationCenterRepository,
-        sessionRepository,
+        await sessionPublicationService.manageEmails({
+          i18n,
+          session,
+          publishedAt,
+          certificationCenterRepository,
+          sessionRepository,
+        });
       });
     } catch (error) {
       result.addPublicationError(sessionId, error);

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -1,10 +1,12 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const getStatusesBySessionId = async function (sessionId) {
-  // isCancelled will be removed
-  return knex('certification-courses')
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('certification-courses')
     .select({
       certificationCourseId: 'certification-courses.id',
+      // isCancelled will be removed
       isCancelled: 'certification-courses.isCancelled',
       pixCertificationStatus: 'assessment-results.status',
     })

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -32,8 +32,9 @@ const publishCertificationCourses = async function (certificationStatuses) {
     version: -1, // Version number used to meet requirements regarding the version column non-null constraint in the insert request below
   }));
 
+  const knexConn = DomainTransaction.getConnection();
   // Trick to .batchUpdate(), which does not exist in knex per say
-  await knex('certification-courses')
+  await knexConn('certification-courses')
     .insert(certificationDataToUpdate)
     .onConflict('id')
     .merge(['isPublished', 'updatedAt']);

--- a/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/finalized-session-repository.js
@@ -17,7 +17,8 @@ const remove = async function ({ sessionId }) {
 };
 
 const get = async function ({ sessionId }) {
-  const finalizedSessionDto = await knex('finalized-sessions').where({ sessionId }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const finalizedSessionDto = await knexConn('finalized-sessions').where({ sessionId }).first();
 
   if (!finalizedSessionDto) {
     throw new NotFoundError(`Session of id ${sessionId} does not exist.`);

--- a/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
@@ -1,4 +1,3 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCenter } from '../../../../shared/domain/models/CertificationCenter.js';
@@ -85,8 +84,9 @@ export const findByExternalId = async ({ externalId }) => {
   });
 };
 
-export const getRefererEmails = async ({ id }) =>
-  await knex('certification-centers')
+export const getRefererEmails = async ({ id }) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('certification-centers')
     .select('users.email')
     .join(
       'certification-center-memberships',
@@ -96,3 +96,4 @@ export const getRefererEmails = async ({ id }) =>
     .join('users', 'users.id', 'certification-center-memberships.userId')
     .where('certification-centers.id', id)
     .where('certification-center-memberships.isReferer', true);
+};

--- a/api/src/certification/shared/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/session-repository.js
@@ -1,11 +1,13 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCandidate } from '../../../../shared/domain/models/index.js';
 import { ComplementaryCertification } from '../../../session-management/domain/models/ComplementaryCertification.js';
 import { SessionManagement } from '../../../session-management/domain/models/SessionManagement.js';
 
 const getWithCertificationCandidates = async function ({ id }) {
-  const session = await knex.from('sessions').where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const session = await knexConn.from('sessions').where({ id }).first();
 
   if (!session) {
     throw new NotFoundError("La session n'existe pas ou son accès est restreint");

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
@@ -1,9 +1,11 @@
 import { publishSession } from '../../../../../../src/certification/session-management/domain/usecases/publish-session.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Session-Management | Unit | Domain | Use Cases | Publish-Session', function () {
   it('delegates the action to the session-publication-service and return the session', async function () {
     // given
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     const i18n = Symbol('i18n');
     const sessionId = Symbol('a session id');
     const session = Symbol('a session');

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -1,4 +1,5 @@
 import { publishSessionsInBatch } from '../../../../../../src/certification/session-management/domain/usecases/publish-sessions-in-batch.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | publish-sessions-in-batch', function () {
@@ -20,6 +21,8 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       publishSession: sinon.stub(),
       manageEmails: sinon.stub(),
     };
+
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
   });
 
   it('delegates to the publish session service', async function () {


### PR DESCRIPTION
## 🌸 Problème

Les usecases de publication de sessions ne sont pas transactionnels.
Cela a causé des problèmes en production, qui peuvent se reproduire dans le futur.

## 🌳 Proposition

Ajout d'une transaction aux deux usecases de publication (individuelle et en masse) ainsi qu'aux différentes méthodes de repo utilisées par ceux-ci.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

**ATTENTION: Un commit contenant deux `throw new Error()` (publication individuelle et en masse) a été ajouté afin de simuler une erreur quelconque.**

- Créer plusieurs sessions V3 et y inscrire un candidat avec un mail de destinataire des résultats
- Faire les tests comme bon vous semble (rejet, validation, annulation)
- Finaliser les sessions

Publication :
- Publier une session 
- Vérifier que la publication ne fonctionne pas
- En BDD, vérifier que `sessions.publishedAt` et `finalizedSessions.publishedAt` sont`null`

Modifier le commit contenant les erreurs pour ne garder que celle de la publication d'erreur en masse.

Publication en masse :
- Publier les sessions
- Vérifier que les publications ne fonctionnent pas
- En BDD, vérifier que les différents`sessions.publishedAt` et `finalizedSessions.publishedAt` sont `null` 

Retirer le commit contenant les erreurs.

Réitérer les process de publication individuelle et en masse de sessions, et vérifier que tout se passe bien et que les `sessions.publishedAt` et `finalizedSessions.publishedAt` ont été mis à jour.
Attester de la bonne réception un mail contenant les résultats du/des candidats.
