### PR TITLE
[TECH] Optimiser la CI et les RA de l'audit logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,18 +167,10 @@ workflows:
           requires:
             - api_install
 
-      - audit_logger_install:
-          context: Pix
-          requires:
-            - checkout
-      - audit_logger_lint:
-          context: Pix
-          requires:
-            - audit_logger_install
       - audit_logger_test:
           context: Pix
           requires:
-            - audit_logger_install
+            - checkout
 
       - mon_pix_build:
           context: Pix
@@ -508,9 +500,9 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results
 
-  audit_logger_install:
+  audit_logger_test:
     executor:
-      name: node-docker
+      name: node-postgres-docker
     working_directory: ~/pix/audit-logger
     steps:
       - attach_workspace:
@@ -524,37 +516,15 @@ jobs:
           key: v7-audit-logger-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
-      - persist_to_workspace:
-          root: ~/pix
-          paths:
-            - audit-logger
-
-  audit_logger_lint:
-    executor:
-      name: node-postgres-docker
-    working_directory: ~/pix/audit-logger
-    steps:
-      - attach_workspace:
-          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
-          when: always
-
-  audit_logger_test:
-    executor:
-      name: node-postgres-docker
-    working_directory: ~/pix/audit-logger
-    steps:
-      - attach_workspace:
-          at: ~/pix
       - run:
           name: Test
           command: npm run test
           environment:
             PIX_API_CLIENT_SECRET: $2a$04$vkPRiypzeVQVG92/dCll7.5brjDQZVZc750VwKBc01icXjVIQqRVq
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
-          when: always
       - store_test_results:
           path: /home/circleci/test-results
       - store_artifacts:

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -35,12 +35,6 @@
       "options": {
         "version": "15.10"
       }
-    },
-    {
-      "plan": "redis:redis-sandbox",
-      "options": {
-        "version": "7.2.5"
-      }
     }
   ],
   "formation": {


### PR DESCRIPTION
## 🌸 Problème

Les phases d'installation, linting et testing de l'audit logger sont faites dans 3 workers différents. Mais ce sont des étapes très rapide qui ne nécessite pas des workers dédiés ou de parallélisation.

## 🌳 Proposition

Factoriser et séquencer ces 3 étapes de CI de l'audit logger dans un seul worker au lieu de 3.

**Avant:**
![image](https://github.com/user-attachments/assets/09ffe0f5-d24b-4588-9e1e-2842e8b1e779)

**Après:**
![image](https://github.com/user-attachments/assets/efd9f817-5c5b-494c-8c55-1f4054bb8353)

## 🐝 Remarques

La configuration de RA de l'audit logger exécute **un Addon Redis qui n'est pas nécessaire**. Il a été enlevé de la configuration `scalingo.json`.

## 🤧 Pour tester

Vérifier la CI et la RA.
