### PR TITLE
[FEATURE] Ajoute la validation sur le système de quêtes (PIX-17236)

### DIFF
--- a/admin/app/components/administration/block-layout.gjs
+++ b/admin/app/components/administration/block-layout.gjs
@@ -12,6 +12,6 @@ import PixBlock from '@1024pix/pix-ui/components/pix-block';
       <p class="description">{{@description}}</p>
     {{/if}}
 
-    <div class="block-layout__actions">{{yield}}</div>
+    <div class="block-layout__actions {{@actionsClass}}">{{yield}}</div>
   </PixBlock>
 </template>

--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -1,9 +1,13 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { modifier } from 'ember-modifier';
+import isEmpty from 'lodash/isEmpty';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
@@ -16,9 +20,12 @@ export default class UpsertQuestsInBatch extends Component {
   @service fileSaver;
   @service errorResponseHandler;
 
+  @tracked errors = null;
+
   @action
   async upsertQuestsInBatch(files) {
     let response;
+    this.errors = null;
     try {
       const fileContent = files[0];
 
@@ -38,7 +45,12 @@ export default class UpsertQuestsInBatch extends Component {
         });
         return;
       } else {
-        this.errorResponseHandler.notify(await response.json());
+        const { errors: responseErrors } = await response.json();
+        if (isJSONAPIError(responseErrors)) {
+          this.errors = responseErrors;
+        } else {
+          this.errorResponseHandler.notify(await response.json(), undefined, true);
+        }
       }
     } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
@@ -51,6 +63,7 @@ export default class UpsertQuestsInBatch extends Component {
     <AdministrationBlockLayout
       @title={{t "components.administration.upsert-quests-in-batch.title"}}
       @description={{t "components.administration.upsert-quests-in-batch.description"}}
+      class="upsert-quests-in-batch"
     >
       <DownloadTemplate @url="/api/admin/quests/template">
         <PixButtonUpload
@@ -67,5 +80,26 @@ export default class UpsertQuestsInBatch extends Component {
         {{t "components.administration.upsert-quests-in-batch.quest-creator"}}
       </PixButtonLink>
     </AdministrationBlockLayout>
+    {{#if this.errors}}
+      <PixNotificationAlert @withIcon={{true}} @type="error" class="upsert-quests-in-batch__errors">
+        <ul>
+          {{#each this.errors as |error|}}
+            <li class="upsert-quests-in-batch__error">
+              <span>{{error.detail}}</span>
+              <pre class="upsert-quests-in-batch__json">{{(transformMetaToJSON error)}}</pre>
+            </li>
+          {{/each}}
+        </ul>
+      </PixNotificationAlert>
+    {{/if}}
   </template>
+}
+
+function isJSONAPIError(errors) {
+  return !isEmpty(errors) && errors.every((error) => error.title);
+}
+
+function transformMetaToJSON(error) {
+  if (!error.meta.data) return '';
+  return JSON.stringify(error.meta.data, undefined, 2);
 }

--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -13,6 +13,15 @@ import ENV from 'pix-admin/config/environment';
 import AdministrationBlockLayout from '../block-layout';
 import DownloadTemplate from '../download-template';
 
+const scrollToElement = modifier((element) => {
+  const top = element.getBoundingClientRect().top;
+
+  window.scrollTo({
+    top,
+    behavior: 'smooth',
+  });
+});
+
 export default class UpsertQuestsInBatch extends Component {
   @service intl;
   @service pixToast;
@@ -84,9 +93,9 @@ export default class UpsertQuestsInBatch extends Component {
       <PixNotificationAlert @withIcon={{true}} @type="error" class="upsert-quests-in-batch__errors">
         <ul>
           {{#each this.errors as |error|}}
-            <li class="upsert-quests-in-batch__error">
+            <li class="upsert-quests-in-batch__error" {{scrollToElement}}>
               <span>{{error.detail}}</span>
-              <pre class="upsert-quests-in-batch__json">{{(transformMetaToJSON error)}}</pre>
+              <pre class="upsert-quests-in-batch__json">{{transformMetaToJSON error}}</pre>
             </li>
           {{/each}}
         </ul>

--- a/admin/app/modifiers/scroll-to.js
+++ b/admin/app/modifiers/scroll-to.js
@@ -1,0 +1,10 @@
+import { modifier } from 'ember-modifier';
+
+export const scrollToElement = modifier((element) => {
+  const top = element.getBoundingClientRect().top;
+
+  window.scrollTo({
+    top,
+    behavior: 'smooth',
+  });
+});

--- a/admin/app/styles/components/administration/index.scss
+++ b/admin/app/styles/components/administration/index.scss
@@ -2,3 +2,4 @@
 @use 'campaign-update-code';
 @use 'campaigns-swap-code';
 @use 'block-layout';
+@use 'upsert-quests-in-batch';

--- a/admin/app/styles/components/administration/upsert-quests-in-batch.scss
+++ b/admin/app/styles/components/administration/upsert-quests-in-batch.scss
@@ -1,0 +1,24 @@
+.upsert-quests-in-batch {
+  &__errors {
+    margin-top: var(--pix-spacing-4x);
+
+    & > span {
+      width: 100%;
+    }
+  }
+
+  &__error {
+    & > span {
+      font-weight: var(--pix-font-bold);
+    }
+
+    margin-bottom: var(--pix-spacing-2x);
+  }
+
+  &__json {
+    width: 100%;
+    padding: var(--pix-spacing-4x);
+    background-color:var(--pix-error-100);
+    border-radius: var(--pix-spacing-1x);
+  }
+}

--- a/admin/app/styles/components/administration/upsert-quests-in-batch.scss
+++ b/admin/app/styles/components/administration/upsert-quests-in-batch.scss
@@ -1,4 +1,13 @@
 .upsert-quests-in-batch {
+  &__actions {
+    display: block;
+  }
+
+  &__buttons {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+  }
+
   &__errors {
     margin-top: var(--pix-spacing-4x);
 

--- a/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { getDefaultNormalizer, render } from '@1024pix/ember-testing-library';
 import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
@@ -59,7 +59,7 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
   });
 
   module('when import fails', function () {
-    test('it displays an error notification by status', async function (assert) {
+    test('it displays an error block', async function (assert) {
       // given
       fetchStub
         .withArgs(`${ENV.APP.API_HOST}/api/admin/quests`, {
@@ -74,7 +74,15 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
         .resolves(
           fetchResponse({
             body: {
-              errors: [{ status: '412', title: "Un soucis avec l'import", code: '412', detail: 'Erreur d’import' }],
+              errors: [
+                {
+                  status: '412',
+                  title: "Un soucis avec l'import",
+                  code: '412',
+                  detail: "Erreur d'import",
+                  meta: { data: { something: 1 } },
+                },
+              ],
             },
             status: 412,
           }),
@@ -86,7 +94,17 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(await screen.findByText('Les préconditions ne sont pas réunies.'));
+      assert.ok(await screen.findByText("Erreur d'import", { exact: false }));
+      assert.ok(
+        await screen.findByText(
+          `{
+  "something": 1
+}`,
+          {
+            normalizer: getDefaultNormalizer({ trim: false, collapseWhitespace: false }),
+          },
+        ),
+      );
     });
 
     test('it displays an error notification', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -199,7 +199,7 @@
         "upload-button": "Import CSV file"
       },
       "upsert-quests-in-batch": {
-        "description": "Beware: there are no validation when importing a CSV file. Check with a spécialiste in the doubt ;)",
+        "description": "Check with a spécialiste in the doubt ;)",
         "notifications": {
           "success": "Quests have been imported."
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -199,7 +199,7 @@
         "upload-button": "Importer un fichier CSV"
       },
       "upsert-quests-in-batch": {
-        "description": "Attention: aucune validation n'est effectuée lors de l'import. Consultez un spécialiste dans le doute ;)",
+        "description": "Consultez un spécialiste dans le doute ;)",
         "notifications": {
           "success": "Les quêtes ont bien été importées."
         },

--- a/api/src/quest/domain/models/Criterion.js
+++ b/api/src/quest/domain/models/Criterion.js
@@ -1,9 +1,17 @@
+import Joi from 'joi';
+
 import { CriterionProperty } from './CriterionProperty.js';
+
+const schema = Joi.object({ data: Joi.object().pattern(Joi.string(), Joi.object()).required() });
 
 export class Criterion {
   #properties;
 
-  constructor({ data }) {
+  constructor(args) {
+    this.#validate(args);
+
+    const { data } = args;
+
     this.#properties = Object.keys(data).map((key) => {
       const property = data[key];
       return new CriterionProperty({
@@ -12,6 +20,10 @@ export class Criterion {
         comparison: property.comparison,
       });
     });
+  }
+
+  #validate(args) {
+    schema.validate(args);
   }
 
   get data() {

--- a/api/src/quest/domain/models/CriterionProperty.js
+++ b/api/src/quest/domain/models/CriterionProperty.js
@@ -17,23 +17,33 @@ const schema = Joi.object({
     .required(),
 });
 
+export class CriterionPropertyError extends Error {
+  constructor({ message, details }) {
+    super(message);
+    this.details = details;
+  }
+}
+
 export class CriterionProperty {
   #key;
   #data;
   #comparison;
 
   constructor(args) {
-    this.#validate(args);
-
     const { key, data, comparison } = args;
 
     this.#key = key;
     this.#data = data;
     this.#comparison = comparison;
+
+    this.#validate(args);
   }
 
   #validate(args) {
-    schema.validate(args);
+    const { error } = schema.validate(args);
+    if (error) {
+      throw new CriterionPropertyError({ message: 'arguments are invalid', details: error.details });
+    }
   }
 
   get key() {

--- a/api/src/quest/domain/models/CriterionProperty.js
+++ b/api/src/quest/domain/models/CriterionProperty.js
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 import { InvalidComparisonError } from '../errors.js';
 
 export const COMPARISONS = {
@@ -7,15 +9,31 @@ export const COMPARISONS = {
   LIKE: 'like',
 };
 
+const schema = Joi.object({
+  key: Joi.string().required(),
+  data: Joi.any().required(),
+  comparison: Joi.string()
+    .valid(...Object.values(COMPARISONS))
+    .required(),
+});
+
 export class CriterionProperty {
   #key;
   #data;
   #comparison;
 
-  constructor({ key, data, comparison }) {
+  constructor(args) {
+    this.#validate(args);
+
+    const { key, data, comparison } = args;
+
     this.#key = key;
     this.#data = data;
     this.#comparison = comparison;
+  }
+
+  #validate(args) {
+    schema.validate(args);
   }
 
   get key() {

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 import { COMPARISONS as _CRITERION_COMPARISONS } from './CriterionProperty.js';
 import {
   COMPARISONS as _REQUIREMENT_COMPARISONS,
@@ -12,6 +14,13 @@ export const REQUIREMENT_COMPARISONS = _REQUIREMENT_COMPARISONS;
 export const CRITERION_COMPARISONS = _CRITERION_COMPARISONS;
 export const REQUIREMENT_TYPES = _REQUIREMENT_TYPES;
 
+const schema = Joi.object({
+  eligibilityRequirements: Joi.array().items(Joi.object()).required(),
+  successRequirements: Joi.array().items(Joi.object()).required(),
+  rewardType: Joi.string().valid('attestations').required(),
+  rewardId: Joi.number().required(),
+});
+
 class Quest {
   #eligibilityRequirements;
   #successRequirements;
@@ -20,6 +29,9 @@ class Quest {
     this.id = id;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+
+    this.#validate({ rewardType, rewardId, eligibilityRequirements, successRequirements });
+
     this.rewardType = rewardType;
     this.rewardId = rewardId;
     this.#eligibilityRequirements = new ComposedRequirement({
@@ -31,6 +43,10 @@ class Quest {
       data: successRequirements,
       comparison: REQUIREMENT_COMPARISONS.ALL,
     });
+  }
+
+  #validate(quest) {
+    schema.validate(quest);
   }
 
   get eligibilityRequirements() {

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { COMPARISONS as _CRITERION_COMPARISONS } from './CriterionProperty.js';
 import {
   COMPARISONS as _REQUIREMENT_COMPARISONS,
@@ -46,7 +47,10 @@ class Quest {
   }
 
   #validate(quest) {
-    schema.validate(quest);
+    const { error } = schema.validate(quest);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: quest });
+    }
   }
 
   get eligibilityRequirements() {

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -233,30 +233,30 @@ class ImportLearnerConfigurationError extends DomainError {
 }
 
 class EntityValidationError extends DomainError {
-  constructor({ invalidAttributes }) {
-    super("Échec de validation de l'entité.");
+  constructor({ invalidAttributes }, code, meta) {
+    super("Échec de validation de l'entité.", code, meta);
     this.invalidAttributes = invalidAttributes;
   }
 
-  static fromJoiError(joiError) {
+  static fromJoiError(joiError, code, meta) {
     const invalidAttributes = { attribute: joiError.context.key, message: joiError.message };
 
-    return new EntityValidationError({ invalidAttributes });
+    return new EntityValidationError({ invalidAttributes }, code, meta);
   }
 
-  static fromJoiErrors(joiErrors) {
+  static fromJoiErrors(joiErrors, code, meta) {
     const invalidAttributes = joiErrors.map((error) => {
       return { attribute: error.context.key, message: error.message };
     });
-    return new EntityValidationError({ invalidAttributes });
+    return new EntityValidationError({ invalidAttributes }, code, meta);
   }
 
-  static fromMultipleEntityValidationErrors(entityValidationErrors) {
+  static fromMultipleEntityValidationErrors(entityValidationErrors, code, meta) {
     const invalidAttributes = entityValidationErrors.reduce((invalidAttributes, entityValidationError) => {
       invalidAttributes.push(...entityValidationError.invalidAttributes);
       return invalidAttributes;
     }, []);
-    return new EntityValidationError({ invalidAttributes });
+    return new EntityValidationError({ invalidAttributes }, code, meta);
   }
 }
 

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -124,7 +124,7 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
       await databaseBuilder.commit();
       // TODO j'ai l'impression qu'en séparateur en ; il capte pas les différents headers
       const input = `Quest ID,Json configuration for quest
-,"{""rewardType"":""coucou"",""rewardId"":null,""eligibilityRequirements"":[{""requirement_type"":""organization"",""data"":{""type"":""SCO""},""comparison"":""all""}],""successRequirements"":[{""requirement_type"":""skillProfile"",""data"":{""skillIds"":[""skillA"",""skillB""],""threshold"":66}}]}"`;
+,"{""rewardType"":""attestations"",""rewardId"":1,""eligibilityRequirements"":[{""requirement_type"":""organization"",""data"":{""type"":{""data"":""SCO"",""comparison"":""equal""}}, ""comparison"": ""all""}],""successRequirements"":[{""requirement_type"":""skillProfile"",""data"":{""skillIds"":[""skillA"",""skillB""],""threshold"":66}}]}"`;
 
       const options = {
         method: 'POST',

--- a/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
@@ -15,7 +15,7 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
     filePath = await createTempFile(
       'test.csv',
       `Quest ID;Json configuration for quest
-    ;{"rewardType":"coucou","rewardId":null,"eligibilityRequirements":[],"successRequirements":[]}`,
+    ;{"rewardType":"attestations","rewardId":1,"eligibilityRequirements":[],"successRequirements":[]}`,
     );
     const spySave = sinon.spy(repositories.questRepository, 'saveInBatch');
     const spyDelete = sinon.spy(repositories.questRepository, 'deleteByIds');
@@ -31,8 +31,8 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
           id: undefined,
           createdAt: undefined,
           updatedAt: undefined,
-          rewardType: 'coucou',
-          rewardId: null,
+          rewardType: 'attestations',
+          rewardId: 1,
           eligibilityRequirements: [],
           successRequirements: [],
         }),
@@ -45,9 +45,9 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
     filePath = await createTempFile(
       'test.csv',
       `Quest ID;Json configuration for quest;deleteQuest
-    3;{"rewardType":"coucou","rewardId":null,"eligibilityRequirements":[],"successRequirements":[]};OUI
-    5;{"rewardType":"bonjour","rewardId":null,"eligibilityRequirements":[],"successRequirements":[]};oui
-    4;{"rewardType":"salut","rewardId":null,"eligibilityRequirements":[],"successRequirements":[]};Non
+    3;{"rewardType":"attestations","rewardId":1,"eligibilityRequirements":[],"successRequirements":[]};OUI
+    5;{"rewardType":"attestations","rewardId":2,"eligibilityRequirements":[],"successRequirements":[]};oui
+    4;{"rewardType":"attestations","rewardId":3,"eligibilityRequirements":[],"successRequirements":[]};Non
     `,
     );
     const spySave = sinon.spy(repositories.questRepository, 'saveInBatch');
@@ -63,8 +63,8 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
           id: '4',
           createdAt: undefined,
           updatedAt: undefined,
-          rewardType: 'salut',
-          rewardId: null,
+          rewardType: 'attestations',
+          rewardId: 3,
           eligibilityRequirements: [],
           successRequirements: [],
         }),

--- a/api/tests/quest/unit/domain/models/CriterionProperty_test.js
+++ b/api/tests/quest/unit/domain/models/CriterionProperty_test.js
@@ -3,6 +3,34 @@ import { COMPARISONS, CriterionProperty } from '../../../../../src/quest/domain/
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CriterionProperty', function () {
+  describe('#validate', function () {
+    it('should not throw with valid args', function () {
+      expect(() => {
+        new CriterionProperty({
+          key: 'something',
+          data: 1,
+          comparison: 'equal',
+        });
+      }).not.to.throw();
+    });
+
+    it('should throw without args', function () {
+      expect(function () {
+        new CriterionProperty();
+      }).to.throw();
+    });
+
+    it('should throw with invalid args', function () {
+      expect(function () {
+        new CriterionProperty({
+          key: 1,
+          data: {},
+          comparison: 'wrong',
+        });
+      }).to.throw();
+    });
+  });
+
   describe('#check', function () {
     describe('when criterion attribute is not an Array', function () {
       context('when comparison is EQUAL', function () {

--- a/api/tests/quest/unit/domain/models/Criterion_test.js
+++ b/api/tests/quest/unit/domain/models/Criterion_test.js
@@ -3,6 +3,33 @@ import { COMPARISONS as CRITERION_PROPERTY_COMPARISONS } from '../../../../../sr
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | Criterion ', function () {
+  describe('#validate', function () {
+    it('should throw if args are not valid', function () {
+      expect(() => {
+        new Criterion({ data: [] });
+      }).to.throw();
+    });
+
+    it('should throw without args', function () {
+      expect(() => {
+        new Criterion();
+      }).to.throw();
+    });
+
+    it('should not throw if args are valid', function () {
+      expect(() => {
+        new Criterion({
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: 'equal',
+            },
+          },
+        });
+      }).not.to.throw();
+    });
+  });
+
   describe('#check', function () {
     describe('when comparisonFunction is some', function () {
       it('should return true if one data attribute is equal to its criterion attribute', function () {

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -71,6 +71,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
   describe('#isEligible', function () {
     it('return true', function () {
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [
           {
             requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
@@ -94,6 +96,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
 
     it('return false', function () {
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [
           {
             requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
@@ -120,6 +124,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     it('returns true when successfulRequirement is empty', function () {
       // given
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [],
         successRequirements: [],
       });
@@ -139,6 +145,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     it('returns true when all requirements are met', function () {
       // given
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [],
         successRequirements: [
           {
@@ -179,6 +187,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     it('returns false when at least one requirement is not met', function () {
       // given
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [],
         successRequirements: [
           {
@@ -219,6 +229,8 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     it('returns false when none of the requirements are met', function () {
       // given
       const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
         eligibilityRequirements: [],
         successRequirements: [
           {
@@ -283,7 +295,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements,
+      });
       const campaignParticipations = [
         { id: 10, targetProfileId: 123 },
         { id: 10, targetProfileId: 456 },
@@ -319,7 +336,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements: [],
+      });
       const campaignParticipations = [{ id: 10, targetProfileId: 789 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -353,7 +375,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements: [],
+      });
       const campaignParticipations = [{ id: 10, targetProfileId: 789 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -390,7 +417,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements,
+      });
       const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -429,7 +461,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements,
+      });
       const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -450,7 +487,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements: [],
+      });
       const campaignParticipations = [{ id: 10, targetProfileId: 123 }];
       const eligibility = new Eligibility({ organization: {}, organizationLearner: {}, campaignParticipations });
       const dataForQuest = new DataForQuest({ eligibility });
@@ -486,7 +528,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           comparison: REQUIREMENT_COMPARISONS.ALL,
         },
       ];
-      const quest = new Quest({ eligibilityRequirements, successRequirements });
+      const quest = new Quest({
+        rewardId: 1,
+        rewardType: 'attestations',
+        eligibilityRequirements,
+        successRequirements,
+      });
       const campaignParticipations = [
         { id: 10, targetProfileId: 123 },
         { id: 100, targetProfileId: 456 },
@@ -544,7 +591,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
         ];
-        const quest = new Quest({ eligibilityRequirements, successRequirements });
+        const quest = new Quest({
+          rewardId: 1,
+          rewardType: 'attestations',
+          eligibilityRequirements,
+          successRequirements,
+        });
         const campaignParticipations = [
           { id: 10, targetProfileId: 1 },
           { id: 11, targetProfileId: 3 },
@@ -597,7 +649,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
         ];
-        const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+        const quest = new Quest({
+          rewardId: 1,
+          rewardType: 'attestations',
+          eligibilityRequirements,
+          successRequirements: [],
+        });
         const campaignParticipations = [
           { id: 10, targetProfileId: 1 },
           { id: 11, targetProfileId: 3 },
@@ -652,7 +709,12 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
         ];
-        const quest = new Quest({ eligibilityRequirements, successRequirements });
+        const quest = new Quest({
+          rewardId: 1,
+          rewardType: 'attestations',
+          eligibilityRequirements,
+          successRequirements,
+        });
         const campaignParticipations = [
           { id: 10, targetProfileId: 1 },
           { id: 11, targetProfileId: 3 },
@@ -689,15 +751,20 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
           {
             requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION_LEARNER,
             data: {
-              type: {
-                id: 123,
+              id: {
+                data: 123,
                 comparison: CRITERION_COMPARISONS.EQUAL,
               },
             },
             comparison: REQUIREMENT_COMPARISONS.ALL,
           },
         ];
-        const quest = new Quest({ eligibilityRequirements, successRequirements: [] });
+        const quest = new Quest({
+          rewardId: 1,
+          rewardType: 'attestations',
+          eligibilityRequirements,
+          successRequirements: [],
+        });
         const campaignParticipations = [{ id: 10 }, { id: 11 }];
         const eligibility = new Eligibility({ organization, organizationLearner, campaignParticipations });
         const data = new DataForQuest({ eligibility });
@@ -722,7 +789,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         id: 123,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2020-02-02'),
-        rewardType: 'attestation',
+        rewardType: 'attestations',
         rewardId: 456,
         eligibilityRequirements: [
           {
@@ -787,7 +854,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         id: 123,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2020-02-02'),
-        rewardType: 'attestation',
+        rewardType: 'attestations',
         rewardId: 456,
         eligibilityRequirements: [
           {

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -11,6 +11,63 @@ import { KnowledgeElement } from '../../../../../src/shared/domain/models/index.
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | Quest ', function () {
+  describe('#constructor', function () {
+    it('should throw if args are not valid', function () {
+      expect(() => {
+        new Quest({ rewardId: 1 });
+      }).to.throw;
+    });
+
+    it('should not throw if args are valid', function () {
+      expect(() => {
+        new Quest({
+          rewardType: 'attestations',
+          rewardId: 1,
+          eligiblityRequirements: [
+            {
+              data: {
+                status: {
+                  data: ['SHARED', 'TO_SHARE'],
+                  comparison: 'one-of',
+                },
+                targetProfileId: {
+                  data: 2,
+                  comparison: 'equal',
+                },
+              },
+              comparison: 'all',
+              requirement_type: 'campaignParticipations',
+            },
+          ],
+          successRequirements: [
+            {
+              requirement_type: 'cappedTubes',
+              data: {
+                cappedTubes: [
+                  {
+                    tubeId: 'tube11aVujagTGVuMY',
+                    level: 2,
+                  },
+                  {
+                    tubeId: 'recBbCIEKgrQi7eb6',
+                    level: 5,
+                  },
+                ],
+                threshold: 50,
+              },
+            },
+          ],
+        });
+      }).to.throw;
+    });
+
+    it('should throw without args', function () {
+      expect(() => {
+        new Quest();
+      }).to.throw;
+    });
+  });
+
   describe('#isEligible', function () {
     it('return true', function () {
       const quest = new Quest({

--- a/api/tests/quest/unit/domain/models/Quest_test.js
+++ b/api/tests/quest/unit/domain/models/Quest_test.js
@@ -15,7 +15,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
     it('should throw if args are not valid', function () {
       expect(() => {
         new Quest({ rewardId: 1 });
-      }).to.throw;
+      }).to.throw();
     });
 
     it('should not throw if args are valid', function () {
@@ -23,7 +23,7 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
         new Quest({
           rewardType: 'attestations',
           rewardId: 1,
-          eligiblityRequirements: [
+          eligibilityRequirements: [
             {
               data: {
                 status: {
@@ -58,13 +58,13 @@ describe('Quest | Unit | Domain | Models | Quest ', function () {
             },
           ],
         });
-      }).to.throw;
+      }).not.to.throw();
     });
 
     it('should throw without args', function () {
       expect(() => {
         new Quest();
-      }).to.throw;
+      }).to.throw();
     });
   });
 

--- a/api/tests/quest/unit/domain/models/Requirement_test.js
+++ b/api/tests/quest/unit/domain/models/Requirement_test.js
@@ -133,6 +133,41 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
   });
 
   describe('ComposedRequirement', function () {
+    describe('#validate', function () {
+      it('should throw if args are not valid', function () {
+        expect(() => {
+          new ComposedRequirement({ data: [] });
+        }).to.throw;
+      });
+
+      it('should throw without args', function () {
+        expect(() => {
+          new ComposedRequirement();
+        }).to.throw;
+      });
+
+      it('should not throw if args are valid', function () {
+        expect(() => {
+          new ComposedRequirement({
+            requirement_type: 'compose',
+            comparison: 'all',
+            data: [
+              {
+                requirement_type: 'campaignParticipations',
+                comparison: 'all',
+                data: {
+                  targetProfileId: {
+                    data: 1,
+                    comparison: 'equal',
+                  },
+                },
+              },
+            ],
+          });
+        }).to.throw;
+      });
+    });
+
     describe('constructor', function () {
       it('should build the same instance whether we are passing through raw requirements or instanciated requirements', function () {
         // given
@@ -406,6 +441,35 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
   });
 
   describe('ObjectRequirement', function () {
+    describe('#validate', function () {
+      it('should throw if args are not valid', function () {
+        expect(() => {
+          new ObjectRequirement({ data: [] });
+        }).to.throw();
+      });
+
+      it('should throw without args', function () {
+        expect(() => {
+          new ObjectRequirement();
+        }).to.throw();
+      });
+
+      it('should not throw if args are valid', function () {
+        expect(() => {
+          new ObjectRequirement({
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              targetProfileId: {
+                data: 1,
+                comparison: 'equal',
+              },
+            },
+          });
+        }).not.to.throw();
+      });
+    });
+
     describe('constructor', function () {
       it('should build the same instance whether we are passing through raw criterion or instanciated criterion', function () {
         // given
@@ -654,6 +718,37 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
   });
 
   describe('CappedTubesRequirement', function () {
+    describe('#validate', function () {
+      it('should throw if args are not valid', function () {
+        expect(() => {
+          new CappedTubesRequirement({
+            data: {
+              cappedTubes: [{ tubeId: '1', level: 2 }],
+              threshold: -1000,
+            },
+          });
+        }).to.throw();
+      });
+
+      it('should throw without args', function () {
+        expect(() => {
+          new CappedTubesRequirement();
+        }).to.throw();
+      });
+
+      it('should not throw if args are valid', function () {
+        expect(() => {
+          new CappedTubesRequirement({
+            requirement_type: TYPES.CAPPED_TUBES,
+            data: {
+              cappedTubes: [{ tubeId: '1', level: 2 }],
+              threshold: 50,
+            },
+          });
+        }).not.to.throw();
+      });
+    });
+
     describe('isFulfilled', function () {
       let successWith60MasteryPercentage;
       const cappedTubes = [

--- a/api/tests/quest/unit/domain/models/Requirement_test.js
+++ b/api/tests/quest/unit/domain/models/Requirement_test.js
@@ -105,8 +105,10 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
         // given
         const buildData = {
           requirement_type: TYPES.CAPPED_TUBES,
-          comparison: 'irrelevant',
-          data: {},
+          data: {
+            cappedTubes: [],
+            threshold: 0,
+          },
         };
 
         // when


### PR DESCRIPTION
## 🌸 Problème

Les quêtes ne sont pas validées lorsqu'elles créer via PixAdmin, cela donne lieu à des longues phases d'investigation.

## 🌳 Proposition

Ajouter de la validation sur les objets du domain pour empêcher l'insertion de quêtes dont le format n'est pas valide.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Essayer d'insérer de mauvaises quêtes.
