### PR TITLE
[BUGFIX] Normaliser les noms de fichier PDF des attestations (PIX-17206)

### DIFF
--- a/api/src/profile/domain/models/User.js
+++ b/api/src/profile/domain/models/User.js
@@ -19,12 +19,15 @@ export class User {
     return this.#lastName.toUpperCase();
   }
 
-  toForm(createdAt, locale) {
+  toForm(createdAt, locale, transformStringForFileName) {
     const map = new Map();
+
+    const filename =
+      transformStringForFileName(this.firstName) + '_' + transformStringForFileName(this.lastName) + '_' + Date.now();
 
     map.set('firstName', this.firstName);
     map.set('lastName', this.lastName);
-    map.set('filename', this.firstName + '_' + this.lastName + '_' + Date.now());
+    map.set('filename', filename);
     map.set('date', createdAt.toLocaleDateString(locale));
 
     return map;

--- a/api/src/profile/domain/usecases/get-attestation-data-for-users.js
+++ b/api/src/profile/domain/usecases/get-attestation-data-for-users.js
@@ -7,6 +7,7 @@ export async function getAttestationDataForUsers({
   userRepository,
   profileRewardRepository,
   attestationRepository,
+  stringUtils,
 }) {
   const attestationData = await attestationRepository.getByKey({ attestationKey });
 
@@ -20,7 +21,7 @@ export async function getAttestationDataForUsers({
   return {
     data: profileRewards.map(({ userId, createdAt }) => {
       const user = users.find((user) => user.id === userId);
-      return user.toForm(createdAt, locale);
+      return user.toForm(createdAt, locale, stringUtils.normalizeAndRemoveAccents);
     }),
     templateName: attestationData.templateName,
   };

--- a/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-for-organization-by-user-ids.js
@@ -9,6 +9,7 @@ export async function getSharedAttestationsForOrganizationByUserIds({
   profileRewardRepository,
   attestationRepository,
   organizationProfileRewardRepository,
+  stringUtils,
 }) {
   const attestationData = await attestationRepository.getByKey({ attestationKey });
 
@@ -34,7 +35,7 @@ export async function getSharedAttestationsForOrganizationByUserIds({
   return {
     data: filteredProfileRewards.map(({ userId, createdAt }) => {
       const user = users.find((user) => user.id === userId);
-      return user.toForm(createdAt, locale);
+      return user.toForm(createdAt, locale, stringUtils.normalizeAndRemoveAccents);
     }),
     templateName: attestationData.templateName,
   };

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -9,6 +9,7 @@ import * as competenceRepository from '../../../shared/infrastructure/repositori
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as stringUtils from '../../../shared/infrastructure/utils/string-utils.js';
 import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as organizationProfileRewardRepository from '../../infrastructure/repositories/organization-profile-reward-repository.js';
@@ -31,6 +32,7 @@ const dependencies = {
   attestationRepository,
   rewardRepository,
   campaignParticipationRepository,
+  stringUtils,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-attestation-data-for-users_test.js
@@ -1,6 +1,7 @@
 import { AttestationNotFoundError } from '../../../../../src/profile/domain/errors.js';
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Domain | get-attestation-data-for-users', function () {
@@ -42,7 +43,10 @@ describe('Profile | Integration | Domain | get-attestation-data-for-users', func
       });
 
       expect(results).to.deep.equal({
-        data: [firstUser.toForm(firstCreatedAt, locale), secondUser.toForm(secondCreatedAt, locale)],
+        data: [
+          firstUser.toForm(firstCreatedAt, locale, normalizeAndRemoveAccents),
+          secondUser.toForm(secondCreatedAt, locale, normalizeAndRemoveAccents),
+        ],
         templateName: attestation.templateName,
       });
       expect(results.data[0].get('firstName')).to.equal('Alex');

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-for-organization-by-user-ids_test.js
@@ -1,6 +1,7 @@
 import { AttestationNotFoundError, NoProfileRewardsFoundError } from '../../../../../src/profile/domain/errors.js';
 import { User } from '../../../../../src/profile/domain/models/User.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Profile | Integration | Domain | get-shared-attestations-for-organization-by-user-ids', function () {
@@ -55,7 +56,7 @@ describe('Profile | Integration | Domain | get-shared-attestations-for-organizat
       });
 
       expect(results).to.deep.equal({
-        data: [firstUser.toForm(firstProfileReward.createdAt, locale)],
+        data: [firstUser.toForm(firstProfileReward.createdAt, locale, normalizeAndRemoveAccents)],
         templateName: attestation.templateName,
       });
       expect(results.data[0].get('firstName')).to.equal('Alex');

--- a/api/tests/profile/unit/domain/models/User_test.js
+++ b/api/tests/profile/unit/domain/models/User_test.js
@@ -1,4 +1,5 @@
 import { User } from '../../../../../src/profile/domain/models/User.js';
+import { normalizeAndRemoveAccents } from '../../../../../src/shared/infrastructure/utils/string-utils.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Profile | Domain | Models | User', function () {
@@ -38,12 +39,12 @@ describe('Unit | Profile | Domain | Models | User', function () {
     const date = new Date('2024-10-02');
 
     // when
-    const form = user.toForm(date, 'FR-fr');
+    const form = user.toForm(date, 'FR-fr', normalizeAndRemoveAccents);
 
     // then
     expect(form.get('firstName')).to.deep.equal(user.firstName);
     expect(form.get('lastName')).to.deep.equal(user.lastName);
-    expect(form.get('filename')).to.deep.equal(user.firstName + '_' + user.lastName + '_' + Date.now());
+    expect(form.get('filename')).to.deep.equal('theo_courant_' + Date.now());
     expect(form.get('date')).to.deep.equal('02/10/2024');
   });
 });


### PR DESCRIPTION
## 🌸 Problème

sur windows ( merci à toi ) , lorsque l'on télécharge un fichier avec des firstName lastName avec des caractères chelou. les pdf ne sont pas visibles dans le .zip mais sur Mac oui

## 🌳 Proposition

Utiliser la fonction normalizeAndremoveAccents de notre utilitaire string-utils

## 🐝 Remarques

Il sera préférable dans un temps futur de "centraliser" ces différents usages. beaucoup d'utilisation de normalisation dans différent context différent. avec une base de code unique moyennant quelque variations. qui pourrait être centraliser dans cette utilitaire.

## 🤧 Pour tester

Aller sur PixOrga télécharger les attestions dans l'orga possédant des attestations, vérifier que le fichier est en minuscule à l'intérieur du zip 
