### PR TITLE
[BUGFIX] Eviter les doublons de competences dans la reponse Parcoursup  (PIX-17218).

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
@@ -92,14 +92,18 @@ const getByVerificationCode = async ({ verificationCode }) => {
  */
 const _toDomain = (certificationResultDto) => {
   return certificationResultDto.map((certificationResult) => {
-    const competences = certificationResult.competences.map((competence) => {
-      return new Competence({
-        code: competence.competence_code,
-        name: competence.competence_name,
-        areaName: competence.area_name,
-        level: competence.competence_level,
-      });
-    });
+    const uniqCompetences = new Map();
+    for (const competence of certificationResult.competences) {
+      uniqCompetences.set(
+        competence.competence_code,
+        new Competence({
+          code: competence.competence_code,
+          name: competence.competence_name,
+          areaName: competence.area_name,
+          level: competence.competence_level,
+        }),
+      );
+    }
 
     return new CertificationResult({
       ine: certificationResult.national_student_id,
@@ -110,7 +114,7 @@ const _toDomain = (certificationResultDto) => {
       status: certificationResult.status,
       pixScore: certificationResult.pix_score,
       certificationDate: certificationResult.certification_date,
-      competences,
+      competences: Array.from(uniqCompetences.values()),
     });
   });
 };

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-parcoursup-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-parcoursup-repository_test.js
@@ -64,6 +64,60 @@ describe('Certification | Results | Infrastructure | Integration | Repositories 
         });
         expect(results).to.deep.equal([expectedCertification]);
       });
+
+      it('should keep only one competence by competence code', async function () {
+        // given
+        const ine = '1234';
+        const certificationResultData = {
+          nationalStudentId: ine,
+          organizationUai: 'UAI ETAB ELEVE',
+          lastName: 'NOM-ELEVE',
+          firstName: 'PRENOM-ELEVE',
+          birthdate: '2000-01-01',
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: '2024-11-22T09:39:54',
+        };
+        const duplicatedCompetency = {
+          competenceCode: '1.1',
+          competenceName: 'Mener une recherche et une veille d’information',
+          areaName: 'Informations et données',
+          competenceLevel: 3,
+        };
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        await datamartBuilder.commit();
+
+        // when
+        const results = await certificationRepository.getByINE({ ine });
+
+        // then
+        const expectedCertification = domainBuilder.certification.results.parcoursup.buildCertificationResult({
+          ine,
+          organizationUai: 'UAI ETAB ELEVE',
+          lastName: 'NOM-ELEVE',
+          firstName: 'PRENOM-ELEVE',
+          birthdate: '2000-01-01',
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: new Date('2024-11-22T09:39:54Z'),
+          competences: [
+            domainBuilder.certification.results.parcoursup.buildCompetence({
+              code: '1.1',
+              name: 'Mener une recherche et une veille d’information',
+              areaName: 'Informations et données',
+              level: 3,
+            }),
+          ],
+        });
+        expect(results).to.deep.equal([expectedCertification]);
+      });
     });
 
     describe('when no certifications are found for given ine', function () {
@@ -140,6 +194,70 @@ describe('Certification | Results | Infrastructure | Integration | Repositories 
               areaName: 'Informations et données',
               level: 3,
             }),
+            domainBuilder.certification.results.parcoursup.buildCompetence({
+              code: '1.2',
+              name: 'Gérer des données',
+              areaName: 'Informations et données',
+              level: 5,
+            }),
+          ],
+        });
+        expect(results).to.deep.equal([expectedCertification]);
+      });
+
+      it('should keep only one competence by competence code', async function () {
+        // given
+        const organizationUai = '1234567A';
+        const lastName = 'LEPONGE';
+        const firstName = 'Bob';
+        const birthdate = '2000-01-01';
+        const certificationResultData = {
+          nationalStudentId: '1234',
+          organizationUai,
+          lastName,
+          firstName,
+          birthdate,
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: '2024-11-22T09:39:54',
+        };
+
+        const duplicatedCompetency = {
+          competenceCode: '1.2',
+          competenceName: 'Gérer des données',
+          areaName: 'Informations et données',
+          competenceLevel: 5,
+        };
+
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        datamartBuilder.factory.buildCertificationResult({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        await datamartBuilder.commit();
+
+        // when
+        const results = await certificationRepository.getByOrganizationUAI({
+          organizationUai,
+          lastName,
+          firstName,
+          birthdate,
+        });
+
+        // then
+        const expectedCertification = domainBuilder.certification.results.parcoursup.buildCertificationResult({
+          ine: '1234',
+          organizationUai,
+          lastName,
+          firstName,
+          birthdate,
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: new Date('2024-11-22T09:39:54Z'),
+          competences: [
             domainBuilder.certification.results.parcoursup.buildCompetence({
               code: '1.2',
               name: 'Gérer des données',
@@ -233,6 +351,63 @@ describe('Certification | Results | Infrastructure | Integration | Repositories 
               name: 'Gérer des données',
               areaName: 'Informations et données',
               level: 5,
+            }),
+          ],
+        });
+        expect(results).to.deep.equal([expectedCertification]);
+      });
+
+      it('should keep only one competence by competence code', async function () {
+        // given
+        const verificationCode = 'P-1234567A';
+        const lastName = 'LEPONGE';
+        const firstName = 'Bob';
+        const birthdate = '2000-01-01';
+        const certificationResultData = {
+          verificationCode,
+          lastName,
+          firstName,
+          birthdate,
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: '2024-11-22T09:39:54',
+        };
+        const duplicatedCompetency = {
+          ...certificationResultData,
+          competenceCode: '1.1',
+          competenceName: 'Mener une recherche et une veille d’information',
+          areaName: 'Informations et données',
+          competenceLevel: 3,
+        };
+        datamartBuilder.factory.buildCertificationResultCodeValidation({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        datamartBuilder.factory.buildCertificationResultCodeValidation({
+          ...certificationResultData,
+          ...duplicatedCompetency,
+        });
+        await datamartBuilder.commit();
+
+        // when
+        const results = await certificationRepository.getByVerificationCode({
+          verificationCode,
+        });
+
+        // then
+        const expectedCertification = domainBuilder.certification.results.parcoursup.buildCertificationResult({
+          lastName,
+          firstName,
+          birthdate,
+          status: 'validated',
+          pixScore: 327,
+          certificationDate: new Date('2024-11-22T09:39:54Z'),
+          competences: [
+            domainBuilder.certification.results.parcoursup.buildCompetence({
+              code: '1.1',
+              name: 'Mener une recherche et une veille d’information',
+              areaName: 'Informations et données',
+              level: 3,
             }),
           ],
         });


### PR DESCRIPTION
## 🌸 Problème

Le datamart contient des doublons pour un meme candidat au niveau des competences. Du coup on a plusieurs fois une meme competence dans la reponse de retour.

## 🌳 Proposition

Filtrer les doublons (data regarde pour les enlever du datamart ceci est notre réponse en attendant la reconstruction du datamart).

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

* Sur la RA, documentation de Parcoursup sur https://api-pr11856.review.pix.fr/documentation/parcoursup
* Tester une recherche sur l'UAI "UAIMONDOUBLON" + "FamilleMONDOUBLON" + "PrenomMONDOUBLON" + birthdate "1999-11-12", et verifier la réponse JSON qui ne doit **pas** contenir deux fois une meme competence
* Tester sur l'INE "123456789DO", et verifier la réponse JSON qui ne doit **pas** contenir deux fois une meme competence

Pour info la vision BDD
![image](https://github.com/user-attachments/assets/6170b277-6ae8-4649-89a2-9e963f1dfab1)
