### PR TITLE
[FEATURE] Relier le composant transitoire à la page de fin de parcours et à la modal du tab "Formation"(PIX-17016)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,12 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isModalSentResultEnabled: {
+    description: 'Used to enable display of sent-results-modal',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['frontend', 'team-devcomp'],
+  },
   isV3CertificationAttestationEnabled: {
     description: 'Used to enable new certification attestation for V3',
     type: 'boolean',

--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -13,6 +13,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds, participantCoun
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
       participantCount,
+      completionDistribution: { started: participantCount },
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -522,6 +522,7 @@ const configuration = (function () {
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isDirectMetricsEnabled = false;
+    config.featureToggles.isModalSentResultEnabled = false;
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isPixAppNewLayoutEnabled = true;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -527,6 +527,7 @@ const configuration = (function () {
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isPixAppNewLayoutEnabled = true;
     config.featureToggles.isPixCompanionEnabled = false;
+    config.featureToggles.isPixAdminNewSidebarEnabled = false;
     config.featureToggles.isSelfAccountDeletionEnabled = false;
     config.featureToggles.isQuestEnabled = false;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-direct-metrics-enabled': false,
+            'is-modal-sent-result-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'is-oppsy-disabled': false,
             'is-pix-app-new-layout-enabled': true,

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/index.gjs
@@ -66,6 +66,7 @@ export default class EvaluationResultsTabs extends Component {
                 @questResults={{@questResults}}
                 @campaignParticipationResult={{@campaignParticipationResult}}
                 @campaignId={{@campaign.id}}
+                @onResultsShared={{@onResultsShared}}
               />
             </Panel>
           {{/if}}

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -39,6 +39,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
 
       const campaignParticipationResultToShare = this.args.campaignParticipationResult;
       await this.campaignParticipationResult.share(campaignParticipationResultToShare, this.args.questResults);
+      this.args.onResultsShared();
 
       campaignParticipationResultToShare.isShared = true;
       campaignParticipationResultToShare.canImprove = false;

--- a/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
@@ -25,34 +25,34 @@ export default class QuitResults extends Component {
       <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleModal}}>
         {{t "common.actions.quit"}}
       </button>
-      <PixModal
-        @title={{t "pages.evaluation-results.quit-results.modal.title"}}
-        @onCloseButtonClick={{this.toggleModal}}
-        @showModal={{this.showModal}}
-      >
-        <:content>
-          <p class="quit-results__first-paragraph">{{t
-              "pages.evaluation-results.quit-results.modal.content-information"
-            }}</p>
-          <p><strong>{{t "pages.evaluation-results.quit-results.modal.content-instruction"}}</strong></p>
-        </:content>
-
-        <:footer>
-          <div class="quit-results__footer">
-            <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
-              {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
-            </PixButton>
-
-            <PixButtonLink @href="authenticated" @variant="primary">
-              {{t "pages.evaluation-results.quit-results.modal.actions.quit-without-sharing"}}
-            </PixButtonLink>
-          </div>
-        </:footer>
-      </PixModal>
     {{else}}
       <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
         {{t "common.actions.quit"}}
       </LinkTo>
     {{/if}}
+    <PixModal
+      @title={{t "pages.evaluation-results.quit-results.modal.title"}}
+      @onCloseButtonClick={{this.toggleModal}}
+      @showModal={{this.showModal}}
+    >
+      <:content>
+        <p class="quit-results__first-paragraph">{{t
+            "pages.evaluation-results.quit-results.modal.content-information"
+          }}</p>
+        <p><strong>{{t "pages.evaluation-results.quit-results.modal.content-instruction"}}</strong></p>
+      </:content>
+
+      <:footer>
+        <div class="quit-results__footer">
+          <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
+            {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
+          </PixButton>
+
+          <PixButtonLink @href="authenticated" @variant="primary">
+            {{t "pages.evaluation-results.quit-results.modal.actions.quit-without-sharing"}}
+          </PixButtonLink>
+        </div>
+      </:footer>
+    </PixModal>
   </template>
 }

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -29,6 +29,10 @@ export default class EvaluationResults extends Component {
     return !isAutonomousCourse && !this.args.model.campaign.isForAbsoluteNovice;
   }
 
+  get trainingsForModal() {
+    return this.args.model.trainings.slice(0, 2);
+  }
+
   @action
   showTrainings() {
     const tabElement = document.querySelector('[role="tablist"]');
@@ -83,7 +87,7 @@ export default class EvaluationResults extends Component {
       />
       {{#if this.isModalSentResultEnabled}}
         <EvaluationSentResultsModal
-          @trainings={{@model.trainings}}
+          @trainings={{this.trainingsForModal}}
           @showModal={{this.showEvaluationResultsModal}}
           @onCloseButtonClick={{this.closeModal}}
         />

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -1,15 +1,24 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ENV from 'mon-pix/config/environment';
 
 import EvaluationResultsHero from '../../../campaigns/assessment/results/evaluation-results-hero';
 import EvaluationResultsTabs from '../../../campaigns/assessment/results/evaluation-results-tabs';
+import EvaluationSentResultsModal from '../../../campaigns/assessment/results/evaluation-sent-results-modal';
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 
 export default class EvaluationResults extends Component {
   @service tabManager;
+  @service featureToggles;
+
+  @tracked showEvaluationResultsModal = false;
+
+  get isModalSentResultEnabled() {
+    return this.featureToggles.featureToggles?.isModalSentResultEnabled;
+  }
 
   get hasTrainings() {
     return Boolean(this.args.model.trainings.length);
@@ -31,6 +40,16 @@ export default class EvaluationResults extends Component {
     });
 
     this.tabManager.setActiveTab(2);
+  }
+
+  @action
+  shareResults() {
+    this.showEvaluationResultsModal = true;
+  }
+
+  @action
+  closeModal() {
+    this.showEvaluationResultsModal = false;
   }
 
   <template>
@@ -60,7 +79,15 @@ export default class EvaluationResults extends Component {
         @questResults={{@model.questResults}}
         @isSharableCampaign={{this.isSharableCampaign}}
         @trainings={{@model.trainings}}
+        @onResultsShared={{this.shareResults}}
       />
+      {{#if this.isModalSentResultEnabled}}
+        <EvaluationSentResultsModal
+          @trainings={{@model.trainings}}
+          @showModal={{this.showEvaluationResultsModal}}
+          @onCloseButtonClick={{this.closeModal}}
+        />
+      {{/if}}
     </main>
   </template>
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -6,4 +6,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isPixAppNewLayoutEnabled;
   @attr('boolean') isPixCompanionEnabled;
   @attr('boolean') isQuestEnabled;
+  @attr('boolean') isModalSentResultEnabled;
 }

--- a/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-sent-results-modal.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-sent-results-modal.scss
@@ -10,7 +10,7 @@
   left: 0;
   z-index: 1000;
   padding: 0;
-  overflow-y: auto;
+  overflow-y: hidden;
   text-align: center; // Used to center horizontally the inline-block modal content
   // we inline the pix-neutral-800 value
   background-color: rgb(37 56 88 / 50%);
@@ -39,7 +39,7 @@
   display: inline-block;
   width: 100%;
   height: 100%;
-  padding: 6.25vw 5.75vw;
+  padding: 48px 80px;
   overflow: hidden;
   color: var(--pix-neutral-900);
   text-align: center;

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/tabs/trainings-test.js
@@ -91,12 +91,15 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
 
     module('when participation is not already shared', function (hooks) {
       let screen;
+      let onResultsSharedStub;
 
       hooks.beforeEach(async function () {
         // given
         this.set('isParticipationShared', false);
         this.set('campaignId', 1);
         this.set('campaignParticipationResultId', 1);
+        onResultsSharedStub = sinon.stub();
+        this.set('onResultsShared', onResultsSharedStub);
 
         // when
         screen = await render(
@@ -105,6 +108,7 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
   @isParticipationShared={{this.isParticipationShared}}
   @campaignParticipationResultId={{this.campaignParticipationResultId}}
   @campaignId={{this.campaignId}}
+  @onResultsShared={{this.onResultsShared}}
 />`,
         );
       });
@@ -142,6 +146,16 @@ module('Integration | Components | Campaigns | Assessment | Evaluation Results T
 
           // then
           assert.true(campaignParticipationResultServiceStub.calledOnce);
+        });
+        test('it should call the onResultsShared function', async function (assert) {
+          // given
+          sinon.stub(campaignParticipationResultService, 'share');
+
+          // when
+          await click(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+          // then
+          assert.true(onResultsSharedStub.calledOnce);
         });
 
         module('when share action fails', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -88,7 +88,7 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
 
   module('when the campaign has not been shared yet and has trainings', function () {
     module('when clicking on the share results button', function () {
-      test('it should display the evaluation-sent-results modal', async function (assert) {
+      test('it should display the evaluation-sent-results modal with first 3 trainings', async function (assert) {
         // given
         class FeatureTogglesStub extends Service {
           featureToggles = { isModalSentResultEnabled: true };
@@ -125,6 +125,16 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
             editorLogoUrl:
               'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
           },
+          {
+            title: 'Mon super training 4 youhou',
+            link: 'https://training.net/',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            duration: { hours: 6 },
+            editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+            editorLogoUrl:
+              'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+          },
         ];
         this.model.campaignParticipationResult.isShared = false;
         this.model.campaignParticipationResult.competenceResults = [Symbol('competences')];
@@ -137,12 +147,19 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
         // when
         screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
         await click(screen.queryByRole('tab', { name: 'Formations' }));
-        const dialog = await screen.getByRole('dialog');
-        await click(within(dialog).queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+        const trainingsDialog = await screen.getByRole('dialog');
+        await click(within(trainingsDialog).queryByRole('button', { name: t('pages.skill-review.actions.send') }));
         await waitForDialogClose();
+        const sharedResultsModal = await screen.getByRole('dialog', { name: 'Résultats partagés' });
 
         // then
         assert.dom(await screen.findByRole('button', { name: 'Fermer et revenir aux résultats' })).exists();
+        assert
+          .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 1 youhou' }))
+          .exists();
+        assert
+          .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 4 youhou' }))
+          .doesNotExist();
       });
 
       module('when feature_toggle ‘isModalSentResultEnabled‘ is false', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -27,12 +27,12 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
       campaignParticipationResult: { campaignParticipationBadges: [], competenceResults: [] },
       trainings: [],
     });
-
-    // when
-    screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
   });
 
   test('it should display a header', async function (assert) {
+    // when
+    screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+
     // then
     assert.dom(screen.getByRole('heading', { name: /Campaign title/ })).exists();
   });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -1,10 +1,13 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import { waitForDialogClose } from '../../../../../helpers/wait-for';
 
 module('Integration | Components | Routes | Campaigns | Assessment | Evaluation Results', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -80,6 +83,125 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
       assert
         .dom(screen.getByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }))
         .hasAttribute('aria-selected', 'true');
+    });
+  });
+
+  module('when the campaign has not been shared yet and has trainings', function () {
+    module('when clicking on the share results button', function () {
+      test('it should display the evaluation-sent-results modal', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isModalSentResultEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.model.trainings = [
+          {
+            title: 'Mon super training 1 youhou',
+            link: 'https://training.net/',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            duration: { hours: 6 },
+            editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+            editorLogoUrl:
+              'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+          },
+          {
+            title: 'Mon super training 2 youhou',
+            link: 'https://training.net/',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            duration: { hours: 12 },
+            editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+            editorLogoUrl:
+              'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+          },
+          {
+            title: 'Mon super training 3 youhou',
+            link: 'https://training.net/',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            duration: { hours: 6 },
+            editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+            editorLogoUrl:
+              'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+          },
+        ];
+        this.model.campaignParticipationResult.isShared = false;
+        this.model.campaignParticipationResult.competenceResults = [Symbol('competences')];
+        this.model.campaign.isForAbsoluteNovice = false;
+
+        const campaignParticipationResultService = this.owner.lookup('service:campaign-participation-result');
+        const shareStub = sinon.stub(campaignParticipationResultService, 'share');
+        shareStub.resolves();
+
+        // when
+        screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+        await click(screen.queryByRole('tab', { name: 'Formations' }));
+        const dialog = await screen.getByRole('dialog');
+        await click(within(dialog).queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+        await waitForDialogClose();
+
+        // then
+        assert.dom(await screen.findByRole('button', { name: 'Fermer et revenir aux résultats' })).exists();
+      });
+
+      module('when feature_toggle ‘isModalSentResultEnabled‘ is false', function () {
+        test('it should not display the evaluation-sent-results modal', async function (assert) {
+          // given
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isModalSentResultEnabled: false };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.model.trainings = [
+            {
+              title: 'Mon super training 1 youhou',
+              link: 'https://training.net/',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              duration: { hours: 6 },
+              editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+              editorLogoUrl:
+                'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            },
+            {
+              title: 'Mon super training 2 youhou',
+              link: 'https://training.net/',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              duration: { hours: 12 },
+              editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+              editorLogoUrl:
+                'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            },
+            {
+              title: 'Mon super training 3 youhou',
+              link: 'https://training.net/',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              duration: { hours: 6 },
+              editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+              editorLogoUrl:
+                'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            },
+          ];
+          this.model.campaignParticipationResult.isShared = false;
+          this.model.campaignParticipationResult.competenceResults = [Symbol('competences')];
+          this.model.campaign.isForAbsoluteNovice = false;
+
+          const campaignParticipationResultService = this.owner.lookup('service:campaign-participation-result');
+          const shareStub = sinon.stub(campaignParticipationResultService, 'share');
+          shareStub.resolves();
+
+          // when
+          screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+          await click(screen.queryByRole('tab', { name: 'Formations' }));
+          const dialog = await screen.getByRole('dialog');
+          await click(within(dialog).queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+
+          // then
+          assert.dom(screen.queryByRole('dialog', { name: 'Résultats partagés' })).doesNotExist();
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -45,7 +45,7 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
   module('when the campaign has trainings or badges', function () {
     test('it should display a tablist', async function (assert) {
       // given
-      this.model.trainings = [Symbol('training')];
+      this.model.trainings = [{ duration: { days: 1, hours: 1, minutes: 1 } }];
 
       // when
       screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);


### PR DESCRIPTION
## 🌸 Problème

La modale de fin de parcours existe mais n'est pas affichée quand on envoie ses résultats.

## 🌳 Proposition

Afficher la modal de fin de parcours quand on envoie ses résultats. Quand on clique sur "Fermer et voir mes résultats", on retourne à la page avec les résultats et les récompenses.

## 🐝 Remarques

- Dans quit-results.gjs, `<PixModal>` a été extrait du bloc `if/else` afin d'éviter la destruction de cette modal lorsque on partage les résultats de campagne. Ainsi, la modale ne se détruisant pas, le _modifier_ trap-focus n'appelle pas son _destructor_ dont le rôle est de rajouter un scroll sur la page. 
- A faire : ajouter l'action d'afficher la modale pour le bouton de `EvaluationResultsHero` -> dans un autre ticket
- Un featureToggle a été créé pour cette fonctionnalité. Son nom : `isModalSentResultEnabled`

## 🤧 Pour tester

- Aller sur la campagne [EDUSIMPLE](https://app-pr11827.review.pix.fr/campagnes/EDUSIMPLE) en se connectant avec le compte dave-comp@example.net
- Aller dans l'onglet Formations
- Cliquer sur le bouton `J'envoie mes résultats `
- Vérifier que la modale s'affiche et qu'elle contient des contenus formatifs 😸 