### PR TITLE
[FEATURE] Ajoute des boutons pour télécharger les templates des fichiers d'import CSV sur Admin.

### DIFF
--- a/admin/app/components/administration/campaigns/campaigns-import.gjs
+++ b/admin/app/components/administration/campaigns/campaigns-import.gjs
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class CampaignsImport extends Component {
   @service intl;
@@ -44,14 +45,16 @@ export default class CampaignsImport extends Component {
       @title={{t "components.administration.campaigns-import.title"}}
       @description={{t "components.administration.campaigns-import.description"}}
     >
-      <PixButtonUpload
-        @id="campaigns-file-upload"
-        @onChange={{this.importCampaigns}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.campaigns-import.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/campaigns/template">
+        <PixButtonUpload
+          @id="campaigns-file-upload"
+          @onChange={{this.importCampaigns}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.campaigns-import.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/common/add-organization-features-in-batch.gjs
+++ b/admin/app/components/administration/common/add-organization-features-in-batch.gjs
@@ -1,4 +1,6 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -11,6 +13,7 @@ export default class AddOrganizationFeaturesInBatch extends Component {
   @service intl;
   @service pixToast;
   @service session;
+  @service fileSaver;
   @service errorResponseHandler;
 
   @action
@@ -44,19 +47,36 @@ export default class AddOrganizationFeaturesInBatch extends Component {
     }
   }
 
+  @action
+  async downloadTemplate() {
+    try {
+      const url = ENV.APP.API_HOST + '/api/admin/organizations/add-organization-features/template';
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url, token });
+    } catch (error) {
+      this.pixToast.sendErrorNotification({ message: error.message });
+    }
+  }
+
   <template>
     <AdministrationBlockLayout
       @title={{t "components.administration.add-organization-features-in-batch.title"}}
       @description={{t "components.administration.add-organization-features-in-batch.description"}}
     >
-      <PixButtonUpload
-        @id="organizations-batch-update-file-upload"
-        @onChange={{this.addOrganizationFeaturesInBatch}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.add-organization-features-in-batch.upload-button"}}
-      </PixButtonUpload>
+      <div class="csv-import">
+        <PixButtonUpload
+          @id="organizations-batch-update-file-upload"
+          @onChange={{this.addOrganizationFeaturesInBatch}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.add-organization-features-in-batch.upload-button"}}
+        </PixButtonUpload>
+        <PixButton @triggerAction={{this.downloadTemplate}} @variant="tertiary">
+          <PixIcon @name="download" @plainIcon={{true}} @ariaHidden={{true}} />
+          {{t "common.actions.download-template"}}
+        </PixButton>
+      </div>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/common/add-organization-features-in-batch.gjs
+++ b/admin/app/components/administration/common/add-organization-features-in-batch.gjs
@@ -1,6 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -8,6 +6,7 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class AddOrganizationFeaturesInBatch extends Component {
   @service intl;
@@ -47,35 +46,22 @@ export default class AddOrganizationFeaturesInBatch extends Component {
     }
   }
 
-  @action
-  async downloadTemplate() {
-    try {
-      const url = ENV.APP.API_HOST + '/api/admin/organizations/add-organization-features/template';
-      const token = this.session.data.authenticated.access_token;
-      await this.fileSaver.save({ url, token });
-    } catch (error) {
-      this.pixToast.sendErrorNotification({ message: error.message });
-    }
-  }
-
   <template>
     <AdministrationBlockLayout
       @title={{t "components.administration.add-organization-features-in-batch.title"}}
       @description={{t "components.administration.add-organization-features-in-batch.description"}}
     >
       <div class="csv-import">
-        <PixButtonUpload
-          @id="organizations-batch-update-file-upload"
-          @onChange={{this.addOrganizationFeaturesInBatch}}
-          @variant="secondary"
-          accept=".csv"
-        >
-          {{t "components.administration.add-organization-features-in-batch.upload-button"}}
-        </PixButtonUpload>
-        <PixButton @triggerAction={{this.downloadTemplate}} @variant="tertiary">
-          <PixIcon @name="download" @plainIcon={{true}} @ariaHidden={{true}} />
-          {{t "common.actions.download-template"}}
-        </PixButton>
+        <DownloadTemplate @url="/api/admin/organizations/add-organization-features/template">
+          <PixButtonUpload
+            @id="organizations-batch-update-file-upload"
+            @onChange={{this.addOrganizationFeaturesInBatch}}
+            @variant="secondary"
+            accept=".csv"
+          >
+            {{t "components.administration.add-organization-features-in-batch.upload-button"}}
+          </PixButtonUpload>
+        </DownloadTemplate>
       </div>
     </AdministrationBlockLayout>
   </template>

--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -6,11 +6,13 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class UpsertQuestsInBatch extends Component {
   @service intl;
   @service pixToast;
   @service session;
+  @service fileSaver;
   @service errorResponseHandler;
 
   @action
@@ -49,14 +51,16 @@ export default class UpsertQuestsInBatch extends Component {
       @title={{t "components.administration.upsert-quests-in-batch.title"}}
       @description={{t "components.administration.upsert-quests-in-batch.description"}}
     >
-      <PixButtonUpload
-        @id="quests-batch-update-file-upload"
-        @onChange={{this.upsertQuestsInBatch}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.upsert-quests-in-batch.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/quests/template">
+        <PixButtonUpload
+          @id="quests-batch-update-file-upload"
+          @onChange={{this.upsertQuestsInBatch}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.upsert-quests-in-batch.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/download-template.gjs
+++ b/admin/app/components/administration/download-template.gjs
@@ -1,0 +1,33 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
+
+export default class extends Component {
+  @service session;
+  @service fileSaver;
+
+  @action
+  async downloadTemplate() {
+    try {
+      const url = ENV.APP.API_HOST + this.args.url;
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url, token });
+    } catch (error) {
+      this.pixToast.sendErrorNotification({ message: error.message });
+    }
+  }
+
+  <template>
+    <div class="csv-import" ...attributes>
+      {{yield}}
+      <PixButton @triggerAction={{this.downloadTemplate}} @variant="tertiary">
+        <PixIcon @name="download" @plainIcon={{true}} @ariaHidden={{true}} />
+        {{t "common.actions.download-template"}}
+      </PixButton>
+    </div>
+  </template>
+}

--- a/admin/app/styles/components/administration/common.scss
+++ b/admin/app/styles/components/administration/common.scss
@@ -1,3 +1,8 @@
 p.description {
   margin-bottom: var(--pix-spacing-8x);
 }
+
+.csv-import {
+  display: flex;
+  gap: var(--pix-spacing-4x);
+}

--- a/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
@@ -1,7 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import Service from '@ember/service';
-import { click, triggerEvent } from '@ember/test-helpers';
+import { triggerEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import AddOrganizationFeaturesInBatch from 'pix-admin/components/administration/common/add-organization-features-in-batch';
 import ENV from 'pix-admin/config/environment';
@@ -17,41 +17,19 @@ const file = new Blob([fileContent], { type: `valid-file` });
 module('Integration | Component |  administration/add-organization-features-in-batch', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let fetchStub, fileSaverStub;
+  let fetchStub;
 
   hooks.beforeEach(function () {
     class SessionService extends Service {
       data = { authenticated: { access_token: accessToken } };
     }
-    class FileSaver extends Service {
-      save = fileSaverStub;
-    }
     this.owner.register('service:session', SessionService);
-    this.owner.register('service:file-saver', FileSaver);
 
     fetchStub = sinon.stub(window, 'fetch');
-    fileSaverStub = sinon.stub();
   });
 
   hooks.afterEach(function () {
     window.fetch.restore();
-  });
-
-  module('when user download template', function () {
-    test('it calls fileSaver', async function (assert) {
-      // when
-      const screen = await render(<template><AddOrganizationFeaturesInBatch /><PixToastContainer /></template>);
-
-      const button = await screen.getByRole('button', { name: t('common.actions.download-template'), exact: false });
-      await click(button);
-
-      // then
-      sinon.assert.calledWithExactly(fileSaverStub, {
-        url: `${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features/template`,
-        token: accessToken,
-      });
-      assert.ok(true);
-    });
   });
 
   module('when import succeeds', function (hooks) {

--- a/admin/tests/integration/components/administration/download-template_test.gjs
+++ b/admin/tests/integration/components/administration/download-template_test.gjs
@@ -1,0 +1,59 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import DownloadTemplate from 'pix-admin/components/administration/download-template';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering.js';
+const accessToken = 'An access token';
+module('Integration | Component | download-template', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let fileSaverStub;
+
+  hooks.beforeEach(function () {
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    class FileSaver extends Service {
+      save = fileSaverStub;
+    }
+    this.owner.register('service:session', SessionService);
+    this.owner.register('service:file-saver', FileSaver);
+
+    fileSaverStub = sinon.stub();
+  });
+
+  test('should render yielded part', async function (assert) {
+    // when
+    const screen = await render(
+      <template>
+        <DownloadTemplate><span>Hello</span></DownloadTemplate>
+      </template>,
+    );
+
+    assert.ok(screen.getByText('Hello'));
+  });
+
+  module('when user download template', function () {
+    test('it calls fileSaver', async function (assert) {
+      // when
+      const screen = await render(
+        <template><DownloadTemplate @url="/api/admin/organizations/add-organization-features/template" /></template>,
+      );
+
+      const button = await screen.getByRole('button', { name: t('common.actions.download-template'), exact: false });
+      await click(button);
+
+      // then
+      sinon.assert.calledWithExactly(fileSaverStub, {
+        url: `${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features/template`,
+        token: accessToken,
+      });
+      assert.ok(true);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -5,6 +5,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "deactivate": "Deactivate",
+      "download-template": "Download template",
       "edit": "Edit",
       "save": "Save",
       "validate": "Validate"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -5,6 +5,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "deactivate": "Désactiver",
+      "download-template": "Télécharger le template",
       "edit": "Modifier",
       "save": "Enregistrer",
       "validate": "Valider"

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -1,5 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { ORGANIZATION_FEATURES_HEADER } from '../../domain/constants.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationTagCsvParser } from '../../infrastructure/parsers/csv/organization-tag-csv.parser.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
@@ -25,6 +27,17 @@ const attachChildOrganization = async function (request, h) {
   await usecases.attachChildOrganizationToOrganization({ childOrganizationIds, parentOrganizationId });
 
   return h.response().code(204);
+};
+
+const getTemplateForAddOrganizationFeatureInBatch = async function (request, h) {
+  const fields = ORGANIZATION_FEATURES_HEADER.columns.map(({ name }) => name);
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=add-organization-feature-in-batch')
+    .code(200);
 };
 
 const addOrganizationFeatureInBatch = async function (request, h) {
@@ -82,6 +95,7 @@ const organizationAdminController = {
   create,
   archiveOrganization,
   attachChildOrganization,
+  getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,
   getOrganizationDetails,
   updateOrganizationsInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -181,6 +181,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/organizations/add-organization-features/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationAdminController.getTemplateForAddOrganizationFeatureInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'organization-features'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger de template du csv pour activer une fonctionnalité à des organisations',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/organizations/add-organization-features',
       config: {

--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -1,0 +1,26 @@
+import { CsvColumn } from '../../../src/shared/infrastructure/serializers/csv/csv-column.js';
+
+export const ORGANIZATION_FEATURES_HEADER = {
+  columns: [
+    new CsvColumn({
+      property: 'featureId',
+      name: 'Feature ID',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'organizationId',
+      name: 'Organization ID',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'params',
+      name: 'Params',
+      isRequired: false,
+    }),
+    new CsvColumn({
+      property: 'deleteLearner',
+      name: 'Delete Learner',
+      isRequired: false,
+    }),
+  ],
+};

--- a/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js
+++ b/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js
@@ -4,37 +4,12 @@
 
 import { createReadStream } from 'node:fs';
 
-import { CsvColumn } from '../../../../src/shared/infrastructure/serializers/csv/csv-column.js';
 import { getDataBuffer } from '../../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
+import { ORGANIZATION_FEATURES_HEADER } from '../constants.js';
 import { FeatureParamsNotProcessable } from '../errors.js';
 import { OrganizationFeature } from '../models/OrganizationFeature.js';
-
-const organizationFeatureCsvHeader = {
-  columns: [
-    new CsvColumn({
-      property: 'featureId',
-      name: 'Feature ID',
-      isRequired: true,
-    }),
-    new CsvColumn({
-      property: 'organizationId',
-      name: 'Organization ID',
-      isRequired: true,
-    }),
-    new CsvColumn({
-      property: 'params',
-      name: 'Params',
-      isRequired: false,
-    }),
-    new CsvColumn({
-      property: 'deleteLearner',
-      name: 'Delete Learner',
-      isRequired: false,
-    }),
-  ],
-};
 
 export const addOrganizationFeatureInBatch = withTransaction(
   /**
@@ -49,7 +24,7 @@ export const addOrganizationFeatureInBatch = withTransaction(
     const stream = createReadStream(filePath);
     const buffer = await getDataBuffer(stream);
 
-    const csvParser = new CsvParser(buffer, organizationFeatureCsvHeader);
+    const csvParser = new CsvParser(buffer, ORGANIZATION_FEATURES_HEADER);
     const csvData = csvParser.parse();
     const data = csvData.map(({ featureId, organizationId, params, deleteLearner }) => {
       try {

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -99,6 +99,25 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/campaigns/template',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        handler: campaignAdministrationController.getTemplateForCreateCampaigns,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant pour rôle SUPER_ADMIN**\n' +
+            '- Elle permet de télécharger le template pour créer des campagnes à partir d‘un fichier au format CSV\n' +
+            '- Elle ne retourne aucune valeur',
+        ],
+        tags: ['api', 'admin', 'campaigns'],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/campaigns',
       config: {

--- a/api/src/prescription/campaign/application/campaign-adminstration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-adminstration-controller.js
@@ -4,11 +4,23 @@ import { usecases } from '../../../../src/prescription/campaign/domain/usecases/
 import * as checkAdminMemberHasRoleSuperAdminUseCase from '../../../shared/application/usecases/checkAdminMemberHasRoleSuperAdmin.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
+import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as csvCampaignsIdsParser from '../infrastructure/serializers/csv/csv-campaigns-ids-parser.js';
 import * as campaignManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
 import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
+
+const getTemplateForCreateCampaigns = (request, h) => {
+  const fields = csvSerializer.requiredFieldNamesForCampaignsImport;
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=create-campaigns')
+    .code(200);
+};
 
 const createCampaigns = async function (request, h, dependencies = { csvSerializer }) {
   const campaignsToCreate = await dependencies.csvSerializer.deserializeForCampaignsImport(request.payload.path);
@@ -157,6 +169,7 @@ const campaignAdministrationController = {
   archiveCampaigns,
   unarchiveCampaign,
   deleteCampaigns,
+  getTemplateForCreateCampaigns,
 };
 
 export { campaignAdministrationController };

--- a/api/src/quest/application/index.js
+++ b/api/src/quest/application/index.js
@@ -35,6 +35,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/quests/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => questController.getTemplateForCreateOrUpdateQuestsInBatch(request, h),
+        tags: ['api', 'admin', 'quests'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger le template pour créer ou mettre à jour des quêtes',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/quests',
       config: {

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -1,4 +1,6 @@
+import { generateCSVTemplate } from '../../shared/infrastructure/serializers/csv/csv-template.js';
 import * as requestResponseUtils from '../../shared/infrastructure/utils/request-response-utils.js';
+import { QUEST_HEADER } from '../domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as questResultSerializer from '../infrastructure/serializers/quest-result-serializer.js';
 
@@ -13,6 +15,17 @@ const getQuestResults = async function (request, h, dependencies = { questResult
   return h.response(serializedQuestResults);
 };
 
+const getTemplateForCreateOrUpdateQuestsInBatch = async function (request, h) {
+  const fields = QUEST_HEADER.columns.map(({ name }) => name);
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=create-or-update-quests-in-batch')
+    .code(200);
+};
+
 const createOrUpdateQuestsInBatch = async function (request, h) {
   await usecases.createOrUpdateQuestsInBatch({
     filePath: request.payload.path,
@@ -23,6 +36,7 @@ const createOrUpdateQuestsInBatch = async function (request, h) {
 const questController = {
   getQuestResults,
   createOrUpdateQuestsInBatch,
+  getTemplateForCreateOrUpdateQuestsInBatch,
 };
 
 export { questController };

--- a/api/src/quest/domain/constants.js
+++ b/api/src/quest/domain/constants.js
@@ -1,3 +1,23 @@
 import { ATTESTATIONS_TABLE_NAME } from '../../../db/migrations/20240820101115_add-attestations-table.js';
+import { CsvColumn } from '../../shared/infrastructure/serializers/csv/csv-column.js';
 
 export const REWARD_TYPES = { ATTESTATION: ATTESTATIONS_TABLE_NAME };
+export const QUEST_HEADER = {
+  columns: [
+    new CsvColumn({
+      property: 'questId',
+      name: 'Quest ID',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'content',
+      name: 'Json configuration for quest',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'deleteQuest',
+      name: 'Delete quest',
+      isRequired: false,
+    }),
+  ],
+};

--- a/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
+++ b/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
@@ -5,29 +5,9 @@ import { createReadStream } from 'node:fs';
 
 import { getDataBuffer } from '../../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { CsvColumn } from '../../../shared/infrastructure/serializers/csv/csv-column.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
+import { QUEST_HEADER } from '../constants.js';
 import { Quest } from '../models/Quest.js';
-
-const questCsvHeader = {
-  columns: [
-    new CsvColumn({
-      property: 'questId',
-      name: 'Quest ID',
-      isRequired: true,
-    }),
-    new CsvColumn({
-      property: 'content',
-      name: 'Json configuration for quest',
-      isRequired: true,
-    }),
-    new CsvColumn({
-      property: 'deleteQuest',
-      name: 'Delete quest',
-      isRequired: false,
-    }),
-  ],
-};
 
 export const createOrUpdateQuestsInBatch = withTransaction(
   /**
@@ -43,7 +23,7 @@ export const createOrUpdateQuestsInBatch = withTransaction(
     const stream = createReadStream(filePath);
     const buffer = await getDataBuffer(stream);
 
-    const csvParser = new CsvParser(buffer, questCsvHeader);
+    const csvParser = new CsvParser(buffer, QUEST_HEADER);
     const csvData = csvParser.parse();
 
     csvData.forEach(({ questId, content, deleteQuest }) => {

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -453,6 +453,7 @@ export {
   deserializeForOrganizationsImport,
   deserializeForSessionsImport,
   parseForCampaignsImport,
+  requiredFieldNamesForCampaignsImport,
   serializeLine,
   verifyColumnsValueAgainstConstraints,
 };

--- a/api/src/shared/infrastructure/serializers/csv/csv-template.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-template.js
@@ -1,0 +1,11 @@
+import { Parser } from '@json2csv/plainjs';
+
+export function generateCSVTemplate(fields) {
+  const json2csvParser = new Parser({
+    withBOM: true,
+    includeEmptyRows: false,
+    fields,
+    delimiter: ';',
+  });
+  return json2csvParser.parse([]);
+}

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -404,6 +404,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('GET /api/admin/organizations/add-organization-features/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        url: '/api/admin/organizations/add-organization-features/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/organizations/add-organization-features', function () {
     context('When a CSV file is loaded', function () {
       let feature, firstOrganization, otherOrganization;

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -6,6 +6,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -215,6 +216,25 @@ describe('Acceptance | API | campaign-administration-route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('GET /api/admin/campaigns/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const admin = await insertUserWithRoleSuperAdmin();
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        url: '/api/admin/campaigns/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -98,6 +98,25 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
     });
   });
 
+  describe('GET /api/admin/quests/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const admin = await insertUserWithRoleSuperAdmin();
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
+        url: '/api/admin/quests/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/quests', function () {
     it('responds with a 204 - no content', async function () {
       // given

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-template_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-template_test.js
@@ -1,0 +1,14 @@
+import { generateCSVTemplate } from '../../../../../../src/shared/infrastructure/serializers/csv/csv-template.js';
+import { expect } from '../../../../../test-helper.js';
+
+const BOM_CHAR = '\ufeff';
+
+describe('Unit | Serializer | CSV | csv-template', function () {
+  describe('#generateCSVTemplate', function () {
+    it('should return template with columns', function () {
+      const template = generateCSVTemplate(['Column1', 'Column2']);
+
+      expect(template).to.equal(`${BOM_CHAR}"Column1";"Column2"`);
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

C'est fastidieux d'aller lire dans le code les informations pour savoir quelles colonnes sont présentes dans les fichiers d'import CSV pour les pages d'administration dans PixAdmin.

## 🌳 Proposition

Ajoute un bouton à côté des imports pour télécharger le template associé.

## 🐝 Remarques

Ajout d'un composant DownloadTemplate pour permettre de wrapper un élément existant et lui ajouter un bouton pour télécharger un template.

## 🤧 Pour tester

- Se connecter à PixAdmin en tant que SuperAdmin
- Aller dans l'Administration
- Vérifier que le fichier de template dans "Commun" et "Campagnes" sont bons
