### PR TITLE
[FEATURE] [Pix Admin] Si la date de dernière connexion est vide afficher le message « Non connecté depuis 03/2025 » + renommer l’onglet « Méthodes de connexion » (PIX-17109)

### DIFF
--- a/admin/app/components/certification-centers/membership-item.gjs
+++ b/admin/app/components/certification-centers/membership-item.gjs
@@ -5,6 +5,7 @@ import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
 
 import MembershipItemActions from './membership-item-actions';
 import MembershipItemRole from './membership-item-role';
@@ -86,6 +87,8 @@ export default class CertificationCentersMembershipItemComponent extends Compone
       <:cell>
         {{#if @certificationCenterMembership.lastAccessedAt}}
           {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD-MM-YYYY - HH:mm:ss"}}
+        {{else}}
+          {{t "components.certification-centers.membership-item.no-last-connection-date-info"}}
         {{/if}}
       </:cell>
     </PixTableColumn>

--- a/admin/app/components/organizations/member-item.gjs
+++ b/admin/app/components/organizations/member-item.gjs
@@ -1,14 +1,17 @@
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import dayjs from 'dayjs';
 
 import ActionsOnUsersRoleInOrganization from '../actions-on-users-role-in-organization';
 
 export default class MemberItem extends Component {
+  @service intl;
+
   get lastAccessedAt() {
     if (!this.args.organizationMembership.lastAccessedAt) {
-      return null;
+      return this.intl.t('components.organizations.member-items.no-last-connection-date-info');
     }
     return dayjs(this.args.organizationMembership.lastAccessedAt).format('DD/MM/YYYY HH:mm');
   }

--- a/admin/app/components/users/certification-centers/membership-item.gjs
+++ b/admin/app/components/users/certification-centers/membership-item.gjs
@@ -96,6 +96,8 @@ export default class UsersCertificationCentersMembershipItemComponent extends Co
       <:cell>
         {{#if @certificationCenterMembership.lastAccessedAt}}
           {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD/MM/YYYY"}}
+        {{else}}
+          {{t "components.users.certification-centers.memberships.no-last-connection-date-info"}}
         {{/if}}
       </:cell>
     </PixTableColumn>

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.gjs
@@ -126,7 +126,10 @@ export default class AuthenticationMethod extends Component {
   }
 
   _displayAuthenticationMethodDate(date) {
-    if (!date) return null;
+    if (!date)
+      return this.intl.t(
+        'components.users.user-detail-personal-information.authentication-method.no-last-connection-date-info',
+      );
     return this.intl.t('components.users.user-detail-personal-information.authentication-method.last-logged-at', {
       date: dayjs(date).format('DD/MM/YYYY'),
     });

--- a/admin/app/components/users/user-organization-memberships.gjs
+++ b/admin/app/components/users/user-organization-memberships.gjs
@@ -76,6 +76,8 @@ export default class UserOrganizationMemberships extends Component {
             <:cell>
               {{#if organizationMembership.lastAccessedAt}}
                 {{dayjsFormat organizationMembership.lastAccessedAt "DD/MM/YYYY"}}
+              {{else}}
+                {{t "components.users.organizations.memberships.no-last-connection-date-info"}}
               {{/if}}
             </:cell>
           </PixTableColumn>

--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -369,8 +369,12 @@ export default class UserOverview extends Component {
                     {{dayjsFormat @user.userLogin.temporaryBlockedUntil "DD/MM/YYYY HH:mm"}}</li>
                 {{/if}}
                 <li>
-                  Date de dernière connexion globale :
-                  {{#if @user.lastLoggedAt}}{{dayjsFormat @user.lastLoggedAt "DD/MM/YYYY"}}{{/if}}
+                  {{t "components.users.user-overview.global-last-login"}}
+                  {{#if @user.lastLoggedAt}}
+                    {{dayjsFormat @user.lastLoggedAt "DD/MM/YYYY"}}
+                  {{else}}
+                    {{t "components.users.user-overview.no-last-connection-date-info"}}
+                  {{/if}}
                 </li>
               </ul>
             </div>

--- a/admin/app/styles/components/users/user-overview.scss
+++ b/admin/app/styles/components/users/user-overview.scss
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    max-width: 600px;
+    max-width: fit-content;
   }
 
   &__infogroup {

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -15,7 +15,7 @@
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.authentication-methods" @model={{@model}}>
-      {{t "pages.user-details.navbar.authentication-methods"}}
+      {{t "pages.user-details.navbar.connections"}}
       ({{@model.authenticationMethodCount}})
     </LinkTo>
 

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -32,6 +32,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     const expectedParticipationCount = 1;
     const expectedCertificationCenterCount = 3;
     const expectedAuthenticationMethodCount = 3;
+    const connectionTabLabel = this.intl.t('pages.user-details.navbar.connections');
 
     // when
     const screen = await visit(`/users/${user.id}`);
@@ -42,7 +43,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     const userNavigation = within(screen.getByLabelText("Navigation de la section détails d'un utilisateur"));
     assert.dom(userNavigation.getByRole('link', { name: 'Informations prescrit' })).exists();
     assert
-      .dom(userNavigation.getByRole('link', { name: `Méthodes de connexion (${expectedAuthenticationMethodCount})` }))
+      .dom(userNavigation.getByRole('link', { name: `${connectionTabLabel} (${expectedAuthenticationMethodCount})` }))
       .exists();
     assert.dom(userNavigation.getByRole('link', { name: 'Profil' })).exists();
     assert.dom(userNavigation.getByRole('link', { name: `Participations (${expectedParticipationCount})` })).exists();
@@ -104,6 +105,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   module('when administrator click on anonymize button and confirm modal', function () {
     test('anonymizes the user and remove all authentication methods', async function (assert) {
       // given
+      this.intl = this.owner.lookup('service:intl');
       await _buildAndAuthenticateUser(this.server, {
         email: 'john.harry@example.net',
         username: 'john.harry121297',
@@ -136,12 +138,12 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       });
       const expectedAuthenticationMethodCountBeforeAnonymisation = 3;
       const expectedAuthenticationMethodCountAfterAnonymisation = 0;
-
+      const connectionTabLabel = this.intl.t('pages.user-details.navbar.connections');
       const screen = await visit(`/users/${userToAnonymise.id}`);
       assert
         .dom(
           screen.getByRole('link', {
-            name: `Méthodes de connexion (${expectedAuthenticationMethodCountBeforeAnonymisation})`,
+            name: `${connectionTabLabel} (${expectedAuthenticationMethodCountBeforeAnonymisation})`,
           }),
         )
         .exists();
@@ -158,7 +160,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       // when & then #2
       await click(
         screen.getByRole('link', {
-          name: `Méthodes de connexion (${expectedAuthenticationMethodCountAfterAnonymisation})`,
+          name: `${connectionTabLabel} (${expectedAuthenticationMethodCountAfterAnonymisation})`,
         }),
       );
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec identifiant")).exists();
@@ -238,11 +240,15 @@ module('Acceptance | authenticated/users/get', function (hooks) {
 
   module('when administrator click on remove authentication method button', function () {
     test('not displays remove link and display unchecked icon', async function (assert) {
-      const expectedAuthenticationMethodCount = 2;
       // given
+      this.intl = this.owner.lookup('service:intl');
+      const expectedAuthenticationMethodCount = 2;
+      const connectionTabLabel = this.intl.t('pages.user-details.navbar.connections');
       const user = await _buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
       const screen = await visit(`/users/${user.id}`);
-      await click(screen.getByRole('link', { name: `Méthodes de connexion (${expectedAuthenticationMethodCount})` }));
+
+      await click(screen.getByRole('link', { name: `${connectionTabLabel} (${expectedAuthenticationMethodCount})` }));
+
       // when
       await click(screen.getAllByRole('button', { name: 'Supprimer' })[0]);
 

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -1,6 +1,7 @@
 import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import dayjs from 'dayjs';
+import { t } from 'ember-intl/test-support';
 import MembershipItem from 'pix-admin/components/certification-centers/membership-item';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -20,49 +21,84 @@ module('Integration | Component |  certification-centers/membership-item', funct
     sinon.restore();
   });
 
-  test('displays a certification center membership table row item', async function (assert) {
-    // given
-    const user = store.createRecord('user', {
-      id: 1,
-      firstName: 'Jojo',
-      lastName: 'La Gringue',
-      email: 'jojo@example.net',
+  module('displays a certification center membership table row item', function () {
+    test('with last access date if exists', async function (assert) {
+      // given
+      const user = store.createRecord('user', {
+        id: 1,
+        firstName: 'Jojo',
+        lastName: 'La Gringue',
+        email: 'jojo@example.net',
+      });
+      const certificationCenterMembership = store.createRecord('certification-center-membership', {
+        id: 1,
+        user,
+        role: 'MEMBER',
+        createdAt: new Date('2023-09-13T10:47:07Z'),
+        lastAccessedAt: new Date('2023-12-30T15:21:09Z'),
+      });
+
+      const disableCertificationCenterMembership = sinon.stub();
+
+      //  when
+      const screen = await renderScreen(
+        <template>
+          <MembershipItem
+            @certificationCenterMembership={{certificationCenterMembership}}
+            @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
+          />
+        </template>,
+      );
+
+      // then
+      const expectedLastAccessDate = dayjs(certificationCenterMembership.lastAccessedAt).format(
+        'DD-MM-YYYY - HH:mm:ss',
+      );
+      const expectedCreationDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
+
+      assert.dom(screen.getByRole('link', { name: certificationCenterMembership.id })).exists();
+      assert.dom(screen.getByRole('cell', { name: user.firstName })).exists();
+      assert.dom(screen.getByRole('cell', { name: user.lastName })).exists();
+      assert.dom(screen.getByRole('cell', { name: user.email })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
+      assert.dom(screen.getByRole('cell', { name: expectedLastAccessDate })).exists();
+      assert.dom(screen.getByRole('cell', { name: expectedCreationDate })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
     });
-    const certificationCenterMembership = store.createRecord('certification-center-membership', {
-      id: 1,
-      user,
-      role: 'MEMBER',
-      createdAt: new Date('2023-09-13T10:47:07Z'),
-      lastAccessedAt: new Date('2023-12-30T15:21:09Z'),
+
+    test('with default last access date when there is none', async function (assert) {
+      // given
+      const user = store.createRecord('user', {
+        id: 1,
+        firstName: 'Jojo',
+        lastName: 'La Gringue',
+        email: 'jojo@example.net',
+      });
+      const certificationCenterMembership = store.createRecord('certification-center-membership', {
+        id: 1,
+        user,
+        role: 'MEMBER',
+        createdAt: new Date('2023-09-13T10:47:07Z'),
+      });
+
+      const disableCertificationCenterMembership = sinon.stub();
+
+      //  when
+      const screen = await renderScreen(
+        <template>
+          <MembershipItem
+            @certificationCenterMembership={{certificationCenterMembership}}
+            @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
+          />
+        </template>,
+      );
+
+      // then
+      const defaultLastAccessDate = t('components.certification-centers.membership-item.no-last-connection-date-info');
+
+      assert.dom(screen.getByRole('cell', { name: defaultLastAccessDate })).exists();
     });
-
-    const disableCertificationCenterMembership = sinon.stub();
-
-    //  when
-    const screen = await renderScreen(
-      <template>
-        <MembershipItem
-          @certificationCenterMembership={{certificationCenterMembership}}
-          @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
-        />
-      </template>,
-    );
-
-    // then
-    const expectedLastAccessedAtDate = dayjs(certificationCenterMembership.lastAccessedAt).format(
-      'DD-MM-YYYY - HH:mm:ss',
-    );
-    const expectedCreationDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
-
-    assert.dom(screen.getByRole('link', { name: certificationCenterMembership.id })).exists();
-    assert.dom(screen.getByRole('cell', { name: user.firstName })).exists();
-    assert.dom(screen.getByRole('cell', { name: user.lastName })).exists();
-    assert.dom(screen.getByRole('cell', { name: user.email })).exists();
-    assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
-    assert.dom(screen.getByRole('cell', { name: expectedLastAccessedAtDate })).exists();
-    assert.dom(screen.getByRole('cell', { name: expectedCreationDate })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
   });
 
   module('when clicking on "Modifier le rôle" button', function () {

--- a/admin/tests/integration/components/organizations/member-item-test.gjs
+++ b/admin/tests/integration/components/organizations/member-item-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import dayjs from 'dayjs';
+import { t } from 'ember-intl/test-support';
 import MemberItem from 'pix-admin/components/organizations/member-item';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -43,5 +44,34 @@ module('Integration | Component | MemberItem', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: 'Doe' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'toto@example.net' })).exists();
     assert.dom(screen.getByRole('cell', { name: dayjs(now).format('DD/MM/YYYY HH:mm') })).exists();
+  });
+  module('if there is no last access date', function () {
+    test('displays default last access date', async function (assert) {
+      // given
+      const member = {
+        user: {
+          id: 123,
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'toto@example.net',
+        },
+      };
+
+      const screen = await render(<template><MemberItem @organizationMembership={{member}} /></template>);
+
+      // then
+
+      assert.dom(screen.getByRole('cell', { name: '123' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Doe' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'toto@example.net' })).exists();
+      assert
+        .dom(
+          screen.getByRole('cell', {
+            name: t('components.organizations.member-items.no-last-connection-date-info'),
+          }),
+        )
+        .exists();
+    });
   });
 });

--- a/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
@@ -1,5 +1,6 @@
 import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import MembershipItem from 'pix-admin/components/users/certification-centers/membership-item';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -18,48 +19,85 @@ module('Integration | Component | users | certification-centers | membership-ite
   hooks.afterEach(function () {
     sinon.restore();
   });
+  module('displays a certification center membership table row item', function () {
+    test('with last access date if there is one', async function (assert) {
+      // given
+      const certificationCenter = store.createRecord('certification-center', {
+        id: 2,
+        name: 'Centre Jean-Bonboeur',
+        type: 'SUP',
+        externalId: 'PAIN123',
+      });
+      const certificationCenterMembership = store.createRecord('certification-center-membership', {
+        id: 1,
+        certificationCenter,
+        role: 'MEMBER',
+        lastAccessedAt: new Date('2020-01-01'),
+      });
 
-  test('displays a certification center membership table row item', async function (assert) {
-    // given
-    const certificationCenter = store.createRecord('certification-center', {
-      id: 2,
-      name: 'Centre Jean-Bonboeur',
-      type: 'SUP',
-      externalId: 'PAIN123',
+      const disableCertificationCenterMembership = sinon.stub();
+      const onCertificationCenterMembershipRoleChange = sinon.stub();
+
+      //  when
+      const screen = await renderScreen(
+        <template>
+          <MembershipItem
+            @certificationCenterMembership={{certificationCenterMembership}}
+            @onCertificationCenterMembershipRoleChange={{onCertificationCenterMembershipRoleChange}}
+            @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: certificationCenterMembership.id })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCenter.id })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCenter.name })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCenter.type })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCenter.externalId })).exists();
+      assert.dom(screen.getByRole('cell', { name: '01/01/2020' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
+      assert
+        .dom(screen.getByRole('button', { name: 'Modifier le rôle du membre de ce centre de certification' }))
+        .exists();
+      assert.dom(screen.getByRole('button', { name: 'Désactiver le membre de centre de certification' })).exists();
     });
-    const certificationCenterMembership = store.createRecord('certification-center-membership', {
-      id: 1,
-      certificationCenter,
-      role: 'MEMBER',
-      lastAccessedAt: new Date('2020-01-01'),
+
+    test('with default access date if there is none', async function (assert) {
+      // given
+      const certificationCenter = store.createRecord('certification-center', {
+        id: 2,
+        name: 'Centre Jean-Bonboeur',
+        type: 'SUP',
+        externalId: 'PAIN123',
+      });
+      const certificationCenterMembership = store.createRecord('certification-center-membership', {
+        id: 1,
+        certificationCenter,
+        role: 'MEMBER',
+      });
+
+      const disableCertificationCenterMembership = sinon.stub();
+      const onCertificationCenterMembershipRoleChange = sinon.stub();
+
+      //  when
+      const screen = await renderScreen(
+        <template>
+          <MembershipItem
+            @certificationCenterMembership={{certificationCenterMembership}}
+            @onCertificationCenterMembershipRoleChange={{onCertificationCenterMembershipRoleChange}}
+            @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
+          />
+        </template>,
+      );
+
+      // then
+      const defaultLastAccessDate = t(
+        'components.users.user-detail-personal-information.authentication-method.no-last-connection-date-info',
+      );
+
+      assert.dom(screen.getByRole('cell', { name: defaultLastAccessDate })).exists();
     });
-
-    const disableCertificationCenterMembership = sinon.stub();
-    const onCertificationCenterMembershipRoleChange = sinon.stub();
-
-    //  when
-    const screen = await renderScreen(
-      <template>
-        <MembershipItem
-          @certificationCenterMembership={{certificationCenterMembership}}
-          @onCertificationCenterMembershipRoleChange={{onCertificationCenterMembershipRoleChange}}
-          @disableCertificationCenterMembership={{disableCertificationCenterMembership}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByRole('cell', { name: certificationCenterMembership.id })).exists();
-    assert.dom(screen.getByRole('cell', { name: certificationCenter.id })).exists();
-    assert.dom(screen.getByRole('cell', { name: certificationCenter.name })).exists();
-    assert.dom(screen.getByRole('cell', { name: certificationCenter.type })).exists();
-    assert.dom(screen.getByRole('cell', { name: certificationCenter.externalId })).exists();
-    assert.dom(screen.getByRole('cell', { name: '01/01/2020' })).exists();
-    assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
-    assert
-      .dom(screen.getByRole('button', { name: 'Modifier le rôle du membre de ce centre de certification' }))
-      .exists();
-    assert.dom(screen.getByRole('button', { name: 'Désactiver le membre de centre de certification' })).exists();
   });
 
   module('when clicking on "Modifier le rôle" button', function () {

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method-test.gjs
@@ -120,34 +120,58 @@ module('Integration | Component | users | user-detail-personal-information | aut
             .exists();
         });
 
-        test('it displays the last logged at with PIX authentication method', async function (assert) {
-          // given
-          const user = {
-            authenticationMethods: [
-              {
-                identityProvider: 'PIX',
-                authenticationComplement: {},
-                lastLoggedAt: new Date('2022-07-01T00:00:00Z'),
-              },
-            ],
-          };
+        module('when user has a last login date', function () {
+          test('it displays the last login date for PIX authentication method', async function (assert) {
+            // given
+            const user = {
+              authenticationMethods: [
+                {
+                  identityProvider: 'PIX',
+                  authenticationComplement: {},
+                  lastLoggedAt: new Date('2022-07-01T00:00:00Z'),
+                },
+              ],
+            };
 
-          // when
-          const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
+            // when
+            const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
 
-          // then
-          const expectedLabel = t(
-            'components.users.user-detail-personal-information.authentication-method.last-logged-at',
-          );
-          const expectedValue = '01/07/2022';
-          assert
-            .dom(
-              screen.getAllByRole('listitem').find((listItem) => {
-                const childrenText = listItem.textContent.trim().split('\n');
-                return childrenText[0]?.trim() === expectedLabel && childrenText[1]?.trim() === expectedValue;
-              }),
-            )
-            .exists();
+            // then
+            const expectedLabel = t(
+              'components.users.user-detail-personal-information.authentication-method.last-logged-at',
+            );
+            const expectedValue = '01/07/2022';
+            assert
+              .dom(
+                screen.getAllByRole('listitem').find((listItem) => {
+                  const childrenText = listItem.textContent.trim().split('\n');
+                  return childrenText[0]?.trim() === expectedLabel && childrenText[1]?.trim() === expectedValue;
+                }),
+              )
+              .exists();
+          });
+        });
+        module('when user has no last login date', function () {
+          test('it displays last login default date for PIX authentication method', async function (assert) {
+            // given
+            const user = {
+              authenticationMethods: [
+                {
+                  identityProvider: 'PIX',
+                  authenticationComplement: {},
+                  lastLoggedAt: null,
+                },
+              ],
+            };
+
+            // when
+            const screen = await render(<template><AuthenticationMethod @user={{user}} /></template>);
+            // then
+            const lastLoginDefaultDate = t(
+              'components.users.user-detail-personal-information.authentication-method.no-last-connection-date-info',
+            );
+            assert.strictEqual(screen.getAllByText(lastLoginDefaultDate).length, 2);
+          });
         });
       });
 

--- a/admin/tests/integration/components/users/user-organization-memberships-test.gjs
+++ b/admin/tests/integration/components/users/user-organization-memberships-test.gjs
@@ -1,6 +1,7 @@
 import { render, within } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import UserOrganizationMemberships from 'pix-admin/components/users/user-organization-memberships';
 import { module, test } from 'qunit';
 
@@ -63,6 +64,9 @@ module('Integration | Component | users | organization-memberships', function (h
       );
 
       // then
+      const defaultLastAccessDate = t(
+        'components.users.user-detail-personal-information.authentication-method.no-last-connection-date-info',
+      );
       const rows = await screen.findAllByRole('row');
       assert.dom(within(rows[1]).getByRole('cell', { name: '222' })).exists();
       assert.dom(within(rows[1]).getByRole('cell', { name: '100095' })).exists();
@@ -75,6 +79,7 @@ module('Integration | Component | users | organization-memberships', function (h
       assert.dom(within(rows[2]).getByRole('cell', { name: '100025' })).exists();
       assert.dom(within(rows[2]).getByRole('cell', { name: 'Dragon & Co' })).exists();
       assert.dom(within(rows[2]).getByRole('cell', { name: 'PRO' })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: defaultLastAccessDate })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/users/user-overview-test.gjs
+++ b/admin/tests/integration/components/users/user-overview-test.gjs
@@ -21,7 +21,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    module('when the admin look at user details', function () {
+    module('when the admin looks at user details', function () {
       module('when the user is anonymised', function () {
         module('when the user has self deleted his account', function () {
           test('displays the dedicated deletion message', async function (assert) {
@@ -110,11 +110,11 @@ module('Integration | Component | users | user-overview', function (hooks) {
           lang: 'fr',
           locale: 'fr-FR',
           createdAt: new Date('2021-12-10'),
+          lastLoggedAt: new Date('2023-12-10'),
         });
 
         // when
         const screen = await render(<template><UserOverview @user={{user}} /></template>);
-
         // then
         assert.dom(screen.getByText(`Prénom : ${user.firstName}`)).exists();
         assert.dom(screen.getByText(`Nom : ${user.lastName}`)).exists();
@@ -389,8 +389,8 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.queryByText("Utilisateur temporairement bloqué jusqu'au :")).doesNotExist();
         });
 
-        module('when the user has a last global connection', function () {
-          test('displays user last global connection', async function (assert) {
+        module('displays last global connection', function () {
+          test(`displays user's last login date when he has one`, async function (assert) {
             // given
             const store = this.owner.lookup('service:store');
 
@@ -400,7 +400,40 @@ module('Integration | Component | users | user-overview', function (hooks) {
             const screen = await render(<template><UserOverview @user={{user}} /></template>);
 
             // then
-            assert.dom(screen.getByText('Date de dernière connexion globale : 28/11/2022')).exists();
+            const globalLastLogin = t('components.users.user-overview.global-last-login');
+
+            assert.dom(screen.getByText(`${globalLastLogin} 28/11/2022`)).exists();
+          });
+
+          test('displays default last login date when user has no last login date', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+
+            const user = store.createRecord('user', {
+              firstName: 'John',
+              lastName: 'Snow',
+              email: 'john.snow@winterfell.got',
+              username: 'kingofthenorth',
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+
+            // when
+            const screen = await render(<template><UserOverview @user={{user}} /></template>);
+
+            // then
+            const globalLastLogin = t('components.users.user-overview.global-last-login');
+            const lastLoginDefaultDate = t('components.users.user-overview.no-last-connection-date-info');
+
+            assert.dom(screen.getByText(`Prénom : ${user.firstName}`)).exists();
+            assert.dom(screen.getByText(`Nom : ${user.lastName}`)).exists();
+            assert.dom(screen.getByText(`Adresse e-mail : ${user.email}`)).exists();
+            assert.dom(screen.getByText(`Identifiant : ${user.username}`)).exists();
+            assert.dom(screen.getByText('Langue : fr')).exists();
+            assert.dom(screen.getByText('Locale : fr-FR')).exists();
+            assert.dom(screen.getByText('Date de création : 10/12/2021')).exists();
+            assert.dom(screen.queryByText(`${globalLastLogin} ${lastLoginDefaultDate}`)).exists();
           });
         });
       });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -319,7 +319,8 @@
       "membership-item": {
         "actions": {
           "edit-role": "Edit role"
-        }
+        },
+        "no-last-connection-date-info": "Has not been connected since 03/2025"
       },
       "membership-item-role": {
         "select-role": "Select role"
@@ -455,6 +456,9 @@
           "caption": "Liste des organisations. Contient l'identifiant, le nom, de type et l'identifiant externe de l'organisation."
         }
       },
+      "member-items": {
+        "no-last-connection-date-info": "Has not been connected since 03/2025"
+      },
       "target-profiles-section": {
         "table": {
           "caption": "Liste des profils cibles rattachés à l'organisation. Contient son identifiant et son nom interne. Une action permet de détacher le profil cible quand cela est possible."
@@ -500,6 +504,7 @@
               "select-role": "Select a role"
             }
           },
+          "no-last-connection-date-info": "Has not been connected since 03/2025",
           "section-title": "User Certification Centres",
           "table-headers": {
             "actions-label": "Actions",
@@ -525,6 +530,7 @@
       },
       "organizations": {
         "memberships": {
+          "no-last-connection-date-info": "Has not been connected since 03/2025",
           "table": {
             "caption": "Liste des organisations dont l'utilisateur est membre. Contient l'identifiant en tant que membre, l'identifiant, le nom, l'identifiant externe et le type de l'organisation, et enfin le rôle du membre. Plusieurs actions permettent de changer le rôle du membre et de le désactiver de l'organisation."
           }
@@ -538,6 +544,7 @@
         "authentication-method": {
           "last-application-connection-date": "Last application connection date",
           "last-logged-at": "Last logged at {date}",
+          "no-last-connection-date-info": "Has not been connected since 03/2025",
           "should-change-password-status": "Temporary password :"
         },
         "cgu": {
@@ -558,6 +565,8 @@
         "copied": "Copied!"
       },
       "user-overview": {
+        "global-last-login": "Global last login :",
+        "no-last-connection-date-info": "Has not been connected since 03/2025",
         "sso": "SSO"
       }
     }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1066,10 +1066,10 @@
     },
     "user-details": {
       "navbar": {
-        "authentication-methods": "Méthodes de connexion",
         "certification-centers-list": "Pix Certif",
         "cgu": "Terms of service",
         "cgu-aria-label": "Terms of service",
+        "connections": "Connections",
         "details": "Informations prescrit",
         "organizations-list": "Pix Orga",
         "participations-list": "Participations",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1066,10 +1066,10 @@
     },
     "user-details": {
       "navbar": {
-        "authentication-methods": "Méthodes de connexion",
         "certification-centers-list": "Pix Certif",
         "cgu": "CGU",
         "cgu-aria-label": "Conditions générales d'utilisation",
+        "connections": "Connexions",
         "details": "Informations prescrit",
         "organizations-list": "Pix Orga",
         "participations-list": "Participations",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -319,7 +319,8 @@
       "membership-item": {
         "actions": {
           "edit-role": "Modifier le rôle"
-        }
+        },
+        "no-last-connection-date-info": "Non connecté depuis 03/2025"
       },
       "membership-item-role": {
         "select-role": "Sélectionner un rôle"
@@ -455,6 +456,9 @@
           "caption": "Liste des organisations. Contient l'identifiant, le nom, de type et l'identifiant externe de l'organisation."
         }
       },
+      "member-items": {
+        "no-last-connection-date-info": "Non connecté depuis 03/2025"
+      },
       "target-profiles-section": {
         "table": {
           "caption": "Liste des profils cibles rattachés à l'organisation. Contient son identifiant et son nom interne. Une action permet de détacher le profil cible quand cela est possible."
@@ -500,6 +504,7 @@
               "select-role": "Sélectionner un rôle"
             }
           },
+          "no-last-connection-date-info": "Non connecté depuis 03/2025",
           "section-title": "Centres de certification de l’utilisateur",
           "table-headers": {
             "actions-label": "Actions",
@@ -525,6 +530,7 @@
       },
       "organizations": {
         "memberships": {
+          "no-last-connection-date-info": "Non connecté depuis 03/2025",
           "table": {
             "caption": "Liste des organisations dont l'utilisateur est membre. Contient l'identifiant en tant que membre, l'identifiant, le nom, l'identifiant externe et le type de l'organisation, et enfin le rôle du membre. Plusieurs actions permettent de changer le rôle du membre et de le désactiver de l'organisation."
           }
@@ -538,6 +544,7 @@
         "authentication-method": {
           "last-application-connection-date": "Date de dernière connexion",
           "last-logged-at": "Dernière connexion le {date}",
+          "no-last-connection-date-info": "Non connecté depuis 03/2025",
           "should-change-password-status": "Mot de passe temporaire :"
         },
         "cgu": {
@@ -558,6 +565,8 @@
         "copied": "Copié !"
       },
       "user-overview": {
+        "global-last-login": "Date de dernière connexion globale :",
+        "no-last-connection-date-info": "Non connecté depuis 03/2025",
         "sso": "SSO"
       }
     }


### PR DESCRIPTION
## 🌸 Problème

Si l’utilisateur ne se reconnecte pas à Pix alors de nombreux champs “date de dernier accès” risquent d’être vide. Or, si les champs sont vides, on risque de créer de l’incompréhension pour le métier. 


## 🌳 Proposition

Si aucune date de dernière connexion n'est renseignée en base de données alors afficher la mention `« Non connecté depuis 03/2025 »` dans Pix Admin

À quel endroit afficher cette information  : 

1. Organisation > Equipe > Dernier Accès

2. Centres de certification > Equipe > Dernier Accès

3. Utilisateurs > Pix Orga > Dernier Accès

4. Utilisateurs > Pix Certif > Dernier Accès

5. Utilisateurs > Méthodes de connexion > Dernière connexion

6. Utilisateurs > Vue globale

Exclusion : 

Pour les applications, c’est plus intuitif pour le métier, ce n’est pas nécessaire.

:bulb: En profiter pour renommer également l’onglet _« Méthodes de connexion »_ en _« Connexions »_.

## 🐝 Remarques


## 🤧 Pour tester

Si vous voulez tester en local, il faut faire un
`update "authentication-methods" set "lastLoggedAt"= NULL where "userId" = {id d'Eliza Delajungle}`
sinon les deux derniers points du scénario de test ne passeront pas.


- se connecter sur Pix Admin avec le compte super admin
- Dans les "organisations", choisir le collège House of the Dragon
- Dans le tableau des membres, vérifier que la mention “Non connecté depuis 03/2025”  est visible pour le membre Rhaenyra Targaryen , et que pour tous les membres de cette organisation la colonne "dernier accès" du tableau correspond au résultat de la requête
`select "userId", "lastAccessedAt" from "memberships" where "organizationId" = '2023';`
- Dans le tableau, sélectionner l'id de ce membre pour aller sur sa fiche 
- Vérifier que dans l'onglet Pix Orga de cette fiche, la la mention “Non connecté depuis 03/2025”  est associée au collège House of the Dragon et que pour toutes les organisations de cet utilisateur les résultats correspondent au résultat de la requête
`select "organizationId", "lastAccessedAt" from "memberships" where "userId" = ***`
- Faites les mêmes vérifications à partir du centre de certification Accessorium et de James Palédroits, d'abord dans  la liste des membres de ce centre, puis sur la fiche de James dans l'onglet Pix Certif
- Pour vérifier la présence de la mention dans les informations globales de la fiche utilisateur, cherchez Eliza dans les "Utilisateurs" , et vérifiez la mention 'Date de dernière connexion globale : Non connecté depuis 03/2025' dans les informations globales
- Vérifier enfin que dans l'onglet Connexions d'Eliza que la mention “Non connecté depuis 03/2025”  est associée à toutes ses méthodes de connexion, y compris le GAR, et que ce résultat correspond à la requête
`select "identityProvider", "lastLoggedAt" from "authentication-methods" where "userId" =  ***`