### PR TITLE
[TECH] Migration des test e2e Pix Orga en Playwright

### DIFF
--- a/high-level-tests/e2e-playwright/README.md
+++ b/high-level-tests/e2e-playwright/README.md
@@ -23,8 +23,16 @@ Vous devez avoir démarré les conteneurs Docker Pix au préalable: `docker comp
 npm run test
 ```
 
-## Exécuter en mode UI\*
+## Exécuter en mode UI
 
 ```bash
 npm run test:ui
+```
+
+## Lancer l'enregistreur d'action
+
+Pour faciliter l'écriture des test, playwright propose un utilitaire pour logger les actions utilisateur et générer un scénario.
+
+```bash
+npx playwright codegen
 ```

--- a/high-level-tests/e2e-playwright/pix-orga/migration.md
+++ b/high-level-tests/e2e-playwright/pix-orga/migration.md
@@ -1,0 +1,38 @@
+Login => ok
+
+Onboarding
+
+- Invitation et Signup (rejoindre une organisation)
+- Invitation et Signin (authentifié ou non)
+- Logout
+
+student-sco
+
+- Accès d'un admin vs accès d'une membre
+- Je veux changer le mot de passe d'un élève
+- Je veux créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
+
+student-sup
+
+- Accès d'un admin vs accès d'une membre
+- J'affiche la liste des élèves
+
+campagne-evaluation
+
+- Création d'une campagne d'évaluation
+- Je consulte le détail d'une campagne d'évaluation
+
+campagne-profile
+
+- Création d'une campagne de profil
+- Je consulte le détail d'une campagne de profil
+
+campagne-management
+
+- Duplication
+- Archivage / désarchivage
+- Modification
+
+member-management
+
+- J'envoie une invitation à rejoindre Pix Orga

--- a/high-level-tests/e2e-playwright/pix-orga/migration.md
+++ b/high-level-tests/e2e-playwright/pix-orga/migration.md
@@ -1,38 +1,38 @@
-Login => ok
+- [x] Login
 
-Onboarding
+**Onboarding**
 
-- Invitation et Signup (rejoindre une organisation)
-- Invitation et Signin (authentifié ou non)
-- Logout
+- [x] Invitation et Signup (rejoindre une organisation)
+- [x] Invitation et Signin (authentifié ou non)
+- [ ] Logout
 
-student-sco
+**student-sco**
 
-- Accès d'un admin vs accès d'une membre
-- Je veux changer le mot de passe d'un élève
-- Je veux créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
+- [ ] Accès d'un admin vs accès d'une membre
+- [ ] Je veux changer le mot de passe d'un élève
+- [ ] Je veux créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
 
-student-sup
+**student-sup**
 
-- Accès d'un admin vs accès d'une membre
-- J'affiche la liste des élèves
+- [ ] Accès d'un admin vs accès d'une membre
+- [ ] J'affiche la liste des élèves
 
-campagne-evaluation
+**campaign-evaluation**
 
-- Création d'une campagne d'évaluation
-- Je consulte le détail d'une campagne d'évaluation
+- [ ] Création d'une campagne d'évaluation
+- [ ] Je consulte le détail d'une campagne d'évaluation
 
-campagne-profile
+**campaign-profile**
 
-- Création d'une campagne de profil
-- Je consulte le détail d'une campagne de profil
+- [ ] Création d'une campagne de profil
+- [ ] Je consulte le détail d'une campagne de profil
 
-campagne-management
+**campaign-management**
 
-- Duplication
-- Archivage / désarchivage
-- Modification
+- [ ] Duplication
+- [ ] Archivage / désarchivage
+- [ ] Modification
 
-member-management
+**member-management**
 
-- J'envoie une invitation à rejoindre Pix Orga
+- [ ] J'envoie une invitation à rejoindre Pix Orga

--- a/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
@@ -3,18 +3,12 @@ import { expect } from '@playwright/test';
 import { databaseBuilder } from '../helpers/db.ts';
 import { test } from '../helpers/fixtures.ts';
 
-let invitation: { id: string; code: string };
-const email = 'admin@example.net';
-
-test.beforeEach(async function () {
-  invitation = databaseBuilder.factory.buildOrganizationInvitation({
-    email,
-  });
-  await databaseBuilder.commit();
-});
-
 test('Join an organization without having an account', async function ({ page }) {
+  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+  await databaseBuilder.commit();
+
   await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+
   await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
   await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
   await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
@@ -23,6 +17,25 @@ test('Join an organization without having an account', async function ({ page })
   await page.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }).check();
   await page.getByRole('button', { name: "Je m'inscris" }).click();
   await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
+  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+});
+test('Join an organization with an existing account', async function ({ page }) {
+  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+  databaseBuilder.factory.buildUser.withRawPassword({
+    email: 'random-account@example.net',
+  });
+  await databaseBuilder.commit();
+
+  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+
+  await page.getByRole('button', { name: 'Se connecter' }).click();
+  await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('random-account@example.net');
+  await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
+  await page.getByRole('button', { name: 'Je me connecte' }).click();
+  await expect(
+    page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
+  ).toBeVisible();
   await page.getByRole('button', { name: 'Accepter et continuer' }).click();
   await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
 });

--- a/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
@@ -1,41 +1,73 @@
 import { expect } from '@playwright/test';
 
+import { useLoggedUser } from '../helpers/auth.ts';
 import { databaseBuilder } from '../helpers/db.ts';
 import { test } from '../helpers/fixtures.ts';
 
-test('Join an organization without having an account', async function ({ page }) {
-  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
-  await databaseBuilder.commit();
+test.describe('when user is not authenticated', () => {
+  test('Join an organization without having an account', async function ({ page }) {
+    const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+    await databaseBuilder.commit();
 
-  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+    await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
 
-  await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
-  await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
-  await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
-  await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('minipixou@example.net');
-  await page.getByRole('textbox', { name: 'Mot de passe' }).fill('Azerty123*');
-  await page.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }).check();
-  await page.getByRole('button', { name: "Je m'inscris" }).click();
-  await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
-  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
-  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
-});
-test('Join an organization with an existing account', async function ({ page }) {
-  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
-  databaseBuilder.factory.buildUser.withRawPassword({
-    email: 'random-account@example.net',
+    await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
+    await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
+    await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
+    await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('minipixou@example.net');
+    await page.getByRole('textbox', { name: 'Mot de passe' }).fill('Azerty123*');
+    await page.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }).check();
+    await page.getByRole('button', { name: "Je m'inscris" }).click();
+    await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
+    await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+    await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
   });
-  await databaseBuilder.commit();
 
-  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+  test('Join an organization with an existing account', async function ({ page }) {
+    const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+    databaseBuilder.factory.buildUser.withRawPassword({
+      email: 'random-account@example.net',
+    });
+    await databaseBuilder.commit();
 
-  await page.getByRole('button', { name: 'Se connecter' }).click();
-  await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('random-account@example.net');
-  await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
-  await page.getByRole('button', { name: 'Je me connecte' }).click();
-  await expect(
-    page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
-  ).toBeVisible();
-  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
-  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+    await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+    await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('random-account@example.net');
+    await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
+    await page.getByRole('button', { name: 'Je me connecte' }).click();
+    await expect(
+      page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+    await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+  });
+});
+
+test.describe('when user is authenticated', () => {
+  const userId = useLoggedUser('pix-orga');
+
+  test('Join an organization with an existing account', async function ({ page }) {
+    const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+    databaseBuilder.factory.buildUser.withMembership({
+      id: userId,
+      email: 'already-connected@example.net',
+    });
+    await databaseBuilder.commit();
+
+    await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+    test.step('signing user', async () => {
+      await page.getByRole('button', { name: 'Se connecter' }).click();
+      await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('already-connected@example.net');
+      await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
+      await page.getByRole('button', { name: 'Je me connecte' }).click();
+    });
+
+    await expect(
+      page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+    await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+    await expect(page.getByRole('paragraph').filter({ hasText: 'Observatoire de Pix' })).toBeVisible();
+  });
 });

--- a/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+
+import { databaseBuilder } from '../helpers/db.ts';
+import { test } from '../helpers/fixtures.ts';
+
+let invitation: { id: string; code: string };
+const email = 'admin@example.net';
+
+test.beforeEach(async function () {
+  invitation = databaseBuilder.factory.buildOrganizationInvitation({
+    email,
+  });
+  await databaseBuilder.commit();
+});
+
+test('Join an organization without having an account', async function ({ page }) {
+  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+  await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
+  await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
+  await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
+  await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('minipixou@example.net');
+  await page.getByRole('textbox', { name: 'Mot de passe' }).fill('Azerty123*');
+  await page.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }).check();
+  await page.getByRole('button', { name: "Je m'inscris" }).click();
+  await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
+  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+});

--- a/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/onboarding.test.ts
@@ -4,69 +4,70 @@ import { useLoggedUser } from '../helpers/auth.ts';
 import { databaseBuilder } from '../helpers/db.ts';
 import { test } from '../helpers/fixtures.ts';
 
-test.describe('when user is not authenticated', () => {
-  test('Join an organization without having an account', async function ({ page }) {
-    const invitation = databaseBuilder.factory.buildOrganizationInvitation();
-    await databaseBuilder.commit();
+test('A new user joins a new organization from an invitation link', async function ({ page }) {
+  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+  await databaseBuilder.commit();
 
-    await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+  await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
 
-    await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
+  test.step('signup user', async () => {
     await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
     await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
     await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('minipixou@example.net');
     await page.getByRole('textbox', { name: 'Mot de passe' }).fill('Azerty123*');
     await page.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }).check();
     await page.getByRole('button', { name: "Je m'inscris" }).click();
-    await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
-    await page.getByRole('button', { name: 'Accepter et continuer' }).click();
-    await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
   });
 
-  test('Join an organization with an existing account', async function ({ page }) {
-    const invitation = databaseBuilder.factory.buildOrganizationInvitation();
-    databaseBuilder.factory.buildUser.withRawPassword({
-      email: 'random-account@example.net',
-    });
-    await databaseBuilder.commit();
+  await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
+  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
 
-    await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
-
-    await page.getByRole('button', { name: 'Se connecter' }).click();
-    await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('random-account@example.net');
-    await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
-    await page.getByRole('button', { name: 'Je me connecte' }).click();
-    await expect(
-      page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Accepter et continuer' }).click();
-    await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
-  });
+  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
 });
 
-test.describe('when user is authenticated', () => {
+test('An existing user joins a new organization from an invitation link', async function ({ page }) {
+  const invitation = databaseBuilder.factory.buildOrganizationInvitation();
+  const user = databaseBuilder.factory.buildUser.withRawPassword();
+  await databaseBuilder.commit();
+
+  await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
+  await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
+
+  test.step('signin user', async () => {
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+    await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill(user.email);
+    await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
+    await page.getByRole('button', { name: 'Je me connecte' }).click();
+  });
+
+  await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
+  await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
+});
+
+test.describe('When user is already authenticated to Pix Orga', () => {
   const userId = useLoggedUser('pix-orga');
 
-  test('Join an organization with an existing account', async function ({ page }) {
+  test('Joins a new organization from an invitation link', async function ({ page }) {
     const invitation = databaseBuilder.factory.buildOrganizationInvitation();
-    databaseBuilder.factory.buildUser.withMembership({
-      id: userId,
-      email: 'already-connected@example.net',
-    });
+    const user = databaseBuilder.factory.buildUser.withMembership({ id: userId });
     await databaseBuilder.commit();
 
     await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
-    test.step('signing user', async () => {
+    await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
+
+    test.step('signin user', async () => {
       await page.getByRole('button', { name: 'Se connecter' }).click();
-      await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('already-connected@example.net');
+      await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill(user.email);
       await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
       await page.getByRole('button', { name: 'Je me connecte' }).click();
     });
 
-    await expect(
-      page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }),
-    ).toBeVisible();
+    await page.getByRole('heading', { name: "Veuillez accepter nos Conditions Générales d'Utilisation" }).waitFor();
     await page.getByRole('button', { name: 'Accepter et continuer' }).click();
+
     await expect(page.getByRole('heading', { name: 'Campagnes' })).toBeVisible();
     await expect(page.getByRole('paragraph').filter({ hasText: 'Observatoire de Pix' })).toBeVisible();
   });

--- a/high-level-tests/e2e-playwright/playwright.config.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
             START_JOB_IN_WEB_PROCESS: 'false',
             PIX_AUDIT_LOGGER_ENABLED: 'false',
             MAILING_ENABLED: 'false',
-            FT_PIXAPP_NEW_LAYOUT_ENABLED: 'true',
+            FT_PIXAPP_NEW_LAYOUT_ENABLED: 'false',
           },
         },
         {

--- a/high-level-tests/e2e-playwright/playwright.config.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
             START_JOB_IN_WEB_PROCESS: 'false',
             PIX_AUDIT_LOGGER_ENABLED: 'false',
             MAILING_ENABLED: 'false',
+            FT_PIXAPP_NEW_LAYOUT_ENABLED: 'true',
           },
         },
         {


### PR DESCRIPTION
## 🌸 Problème

Suite à la mise en place de test e2e avec Playwright on souhaite, dans un premier temps, migrer les tests e2e Cypress Pix Orga.

## 🌳 Proposition

Cette PR contient les scénarios d'onboarding de Pix Orga:
- Un nouvel utilisateur rejoint une organisation via une invitation
- Un utilisateur Pix Orga (non connecté) rejoint une nouvelle organisation via une invitation
- Un utilisateur Pix Orga (connecté) rejoint une nouvelle organisation via une invitation

## 🐝 Remarques

L'ensemble des scénarios Pix Orga à migrer sont définis dans le fichier `high-level-tests/e2e-playwright/pix-orga/migration.md`

