### PR TITLE
[FEATURE] Modifier l'interface de la double mire SSO pour inclure toutes les données récupérées des utilisateurs (PIX-16303)

### DIFF
--- a/admin/app/routes/authentication/login-oidc.js
+++ b/admin/app/routes/authentication/login-oidc.js
@@ -76,9 +76,9 @@ export default class LoginOidcRoute extends Route {
       const error = new JSONApiError(apiError.detail, apiError);
 
       const shouldUserCreateAnAccount = error.code === 'SHOULD_VALIDATE_CGU';
-      const { authenticationKey, email } = error.meta ?? {};
+      const { authenticationKey, userClaims } = error.meta ?? {};
       if (shouldUserCreateAnAccount && authenticationKey) {
-        return { shouldUserCreateAnAccount, authenticationKey, email, identityProviderSlug };
+        return { shouldUserCreateAnAccount, authenticationKey, email: userClaims.email, identityProviderSlug };
       }
 
       if (error.status === '403' && error.code === 'PIX_ADMIN_ACCESS_NOT_ALLOWED') {

--- a/admin/tests/unit/routes/authentication/login-oidc-test.js
+++ b/admin/tests/unit/routes/authentication/login-oidc-test.js
@@ -164,7 +164,9 @@ module('Unit | Route | login-oidc', function (hooks) {
               authenticationKey: 'key',
               givenName: 'Mélusine',
               familyName: 'TITEGOUTTE',
-              email: 'melu@example.net',
+              userClaims: {
+                email: 'melu@example.net',
+              },
             },
           },
         ],

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -42,14 +42,8 @@ async function authenticateOidcUser(request, h) {
   // TODO utiliser un message en anglais au lieu du français
   const message = "L'utilisateur n'a pas de compte Pix";
   const responseCode = 'SHOULD_VALIDATE_CGU';
-  const { authenticationKey, givenName, familyName, email } = result;
-  const meta = { authenticationKey, givenName, familyName };
 
-  if (email) {
-    Object.assign(meta, { email });
-  }
-
-  throw new UnauthorizedError(message, responseCode, meta);
+  throw new UnauthorizedError(message, responseCode, result);
 }
 
 /**

--- a/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
@@ -1,4 +1,8 @@
+import lodash from 'lodash';
+
 import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+
+const { omit } = lodash;
 
 /**
  * @typedef {function} authenticateOidcUser
@@ -63,8 +67,17 @@ async function authenticateOidcUser({
 
   if (!user) {
     const authenticationKey = await authenticationSessionService.save({ userInfo, sessionContent });
-    const { firstName: givenName, lastName: familyName, email } = userInfo;
-    return { authenticationKey, givenName, familyName, email, isAuthenticationComplete: false };
+
+    const userClaims = omit(userInfo, ['externalIdentityId']);
+
+    return {
+      authenticationKey,
+      userClaims,
+      isAuthenticationComplete: false,
+      // TODO: The properties givenName and familyName are kept for backward compatibility with the Front. They will be removed soon.
+      givenName: userClaims.firstName,
+      familyName: userClaims.lastName,
+    };
   }
 
   await _assertUserHasAccessToApplication({ requestedApplication, user, adminMemberRepository });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -83,10 +83,20 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       it('returns UnauthorizedError', async function () {
         // given
         const authenticationKey = 'aaa-bbb-ccc';
-        const givenName = 'Mélusine';
-        const familyName = 'TITEGOUTTE';
+        const firstName = 'Mélusine';
+        const lastName = 'TITEGOUTTE';
         const email = 'melu@example.net';
-        usecases.authenticateOidcUser.resolves({ authenticationKey, givenName, familyName, email });
+        const userClaims = {
+          firstName,
+          lastName,
+          email,
+        };
+        usecases.authenticateOidcUser.resolves({
+          authenticationKey,
+          userClaims,
+          givenName: firstName,
+          familyName: lastName,
+        });
 
         // when
         const error = await catchErr(oidcProviderController.authenticateOidcUser)(request, hFake);
@@ -95,7 +105,12 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         expect(error).to.be.an.instanceOf(UnauthorizedError);
         expect(error.message).to.equal("L'utilisateur n'a pas de compte Pix");
         expect(error.code).to.equal('SHOULD_VALIDATE_CGU');
-        expect(error.meta).to.deep.equal({ authenticationKey, givenName, familyName, email });
+        expect(error.meta).to.deep.equal({
+          authenticationKey,
+          userClaims,
+          givenName: firstName,
+          familyName: lastName,
+        });
       });
     });
   });

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -231,9 +231,13 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         expect(authenticationSessionService.save).to.have.been.calledWithExactly({ userInfo, sessionContent });
         expect(result).to.deep.equal({
           authenticationKey,
+          userClaims: {
+            firstName: 'Mélusine',
+            lastName: 'TITEGOUTTE',
+            email: 'melu@example.net',
+          },
           givenName: 'Mélusine',
           familyName: 'TITEGOUTTE',
-          email: 'melu@example.net',
           isAuthenticationComplete: false,
         });
       });

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -2,39 +2,46 @@
 <div class="login-or-register-oidc-form__container">
   <div class="login-or-register-oidc-form__register-container">
     <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.register-form.title"}}</h2>
-    <div>
-      <p class="login-or-register-oidc-form__description">
-        {{! template-lint-disable "no-bare-strings" }}
-        {{t "pages.login-or-register-oidc.register-form.description"}}
-        <em>{{this.identityProviderOrganizationName}}</em>&nbsp;:
-      </p>
-      <div class="login-or-register-oidc-form__information">
-        <ul>
-          <li>{{t "pages.login-or-register-oidc.register-form.information.given-name" givenName=this.givenName}}</li>
-          <li>{{t "pages.login-or-register-oidc.register-form.information.family-name" familyName=this.familyName}}</li>
-        </ul>
+    {{#if this.userClaimsToDisplay.length}}
+      <div>
+        <p class="login-or-register-oidc-form__description">
+          {{! template-lint-disable "no-bare-strings" }}
+          {{t "pages.login-or-register-oidc.register-form.description"}}
+          <em>{{this.identityProviderOrganizationName}}</em>&nbsp;:
+        </p>
+        <div class="login-or-register-oidc-form__information">
+          <ul>
+            {{#each this.userClaimsToDisplay as |userClaimToDisplay|}}
+              <li>{{userClaimToDisplay}}</li>
+            {{/each}}
+          </ul>
+        </div>
       </div>
-    </div>
-    <div class="login-or-register-oidc-form__cgu-container">
-      <PixCheckbox {{on "change" this.onChange}}>
-        <:label>{{t
-            "common.cgu.message"
-            cguUrl=this.cguUrl
-            dataProtectionPolicyUrl=this.dataProtectionPolicyUrl
-            htmlSafe=true
-          }}</:label>
-      </PixCheckbox>
-    </div>
+      <div class="login-or-register-oidc-form__cgu-container">
+        <PixCheckbox {{on "change" this.onChange}}>
+          <:label>{{t
+              "common.cgu.message"
+              cguUrl=this.cguUrl
+              dataProtectionPolicyUrl=this.dataProtectionPolicyUrl
+              htmlSafe=true
+            }}</:label>
+        </PixCheckbox>
+      </div>
 
-    {{#if this.registerErrorMessage}}
+      {{#if this.registerErrorMessage}}
+        <PixNotificationAlert @type="error" class="login-or-register-oidc-form__cgu-error">
+          {{this.registerErrorMessage}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      <PixButton @type="submit" @triggerAction={{this.register}} @isLoading={{this.isRegisterLoading}}>
+        {{t "pages.login-or-register-oidc.register-form.button"}}
+      </PixButton>
+    {{else}}
       <PixNotificationAlert @type="error" class="login-or-register-oidc-form__cgu-error">
-        {{this.registerErrorMessage}}
+        {{this.userClaimsErrorMessage}}
       </PixNotificationAlert>
     {{/if}}
-
-    <PixButton @type="submit" @triggerAction={{this.register}} @isLoading={{this.isRegisterLoading}}>
-      {{t "pages.login-or-register-oidc.register-form.button"}}
-    </PixButton>
   </div>
 
   <div class="login-or-register-oidc-form__divider"></div>

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -35,14 +35,6 @@ export default class LoginOrRegisterOidcComponent extends Component {
     return this.oidcIdentityProviders[this.args.identityProviderSlug]?.organizationName;
   }
 
-  get givenName() {
-    return this.args.givenName;
-  }
-
-  get familyName() {
-    return this.args.familyName;
-  }
-
   get currentLanguage() {
     return this.intl.primaryLocale;
   }
@@ -53,6 +45,41 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
   get dataProtectionPolicyUrl() {
     return this.url.dataProtectionPolicyUrl;
+  }
+
+  get userClaimsErrorMessage() {
+    const { userClaims } = this.args;
+
+    if (!userClaims) {
+      return this.intl.t(`pages.login-or-register-oidc.register-form.information.error`);
+    } else {
+      return null;
+    }
+  }
+
+  get userClaimsToDisplay() {
+    const { userClaims } = this.args;
+
+    const result = [];
+
+    if (userClaims) {
+      const { firstName, lastName, ...rest } = userClaims;
+      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.information.firstName`)} ${firstName}`);
+      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.information.lastName`)} ${lastName}`);
+
+      Object.entries(rest).map(([key, value]) => {
+        let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.information.${key}`)}`;
+        const translation = `${this.intl.t(`pages.login-or-register-oidc.register-form.information.${key}`)}`;
+
+        if (translation.includes('Missing translation')) {
+          label = `${key} :`;
+        }
+
+        return result.push(`${label} ${value}`);
+      });
+    }
+
+    return result;
   }
 
   @action

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -3,8 +3,12 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
+import { SessionStorageEntry } from '../../utils/session-storage-entry';
+
+const oidcUserAuthenticationStorage = new SessionStorageEntry('oidcUserAuthentication');
+
 export default class LoginOrRegisterOidcController extends Controller {
-  queryParams = ['authenticationKey', 'identityProviderSlug', 'givenName', 'familyName'];
+  queryParams = ['identityProviderSlug'];
 
   @service url;
   @service oidcIdentityProviders;
@@ -15,7 +19,6 @@ export default class LoginOrRegisterOidcController extends Controller {
   @service currentDomain;
 
   @tracked showOidcReconciliation = false;
-  @tracked authenticationKey = null;
   @tracked identityProviderSlug = null;
   @tracked email = '';
   @tracked fullNameFromPix = '';
@@ -27,12 +30,24 @@ export default class LoginOrRegisterOidcController extends Controller {
     return this.url.showcase;
   }
 
+  get oidcUserAuthenticationStorage() {
+    return oidcUserAuthenticationStorage.get();
+  }
+
+  get userClaims() {
+    return this.oidcUserAuthenticationStorage?.userClaims;
+  }
+
   get isInternationalDomain() {
     return !this.currentDomain.isFranceDomain;
   }
 
   get selectedLanguage() {
     return this.intl.primaryLocale;
+  }
+
+  get authenticationKey() {
+    return this.oidcUserAuthenticationStorage?.authenticationKey;
   }
 
   @action

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -21,8 +21,7 @@
       <Authentication::LoginOrRegisterOidc
         @identityProviderSlug={{this.identityProviderSlug}}
         @authenticationKey={{this.authenticationKey}}
-        @givenName={{this.givenName}}
-        @familyName={{this.familyName}}
+        @userClaims={{this.userClaims}}
         @onLogin={{this.onLogin}}
       />
     {{/if}}

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -8,7 +8,10 @@ export default function (config) {
         {},
         {
           errors: [
-            { code: 'SHOULD_VALIDATE_CGU', meta: { authenticationKey: 'key', familyName: 'PIX', givenName: 'test' } },
+            {
+              code: 'SHOULD_VALIDATE_CGU',
+              meta: { authenticationKey: 'key', userClaims: { lastName: 'PIX', firstName: 'test' } },
+            },
           ],
         },
       );

--- a/mon-pix/tests/acceptance/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/acceptance/authentication/login-or-register-oidc-test.js
@@ -19,10 +19,7 @@ module('Acceptance | Login or register oidc', function (hooks) {
         const screen = await visit('/connexion/oidc-partner?code=oidc_example_code&state=auth_session_state');
 
         // then
-        assert.strictEqual(
-          currentURL(),
-          '/connexion/oidc?authenticationKey=key&familyName=PIX&givenName=test&identityProviderSlug=oidc-partner',
-        );
+        assert.strictEqual(currentURL(), '/connexion/oidc?identityProviderSlug=oidc-partner');
         assert.dom(screen.getByRole('button', { name: 'Sélectionnez une langue' })).exists();
       });
     });

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -7,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
-import { Response } from 'miragejs';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -70,28 +69,12 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         const state = 'state';
         const session = currentSession();
         session.set('data.state', state);
-        this.server.post('oidc/token', () => {
-          return new Response(
-            401,
-            {},
-            {
-              errors: [
-                {
-                  code: 'SHOULD_VALIDATE_CGU',
-                  meta: {
-                    authenticationKey: 'key',
-                  },
-                },
-              ],
-            },
-          );
-        });
 
         // when
         const screen = await visit(`/connexion/oidc-partner?code=test&state=${state}`);
 
         // then
-        assert.strictEqual(currentURL(), `/connexion/oidc?authenticationKey=key&identityProviderSlug=oidc-partner`);
+        assert.strictEqual(currentURL(), `/connexion/oidc?identityProviderSlug=oidc-partner`);
         assert.ok(screen.getByRole('heading', { name: t('pages.login-or-register-oidc.title') }));
       });
 
@@ -106,7 +89,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         sessionStorage.setItem('campaigns', JSON.stringify(data));
 
         // when
-        const screen = await visit(`/connexion/oidc?authenticationKey=key&identityProviderSlug=oidc-partner`);
+        const screen = await visit(`/connexion/oidc?identityProviderSlug=oidc-partner`);
+
         await click(screen.getByRole('checkbox', { name: t('common.cgu.label') }));
         await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
 

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc-test.js
@@ -36,7 +36,10 @@ module('Unit | Controller | authentication | login-or-register-oidc', function (
         fullNameFromPix: 'Glace Alo',
         authenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
       });
-      controller.authenticationKey = authenticationKey;
+
+      sinon.stub(controller, 'authenticationKey').get(function () {
+        return authenticationKey;
+      });
       controller.identityProviderSlug = 'oidc-partner';
       sinon.stub(controller.store, 'createRecord').returns({ login });
 
@@ -75,6 +78,7 @@ module('Unit | Controller | authentication | login-or-register-oidc', function (
 
       const email = 'glace.alo@example.net';
       const password = 'pix123';
+      const authenticationKey = '1234567azerty';
       const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
       const login = sinon.stub().resolves({
         email,
@@ -89,6 +93,9 @@ module('Unit | Controller | authentication | login-or-register-oidc', function (
       controller.showOidcReconciliation = false;
       controller.identityProviderSlug = 'oidc-partner';
       sinon.spy(controller.store, 'createRecord');
+      sinon.stub(controller, 'authenticationKey').get(function () {
+        return authenticationKey;
+      });
 
       // when
       await controller.onLogin({ enteredEmail: email, enteredPassword: password });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1550,8 +1550,11 @@
         "button": "Create my account",
         "description": "An account will be created based on the information sent by the organisation",
         "information": {
-          "family-name": "Last name  : {familyName}",
-          "given-name": "First name : {givenName}"
+          "employeeNumber": "Employee number :",
+          "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+          "firstName": "First name :",
+          "lastName": "Last name :",
+          "population": "Population :"
         },
         "title": "Sign up"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1550,8 +1550,11 @@
         "button": "Je crée mon compte",
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
         "information": {
-          "family-name": "Nom : {familyName}",
-          "given-name": "Prénom : {givenName}"
+          "employeeNumber": "Numéro d'employé :",
+          "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
+          "firstName": "Prénom :",
+          "lastName": "Nom :",
+          "population": "Population :"
         },
         "title": "Je n’ai pas de compte Pix"
       },


### PR DESCRIPTION
## 🌸 Problème

Actuellement, sur la page de la double mire SSO, la liste des informations récupérées auprès d'un SSO OIDC sont écrites en dur au lieu d'être dynamiques en fonction de ce qui est récupéré effectivement auprès de chaque SSO.

## 🌳 Proposition

Rendre générique la récupération et l'affichage des userClaims.

## 🐝 Remarques

Les informations sont désormais stockées dans le session storage et non plus passées en queryParams


## 🤧 Pour tester

- Sur Mon Pix
  - Se connecter avec le sso fwb
  - Constater que le numéro d'employé et la population s'affichent dans la partie "Je n’ai pas de compte Pix"
  
![image](https://github.com/user-attachments/assets/efdd846f-37f7-4ff9-8399-cc48b4ec1aa8)

  - Se connecter avec le sso pays de la Loire
  - Constater que seuls le Prénom et Nom s'affichent dans la partie "Je n’ai pas de compte Pix"
  
  
![image](https://github.com/user-attachments/assets/3f929d57-66d4-4b19-812d-ed16c20e22f6)

  - Supprimer les "userClaims" dans "oidcUserAuthentication" du session storage
  - rafraichir la page
  - Constater le message d'erreur
  
![Erreur : Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.](https://github.com/user-attachments/assets/9b6e975b-b176-43ab-81e5-9cb1432f9c81)

- Sur Pix Admin : vérifier qu'il est toujours possible de se connecter par SSO (bien repartir d'un situation avec BDD dans un état initial après un `npm run db:reset`).
  
