### PR TITLE
[FEATURE] Remplacer "Résultat thématique" par "Badge" (PIX-17152)

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -72,7 +72,7 @@ export default class Badge extends Component {
         imageUrl: this.IMAGE_BASE_URL + this.form.imageName,
       };
       await this.args.onUpdateBadge(badgeDTO);
-      this.pixToast.sendSuccessNotification({ message: 'Le résultat thématique a été mis à jour.' });
+      this.pixToast.sendSuccessNotification({ message: 'Le badge a été mis à jour.' });
       this.editMode = false;
     } catch (err) {
       let errorMessage;
@@ -120,7 +120,7 @@ export default class Badge extends Component {
             @route="authenticated.target-profiles.target-profile.insights"
           >{{@targetProfile.internalName}}</LinkTo>
           <span class="wire">&nbsp;>&nbsp;</span>
-          <h1>Résultat thématique {{@badge.id}}</h1>
+          <h1>Badge {{@badge.id}}</h1>
         </p>
       </div>
     </header>
@@ -217,7 +217,7 @@ export default class Badge extends Component {
                 <dd class="page-details__value">{{@badge.id}}</dd>
                 <dt class="page-details__label">Clé&nbsp;:&nbsp;</dt>
                 <dd class="page-details__value">{{@badge.key}}</dd>
-                <dt class="page-details__label">Nom du résultat thématique&nbsp;:&nbsp;</dt>
+                <dt class="page-details__label">Nom du badge&nbsp;:&nbsp;</dt>
                 <dd class="page-details__value">{{@badge.title}}</dd>
                 <dt class="page-details__label">Image&nbsp;:&nbsp;</dt>
                 <dd class="page-details__value">{{this.imageName}}</dd>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.gjs
@@ -21,7 +21,7 @@ export default class Badges extends Component {
     if (this.isLoading || this.badges?.length > 0) {
       return undefined;
     }
-    return 'Seul un profil cible comportant au moins un résultat thématique certifiant peut être rattaché à une certification complémentaire. Le profil cible que vous avez sélectionné ne comporte pas de résultat thématique certifiant. Veuillez le modifier puis rafraîchir cette page ou bien sélectionner un autre profil cible.';
+    return 'Seul un profil cible comportant au moins un badge certifiant peut être rattaché à une certification complémentaire. Le profil cible que vous avez sélectionné ne comporte pas de badge certifiant. Veuillez le modifier puis rafraîchir cette page ou bien sélectionner un autre profil cible.';
   }
 
   @action
@@ -67,7 +67,7 @@ export default class Badges extends Component {
   }
 
   #onfetchBadgesError() {
-    this.args.onError('Une erreur est survenue lors de la recherche de résultats thématiques.');
+    this.args.onError('Une erreur est survenue lors de la recherche de badges.');
   }
 
   willDestroy() {

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
@@ -35,14 +35,14 @@ export default class List extends Component {
       {{/if}}
 
       <section class="complementary-certification-attach-badges__section">
-        <h1>Résultats thématiques certifiants</h1>
+        <h1>Badges certifiants</h1>
 
         <div class="complementary-certification-attach-badges-section__table">
           <p>
             {{t "common.forms.mandatory-fields" htmlSafe=true}}
           </p>
 
-          <PixTable @variant="admin" @data={{@options}} @caption="Liste des résultats thématiques">
+          <PixTable @variant="admin" @data={{@options}} @caption="Liste des badges">
             <:columns as |row option|>
               <PixTableColumn @context={{option}}>
                 <:header>
@@ -69,8 +69,8 @@ export default class List extends Component {
                   <ContentHeader>
                     <:default>Niveau</:default>
                     <:tooltip>
-                      Renseignez un chiffre unique pour chaque RT, niveau minimum = 1 niveau maximum = nombre total de
-                      RT.
+                      Renseignez un chiffre unique pour chaque badge, niveau minimum = 1 niveau maximum = nombre total
+                      de badge.
                     </:tooltip>
                   </ContentHeader>
                 </:header>
@@ -78,7 +78,7 @@ export default class List extends Component {
                   <PixInput
                     @id="{{row.id}}-level"
                     name="level"
-                    placeholder="Exemple de niveau de RT : 1"
+                    placeholder="Exemple de niveau de badge : 1"
                     required="true"
                     aria-required="true"
                     @screenReaderOnly={{true}}
@@ -141,7 +141,7 @@ export default class List extends Component {
                   <ContentHeader>
                     <:default>Label du certificat</:default>
                     <:tooltip>
-                      Renseignez un label qui permet de distinguer chaque RT (exemples : Pix+ Droit Expert, CléA
+                      Renseignez un label qui permet de distinguer chaque badge (exemples : Pix+ Droit Expert, CléA
                       Numérique, Pix+ Edu 2nd degré Confirmé etc…)
                     </:tooltip>
                   </ContentHeader>

--- a/admin/app/components/complementary-certifications/attach-badges/index.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/index.gjs
@@ -150,7 +150,7 @@ export default class AttachBadges extends Component {
         {{#if this.selectedTargetProfile}}
           <Card
             class="attach-target-profile__card attach-target-profile__card-badges"
-            @title="2. Complétez les informations des résultats thématiques"
+            @title="2. Complétez les informations des badges"
           >
             <Badges
               @targetProfile={{this.selectedTargetProfile}}

--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -56,7 +56,7 @@ export default class BadgeForm extends Component {
 
     if (!hasCampaignCriteria && !hasCappedTubesCriteria) {
       return this.pixToast.sendErrorNotification({
-        message: "Vous devez sélectionner au moins un critère d'obtention de résultat thématique",
+        message: "Vous devez sélectionner au moins un critère d'obtention de badge",
       });
     }
 
@@ -85,7 +85,7 @@ export default class BadgeForm extends Component {
       });
       await this.args.targetProfile.reload();
 
-      this.pixToast.sendSuccessNotification({ message: 'Le résultat thématique a été créé.' });
+      this.pixToast.sendSuccessNotification({ message: 'Le badge a été créé.' });
       this.router.transitionTo('authenticated.target-profiles.target-profile.insights');
       return badge;
     } catch (error) {
@@ -96,9 +96,9 @@ export default class BadgeForm extends Component {
 
   <template>
     <form class="admin-form admin-form--badge-form" {{on "submit" this.submitBadgeCreation}}>
-      <h2 class="badge-form__title">Création d'un résultat thématique</h2>
+      <h2 class="badge-form__title">Création d'un badge</h2>
       <section class="admin-form__content admin-form__content--with-counters">
-        <Card class="create-target-profile__card" @title="Remplir des informations sur le résultat thématique">
+        <Card class="create-target-profile__card" @title="Remplir des informations sur le badge">
           <div class="badge-form__text-field">
             <PixInput
               @id="title"
@@ -106,7 +106,7 @@ export default class BadgeForm extends Component {
               @requiredLabel={{t "common.forms.mandatory"}}
               {{on "change" (fn this.updateFormValue "title")}}
             >
-              <:label>Nom du résultat thématique :</:label>
+              <:label>Nom du badge :</:label>
             </PixInput>
           </div>
           <div class="badge-form__text-field">
@@ -117,7 +117,7 @@ export default class BadgeForm extends Component {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Voir la liste des résultats thématiques
+                Voir la liste des badges
               </a>
             </p>
             <PixInput
@@ -185,7 +185,7 @@ export default class BadgeForm extends Component {
           {{t "common.actions.cancel"}}
         </PixButtonLink>
         <PixButton @variant="success" @type="submit">
-          Enregistrer le RT
+          Enregistrer le badge
         </PixButton>
       </section>
     </form>

--- a/admin/app/components/target-profiles/badge-form/criteria.gjs
+++ b/admin/app/components/target-profiles/badge-form/criteria.gjs
@@ -66,13 +66,13 @@ export default class Criteria extends Component {
   }
 
   <template>
-    <Card @title="Critères d'obtention du résultat thématique">
+    <Card @title="Critères d'obtention du badge">
       <PixNotificationAlert @type="info" @withIcon={{true}}>
-        Vous pouvez définir des critères de réussite du résultat thématique
+        Vous pouvez définir des critères de réussite du badge
         <strong>sur une liste de sujets ET/OU sur l’ensemble du profil cible</strong>.
         <br />
         <strong>Toutes les conditions devront être remplies</strong>
-        pour obtenir le résultat thématique.
+        pour obtenir le badge.
       </PixNotificationAlert>
       <div class="badge-form-criteria-choice">
         <p>Définir un critère d'obtention&nbsp;:</p>

--- a/admin/app/components/target-profiles/badges.gjs
+++ b/admin/app/components/target-profiles/badges.gjs
@@ -38,7 +38,7 @@ export default class Badges extends Component {
     try {
       badge = this.store.peekRecord('badge', this.badgeIdToDelete);
       await badge.destroyRecord();
-      this.pixToast.sendSuccessNotification({ message: 'Le résultat thématique a été supprimé avec succès.' });
+      this.pixToast.sendSuccessNotification({ message: 'Le badge a été supprimé avec succès.' });
     } catch (error) {
       this.pixToast.sendErrorNotification({ message: error.errors[0].detail });
       badge.rollbackAttributes();
@@ -63,7 +63,7 @@ export default class Badges extends Component {
               <LinkTo
                 @route="authenticated.target-profiles.target-profile.badges.badge"
                 @model={{badge.id}}
-                aria-label="Voir le détail du résultat thématique ID {{badge.id}}"
+                aria-label="Voir le détail du badge ID {{badge.id}}"
               >
                 {{badge.id}}
               </LinkTo>
@@ -137,7 +137,7 @@ export default class Badges extends Component {
                   @route="authenticated.target-profiles.target-profile.badges.badge"
                   @size="small"
                   @model={{badge.id}}
-                  aria-label="Voir le détail du résultat thématique {{badge.title}}"
+                  aria-label="Voir le détail du badge {{badge.title}}"
                 >
                   Voir le détail
                 </PixButtonLink>
@@ -147,7 +147,7 @@ export default class Badges extends Component {
                   @triggerAction={{fn this.toggleDisplayConfirm badge.id}}
                   class="badges-table-actions-delete"
                   @iconBefore="delete"
-                  aria-label="Supprimer le résultat thématique {{badge.title}}"
+                  aria-label="Supprimer le badge {{badge.title}}"
                 >
                   Supprimer
                 </PixButton>
@@ -157,12 +157,12 @@ export default class Badges extends Component {
         </:columns>
       </PixTable>
     {{else}}
-      <div class="table__empty">Aucun résultat thématique associé</div>
+      <div class="table__empty">Aucun badge associé</div>
     {{/if}}
 
     <ConfirmPopup
-      @message="Êtes-vous sûr de vouloir supprimer ce résultat thématique ? (Uniquement si le RT n'a pas encore été assigné)"
-      @title="Suppression d'un résultat thématique"
+      @message="Êtes-vous sûr de vouloir supprimer ce badge ? (Uniquement si le badge n'a pas encore été assigné)"
+      @title="Suppression d'un badge"
       @submitTitle="Confirmer"
       @confirm={{fn this.deleteBadge this.badgeIdToDelete}}
       @cancel={{this.toggleDisplayConfirm}}

--- a/admin/app/components/target-profiles/insights.gjs
+++ b/admin/app/components/target-profiles/insights.gjs
@@ -7,7 +7,7 @@ import Stages from './stages';
 <template>
   <section class="page-section insights">
     <section class="insights__section">
-      <h2 class="insights-section__title">Résultats thématiques</h2>
+      <h2 class="insights-section__title">Badges</h2>
       <Badges @badges={{@targetProfile.badges}} />
       <div class="insights-section__button">
         <PixButtonLink
@@ -16,7 +16,7 @@ import Stages from './stages';
           @model={{@targetProfile.id}}
           @iconBefore="add"
         >
-          Nouveau résultat thématique
+          Nouveau badge
         </PixButtonLink>
       </div>
     </section>

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile-test.js
@@ -237,7 +237,7 @@ module(
             await targetProfileSelectable.click();
 
             await waitForTableResult();
-            const table = screen.getByRole('table', { name: 'Liste des résultats thématiques' });
+            const table = screen.getByRole('table', { name: 'Liste des badges' });
 
             await fillIn(within(table).getByRole('spinbutton', { name: '200 Badge Arène Feu Niveau' }), '1');
             await fillIn(
@@ -313,7 +313,7 @@ module(
             await targetProfileSelectable.click();
 
             await waitForTableResult();
-            const table = screen.getByRole('table', { name: 'Liste des résultats thématiques' });
+            const table = screen.getByRole('table', { name: 'Liste des badges' });
 
             const ariaLabel = '200 Badge Arène Feu';
             await fillIn(

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
@@ -445,7 +445,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Voir le détail du résultat thématique tagada');
+        await clickByName('Voir le détail du badge tagada');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/100');
@@ -493,7 +493,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Voir le détail du résultat thématique ancien titre');
+        await clickByName('Voir le détail du badge ancien titre');
         await clickByName('Modifier les informations');
         await fillIn(screen.getByLabelText('Titre *', { exact: false }), 'nouveau titre');
         await fillIn(screen.getByLabelText('Clé *', { exact: false }), 'NEW_KEY');
@@ -525,7 +525,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Voir le détail du résultat thématique tagada');
+        await clickByName('Voir le détail du badge tagada');
         await clickByName('Modifier les informations');
         await fillIn(screen.getByLabelText('Titre *', { exact: false }), 'tsouintsouin');
         await clickByName('Annuler');
@@ -586,11 +586,11 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Nouveau résultat thématique');
-        await fillByLabel(/Nom du résultat thématique :/, 'Mon nouveau RT');
+        await clickByName('Nouveau badge');
+        await fillByLabel(/Nom du badge :/, 'Mon nouveau badge');
         await fillIn(screen.getByLabelText("Nom de l'image (svg) *", { exact: false }), 'troll.png');
         await fillByLabel(/Texte alternatif pour l'image :/, 'Je mets du png je fais ce que je veux');
-        await fillByLabel('Message :', 'message de mon RT');
+        await fillByLabel('Message :', 'message de mon badge');
         await fillByLabel(/Clé/, 'MY_BADGE');
         await clickByName('Certifiable');
         await clickByName('Lacunes');
@@ -636,16 +636,16 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         await click(screen.getByRole('option', { name: '3' }));
         await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
-        await clickByName('Enregistrer le RT');
-        await clickByName('Voir le détail du résultat thématique Mon nouveau RT');
+        await clickByName('Enregistrer le badge');
+        await clickByName('Voir le détail du badge Mon nouveau badge');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/1');
         assert.dom(screen.getByText('1')).exists();
-        assert.dom(screen.getByText('Mon nouveau RT')).exists();
+        assert.dom(screen.getByText('Mon nouveau badge')).exists();
         assert.dom(screen.getByText('troll.png')).exists();
         assert.dom(screen.getByText('MY_BADGE')).exists();
-        assert.dom(screen.getByText('message de mon RT')).exists();
+        assert.dom(screen.getByText('message de mon badge')).exists();
         assert.dom(screen.getByText('Je mets du png je fais ce que je veux')).exists();
         assert.dom(screen.getByText('Certifiable')).exists();
         assert.dom(screen.getByText('Lacunes')).exists();
@@ -672,7 +672,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
-        await clickByName('Nouveau résultat thématique');
+        await clickByName('Nouveau badge');
         await clickByName('Annuler');
 
         // then

--- a/admin/tests/integration/components/badges/campaign-criterion-test.gjs
+++ b/admin/tests/integration/components/badges/campaign-criterion-test.gjs
@@ -154,7 +154,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
         criterion.save.throws({
           errors: [
             {
-              detail: "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
+              detail: "Il est interdit de modifier un critère d'un badge déjà acquis par un utilisateur.",
             },
           ],
         });
@@ -164,7 +164,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
 
         // then
         sinon.assert.calledWith(notificationErrorStub, {
-          message: "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
+          message: "Il est interdit de modifier un critère d'un badge déjà acquis par un utilisateur.",
         });
         assert.ok(true);
       });

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/index-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/index-test.gjs
@@ -57,7 +57,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
           .dom(
             screen.getByRole('alert', {
               value:
-                'Seul un profil cible comportant au moins un résultat thématique certifiant peut être rattaché à une certification complémentaire. Le profil cible que vous avez sélectionné ne comporte pas de résultat thématique certifiant. Veuillez le modifier puis rafraîchir cette page ou bien sélectionner un autre profil cible.',
+                'Seul un profil cible comportant au moins un badge certifiant peut être rattaché à une certification complémentaire. Le profil cible que vous avez sélectionné ne comporte pas de badge certifiant. Veuillez le modifier puis rafraîchir cette page ou bien sélectionner un autre profil cible.',
             }),
           )
           .exists();
@@ -92,7 +92,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
 
         // then
         assert.dom(await screen.queryByRole('alert')).doesNotExist();
-        const table = screen.getByRole('table', { name: 'Liste des résultats thématiques' });
+        const table = screen.getByRole('table', { name: 'Liste des badges' });
         assert.dom(within(table).getByRole('cell', { name: '1000' })).exists();
         assert.dom(within(table).getByRole('cell', { name: 'canards' })).exists();
       });

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/list-test.gjs
@@ -31,7 +31,7 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       const screen = await render(<template><List /></template>);
 
       // then
-      assert.dom(screen.getByRole('table', { name: 'Liste des résultats thématiques' })).exists();
+      assert.dom(screen.getByRole('table', { name: 'Liste des badges' })).exists();
       const rows = screen.getAllByRole('row');
       assert.strictEqual(rows.length, 1);
     });

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list-test.gjs
@@ -36,7 +36,7 @@ module('Integration | Component | complementary-certifications/target-profiles/b
     assert.dom(within(table).getByRole('columnheader', { name: 'Image du badge certifié' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Niveau du badge certifié' })).exists();
-    assert.dom(within(table).getByRole('columnheader', { name: 'ID du RT certifiant' })).exists();
+    assert.dom(within(table).getByRole('columnheader', { name: 'ID du badge certifiant' })).exists();
     assert.dom(within(table).getByRole('row', { name: 'Badge Cascade Badge Cascade 3 1023' })).exists();
     assert.dom(within(table).getByRole('row', { name: 'Badge Volcan Badge Volcan 1 1025' })).exists();
   });

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights-test.gjs
@@ -23,8 +23,8 @@ module('Integration | Component | routes/authenticated/target-profiles/target-pr
       );
 
       // then
-      assert.dom(screen.getByText('Résultats thématiques')).exists();
-      assert.dom(screen.getByText('Aucun résultat thématique associé')).exists();
+      assert.dom(screen.getByText('Badges')).exists();
+      assert.dom(screen.getByText('Aucun badge associé')).exists();
     });
 
     test('it should display the stages title and an empty list', async function (assert) {

--- a/admin/tests/integration/components/target-profiles/badge-form-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badge-form-test.gjs
@@ -45,7 +45,7 @@ module('Integration | Component | BadgeForm', function (hooks) {
     const screen = await render(<template><BadgeForm /></template>);
 
     // then
-    assert.dom(screen.getByRole('heading', { name: "Création d'un résultat thématique" })).exists();
+    assert.dom(screen.getByRole('heading', { name: "Création d'un badge" })).exists();
   });
 
   test('it should display new creation form', async function (assert) {
@@ -68,16 +68,16 @@ module('Integration | Component | BadgeForm', function (hooks) {
     // when
     const screen = await render(<template><BadgeForm @targetProfile={{targetProfile}} /></template>);
 
-    await fillIn(screen.getByLabelText(/Nom du résultat thématique/), 'dummy');
+    await fillIn(screen.getByLabelText(/Nom du badge/), 'dummy');
     await fillIn(screen.getByLabelText(/Nom de l'image/), 'dummy');
     await fillIn(screen.getByLabelText(/Texte alternatif pour l'image/), 'dummy');
     await fillIn(screen.getByLabelText(/Clé/), 'dummy');
 
-    await click(screen.getByRole('button', { name: 'Enregistrer le RT' }));
+    await click(screen.getByRole('button', { name: 'Enregistrer le badge' }));
 
     // then
     sinon.assert.calledWith(notificationErrorStub, {
-      message: "Vous devez sélectionner au moins un critère d'obtention de résultat thématique",
+      message: "Vous devez sélectionner au moins un critère d'obtention de badge",
     });
     assert.ok(true);
   });
@@ -165,14 +165,14 @@ module('Integration | Component | BadgeForm', function (hooks) {
       // when
       const screen = await render(<template><BadgeForm @targetProfile={{targetProfile}} /></template>);
 
-      await fillIn(screen.getByLabelText(/Nom du résultat thématique/), 'dummy');
+      await fillIn(screen.getByLabelText(/Nom du badge/), 'dummy');
       await fillIn(screen.getByLabelText(/Nom de l'image/), 'dummy');
       await fillIn(screen.getByLabelText(/Texte alternatif pour l'image/), 'dummy');
       await fillIn(screen.getByLabelText(/Clé/), 'dummy');
 
       await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
       await fillIn(screen.getByLabelText(/Taux de réussite requis/), 20);
-      await click(screen.getByRole('button', { name: 'Enregistrer le RT' }));
+      await click(screen.getByRole('button', { name: 'Enregistrer le badge' }));
 
       // then
       sinon.assert.calledWith(notificationErrorStub, {

--- a/admin/tests/integration/components/target-profiles/badges-test.gjs
+++ b/admin/tests/integration/components/target-profiles/badges-test.gjs
@@ -19,7 +19,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
 
       // then
       assert.dom('table').doesNotExist();
-      assert.dom(screen.getByText('Aucun résultat thématique associé')).exists();
+      assert.dom(screen.getByText('Aucun badge associé')).exists();
     });
   });
 
@@ -41,7 +41,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       const screen = await render(<template><Badges @badges={{badges}} /></template>);
 
       // then
-      assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+      assert.dom(screen.queryByText('Aucun badge associé')).doesNotExist();
       const table = screen.getByRole('table', { name: t('components.target-profiles.badges.table.caption') });
       assert.dom(within(table).getByRole('columnheader', { name: 'ID' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Image' })).exists();
@@ -51,7 +51,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       assert.dom(within(table).getByRole('columnheader', { name: 'Paramètres' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Actions' })).exists();
 
-      assert.dom(within(table).getByRole('cell', { name: 'Voir le détail du résultat thématique ID 1' })).exists();
+      assert.dom(within(table).getByRole('cell', { name: 'Voir le détail du badge ID 1' })).exists();
 
       assert.dom(within(table).getByRole('img', { name: 'My alt message' })).exists();
       assert.dom(screen.getAllByRole('cell')[1].children[0]).hasAttribute('src', 'data:,');
@@ -59,7 +59,7 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       assert.dom(within(table).getByRole('cell', { name: 'My title' })).exists();
       assert.dom(within(table).getByRole('cell', { name: 'My message' })).exists();
       assert.dom(within(table).getByRole('cell', { name: 'Pas en lacune Pas certifiable' })).exists();
-      assert.dom(within(table).getByRole('button', { name: 'Supprimer le résultat thématique My title' })).exists();
+      assert.dom(within(table).getByRole('button', { name: 'Supprimer le badge My title' })).exists();
     });
 
     module('when the badge is always visible', function () {
@@ -156,11 +156,11 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
       await screen.findByRole('dialog');
 
       // then
-      assert.dom(screen.getByRole('heading', { name: "Suppression d'un résultat thématique" })).exists();
+      assert.dom(screen.getByRole('heading', { name: "Suppression d'un badge" })).exists();
       assert
         .dom(
           screen.getByText(
-            "Êtes-vous sûr de vouloir supprimer ce résultat thématique ? (Uniquement si le RT n'a pas encore été assigné)",
+            "Êtes-vous sûr de vouloir supprimer ce badge ? (Uniquement si le badge n'a pas encore été assigné)",
           ),
         )
         .exists();

--- a/admin/tests/integration/components/target-profiles/copy-modal-test.gjs
+++ b/admin/tests/integration/components/target-profiles/copy-modal-test.gjs
@@ -24,9 +24,7 @@ module('Integration | Component | Target Profiles | Modal | Copy', function (hoo
     // then
     assert.dom(screen.getByText('Dupliquer le profil cible ?')).exists();
     assert
-      .dom(
-        screen.getByText('Cette action dupliquera le profil cible avec ses sujets, résultats thématiques et paliers.'),
-      )
+      .dom(screen.getByText('Cette action dupliquera le profil cible avec ses sujets, badges et paliers.'))
       .exists();
     assert.dom(screen.getByRole('button', { name: 'Valider' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();

--- a/admin/tests/integration/components/target-profiles/stages-test.gjs
+++ b/admin/tests/integration/components/target-profiles/stages-test.gjs
@@ -246,7 +246,7 @@ module('Integration | Component | Stages', function (hooks) {
       assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
       assert.dom(screen.getByText('Voir détail')).exists();
       assert.dom(screen.getByRole('button', { name: /Supprimer/ })).exists();
-      assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+      assert.dom(screen.queryByText('Aucun badge associé')).doesNotExist();
     });
   });
 
@@ -288,7 +288,7 @@ module('Integration | Component | Stages', function (hooks) {
       assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
       assert.dom(screen.getByText('Voir détail')).exists();
       assert.dom(screen.getByRole('button', { name: /Supprimer/ })).exists();
-      assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
+      assert.dom(screen.queryByText('Aucun badge associé')).doesNotExist();
     });
   });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -342,9 +342,9 @@
       },
       "target-profiles": {
         "badges-list": {
-          "caption": "Liste des résultats thématiques (RT) certifiant liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
+          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
           "header": {
-            "id": "ID du RT certifiant",
+            "id": "ID du badge certifiant",
             "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
             "minimum-earned-pix": "Nombre de pix minimum",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -288,7 +288,7 @@
         "key-already-exists": "La clé de badge {badgeKey} est déjà utilisée"
       },
       "tooltips": {
-        "parameters": "<u>En lacune</u><br/>Si le RT est en lacune et que l'apprenant n'a pas rempli les conditions d'obtention de ce RT, alors on ne verra le RT sur l'écran de résultats.<br/><br/><u>Certifiable</u><br/>Le RT devient un pré-requis pour une certification."
+        "parameters": "<u>En lacune</u><br/>Si le badge est en lacune et que l'apprenant n'a pas rempli les conditions d'obtention de ce badge, alors on ne verra le badge sur l'écran de résultats.<br/><br/><u>Certifiable</u><br/>Le badge devient un pré-requis pour une certification."
       }
     },
     "campaign": {
@@ -342,9 +342,9 @@
       },
       "target-profiles": {
         "badges-list": {
-          "caption": "Liste des résultats thématiques (RT) certifiant liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
+          "caption": "Liste des badges certifiants liés au profil cible, comprenant l'identifiant unique, l'image associée, le niveau, le nombre de pix minimum pour l'obtenir et le nom du badge.",
           "header": {
-            "id": "ID du RT certifiant",
+            "id": "ID du badge certifiant",
             "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
             "minimum-earned-pix": "Nombre de pix minimum",
@@ -966,7 +966,7 @@
           "label": "Dupliquer ce profil cible"
         },
         "modal": {
-          "label": "Cette action dupliquera le profil cible avec ses sujets, résultats thématiques et paliers.",
+          "label": "Cette action dupliquera le profil cible avec ses sujets, badges et paliers.",
           "title": "Dupliquer le profil cible ?"
         },
         "notifications": {

--- a/api/src/certification/complementary-certification/application/attach-target-profile-route.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-route.js
@@ -69,7 +69,7 @@ const register = async function (server) {
         tags: ['api', 'complementary-certification', 'badges'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Elle permet de rattacher des résultats thématiques certifiants à une certification complémentaire',
+            '- Elle permet de rattacher des badges certifiants à une certification complémentaire',
         ],
       },
     },

--- a/api/src/evaluation/application/badge-criteria/index.js
+++ b/api/src/evaluation/application/badge-criteria/index.js
@@ -58,7 +58,7 @@ const register = async function (server) {
         tags: ['api', 'admin', 'bagde-criteria'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            "- Elle permet de modifier un critère d'acquisition d'un résultat thématique",
+            "- Elle permet de modifier un critère d'acquisition d'un badge",
         ],
       },
     },

--- a/api/src/evaluation/application/badges/index.js
+++ b/api/src/evaluation/application/badges/index.js
@@ -45,7 +45,7 @@ const register = async function (server) {
         tags: ['api', 'admin', 'badges'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de modifier un résultat thématique.',
+            '- Elle permet de modifier un badge.',
         ],
       },
     },
@@ -73,7 +73,7 @@ const register = async function (server) {
         tags: ['api', 'admin', 'badges'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de supprimer un résultat thématique non assigné.',
+            '- Elle permet de supprimer un badge non assigné.',
         ],
       },
     },
@@ -128,7 +128,7 @@ const register = async function (server) {
         tags: ['api', 'admin', 'badges'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de créer un résultat thématique rattaché au profil cible.',
+            '- Elle permet de créer un badge rattaché au profil cible.',
         ],
       },
     },

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -32,9 +32,7 @@ class CompetenceResetError extends DomainError {
 }
 
 class AcquiredBadgeForbiddenUpdateError extends DomainError {
-  constructor(
-    message = "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
-  ) {
+  constructor(message = "Il est interdit de modifier un critère d'un badge déjà acquis par un utilisateur.") {
     super(message);
   }
 }

--- a/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
@@ -36,7 +36,7 @@ const updateCriterion = async function (id, attributesToUpdate) {
   const [updatedCriterion] = await knex(TABLE_NAME).update(attributesToUpdate).where({ id }).returning('*');
 
   if (!updatedCriterion) {
-    throw new NotFoundError('Erreur, critère de résultat thématique introuvable');
+    throw new NotFoundError('Erreur, critère de badge introuvable');
   }
 
   return new BadgeCriterion(updatedCriterion);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -213,7 +213,7 @@ class CandidateNotAuthorizedToResumeCertificationTestError extends DomainError {
 }
 
 class CertificationBadgeForbiddenDeletionError extends DomainError {
-  constructor(message = 'Il est interdit de supprimer un résultat thématique lié à une certification.') {
+  constructor(message = 'Il est interdit de supprimer un badge lié à une certification.') {
     super(message);
   }
 }
@@ -457,7 +457,7 @@ class MissingAssessmentId extends DomainError {
 }
 
 class MissingBadgeCriterionError extends DomainError {
-  constructor(message = 'Vous devez définir au moins un critère pour créer ce résultat thématique.') {
+  constructor(message = 'Vous devez définir au moins un critère pour créer ce badge.') {
     super(message);
   }
 }
@@ -995,7 +995,7 @@ class OrganizationLearnerCannotBeDissociatedError extends DomainError {
 }
 
 class AcquiredBadgeForbiddenDeletionError extends DomainError {
-  constructor(message = 'Il est interdit de supprimer un résultat thématique déjà acquis par un utilisateur.') {
+  constructor(message = 'Il est interdit de supprimer un badge déjà acquis par un utilisateur.') {
     super(message);
   }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1854,7 +1854,7 @@
         "not-acquired-full": "Badge not awarded",
         "progress-bar-label": "Badge result percentage"
       },
-      "badges-title": "Your thematic results",
+      "badges-title": "Your badges",
       "details": {
         "caption": "Details of your results in percentage according to competences",
         "header-result": "Results",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1848,13 +1848,13 @@
       "already-shared": "¡Gracias, tus resultados se han enviado correctamente!",
       "badge-card": {
         "acquired": "Aprobado",
-        "acquired-full": "Resultado temático obtenido",
+        "acquired-full": "Insignia obtenida",
         "certifiable": "Certificación",
         "not-acquired": "No has aprobado",
-        "not-acquired-full": "Resultado temático no obtenido",
-        "progress-bar-label": "Porcentaje de éxito del resultado temático"
+        "not-acquired-full": "Insignia no obtenida",
+        "progress-bar-label": "Porcentaje de éxito de la insignia"
       },
-      "badges-title": "Tus resultados temáticos",
+      "badges-title": "Tus insignias",
       "details": {
         "caption": "Detalle de tus resultados en términos porcentuales según las competencias",
         "header-result": "Resultados",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1848,13 +1848,13 @@
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
       "badge-card": {
         "acquired": "Obtenu",
-        "acquired-full": "Résultat thématique obtenu",
+        "acquired-full": "Badge obtenu",
         "certifiable": "Certifiant",
         "not-acquired": "Non obtenu",
-        "not-acquired-full": "Résultat thématique non obtenu",
-        "progress-bar-label": "Pourcentage de réussite du résultat thématique"
+        "not-acquired-full": "Badge non obtenu",
+        "progress-bar-label": "Pourcentage de réussite du badge"
       },
-      "badges-title": "Vos résultats thématiques",
+      "badges-title": "Vos badges",
       "details": {
         "caption": "Détails de vos résultats sous forme de pourcentage en fonction des compétences",
         "header-result": "Résultats",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1848,13 +1848,13 @@
       "already-shared": "Bedankt, je resultaten zijn verzonden!",
       "badge-card": {
         "acquired": "Verkregen",
-        "acquired-full": "Thematisch resultaat",
+        "acquired-full": "Badge verkregen",
         "certifiable": "Certificeren",
         "not-acquired": "Niet verkregen",
-        "not-acquired-full": "Thematisch resultaat niet verkregen",
-        "progress-bar-label": "Percentage succesvolle resultaten"
+        "not-acquired-full": "Badge niet verkregen",
+        "progress-bar-label": "Percentage succesvolle badge"
       },
-      "badges-title": "Je thematische resultaten",
+      "badges-title": "Je badges",
       "details": {
         "caption": "Details van je resultaten in percentages volgens vaardigheden",
         "header-result": "Resultaten",

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -157,7 +157,7 @@ export default class ParticipationFilters extends Component {
       event: 'custom-event',
       'pix-event-category': 'Campagnes',
       'pix-event-action': 'Filtrer les participations',
-      'pix-event-name': 'Usage du filtre par Résultats Thématiques',
+      'pix-event-name': 'Usage du filtre par Badges',
     });
   }
 
@@ -169,7 +169,7 @@ export default class ParticipationFilters extends Component {
       event: 'custom-event',
       'pix-event-category': 'Campagnes',
       'pix-event-action': 'Filtrer les participations',
-      'pix-event-name': 'Utilisation du filtre "Thématiques non obtenues"',
+      'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
     });
   }
 

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -536,7 +536,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
+        assert.notOk(screen.queryByRole('button', { name: 'Badges' }));
         assert.notOk(screen.queryByLabelText('Les bases'));
       });
 
@@ -585,7 +585,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           event: 'custom-event',
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Utilisation du filtre "Thématiques non obtenues"',
+          'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
         });
       });
 
@@ -631,7 +631,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           event: 'custom-event',
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Usage du filtre par Résultats Thématiques',
+          'pix-event-name': 'Usage du filtre par Badges',
         });
       });
     });
@@ -696,7 +696,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
+        assert.notOk(screen.queryByRole('button', { name: 'Badges' }));
         assert.notOk(screen.queryByLabelText('Les bases'));
       });
 
@@ -745,7 +745,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           event: 'custom-event',
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Utilisation du filtre "Thématiques non obtenues"',
+          'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
         });
       });
 
@@ -791,7 +791,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           event: 'custom-event',
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Usage du filtre par Résultats Thématiques',
+          'pix-event-name': 'Usage du filtre par Badges',
         });
       });
     });
@@ -811,7 +811,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
+        assert.notOk(screen.queryByRole('button', { name: 'Badges' }));
       });
     });
 
@@ -831,7 +831,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
+        assert.notOk(screen.queryByRole('button', { name: 'Badges' }));
       });
     });
   });

--- a/orga/tests/integration/components/campaign/results/assessment-list-test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list-test.js
@@ -459,7 +459,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
       );
 
       // then
-      assert.notOk(screen.queryByRole('columnheader', { name: 'Résultats Thématiques' }));
+      assert.notOk(screen.queryByRole('columnheader', { name: 'Badges' }));
     });
   });
 
@@ -493,7 +493,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
       );
 
       // then
-      assert.ok(screen.getByRole('columnheader', { name: 'Résultats Thématiques' }));
+      assert.ok(screen.getByRole('columnheader', { name: 'Badges' }));
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -93,9 +93,9 @@
       "value": "/{total} seats"
     },
     "badges-acquisitions": {
-      "information": "Find here the number of Thematic Results obtained by your participants in this campaign as well as their percentage.",
+      "information": "Find here the number of badges obtained by your participants in this campaign as well as their percentage.",
       "obtained": "obtained",
-      "title": "Thematic results"
+      "title": "Badges"
     },
     "occupied-seats-count": {
       "anonymous": "including {count, plural, =1 {1 seat} other {{count, number} seats}} with no-account access",
@@ -269,7 +269,7 @@
         "without-account": "Access without account"
       },
       "subjects": "Topics: {value, number}",
-      "thematic-results": "Thematic results: {value, number}"
+      "thematic-results": "Badges: {value, number}"
     }
   },
   "components": {
@@ -412,7 +412,7 @@
   },
   "pages": {
     "assessment-individual-results": {
-      "badges": "Thematic results",
+      "badges": "Badges",
       "breadcrumb-current-page-label": "Participation of {firstName} {lastName}",
       "participation-label": "Participation #{participationNumber}",
       "participation-not-shared": "Results to submit",
@@ -636,7 +636,7 @@
         "aria-label": "Filters on participations",
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
-          "badges": "Acquired thematic results",
+          "badges": "Acquired badges",
           "groups": {
             "empty": "No group",
             "title": "Groups"
@@ -646,7 +646,7 @@
             "empty": "All statuses",
             "title": "Status"
           },
-          "unacquired-badges": "Unacquired thematic results"
+          "unacquired-badges": "Unacquired badges"
         }
       },
       "result": "Result",
@@ -658,7 +658,7 @@
         "caption": "This table lists the participants who have shared their results. For each participant, it shows their surname, first name and elements of results.",
         "column": {
           "ariaSharedResultCount": "Number of sent results",
-          "badges": "Thematic results",
+          "badges": "Badges",
           "evolution": "Evolution",
           "first-name": "First name",
           "last-name": "Last name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -93,9 +93,9 @@
       "value": "/{total} places"
     },
     "badges-acquisitions": {
-      "information": "Retrouvez ici le nombre de Résultats Thématiques obtenus par vos participants dans cette campagne ainsi que leur pourcentage d’obtention. ",
+      "information": "Retrouvez ici le nombre de Badges obtenus par vos participants dans cette campagne ainsi que leur pourcentage d’obtention. ",
       "obtained": "obtenus",
-      "title": "Résultats thématiques"
+      "title": "Badges"
     },
     "occupied-seats-count": {
       "anonymous": "dont {count, plural, =1 {1 place} other {{count, number} places}} avec un accès sans compte",
@@ -269,7 +269,7 @@
         "without-account": "Accès sans compte"
       },
       "subjects": "Sujets : {value, number}",
-      "thematic-results": "Résultats thématiques : {value, number}"
+      "thematic-results": "Badges : {value, number}"
     }
   },
   "components": {
@@ -412,7 +412,7 @@
   },
   "pages": {
     "assessment-individual-results": {
-      "badges": "Résultats Thématiques",
+      "badges": "Badges",
       "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
       "participation-label": "Participation #{participationNumber}",
       "participation-not-shared": "Résultats non-envoyés",
@@ -636,7 +636,7 @@
         "aria-label": "Filtres sur les participations",
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
         "type": {
-          "badges": "Thématiques obtenues",
+          "badges": "Badges obtenus",
           "groups": {
             "empty": "Aucun groupe",
             "title": "Groupes"
@@ -646,7 +646,7 @@
             "empty": "Tous les statuts",
             "title": "Statut"
           },
-          "unacquired-badges": "Thématiques non obtenues"
+          "unacquired-badges": "Badges non obtenus"
         }
       },
       "result": "Résultat",
@@ -658,7 +658,7 @@
         "caption": "Ce tableau comporte la liste des participants ayant partagé leurs résultats. Il indique pour chaque participant leur nom, prénom et des éléments de résultats.",
         "column": {
           "ariaSharedResultCount": "Nombre de résultats envoyés",
-          "badges": "Résultats Thématiques",
+          "badges": "Badges",
           "evolution": "Évolution",
           "first-name": "Prénom",
           "last-name": "Nom",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -93,9 +93,9 @@
       "value": "/{total} plaatsen"
     },
     "badges-acquisitions": {
-      "information": "Hier vind je het aantal thematische resultaten die je deelnemers in deze campagne hebben behaald en hun percentage.",
+      "information": "Hier vind je het aantal badges die je deelnemers in deze campagne hebben behaald en hun percentage.",
       "obtained": "verkregen",
-      "title": "Thematische resultaten"
+      "title": "Badges"
     },
     "occupied-seats-count": {
       "anonymous": "inclusief {count, plural, =1 {1 plaats} other {{count, number} plaatsen}} met toegang zonder account",
@@ -268,7 +268,7 @@
         "without-account": "Toegang zonder account"
       },
       "subjects": "Onderwerpen: {value, number}",
-      "thematic-results": "Thematische resultaten: {value, number}"
+      "thematic-results": "Badges: {value, number}"
     },
     "no-content": "Geen inhoud"
   },
@@ -412,7 +412,7 @@
   },
   "pages": {
     "assessment-individual-results": {
-      "badges": "Thematische resultaten",
+      "badges": "Badges",
       "breadcrumb-current-page-label": "Deelname van {firstName} {lastName}",
       "participation-label": "Deelname #{participationNumber}",
       "participation-not-shared": "Resultaten niet verzonden",
@@ -622,7 +622,7 @@
         "caption": "In deze tabel staan de deelnemers die hun resultaten hebben gedeeld. Voor elke deelnemer worden de achternaam, voornaam en resultaten weergegeven.",
         "column": {
           "ariaSharedResultCount": "Aantal verzonden resultaten",
-          "badges": "Thematische resultaten",
+          "badges": "Badges",
           "evolution": "Evolutie",
           "first-name": "Voornaam",
           "last-name": "Achternaam",


### PR DESCRIPTION
## 🌸 Problème

Le terme "Résultat thématique" n'est pas très transparent, les utilisateurs comme les pixous utilisent plutôt le terme "badge".

## 🌳 Proposition

Remplacer "Résultat thématique" par "Badge" 😄

## 🐝 Remarques
Je n'ai pas touché aux seeds et aux strings dans les tests 

## 🤧 Pour tester

Faire un tour sur les apps pour s'assurer que tout est ok
Vérifier qu'il ne reste pas de résultat thématique orphelin