### PR TITLE
[TECH] utilise un verrou pour protéger l'accès à une participation avant de la partagée (PIX-17156)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
@@ -9,7 +9,7 @@ const shareCampaignResult = async function ({
   participationResultCalculationJobRepository,
   participationSharedJobRepository,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+  const campaignParticipation = await campaignParticipationRepository.getLocked(campaignParticipationId);
 
   _checkUserIsOwnerOfCampaignParticipation(campaignParticipation, userId);
 

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/share-campaign-result_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | share-campaign-result', function () {
       performAsync: sinon.stub(),
     };
     campaignParticipationRepository = {
-      get: sinon.stub(),
+      getLocked: sinon.stub(),
       updateWithSnapshot: sinon.stub(),
     };
     userId = 123;
@@ -29,7 +29,7 @@ describe('Unit | UseCase | share-campaign-result', function () {
   context('when user is not the owner of the campaign participation', function () {
     it('throws a UserNotAuthorizedToAccessEntityError error ', async function () {
       // given
-      campaignParticipationRepository.get.resolves({ userId: userId + 1 });
+      campaignParticipationRepository.getLocked.resolves({ userId: userId + 1 });
 
       // when
       const error = await catchErr(usecases.shareCampaignResult)({
@@ -53,7 +53,7 @@ describe('Unit | UseCase | share-campaign-result', function () {
         userId,
       });
       sinon.stub(campaignParticipation, 'share');
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+      campaignParticipationRepository.getLocked.withArgs(campaignParticipationId).resolves(campaignParticipation);
 
       // when
       await usecases.shareCampaignResult({
@@ -77,7 +77,7 @@ describe('Unit | UseCase | share-campaign-result', function () {
       });
       sinon.stub(campaignParticipation, 'share');
 
-      campaignParticipationRepository.get.resolves(campaignParticipation);
+      campaignParticipationRepository.getLocked.resolves(campaignParticipation);
 
       // when
       await usecases.shareCampaignResult({


### PR DESCRIPTION
## 🌸 Problème

On a des doublons dans la table `knowledge-element-snapshots` probablement du a des appel concurrents.

## 🌳 Proposition

On crée une nouvelle méthode (`getLocked`) qui utilise un verrou pour lire les infos d'une participation avant de la partager.

## 🐝 Remarques

Ras

## 🤧 Pour tester

- Faire une campagne PROASSMUL mais ne pas partager les résultats
- via la terminal, lancer 2 requete curl pour partager la participation 
 ```sh
 ACCESS_TOKEN=$(curl -s 'https://pix-api-review-pr11818.osc-fr1.scalingo.io/api/token' --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123&scope=pix-orga' | jq -r .access_token)
for i in {1..2}; do (curl  -H "Authorization: Bearer $ACCESS_TOKEN" -X PATCH https://pix-api-review-pr11818.osc-fr1.scalingo.io//api/campaign-participations/{campaignParticipationId}
```
- la deuxième requete doit echouée