### PR TITLE
[TECH] déplace la table `campaign-participation-tube-reached-levels` dans le datamart (pix-17221)

### DIFF
--- a/api/datamart/migrations/20250326100840_add-campaign-participation-tube-reached-levels-table.js
+++ b/api/datamart/migrations/20250326100840_add-campaign-participation-tube-reached-levels-table.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'campaign_participation_tube_reached_levels';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary();
+
+    table.string('tube_id').notNullable().comment('Framework tube id');
+
+    table.integer('campaign_participation_id').notNullable().comment('Campaign participation id');
+
+    table
+      .smallint('reached_level')
+      .notNullable()
+      .comment(
+        'Maximum level reached by the learner. It matches the highest skill level obtained by the user for this tube.',
+      );
+
+    table.unique(['campaign_participation_id', 'tube_id']);
+
+    table.comment(
+      `This table stores the levels reached by the learners once they share the campaign.
+          Each row contains the highest reached level for a campaign tube.`,
+    );
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20250326164240_remove-campaign-participation-tube-reached-levels-table.js
+++ b/api/db/migrations/20250326164240_remove-campaign-participation-tube-reached-levels-table.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'campaign-participation-tube-reached-levels';
+
+const up = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+const down = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary();
+
+    table.string('tubeId').notNullable().comment('Framework tube id');
+
+    table
+      .integer('campaignParticipationId')
+      .references('campaign-participations.id')
+      .notNullable()
+      .comment('Campaign participation id');
+
+    table
+      .smallint('reachedLevel')
+      .notNullable()
+      .comment(
+        'Maximum level reached by the learner. It matches the highest skill level obtained by the user for this tube.',
+      );
+    table.comment(
+      `This table stores the levels reached by the learners once they share the campaign.
+          Each row contains the highest reached level for a campaign tube.`,
+    );
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

La table qui agrège les données des niveaux atteins par tube pour une participation ne respecte pas l'[adr 51](https://github.com/1024pix/pix/blob/dev/docs/adr/0059-mise-a-disposition-de-donnees.md).

## 🌳 Proposition

On déplace la table dans le datamart

## 🐝 Remarques

RAS

## 🤧 Pour tester
```bash
 scalingo -a pix-api-maddo-review-pr11857 pgsql-console
```
```sql
\d data_campaign_participation_tube_reached_levels
```
