### PR TITLE
[TECH] Utiliser la version de production de PG sur les RA

### DIFF
--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -33,7 +33,7 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "15.10"
+        "version": "16.6"
       }
     },
     {

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -33,7 +33,7 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "15.10"
+        "version": "16.6"
       }
     }
   ],


### PR DESCRIPTION
## 🌸 Problème

La version de prod du PG est plus récente que celle sur les RA

## 🌳 Proposition

MAJ la version dans le scalingo.json

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
Allez sur le dashboard de la RA et constater que la version est cohérente.
