### PR TITLE
[BUGFIX] Ajout d'un script pour finaliser des sessions pas entièrement finalisées (PIX-16785).

### DIFF
--- a/api/scripts/certification/fix-not-fully-finalized-session.js
+++ b/api/scripts/certification/fix-not-fully-finalized-session.js
@@ -1,0 +1,64 @@
+import 'dotenv/config';
+
+import { usecases } from '../../src/certification/session-management/domain/usecases/index.js';
+import * as sessionRepository from '../../src/certification/session-management/infrastructure/repositories/session-repository.js';
+import * as certificationReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-report-repository.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class FixNotFullyFinalizedSession extends Script {
+  constructor() {
+    super({
+      description: 'Re-finalize session without finalized-session entry',
+      permanent: false,
+      options: {
+        sessionId: {
+          type: 'integer',
+          describe: 'Id of the session to be finalized',
+          demandOption: true,
+          requiresArg: true,
+        },
+      },
+    });
+  }
+
+  async handle({
+    options,
+    logger,
+    finalizeSession = usecases.finalizeSession,
+    unfinalizeSession = usecases.unfinalizeSession,
+    processAutoJury = usecases.processAutoJury,
+    registerPublishableSession = usecases.registerPublishableSession,
+  } = {}) {
+    await DomainTransaction.execute(async () => {
+      const { sessionId } = options;
+      this.logger = logger;
+
+      this.logger.info(`Updating session ${sessionId}.`);
+
+      await unfinalizeSession({ sessionId });
+
+      const { examinerGlobalComment, hasIncident, hasJoiningIssue } = await sessionRepository.get({ id: sessionId });
+      const certificationReports = await certificationReportRepository.findBySessionId({ sessionId });
+
+      const sessionFinalized = await finalizeSession({
+        sessionId,
+        certificationReports,
+        examinerGlobalComment,
+        hasIncident,
+        hasJoiningIssue,
+      });
+
+      const autoJuryDone = await processAutoJury({ sessionFinalized });
+
+      await registerPublishableSession({ autoJuryDone });
+
+      this.logger.info(`${sessionId} finalized`);
+
+      return 0;
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixNotFullyFinalizedSession);

--- a/api/tests/integration/scripts/certification/fix-not-fully-finalized-session_test.js
+++ b/api/tests/integration/scripts/certification/fix-not-fully-finalized-session_test.js
@@ -1,0 +1,64 @@
+import { FixNotFullyFinalizedSession } from '../../../../scripts/certification/fix-not-fully-finalized-session.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | fix not fully finalized session', function () {
+  let assessment, certificationCourse, session, fixNotFullyFinalizedSessionScript, logger;
+
+  beforeEach(async function () {
+    session = databaseBuilder.factory.buildSession({
+      version: 2,
+      finalizedAt: new Date('2024-01-02T00:00:00Z'),
+    });
+    const user = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildCertificationCandidate({
+      sessionId: session.id,
+      userId: user.id,
+    });
+    certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+      createdAt: new Date('2024-02-01T00:00:00Z'),
+      sessionId: session.id,
+      userId: user.id,
+      completedAt: new Date('2024-02-01T08:00:00Z'),
+      isPublished: false,
+      isCancelled: false,
+      abortReason: null,
+      version: 2,
+      isRejectedForFraud: false,
+      endedAt: null,
+    });
+    assessment = databaseBuilder.factory.buildAssessment({
+      certificationCourseId: certificationCourse.id,
+      userId: user.id,
+      type: 'CERTIFICATION',
+      state: 'completed',
+      method: 'CERTIFICATION_DETERMINED',
+    });
+    databaseBuilder.factory.buildAssessmentResult({
+      assessmentId: assessment.id,
+      userId: user.id,
+      type: 'CERTIFICATION',
+      status: 'validated',
+    });
+
+    await databaseBuilder.commit();
+
+    logger = { info: sinon.stub() };
+    fixNotFullyFinalizedSessionScript = new FixNotFullyFinalizedSession();
+  });
+
+  it('creates a finalized session', async function () {
+    // when
+    await fixNotFullyFinalizedSessionScript.handle({
+      options: { sessionId: session.id },
+      logger,
+    });
+
+    // then
+    const { count: finalizedSessionCount } = await knex('finalized-sessions')
+      .where({ sessionId: session.id })
+      .count()
+      .first();
+
+    expect(finalizedSessionCount).to.equal(1);
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

En production, certaines sessions V2 se retrouvent à avoir été finalisées sans pouvoir être publiées.
Ce problème se trouve être du au fait que l'entrée dans la table `finalized-sessions` normalement insérée en BDD lors de la finalisation n'existe pas.

## 🌳 Proposition

Nous créons un script pour dé-finaliser ces sessions avant de les re-finaliser.

## 🐝 Remarques

Nous ne savons pas si ces sessions se retrouvent à ne pas être publiables à cause du même problème.
Nous préférons ainsi exécuter ce script pour une seule session afin de déceler l'origine du problème en cas d'erreur lors de la finalisation.

## 🤧 Pour tester

- Créer une session V2 et y ajouter un candidat
- Terminer le test
- Finaliser la session
- En BDD supprimer l'entrée `finalized-session` créée pour cette session
- Dans pix-admin, confirmer que la session ne soit pas publiable
- Lancer le script avec 

```bash
scalingo -a pix-api-review-pr11414 run "LOG_LEVEL=info fix-not-fully-finalized-session.js --sessionId=<SESSION_ID>"
```
- Vérifier qu'une nouvelle entrée dans `finalized-session` a été ajoutée
- Vérifier que la session soit publiable