### PR TITLE
[TECH] :card_file_box: Supprime la contrainte « not null » de la colonne `emitter` de la table `assessement-results` (PIX-17237)

### DIFF
--- a/api/db/migrations/20250327141651_remove-emitter-constraints.js
+++ b/api/db/migrations/20250327141651_remove-emitter-constraints.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'assessment-results';
+const COLUMN_NAME = 'emitter';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).defaultTo(null).nullable().comment('DEPRECATED, this column will be unused soon').alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).notNull().comment('').alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

L'emitter est utilisé dans l'AssessmentResult et dans le CertificationResult. Alors qu'en fait, il ne sert plus vraiment à grand-chose...

## 🌳 Proposition

Supprimer la contrainte « not null » de la colonne pour 
- pouvoir supprimer le code qui l'utilise (autre PR)
- supprimer la colonne (autre PR)

## 🐝 Remarques



## 🤧 Pour tester

Rien ne doit avoir changé.
