### PR TITLE
[FEATURE] Autoriser une limite de date sur le script de récupération des décalages de live alerts (PIX-17051).

### DIFF
--- a/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
+++ b/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
@@ -9,7 +9,7 @@ describe('Integration | Scripts | Certification | fix-validated-live-alert-certi
       it('should fix the capacities challenges ids', async function () {
         // given
         const certificationCourseId = 321;
-        const options = { dryRun: false, batchSize: 10 };
+        const options = { dryRun: false, batchSize: 10, startingFromDate: new Date(2024, 10, 4) };
         const logger = {
           info: sinon.stub(),
           debug: sinon.stub(),
@@ -20,6 +20,7 @@ describe('Integration | Scripts | Certification | fix-validated-live-alert-certi
           id: certificationCourseId,
           userId: user.id,
           version: AlgorithmEngineVersion.V3,
+          createdAt: new Date(2024, 10, 5),
         });
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,


### PR DESCRIPTION
## 🌸 Problème

On a des soucis de données sur la phase pilote V3 en terme de données. On veut pouvoir débloquer nos usagers "post generalisation" et traiter à part les soucis de données pilotes pour nettoyer notre base de données.

## 🌳 Proposition

Ajouter une date limite pour traiter les certifications post-generalisation

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

* Si vous avez l'envie : jouer sur le paramètre startingFromDate du script qui est par défaut au new Date(2024, 10, 4) soit la généralisation