### PR TITLE
[TECH] :truck: Déplace le cas d'usage `find-tutorial` vers `src/`

### DIFF
--- a/api/src/devcomp/domain/usecases/find-tutorials.js
+++ b/api/src/devcomp/domain/usecases/find-tutorials.js
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 
-import { Scorecard } from '../../../src/evaluation/domain/models/Scorecard.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../src/shared/domain/errors.js';
-import { KnowledgeElement } from '../../../src/shared/domain/models/KnowledgeElement.js';
+// TODO Bounded context violation
+import { Scorecard } from '../../../evaluation/domain/models/Scorecard.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
+import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
 
 const findTutorials = async function ({
   authenticatedUserId,
@@ -13,8 +14,10 @@ const findTutorials = async function ({
   tutorialRepository,
   locale,
 }) {
+  // TODO replace scorecardId by competenceId
   const { userId, competenceId } = Scorecard.parseId(scorecardId);
 
+  // TODO refactor to extract this guard to controller
   if (parseInt(authenticatedUserId) !== parseInt(userId)) {
     throw new UserNotAuthorizedToAccessEntityError();
   }

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -8,6 +8,7 @@ import * as campaignParticipationRepository from '../../../prescription/campaign
 import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -20,6 +21,7 @@ const dependencies = {
   campaignParticipationRepository,
   knowledgeElementRepository,
   targetProfileRepository,
+  tubeRepository,
   targetProfileTrainingRepository,
   skillRepository,
   userRepository,

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -1,4 +1,6 @@
-import { usecases } from '../../../../lib/domain/usecases/index.js';
+// TODO Bounded context violation
+import { usecases as devCompUsecases } from '../../../devcomp/domain/usecases/index.js';
+// TODO Bounded context violation
 import * as tutorialSerializer from '../../../devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
@@ -23,7 +25,7 @@ const findTutorials = function (request, h, dependencies = { requestResponseUtil
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
-  return usecases
+  return devCompUsecases
     .findTutorials({
       authenticatedUserId,
       scorecardId,

--- a/api/tests/devcomp/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-tutorials_test.js
@@ -1,8 +1,8 @@
-import { findTutorials } from '../../../../lib/domain/usecases/find-tutorials.js';
-import { Scorecard } from '../../../../src/evaluation/domain/models/Scorecard.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../../src/shared/domain/errors.js';
-import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { findTutorials } from '../../../../../src/devcomp/domain/usecases/find-tutorials.js';
+import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../src/shared/domain/errors.js';
+import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | find-tutorials', function () {
   let authenticatedUserId;

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -1,6 +1,6 @@
-import { usecases } from '../../../../../lib/domain/usecases/index.js';
-import { evaluationUsecases } from '../../../../../src/evaluation//domain/usecases/index.js';
+import { usecases as devCompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { scorecardController } from '../../../../../src/evaluation/application/scorecards/scorecard-controller.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import * as requestResponseUtils from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 
@@ -56,7 +56,10 @@ describe('Unit | Controller | scorecard-controller', function () {
     const tutorials = [];
 
     beforeEach(function () {
-      sinon.stub(usecases, 'findTutorials').withArgs({ authenticatedUserId, scorecardId, locale }).resolves(tutorials);
+      sinon
+        .stub(devCompUsecases, 'findTutorials')
+        .withArgs({ authenticatedUserId, scorecardId, locale })
+        .resolves(tutorials);
     });
 
     it('should call the expected usecase', async function () {


### PR DESCRIPTION
## 🌸 Problème

Le cas d'usage `find-tutorial` est encore dans `lib/`

## 🌳 Proposition

Déplacer le cas d'usage `find-tutorial` vers `src/`

## 🐝 Remarques

Il y a un appel à un cas d'usage de devcomp, mais qui utilise une scorecard qui est de chez évaluation ... Il y a des dépendances à nettoyer par ici, mais ce n'est pas l'objet de cette PR. J'ai laissé des traces (commentaire) pour y penser à l'occasion...

## 🤧 Pour tester