### PR TITLE
[FEATURE] Revoir le design de la page d'erreur (PIX-17054).

### DIFF
--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -49,18 +49,15 @@
     padding: var(--pix-spacing-6x) 0;
   }
 
+  @include breakpoints.device-is('mobile') {
+    padding: 0 0 var(--pix-spacing-4x);
+  }
+
   &__title {
     @extend %pix-title-m;
 
     padding-bottom: var(--pix-spacing-6x);
-
-    @include breakpoints.device-is('mobile') {
-      text-align: center;
-    }
-
-    @include breakpoints.device-is('tablet') {
-      text-align: center;
-    }
+    text-align: center;
   }
 
   p {

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
 
 .error-page {
   display: flex;
@@ -7,15 +8,20 @@
   margin-top: 5%;
 
   &__error {
-    margin: 20px;
-    padding: 20px;
+    margin: var(--pix-spacing-6x);
+    padding: var(--pix-spacing-6x);
     color: var(--pix-neutral-500);
     background: var(--pix-neutral-20);
+
+    p {
+      margin-bottom: var(--pix-spacing-4x);
+    }
   }
 
   &__error-title {
-    font-weight: 600;
-    font-size: 0.938rem;
+    @extend %pix-body-l;
+
+    font-weight: var(--pix-font-bold);
   }
 }
 
@@ -31,34 +37,41 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 20px;
-  padding: 40px;
-  border-bottom: 1px dashed var(--pix-neutral-100);
+  margin: 0 var(--pix-spacing-6x);
+  padding: var(--pix-spacing-8x);
+  border-bottom: solid 1px var(--pix-neutral-100);
 
   @include breakpoints.device-is('desktop') {
-    padding: 80px 0;
+    padding: var(--pix-spacing-6x) 0;
+  }
+
+  &__title {
+    @extend %pix-title-m;
+
+    padding-bottom: var(--pix-spacing-6x);
   }
 
   p {
-    padding-bottom: 0.8rem;
-    font-size: 1rem;
+    @extend %pix-body-l;
+
+    padding-bottom: var(--pix-spacing-3x);
+    color: var(--pix-neutral-500);
     text-align: center;
 
     a {
       text-decoration: underline;
     }
   }
-}
 
-.error-page-main-content__title {
-  padding-bottom: 20px;
-  font-size: 1.5rem;
+  &__button-link {
+    margin-top: var(--pix-spacing-6x);
+  }
 }
 
 .error-page__index-link {
-  margin-top: 20px;
+  margin-top: var(--pix-spacing-6x);
 
   @include breakpoints.device-is('desktop') {
-    margin-top: 40px;
+    margin-top: var(--pix-spacing-8x);
   }
 }

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -31,6 +31,10 @@
   @include breakpoints.device-is('desktop') {
     max-width: 980px;
   }
+
+  @include breakpoints.device-is('mobile') {
+    margin:  0 0 var(--pix-spacing-4x);
+  }
 }
 
 .error-page__main-content {
@@ -49,6 +53,14 @@
     @extend %pix-title-m;
 
     padding-bottom: var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('mobile') {
+      text-align: center;
+    }
+
+    @include breakpoints.device-is('tablet') {
+      text-align: center;
+    }
   }
 
   p {

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -2,19 +2,24 @@
 
 <Global::AppLayout>
   <div class="error-page">
-    <div class="rounded-panel rounded-panel--strong error-page__body-section">
+    <PixBlock class="error-page__body-section">
       <div class="error-page__main-content">
-        <h1 class="error-page-main-content__title">{{t "pages.error.first-title"}}</h1>
+        <h1 class="error-page__main-content__title">{{t "pages.error.first-title"}}</h1>
         {{t "pages.error.content-text" htmlSafe=true}}
-        <LinkTo @route="authentication.login" class="button button--extra-big button--link error-page__index-link">
-          {{t "navigation.back-to-homepage"}}</LinkTo>
+        <PixButtonLink
+          @route="authentication.login"
+          @size="large"
+          aria-label={{t "navigation.back-to-homepage"}}
+          class="error-page__main-content__button-link"
+        >
+          {{t "navigation.back-to-homepage"}}
+        </PixButtonLink>
       </div>
       <div class="error-page__error">
         <p class="error-page__error-title">{{this.errorTitle}}</p>
         <p>{{this.errorStatus}}</p>
         <p>{{this.errorMessage}}</p>
-        <p>{{this.errorDetail}}</p>
       </div>
-    </div>
+    </PixBlock>
   </div>
 </Global::AppLayout>

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -18,6 +18,7 @@
       <div class="error-page__error">
         <p class="error-page__error-title">{{this.errorTitle}}</p>
         <p>{{this.errorStatus}}</p>
+        <p>{{this.errorDetail}}</p>
         <p>{{this.errorMessage}}</p>
       </div>
     </PixBlock>


### PR DESCRIPTION
## 🌸 Problème
Suite à la PR sur les nouveaux gabarits Pix App, il y a quelques ajustements à réaliser. Celui-ci en est un.

## 🌳 Proposition
Appliquer cette [maquette](https://www.figma.com/design/tlukMJuPbw6yec01fWDCuV/App---Rdy-Dev?node-id=12905-78911&m=dev)
- PixBlock en pleine largeur
- Utilisation des PixButton
- Utilisation des TokensFont

## 🤧 Pour tester
- Difficile à tester en RA, je recommande de tester en local
- En local :
- Aller sur Pix App, se connecter pour accéder à l'accueil
- Modifier la méthode getCampaignParticipationOverviews présente dans le controller campaign-participation-controller.js. Ajouter la commande `throw new Error()` en début de méthode.
- Recharger la page d'accueil, la page d'erreur doit s'afficher. Constater l'alignement de cette page à la maquette demandée
