### PR TITLE
[FEATURE] Ajout d'une route de mise à disposition pour les résultats de campagne

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -97,7 +97,7 @@ function createClientApplications(databaseBuilder) {
     name: 'multi-organizations-client-application',
     clientId: 'maddo-client',
     clientSecret: 'maddo-secret',
-    scopes: ['meta'],
+    scopes: ['meta', 'campaigns'],
     jurisdiction: { rules: [{ name: 'tags', value: [COLLEGE_TAG.name] }] },
   });
 }

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -6,8 +6,9 @@ import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
-import * as organizationRoutes from './src/maddo/application/organizations-routes.js';
-import * as replicationRoutes from './src/maddo/application/replications-routes.js';
+import * as campaignsRoutes from './src/maddo/application/campaigns-routes.js';
+import * as organizationsRoutes from './src/maddo/application/organizations-routes.js';
+import * as replicationsRoutes from './src/maddo/application/replications-routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
 import { config } from './src/shared/config.js';
@@ -180,7 +181,13 @@ const setupAuthentication = function (server) {
 };
 
 const setupRoutesAndPlugins = async function (server) {
-  const routes = [healthcheckRoutes, ...identityAccessManagementRoutes, replicationRoutes, organizationRoutes];
+  const routes = [
+    ...identityAccessManagementRoutes,
+    campaignsRoutes,
+    healthcheckRoutes,
+    organizationsRoutes,
+    replicationsRoutes,
+  ];
   const routesWithOptions = routes.map((route) => ({
     plugin: route,
     options: { tags: ['maddo'] },

--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -1,0 +1,12 @@
+import { usecases } from '../domain/usecases/index.js';
+
+export async function getCampaignParticipations(
+  request,
+  h,
+  dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
+) {
+  const campaignParticipations = await dependencies.getCampaignParticipations({
+    campaignId: request.params.campaignId,
+  });
+  return h.response(campaignParticipations).code(200);
+}

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -1,0 +1,29 @@
+import Joi from 'joi';
+
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { getCampaignParticipations } from './campaigns-controller.js';
+import { isCampaignInJurisdictionPreHandler, organizationPreHandler } from './pre-handlers.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/campaigns/{campaignId}/participations',
+      config: {
+        auth: { access: { scope: 'campaigns' } },
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        pre: [organizationPreHandler, isCampaignInJurisdictionPreHandler],
+        handler: getCampaignParticipations,
+        notes: ['- Retourne les résultats de la campagne donnée.'],
+        tags: ['api', 'campaigns', 'maddo'],
+      },
+    },
+  ]);
+};
+
+const name = 'maddo-campaigns-api';
+export { name, register };

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,5 +1,3 @@
-import boom from '@hapi/boom';
-
 import { usecases } from '../domain/usecases/index.js';
 
 export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
@@ -8,11 +6,7 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 }
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
-  const organizationIds = request.pre.organizationIds;
   const requestedOrganizationId = request.params.organizationId;
-  if (!organizationIds.includes(requestedOrganizationId)) {
-    return boom.forbidden();
-  }
   const campaigns = await dependencies.findCampaigns({ organizationId: requestedOrganizationId });
   return h.response(campaigns).code(200);
 }

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { getOrganizationCampaigns, getOrganizations } from './organizations-controller.js';
-import { organizationPreHandler } from './pre-handlers.js';
+import { isOrganizationInJurisdictionPreHandler, organizationPreHandler } from './pre-handlers.js';
 
 const register = async function (server) {
   server.route([
@@ -27,7 +27,7 @@ const register = async function (server) {
             organizationId: identifiersType.organizationId,
           }),
         },
-        pre: [organizationPreHandler],
+        pre: [organizationPreHandler, isOrganizationInJurisdictionPreHandler],
         handler: getOrganizationCampaigns,
         notes: ["- Retourne la liste des campaignes de l'organisation fournie"],
         tags: ['api', 'meta'],

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -21,7 +21,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/organizations/{organizationId}/campaigns',
       config: {
-        auth: { access: { scope: 'meta' } },
+        auth: { access: { scope: 'campaigns' } },
         validate: {
           params: Joi.object({
             organizationId: identifiersType.organizationId,
@@ -29,7 +29,7 @@ const register = async function (server) {
         },
         pre: [organizationPreHandler, isOrganizationInJurisdictionPreHandler],
         handler: getOrganizationCampaigns,
-        notes: ["- Retourne la liste des campaignes de l'organisation fournie"],
+        notes: ["- Retourne la liste des campaignes de l'organisation donnée"],
         tags: ['api', 'meta'],
       },
     },

--- a/api/src/maddo/application/pre-handlers.js
+++ b/api/src/maddo/application/pre-handlers.js
@@ -20,8 +20,13 @@ export const isOrganizationInJurisdictionPreHandler = {
 };
 
 export const isCampaignInJurisdictionPreHandler = {
-  method: async function (request, h, dependencies) {
-    const organizationId = await dependencies.getCampaignOrganizationId(request.params.campaignId);
+  method: async function (
+    request,
+    h,
+    dependencies = { getCampaignOrganizationId: usecases.getCampaignOrganizationId },
+  ) {
+    const { campaignId } = request.params;
+    const organizationId = await dependencies.getCampaignOrganizationId({ campaignId });
     return isOrganizationInJurisdiction(request.pre?.organizationIds, organizationId, h);
   },
 };

--- a/api/src/maddo/application/pre-handlers.js
+++ b/api/src/maddo/application/pre-handlers.js
@@ -1,3 +1,5 @@
+import boom from '@hapi/boom';
+
 import { usecases } from '../domain/usecases/index.js';
 
 export const organizationPreHandler = {
@@ -8,5 +10,15 @@ export const organizationPreHandler = {
     dependencies = { findOrganizationIdsByClientApplication: usecases.findOrganizationIdsByClientApplication },
   ) {
     return dependencies.findOrganizationIdsByClientApplication({ clientId: request.auth.credentials.client_id });
+  },
+};
+
+export const isOrganizationInJurisdictionPreHandler = {
+  method: function (request, h) {
+    const jurisdictionOrganizationIds = request.pre?.organizationIds ?? [];
+    if (!jurisdictionOrganizationIds.includes(request.params.organizationId)) {
+      return boom.forbidden();
+    }
+    return h.continue;
   },
 };

--- a/api/src/maddo/application/pre-handlers.js
+++ b/api/src/maddo/application/pre-handlers.js
@@ -15,10 +15,20 @@ export const organizationPreHandler = {
 
 export const isOrganizationInJurisdictionPreHandler = {
   method: function (request, h) {
-    const jurisdictionOrganizationIds = request.pre?.organizationIds ?? [];
-    if (!jurisdictionOrganizationIds.includes(request.params.organizationId)) {
-      return boom.forbidden();
-    }
-    return h.continue;
+    return isOrganizationInJurisdiction(request.pre?.organizationIds, request.params.organizationId, h);
   },
 };
+
+export const isCampaignInJurisdictionPreHandler = {
+  method: async function (request, h, dependencies) {
+    const organizationId = await dependencies.getCampaignOrganizationId(request.params.campaignId);
+    return isOrganizationInJurisdiction(request.pre?.organizationIds, organizationId, h);
+  },
+};
+
+function isOrganizationInJurisdiction(jurisdictionOrganizationIds = [], organizationId, h) {
+  if (!jurisdictionOrganizationIds.includes(organizationId)) {
+    return boom.forbidden();
+  }
+  return h.continue;
+}

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -1,0 +1,26 @@
+class CampaignParticipation {
+  constructor({
+    id,
+    createdAt,
+    participantExternalId,
+    status,
+    sharedAt,
+    deletedAt,
+    deletedBy,
+    campaignId,
+    userId,
+    organizationLearnerId,
+  } = {}) {
+    this.id = id;
+    this.createdAt = createdAt;
+    this.status = status;
+    this.participantExternalId = participantExternalId;
+    this.sharedAt = sharedAt;
+    this.campaignId = campaignId;
+    this.userId = userId;
+    this.status = status;
+    this.organizationLearnerId = organizationLearnerId;
+  }
+}
+
+export { CampaignParticipation };

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -5,8 +5,6 @@ class CampaignParticipation {
     participantExternalId,
     status,
     sharedAt,
-    deletedAt,
-    deletedBy,
     campaignId,
     userId,
     organizationLearnerId,

--- a/api/src/maddo/domain/usecases/get-campaign-organization-id.js
+++ b/api/src/maddo/domain/usecases/get-campaign-organization-id.js
@@ -1,0 +1,3 @@
+export async function getCampaignOrganizationId({ campaignId, campaignRepository }) {
+  return campaignRepository.getOrganizationId(campaignId);
+}

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -1,0 +1,3 @@
+export async function getCampaignParticipations({ campaignId, campaignParticipationRepository }) {
+  return campaignParticipationRepository.findByCampaignId(campaignId);
+}

--- a/api/src/maddo/domain/usecases/index.js
+++ b/api/src/maddo/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as clientApplicationRepository from '../../infrastructure/repositories/client-application-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
@@ -13,6 +14,7 @@ const dependencies = {
   clientApplicationRepository,
   organizationRepository,
   campaignRepository,
+  campaignParticipationRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -1,0 +1,26 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
+
+export async function findByCampaignId(campaignId) {
+  const rawCampaigns = await knex
+    .select(
+      'id',
+      'createdAt',
+      'participantExternalId',
+      'status',
+      'sharedAt',
+      'deletedAt',
+      'deletedBy',
+      'campaignId',
+      'userId',
+      'organizationLearnerId',
+    )
+    .from('campaign-participations')
+    .where('campaignId', campaignId)
+    .orderBy('id');
+  return rawCampaigns.map(toDomain);
+}
+
+function toDomain(rawCampaignParticipation) {
+  return new CampaignParticipation(rawCampaignParticipation);
+}

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -22,6 +22,11 @@ export async function findByOrganizationId(organizationId) {
   return rawCampaigns.map(toDomain);
 }
 
+export async function getOrganizationId(campaignId) {
+  const [organizationId] = await knex.pluck('organizationId').from('campaigns').where('id', campaignId);
+  return organizationId;
+}
+
 function toDomain(rawCampaign) {
   return new Campaign(rawCampaign);
 }

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -1,0 +1,60 @@
+import { CampaignParticipation } from '../../../../src/maddo/domain/models/CampaignParticipation.js';
+import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import {
+  createMaddoServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from '../../../test-helper.js';
+
+describe('Acceptance | Maddo | Route | Campaigns', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createMaddoServer();
+  });
+
+  describe('GET /api/campaigns/{campaignId}/participations', function () {
+    it('returns the list of all participations of campaign with an HTTP status code 200', async function () {
+      // given
+      const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+      databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
+
+      const tag = databaseBuilder.factory.buildTag();
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+
+      const clientId = 'client';
+      databaseBuilder.factory.buildClientApplication({
+        clientId: 'client',
+        jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+      });
+
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId: orgaInJurisdiction.id });
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/participations`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal([
+        new CampaignParticipation(participation1),
+        new CampaignParticipation(participation2),
+      ]);
+    });
+  });
+});

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -92,7 +92,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
         method: 'GET',
         url: `/api/organizations/${orgaInJurisdiction.id}/campaigns`,
         headers: {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'meta'),
+          authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
         },
       };
 

--- a/api/tests/maddo/application/unit/pre-handlers_test.js
+++ b/api/tests/maddo/application/unit/pre-handlers_test.js
@@ -98,7 +98,10 @@ describe('Unit | Maddo | Application | pre handlers', function () {
       };
 
       const getCampaignOrganizationId = sinon.stub();
-      getCampaignOrganizationId.withArgs('campaignInJurisdictionId').resolves('orgaInJuridictionId');
+      getCampaignOrganizationId
+        .rejects()
+        .withArgs({ campaignId: 'campaignInJurisdictionId' })
+        .resolves('orgaInJuridictionId');
 
       // when
       const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {
@@ -121,7 +124,10 @@ describe('Unit | Maddo | Application | pre handlers', function () {
       };
 
       const getCampaignOrganizationId = sinon.stub();
-      getCampaignOrganizationId.withArgs('campaignNotInJurisdictionId').resolves('orgaNotInJuridictionId');
+      getCampaignOrganizationId
+        .rejects()
+        .withArgs({ campaignId: 'campaignNotInJurisdictionId' })
+        .resolves('orgaNotInJuridictionId');
 
       // when
       const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {
@@ -141,7 +147,10 @@ describe('Unit | Maddo | Application | pre handlers', function () {
       };
 
       const getCampaignOrganizationId = sinon.stub();
-      getCampaignOrganizationId.withArgs('campaignNotInJurisdictionId').resolves('orgaNotInJuridictionId');
+      getCampaignOrganizationId
+        .rejects()
+        .withArgs({ campaignId: 'campaignNotInJurisdictionId' })
+        .resolves('orgaNotInJuridictionId');
 
       // when
       const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {

--- a/api/tests/maddo/application/unit/pre-handlers_test.js
+++ b/api/tests/maddo/application/unit/pre-handlers_test.js
@@ -1,4 +1,9 @@
-import { organizationPreHandler } from '../../../../src/maddo/application/pre-handlers.js';
+import boom from '@hapi/boom';
+
+import {
+  isOrganizationInJurisdictionPreHandler,
+  organizationPreHandler,
+} from '../../../../src/maddo/application/pre-handlers.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Maddo | Application | pre handlers', function () {
@@ -23,6 +28,59 @@ describe('Unit | Maddo | Application | pre handlers', function () {
 
       // then
       expect(organizationIds).to.deep.equal(['orga1', 'orga2']);
+    });
+  });
+
+  describe('#isOrganizationInJurisdictionPreHandler', function () {
+    it('calls continue when organization belongs to jurisdiction', function () {
+      // given
+      const request = {
+        pre: {
+          organizationIds: ['orgaInJuridictionId'],
+        },
+        params: {
+          organizationId: 'orgaInJuridictionId',
+        },
+      };
+
+      // when
+      const prehandlerResult = isOrganizationInJurisdictionPreHandler.method(request, hFake);
+
+      // then
+      expect(prehandlerResult).to.equal(hFake.continue);
+    });
+
+    it('returns forbidden when organization does not belong to jurisdiction', function () {
+      // given
+      const request = {
+        pre: {
+          organizationIds: ['orgaInJuridictionId'],
+        },
+        params: {
+          organizationId: 'orgaNotInJuridictionId',
+        },
+      };
+
+      // when
+      const prehandlerResult = isOrganizationInJurisdictionPreHandler.method(request, hFake);
+
+      // then
+      expect(prehandlerResult).to.deep.equal(boom.forbidden());
+    });
+
+    it('returns forbidden when jurisdiction has not been resolved before', function () {
+      // given
+      const request = {
+        params: {
+          organizationId: 'orgaNotInJuridictionId',
+        },
+      };
+
+      // when
+      const prehandlerResult = isOrganizationInJurisdictionPreHandler.method(request, hFake);
+
+      // then
+      expect(prehandlerResult).to.deep.equal(boom.forbidden());
     });
   });
 });

--- a/api/tests/maddo/application/unit/pre-handlers_test.js
+++ b/api/tests/maddo/application/unit/pre-handlers_test.js
@@ -1,6 +1,7 @@
 import boom from '@hapi/boom';
 
 import {
+  isCampaignInJurisdictionPreHandler,
   isOrganizationInJurisdictionPreHandler,
   organizationPreHandler,
 } from '../../../../src/maddo/application/pre-handlers.js';
@@ -78,6 +79,74 @@ describe('Unit | Maddo | Application | pre handlers', function () {
 
       // when
       const prehandlerResult = isOrganizationInJurisdictionPreHandler.method(request, hFake);
+
+      // then
+      expect(prehandlerResult).to.deep.equal(boom.forbidden());
+    });
+  });
+
+  describe('#isCampaignInJurisdictionPreHandler', function () {
+    it('calls continue when campaign is linked to an organization belonging to jurisdiction', async function () {
+      // given
+      const request = {
+        pre: {
+          organizationIds: ['orgaInJuridictionId'],
+        },
+        params: {
+          campaignId: 'campaignInJurisdictionId',
+        },
+      };
+
+      const getCampaignOrganizationId = sinon.stub();
+      getCampaignOrganizationId.withArgs('campaignInJurisdictionId').resolves('orgaInJuridictionId');
+
+      // when
+      const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {
+        getCampaignOrganizationId,
+      });
+
+      // then
+      expect(prehandlerResult).to.equal(hFake.continue);
+    });
+
+    it('returns forbidden when campaign is linked to an organization not belonging to jurisdiction', async function () {
+      // given
+      const request = {
+        pre: {
+          organizationIds: ['orgaInJuridictionId'],
+        },
+        params: {
+          campaignId: 'campaignNotInJurisdictionId',
+        },
+      };
+
+      const getCampaignOrganizationId = sinon.stub();
+      getCampaignOrganizationId.withArgs('campaignNotInJurisdictionId').resolves('orgaNotInJuridictionId');
+
+      // when
+      const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {
+        getCampaignOrganizationId,
+      });
+
+      // then
+      expect(prehandlerResult).to.deep.equal(boom.forbidden());
+    });
+
+    it('returns forbidden when jurisdiction has not been resolved before', async function () {
+      // given
+      const request = {
+        params: {
+          campaignId: 'campaignNotInJurisdictionId',
+        },
+      };
+
+      const getCampaignOrganizationId = sinon.stub();
+      getCampaignOrganizationId.withArgs('campaignNotInJurisdictionId').resolves('orgaNotInJuridictionId');
+
+      // when
+      const prehandlerResult = await isCampaignInJurisdictionPreHandler.method(request, hFake, {
+        getCampaignOrganizationId,
+      });
 
       // then
       expect(prehandlerResult).to.deep.equal(boom.forbidden());

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
@@ -1,0 +1,29 @@
+import { CampaignParticipation } from '../../../../../src/maddo/domain/models/CampaignParticipation.js';
+import { findByCampaignId } from '../../../../../src/maddo/infrastructure/repositories/campaign-participation-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | campaign-participation', function () {
+  describe('#findByCampaignId', function () {
+    it('lists campaign participations belonging to campaign with given id', async function () {
+      // given
+      const campaign1 = databaseBuilder.factory.buildCampaign();
+      const campaign2 = databaseBuilder.factory.buildCampaign();
+
+      const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign1.id });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign2.id });
+      const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign1.id });
+      await databaseBuilder.commit();
+
+      const expectedCampaignParticipations = [
+        new CampaignParticipation(campaignParticipation1),
+        new CampaignParticipation(campaignParticipation3),
+      ];
+
+      // when
+      const campaignParticipations = await findByCampaignId(campaign1.id);
+
+      // then
+      expect(campaignParticipations).to.deep.equal(expectedCampaignParticipations);
+    });
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/usecases/get-campaign-organization-id_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/usecases/get-campaign-organization-id_test.js
@@ -1,0 +1,30 @@
+import { usecases } from '../../../../../../src/maddo/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Maddo | Domain | Usecase | Get campaign organization id', function () {
+  it('returns the organization id for a given campaign', async function () {
+    // given
+    const { id: expectedOrganizationId } = databaseBuilder.factory.buildOrganization();
+    const { id: campaignId } = databaseBuilder.factory.buildCampaign({ organizationId: expectedOrganizationId });
+    await databaseBuilder.commit();
+
+    // when
+    const organizationId = await usecases.getCampaignOrganizationId({ campaignId });
+
+    // then
+    expect(organizationId).to.equal(expectedOrganizationId);
+  });
+
+  context('when the campaign does not exist', function () {
+    it('returns undefined', async function () {
+      // given
+      const campaignId = -1;
+
+      // when
+      const organizationId = await usecases.getCampaignOrganizationId({ campaignId });
+
+      // then
+      expect(organizationId).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Les résultats de campagne ne sont pas mises à disposition via l'API Maddo.

## 🌳 Proposition

Ajouter une route `/api/campaigns/{id}/results` pour les mettre à disposition via l'API Maddo.

## 🐝 Remarques

L'accès à l'API est refusé si l'application cliente : 
* n'a pas le scope `campaigns`
* n'a pas l'organisation de la campagne dans sa juridiction

## 🤧 Pour tester

Récupérer un token avec

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11868.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```
Appeler la route `/api/campaigns/:id/participations` avec le token et en remplaçant l'id de campagne par celui d'une campagne ayant des participations.

-> Les participations de la campagne sont retournées.

Tests de sécu : 
* Appel sans token
* Appel avec un token sans scope campaigns
* Appel avec un client sans scope campaigns
* Appel sur une campagne n'appartenant pas aux organisations du client

