### PR TITLE
[TECH] Eviter de re-déclencher les calculs pour déterminer la prochaine épreuve dans assessments/:id/next si la dernière épreuve proposée n'a pas encore été répondue

### DIFF
--- a/api/src/shared/domain/models/Challenge.js
+++ b/api/src/shared/domain/models/Challenge.js
@@ -20,6 +20,12 @@ const Accessibility = Object.freeze({
   OK: 'OK',
 });
 
+const Statuses = Object.freeze({
+  VALIDATED: 'validé',
+  ARCHIVED: 'archivé',
+  OBSOLETE: 'périmé',
+});
+
 /**
  * Traduction: Épreuve
  */
@@ -163,6 +169,10 @@ class Challenge {
     return this._isCompliant('Tablet');
   }
 
+  get isOperative() {
+    return [Statuses.VALIDATED, Statuses.ARCHIVED].includes(this.status);
+  }
+
   get isAccessible() {
     return (
       (this.blindnessCompatibility === Accessibility.OK || this.blindnessCompatibility === Accessibility.RAS) &&
@@ -208,4 +218,4 @@ class Challenge {
 
 Challenge.Type = ChallengeType;
 
-export { Accessibility, Challenge, ChallengeType as Type };
+export { Accessibility, Challenge, Statuses, ChallengeType as Type };

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -23,7 +23,12 @@ export async function getNextChallenge({
     lastChallengeId: assessment.lastChallengeId,
   });
   if (!hasAnswered) {
-    return challengeRepository.get(assessment.lastChallengeId);
+    nextChallenge = await challengeRepository.get(assessment.lastChallengeId);
+    if (nextChallenge.isOperative) {
+      return nextChallenge;
+    } else {
+      nextChallenge = null;
+    }
   }
   if (assessment.isCertification()) {
     nextChallenge = await certificationEvaluationRepository.selectNextCertificationChallenge({

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -1,3 +1,5 @@
+import { AssessmentEndedError } from '../errors.js';
+
 export async function getNextChallenge({
   assessmentId,
   userId,
@@ -7,10 +9,10 @@ export async function getNextChallenge({
   certificationEvaluationRepository,
 }) {
   const assessment = await assessmentRepository.get(assessmentId);
-
-  if (assessment.isStarted()) {
-    await assessmentRepository.updateLastQuestionDate({ id: assessment.id, lastQuestionDate: new Date() });
+  if (!assessment.isStarted()) {
+    throw new AssessmentEndedError();
   }
+  await assessmentRepository.updateLastQuestionDate({ id: assessment.id, lastQuestionDate: new Date() });
 
   let nextChallenge = null;
   if (assessment.isCertification()) {

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -18,11 +18,11 @@ export async function getNextChallenge({
 
   let nextChallenge = null;
   const answers = await answerRepository.findByAssessment(assessment.id);
-  const hasAnswered = hasAnsweredLatestChallengeAsked({
+  const waitingForLatestChallengeAnswer = checkIfLatestChallengeOfAssessmentIsAwaitingToBeAnswered({
     answers,
     lastChallengeId: assessment.lastChallengeId,
   });
-  if (!hasAnswered) {
+  if (waitingForLatestChallengeAnswer) {
     nextChallenge = await challengeRepository.get(assessment.lastChallengeId);
     if (nextChallenge.isOperative) {
       return nextChallenge;
@@ -63,9 +63,9 @@ export async function getNextChallenge({
   return nextChallenge;
 }
 
-function hasAnsweredLatestChallengeAsked({ answers, lastChallengeId }) {
+function checkIfLatestChallengeOfAssessmentIsAwaitingToBeAnswered({ answers, lastChallengeId }) {
   if (!lastChallengeId) {
-    return true;
+    return false;
   }
-  return answers.some((answer) => answer.challengeId === lastChallengeId);
+  return !answers.some((answer) => answer.challengeId === lastChallengeId);
 }

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import * as complementaryCertificationBadgeRepository from '../../../certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as badgeRepository from '../../../evaluation/infrastructure/repositories/badge-repository.js';
+import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import { repositories as sharedInjectedRepositories } from '../../infrastructure/repositories/index.js';
@@ -17,6 +18,7 @@ const usecasesWithoutInjectedDependencies = {
 
 const dependencies = {
   assessmentRepository,
+  answerRepository,
   complementaryCertificationBadgeRepository,
   badgeRepository,
   challengeRepository,

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -4,7 +4,7 @@ import { ValidatorQCU } from '../../../../src/evaluation/domain/models/Validator
 import { ValidatorQROC } from '../../../../src/evaluation/domain/models/ValidatorQROC.js';
 import { ValidatorQROCMDep } from '../../../../src/evaluation/domain/models/ValidatorQROCMDep.js';
 import { ValidatorQROCMInd } from '../../../../src/evaluation/domain/models/ValidatorQROCMInd.js';
-import { Accessibility, Challenge } from '../../../../src/shared/domain/models/Challenge.js';
+import { Accessibility, Challenge, Statuses } from '../../../../src/shared/domain/models/Challenge.js';
 import { Skill } from '../../../../src/shared/domain/models/Skill.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
 
@@ -364,6 +364,41 @@ describe('Unit | Domain | Models | Challenge', function () {
           });
         },
       );
+    });
+  });
+
+  describe('#isOperative', function () {
+    it('should return true when challenge is validated', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({ status: Statuses.VALIDATED });
+
+      // when
+      const isOperative = challenge.isOperative;
+
+      // then
+      expect(isOperative).to.be.true;
+    });
+
+    it('should return true when challenge is archived', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({ status: Statuses.ARCHIVED });
+
+      // when
+      const isOperative = challenge.isOperative;
+
+      // then
+      expect(isOperative).to.be.true;
+    });
+
+    it('should return false when challenge is obsolete', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({ status: Statuses.OBSOLETE });
+
+      // when
+      const isOperative = challenge.isOperative;
+
+      // then
+      expect(isOperative).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème
la route **_api/assessments/:id/next_** (la fameuse GetNext) est une des routes les plus appelées.
Certains de ces appels ont lieu alors qu'il n'y a pas besoin de recalculer quelle sera la prochaine épreuve à poser, car la dernière posée n'a pas encore été répondue.
Les cas qui me viennent en tête, et qui sont fréquents :
- Cas de rechargement de page
- Cas de "j'arrête pour aujourd'hui je reprends demain"
- Le front aujourd'hui fait systématiquement **deux appels** à GetNext avant d'afficher l'épreuve (ce cas là est pas soluble en une aprem tech il faut un peu de temps pour se pencher sur le sujet)

## 🌳 Proposition
Il se trouve que, lorsqu'on fini de recalculer quelle sera la prochaine épreuve à poser, on enregistre l'id de la prochaine épreuve dans la table `assessments`, sous `lastChallengeId`.
On peut utiliser cet id pour déterminer si, en regardant les réponses apportées dans le cadre de l'assessment en cours, cette épreuve a déjà été répondue ou pas. A défaut de réponse, on sait qu'il n'y a pas besoin de redéclencher tout le GetNext (qui est par ailleurs déterministe et qui retournera de toute façon le même ID). Il suffit de retourner l'épreuve pointée par l'id dans `lastChallengeId`.

Cette PR contient :
- L'ajout d'une petite garde en début de GetNext pour ne pas déclencher les calculs GetNext si l'assessment n'est pas en cours.
- L'ajout de la vérification de si la dernière épreuve posée a déjà été répondue ou pas, auquel cas on retourne directement l'épreuve sans redéclencher tous les calculs

## 🐝 Remarques

-

## 🤧 Pour tester

Non régression de toutes les modalités d'assessment (sauf PixJunior).
Toujours deux appels API consécutifs mais normalement le deuxième appel ne devrait pas refaire tous les calculs.
Une manière de vérifier en local pourrait être de lancer son serveur en mode DEBUG=knex:* et de constater que sur le deuxième appel de GetNext on n'a pas remonté la terre entière dans la BDD
