### PR TITLE
[FEATURE] Corrections PixApp page mes parcours (PIX-17182)

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -1,4 +1,4 @@
-<article class="campaign-participation-overview-card" role="article">
+<PixBlock class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
     <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.disabled"}}
@@ -43,4 +43,4 @@
       </div>
     {{/if}}
   </section>
-</article>
+</PixBlock>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -1,4 +1,4 @@
-<article class="campaign-participation-overview-card" role="article">
+<PixBlock class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
     <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.finished"}}
@@ -32,4 +32,4 @@
       {{t "pages.campaign-participation-overview.card.see-more"}}
     </PixButton>
   </section>
-</article>
+</PixBlock>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.js
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+
 export default class Ended extends Component {
   @service router;
   @service metrics;

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -1,4 +1,4 @@
-<article class="campaign-participation-overview-card" role="article">
+<PixBlock class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
     <PixTag class="campaign-participation-overview-card-header__tag" @color="green-light">
       {{t "pages.campaign-participation-overview.card.tag.started"}}
@@ -23,4 +23,4 @@
       {{t "pages.campaign-participation-overview.card.resume.information"}}
     </PixButtonLink>
   </section>
-</article>
+</PixBlock>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
@@ -1,4 +1,4 @@
-<article class="campaign-participation-overview-card" role="article">
+<PixBlock class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
     <PixTag class="campaign-participation-overview-card-header__tag" @color="yellow-light">
       {{t "pages.campaign-participation-overview.card.tag.completed"}}
@@ -19,4 +19,4 @@
       {{t "pages.campaign-participation-overview.card.send"}}
     </PixButtonLink>
   </section>
-</article>
+</PixBlock>

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -3,8 +3,6 @@
 @use 'pix-design-tokens/shadows';
 
 .campaign-participation-overview-card {
-  @extend %pix-shadow-xs;
-
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-8x);
@@ -13,7 +11,6 @@
   height: 290px;
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: var(--pix-neutral-0);
-  border-radius: 8px;
 
   &__header {
     width: 100%;
@@ -86,6 +83,7 @@
     display: block;
     margin-top: var(--pix-spacing-2x);
     color: var(--pix-neutral-500);
+    font-weight: var(--pix-font-bold);
   }
 
   &__date {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1256,7 +1256,7 @@
         },
         "subtitle": "Resume your customised tests or submit your results",
         "tests-link": "All my customised tests",
-        "title": "Customised tests"
+        "title": "My customised tests"
       },
       "empty-dashboard": {
         "link-to-competences": "See my skills",
@@ -2152,7 +2152,7 @@
         },
         "title": "Deactivated courses"
       },
-      "description": "Find here the evaluation courses you have started or completed.",
+       "description": "Access your Pix tests, track your progress, and easily pick up where you left off.",
       "title": "My customised tests"
     },
     "user-trainings": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1256,7 +1256,7 @@
         },
         "subtitle": "Continúa con la prueba actual o envía tus resultados",
         "tests-link": "Todos mis tests",
-        "title": "Test"
+        "title": "Mis tests"
       },
       "empty-dashboard": {
         "link-to-competences": "Ver mis competencias",
@@ -2144,8 +2144,8 @@
       "title": "Mi cuenta"
     },
     "user-tests": {
+      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
       "title": "Mis tests",
-      "description": "Encuentre aquí los cursos de evaluación que ha comenzado o completado.",
       "anonymised-participations": {
         "course": "Recorrido",
         "states": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1256,7 +1256,7 @@
         },
         "subtitle": "Continuez vos parcours de test en cours ou envoyez vos résultats",
         "tests-link": "Tous mes parcours",
-        "title": "Parcours"
+        "title": "Mes parcours"
       },
       "empty-dashboard": {
         "link-to-competences": "Voir mes compétences",
@@ -2152,8 +2152,8 @@
         },
         "title": "Parcours désactivés"
       },
-      "description": "Retrouvez ici les parcours d’évaluation que vous avez commencés ou terminés.",
-      "title": "Parcours"
+      "description": "Retrouvez vos parcours Pix, suivez votre progression et reprenez simplement là où vous en étiez.",
+      "title": "Mes parcours"
     },
     "user-trainings": {
       "description": "Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -348,7 +348,7 @@
       "account": "Mijn account",
       "certifications": "Mijn certificaten",
       "sign-out": "Log uit.",
-      "tests": "Mijn carrièrepaden"
+      "tests": "Mijn tests"
     }
   },
   "pages": {
@@ -1255,8 +1255,8 @@
           "text": "<h2>Vergeet niet het indienen van je profiel te voltooien!</h2>"
         },
         "subtitle": "Ga door met uw huidige tests of stuur uw resultaten op",
-        "tests-link": "Al mijn carrièrepaden",
-        "title": "Test"
+        "tests-link": "Al mijn tests",
+        "title": "Mijn tests"
       },
       "empty-dashboard": {
         "link-to-competences": "Bekijk mijn vaardigheden",
@@ -2144,8 +2144,8 @@
       "title": "Mijn account"
     },
     "user-tests": {
-      "title": "Mijn carrièrepaden",
-      "description": "Bekijk hier de beoordelingstrajecten die je bent begonnen of afgerond.",
+      "title": "Mijn tests",
+      "description": "Bekijk je Pix-trajecten, volg je voortgang en ga eenvoudig verder waar je was gebleven.",
       "anonymised-participations": {
         "course": "Route",
         "states": {


### PR DESCRIPTION
## 🌸 Problème

Quelques ajustements à faire, repérés lors du recettage de l'intégration de la nouvelle nav sur PixApp.

## 🌳 Proposition
- modifier le wording du titre de la page à “Mes parcours”
- modifier le wording de la section à "Mes parcours" sur la page d'accueil 
- appliquer PixBlock aux cartes parcours
- mettre les titres des campagnes en gras
- modifier le sous titre de la page Mes parcours à "Retrouvez vos parcours Pix, suivez votre progression et reprenez simplement là où vous en étiez."

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Ouvrir l'oeil 
🫰 