### PR TITLE
[TECH] ajoute la table `campaign-participation-tube-reached-levels` (PIX-17168)

### DIFF
--- a/api/db/migrations/20250325100840_add-campaign-participation-tube-reached-levels-table.js
+++ b/api/db/migrations/20250325100840_add-campaign-participation-tube-reached-levels-table.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'campaign-participation-tube-reached-levels';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary();
+
+    table.string('tubeId').notNullable().comment('Framework tube id');
+
+    table
+      .integer('campaignParticipationId')
+      .references('campaign-participations.id')
+      .notNullable()
+      .comment('Campaign participation id');
+
+    table
+      .smallint('reachedLevel')
+      .notNullable()
+      .comment(
+        'Maximum level reached by the learner. It matches the highest skill level obtained by the user for this tube.',
+      );
+    table.comment(
+      `This table stores the levels reached by the learners once they share the campaign.
+          Each row contains the highest reached level for a campaign tube.`,
+    );
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Actuellement, le taux de couverture nécessite d'aller chercher beaucoup de données (referentiel, knowledge-element) qui oblige a le pré-calculer.

## 🌳 Proposition

On veut stocker les niveaux max atteint pour une participation pour un tube afin de faciliter le calcul du TDC

## 🐝 Remarques

RAS

## 🤧 Pour tester

se connecter sur pg et lancer  
```sql
\d  "campaign-participation-tube-reached-levels"; 
```
