### PR TITLE
[FEATURE] Maddo - Récupération des campagnes d'une organisation (PIX-17223).

### DIFF
--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -37,6 +37,7 @@ async function _createScoOrganization(databaseBuilder) {
       { id: FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID },
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
     ],
+    tagIds: [COLLEGE_TAG.id],
   });
 
   await organization.createOrganization({
@@ -52,7 +53,6 @@ async function _createScoOrganization(databaseBuilder) {
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
       { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID, params: JSON.stringify([ATTESTATIONS.SIXTH_GRADE]) },
     ],
-    tagIds: [COLLEGE_TAG.id],
   });
 
   await organization.createOrganization({

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,6 +1,18 @@
+import boom from '@hapi/boom';
+
 import { usecases } from '../domain/usecases/index.js';
 
 export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
   const organizations = await dependencies.findOrganizations({ organizationIds: request.pre.organizationIds });
   return h.response(organizations).code(200);
+}
+
+export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
+  const organizationIds = request.pre.organizationIds;
+  const requestedOrganizationId = request.params.organizationId;
+  if (!organizationIds.includes(requestedOrganizationId)) {
+    return boom.forbidden();
+  }
+  const campaigns = await dependencies.findCampaigns({ organizationId: requestedOrganizationId });
+  return h.response(campaigns).code(200);
 }

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -1,4 +1,7 @@
-import { getOrganizations } from './organizations-controller.js';
+import Joi from 'joi';
+
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { getOrganizationCampaigns, getOrganizations } from './organizations-controller.js';
 import { organizationPreHandler } from './pre-handlers.js';
 
 const register = async function (server) {
@@ -10,7 +13,23 @@ const register = async function (server) {
         auth: { access: { scope: 'meta' } },
         pre: [organizationPreHandler],
         handler: getOrganizations,
-        notes: ["- Retourne la liste des organizations auxquelles l'application client a droit"],
+        notes: ["- Retourne la liste des organisations auxquelles l'application client a droit"],
+        tags: ['api', 'meta'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/campaigns',
+      config: {
+        auth: { access: { scope: 'meta' } },
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        pre: [organizationPreHandler],
+        handler: getOrganizationCampaigns,
+        notes: ["- Retourne la liste des campaignes de l'organisation fournie"],
         tags: ['api', 'meta'],
       },
     },

--- a/api/src/maddo/domain/models/Campaign.js
+++ b/api/src/maddo/domain/models/Campaign.js
@@ -1,0 +1,23 @@
+export class Campaign {
+  constructor({
+    id,
+    name,
+    organizationId,
+    organizationName,
+    type,
+    targetProfileId,
+    targetProfileName,
+    code,
+    createdAt,
+  }) {
+    this.id = id;
+    this.name = name;
+    this.organizationId = organizationId;
+    this.organizationName = organizationName;
+    this.type = type;
+    this.targetProfileId = targetProfileId;
+    this.targetProfileName = targetProfileName;
+    this.code = code;
+    this.createdAt = createdAt;
+  }
+}

--- a/api/src/maddo/domain/usecases/find-campaigns.js
+++ b/api/src/maddo/domain/usecases/find-campaigns.js
@@ -1,0 +1,3 @@
+export async function findCampaigns({ organizationId, campaignRepository }) {
+  return campaignRepository.findByOrganizationId(organizationId);
+}

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
 
@@ -11,6 +12,7 @@ const path = dirname(fileURLToPath(import.meta.url));
 const dependencies = {
   clientApplicationRepository,
   organizationRepository,
+  campaignRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -1,0 +1,27 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { Campaign } from '../../domain/models/Campaign.js';
+
+export async function findByOrganizationId(organizationId) {
+  const rawCampaigns = await knex
+    .select(
+      'campaigns.id',
+      'campaigns.organizationId',
+      'campaigns.name',
+      'campaigns.type',
+      'campaigns.targetProfileId',
+      'campaigns.code',
+      'campaigns.createdAt',
+      'target-profiles.name as targetProfileName',
+      'organizations.name as organizationName',
+    )
+    .from('campaigns')
+    .join('organizations', 'campaigns.organizationId', 'organizations.id')
+    .join('target-profiles', 'campaigns.targetProfileId', 'target-profiles.id')
+    .where('campaigns.organizationId', organizationId)
+    .orderBy('campaigns.id');
+  return rawCampaigns.map(toDomain);
+}
+
+function toDomain(rawCampaign) {
+  return new Campaign(rawCampaign);
+}

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -1,0 +1,53 @@
+import { Campaign } from '../../../../../src/maddo/domain/models/Campaign.js';
+import { findByOrganizationId } from '../../../../../src/maddo/infrastructure/repositories/campaign-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | campaign', function () {
+  describe('#findByOrganizationId', function () {
+    it('lists campaigns belonging to organization with given id', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const { id: otherOrganizationId } = databaseBuilder.factory.buildOrganization();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const campaign1 = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+      });
+      const campaign2 = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+      });
+      databaseBuilder.factory.buildCampaign({ organizationId: otherOrganizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const campaigns = await findByOrganizationId(organization.id);
+
+      // then
+      expect(campaigns).to.deep.equal([
+        new Campaign({
+          id: campaign1.id,
+          name: campaign1.name,
+          organizationId: organization.id,
+          organizationName: organization.name,
+          type: campaign1.type,
+          targetProfileId: targetProfile.id,
+          targetProfileName: targetProfile.name,
+          code: campaign1.code,
+          createdAt: campaign1.createdAt,
+        }),
+        new Campaign({
+          id: campaign2.id,
+          name: campaign2.name,
+          organizationId: organization.id,
+          organizationName: organization.name,
+          type: campaign2.type,
+          targetProfileId: targetProfile.id,
+          targetProfileName: targetProfile.name,
+          code: campaign2.code,
+          createdAt: campaign2.createdAt,
+        }),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Il n'est pas possible de récupérer les données de toutes les campagnes d'une organisation donnée via un appel d'API autorisé pour une application cliente.

## 🌳 Proposition

On ajoute une route `/api/organizations/:organizationId/campaigns` qui retourne les données des campagnes de l'organisation demandée.

La route vérifie que l'organisation demandée fait bien partie de la juridiction de l'application cliente.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

Les données de taux de couverture ne sont pas disponibles pour le moment.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Récupérer un token avec

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11779.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta' | jq -r .access_token)
```

Appeler la route `/api/organizations` avec ce token.

```
curl https://pix-api-maddo-review-pr11779.osc-fr1.scalingo.io/api/organizations -H "Authorization: Bearer $ACCESS_TOKEN"
```

Appeler la route `/api/organizations/:id/campaigns` avec le token et en remplaçant l'id d'organisation par celui d'une organisation de la réponse précédente.
