### PR TITLE
[BUGFIX] Encoder l'adresse email présente dans l'URL (PIX-17205).

### DIFF
--- a/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
+++ b/api/src/identity-access-management/domain/emails/create-warning-connection.email.js
@@ -27,7 +27,7 @@ export function createWarningConnectionEmail({ locale, email, firstName, validat
 
   const { i18n, defaultVariables } = factory;
   const pixAppUrl = urlBuilder.getPixAppBaseUrl(locale);
-  const resetUrl = `${pixAppUrl}/mot-de-passe-oublie?lang=${lang}&email=${email}`;
+  const resetUrl = `${pixAppUrl}/mot-de-passe-oublie?lang=${lang}&email=${encodeURIComponent(email)}`;
 
   return factory.buildEmail({
     template: mailer.warningConnectionTemplateId,

--- a/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
+++ b/api/tests/identity-access-management/unit/domain/emails/create-warning-connection.email.test.js
@@ -59,7 +59,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fen%2Fsupport';
 
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Den%26email%3Dtoto%40example.net';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Den%26email%3Dtoto%2540example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -83,7 +83,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const expectedSupportUrl =
         'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
       const expectedResetUrl =
-        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%40example.net';
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%2540example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -107,7 +107,7 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       const expectedSupportUrl =
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Ffr%2Fsupport';
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%40example.net';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%2540example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });
@@ -129,10 +129,34 @@ describe('Unit | Identity Access Management | Domain | Email | create-warning-co
       // then
       const { resetUrl, helpDeskUrl } = email.variables;
       const expectedResetUrl =
-        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl%26email%3Dtoto%40example.net';
+        'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.org%2Fmot-de-passe-oublie%3Flang%3Dnl%26email%3Dtoto%2540example.net';
 
       const expectedSupportUrl =
         'https://test.app.pix.org/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.org%2Fnl-be%2Fsupport';
+      expect(resetUrl).to.equal(expectedResetUrl);
+      expect(helpDeskUrl).to.equal(expectedSupportUrl);
+    });
+  });
+
+  describe('when the email query parameter contains a +', function () {
+    it('provides the correct urls', function () {
+      // given
+      const emailParams = {
+        email: 'toto+tata@example.net',
+        locale: 'fr-fr',
+        firstName: 'John',
+        validationToken: 'token',
+      };
+
+      // when
+      const email = createWarningConnectionEmail(emailParams);
+
+      // then
+      const { helpDeskUrl, resetUrl } = email.variables;
+      const expectedSupportUrl =
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Fpix.fr%2Fsupport';
+      const expectedResetUrl =
+        'https://test.app.pix.fr/api/users/validate-email?token=token&redirect_url=https%3A%2F%2Ftest.app.pix.fr%2Fmot-de-passe-oublie%3Flang%3Dfr%26email%3Dtoto%252Btata%2540example.net';
       expect(resetUrl).to.equal(expectedResetUrl);
       expect(helpDeskUrl).to.equal(expectedSupportUrl);
     });


### PR DESCRIPTION
## 🌸 Problème

Je reçois mon e-mail de notification de reconnexion, je clique sur le bouton pour réinitialiser mon mot de passe, mon adresse e-mail est bien reportée mais le “+” n’est pas reporté.

Cette PR fait suite à #11753.

## 🌳 Proposition
Encoder le contenu du query parameter email.

## 🤧 Pour tester
- Se créer un compte sur Pix App avec son adresse mail suivi d'un alias (ex: prenom.nom+alias@pix.fr)
- Se déconnecter de Pix App
- Se connecter à la base de données de la RA
- Jouer les requêtes suivantes :
```
select * from users where "email"='prenom.nom+alias@pix.fr';
select * from "user-logins" where "userId"='votreUserId';
UPDATE "user-logins" SET "lastLoggedAt" = '2020/01/01' where id=votreUserLoginsId;
```
- Se connecter à Pix App
- Aller consulter ses mails pour retrouver pour y trouver le mail envoyé par Pix qui propose à l'utilisateur de réinitialiser son mot de passe
- Cliquer sur ce lien, modifier https://app.pix.fr en https://app-pr11852.review.pix.fr/ 
- Constater que le paramètre email=prenom.nom+alias@pix.fr est présent dans l'url
- Constater que votre email a été automatiquement reporté dans le champ concerné avec le "+" conservé
