### PR TITLE
[FEATURE] supprime la propriété `answerId` des snapshots (Pix-17187)

### DIFF
--- a/api/scripts/prod/clean-ke-snapshots.js
+++ b/api/scripts/prod/clean-ke-snapshots.js
@@ -14,7 +14,7 @@ const pause = async (duration) => {
 };
 
 function getKnowlegdeElementSnapshotsQuery() {
-  return knex('knowledge-element-snapshots').whereRaw("(snapshot->0->>'userId') is not null");
+  return knex('knowledge-element-snapshots').whereRaw("(snapshot->0->>'answerId') is not null");
 }
 
 function getKnowlegdeElementSnapshotLimit(firstId, limit = DEFAULT_CHUNK_SIZE) {
@@ -73,7 +73,6 @@ export class CleanKeSnapshotScript extends Script {
             'source',
             'status',
             'skillId',
-            'answerId',
             'createdAt',
             'earnedPix',
             'competenceId',

--- a/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
+++ b/api/src/prescription/shared/domain/models/KnowledgeElementCollection.js
@@ -17,7 +17,9 @@ class KnowledgeElementCollection {
 
   toSnapshot() {
     return JSON.stringify(
-      this.latestUniqNonResetKnowledgeElements.map((ke) => _.omit(ke, ['id', 'assessmentId', 'userId'])),
+      this.latestUniqNonResetKnowledgeElements.map((ke) =>
+        _.pick(ke, ['createdAt', 'source', 'status', 'earnedPix', 'skillId', 'competenceId']),
+      ),
     );
   }
 }

--- a/api/tests/integration/scripts/prod/clean-ke-snapshots_test.js
+++ b/api/tests/integration/scripts/prod/clean-ke-snapshots_test.js
@@ -80,7 +80,7 @@ describe('Script | Prod | Clean knowledge-element-snapshot snapshot (jsonb)', fu
         userId: user.id,
         snappedAt: participation3.sharedAt,
         knowledgeElementsAttributes: [
-          { skillId: 'skill_2', status: 'validated', earnedPix: 40, userId: null, assessmentId: null },
+          { skillId: 'skill_2', status: 'validated', earnedPix: 40, userId: null, assessmentId: null, answerId: null },
         ],
       });
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -87,7 +87,6 @@ describe('Integration | Repository | Campaign Participation', function () {
         expect(snapshotInDB).to.deep.equal([
           [
             {
-              answerId: ke.answerId,
               competenceId: ke.competenceId,
               createdAt: ke.createdAt.toISOString(),
               earnedPix: 2,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -192,6 +192,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
             id: undefined,
             assessmentId: undefined,
             userId: undefined,
+            answerId: undefined,
           },
         ],
       });
@@ -241,6 +242,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
             id: undefined,
             assessmentId: undefined,
             userId: undefined,
+            answerId: undefined,
           },
         ],
         [secondCampaignParticipationId]: [
@@ -249,6 +251,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
             id: undefined,
             assessmentId: undefined,
             userId: undefined,
+            answerId: undefined,
           },
         ],
       });
@@ -362,6 +365,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
               id: undefined,
               assessmentId: undefined,
               userId: undefined,
+              answerId: undefined,
             },
           ],
           campaignParticipationId: campaignParticipationId1,
@@ -373,6 +377,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
               id: undefined,
               assessmentId: undefined,
               userId: undefined,
+              answerId: undefined,
             },
           ],
           campaignParticipationId: campaignParticipationId2,
@@ -384,6 +389,7 @@ describe('Integration | Repository | KnowledgeElementSnapshotRepository', functi
               id: undefined,
               assessmentId: undefined,
               userId: undefined,
+              answerId: undefined,
             },
           ],
           campaignParticipationId: campaignParticipationId3,

--- a/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
+++ b/api/tests/prescription/shared/unit/domain/models/KnowledgeElementCollection_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
       });
       const keCollection = new KnowledgeElementCollection([ke1]);
       expect(keCollection.toSnapshot()).equal(
-        '[{"createdAt":"2025-01-10T00:00:00.000Z","source":"direct","status":"validated","earnedPix":4,"answerId":1,"skillId":"rec1","competenceId":5}]',
+        '[{"createdAt":"2025-01-10T00:00:00.000Z","source":"direct","status":"validated","earnedPix":4,"skillId":"rec1","competenceId":5}]',
       );
     });
 
@@ -43,7 +43,7 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
       expect(snapshot).equals('[]');
     });
 
-    it('should drop id, userId, skillId', function () {
+    it('should drop id, userId, assessmentId, answerId', function () {
       const ke1 = buildKnowledgeElement({
         skillId: 'rec1',
         competenceId: 5,
@@ -52,6 +52,8 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
         answerId: 1,
         assessmentId: 2,
         id: 1,
+        source: KnowledgeElement.SourceType.DIRECT,
+        status: KnowledgeElement.StatusType.VALIDATED,
         userId: 1,
       });
       const keCollection = new KnowledgeElementCollection([ke1]);
@@ -59,6 +61,7 @@ describe('Unit | Domain | Models | KnowledgeElementCollection', function () {
       expect(snapshot).not.match(/"userId":/i);
       expect(snapshot).not.match(/"id":/i);
       expect(snapshot).not.match(/"assessmentId":/i);
+      expect(snapshot).not.match(/"answerId":/i);
     });
   });
 

--- a/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -221,6 +221,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
                   new KnowledgeElement({
                     ...knowledgeElementsToSave[0],
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                     createdAt: new Date(),
@@ -228,6 +229,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
                   new KnowledgeElement({
                     ...knowledgeElementsToSave[1],
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                     createdAt: new Date(),
@@ -235,12 +237,14 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
                   new KnowledgeElement({
                     ...knowledgeElement1,
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                   }),
                   new KnowledgeElement({
                     ...knowledgeElement2,
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                   }),
@@ -278,6 +282,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
                   new KnowledgeElement({
                     ...knowledgeElementsToSave[0],
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                     createdAt: new Date(),
@@ -285,6 +290,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
                   new KnowledgeElement({
                     ...knowledgeElementsToSave[1],
                     assessmentId: undefined,
+                    answerId: undefined,
                     userId: undefined,
                     id: undefined,
                     createdAt: new Date(),
@@ -1019,6 +1025,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
             new KnowledgeElement({
               ...domainKEInParticipation,
               assessmentId: undefined,
+              answerId: undefined,
               id: undefined,
               userId: undefined,
             }),


### PR DESCRIPTION
## 🌸 Problème

Dans le cadre de la mise en conformité des données, on souhaite ne pas pouvoir rattacher un utilisateur anonymiser à ses participations. Actuellement dans la table `knowledge-element-snapshots` on stocke l'answerId qui permet de refaire le lien avec l'utilisateur

## 🌳 Proposition

Arrêter d'enregistrer les `answerId` dans les snapshot et rajouter la propriété dans la liste des propriété à supprimer dans le script de nettoyage des snapshot

## 🐝 Remarques

RAS
## 🤧 Pour tester

- lancer le script de nettoyage sur la RA 
- se connecter dans pg et constater qu'il n'y a plus de answerId dans les snapshot