### PR TITLE
[BUGFIX] Utiliser les bonnes category dans les seeds des profils cibles (PIX-17239)

### DIFF
--- a/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { categories } from '../../../../../src/shared/domain/models/TargetProfile.js';
 import {
   REAL_PIX_SUPER_ADMIN_ID,
   USER_ID_ADMIN_ORGANIZATION,
@@ -39,7 +40,13 @@ export default async function initUser(databaseBuilder) {
       isSimplifiedAccess: true,
       name: `Profil-cible pour parcours autonome n°${i}`,
       description: 'Profil cible pour parcours autonome',
-      category: ['Les 16 compétences', 'Thématiques', 'Parcours sur-mesure', 'Parcours prédéfinis', 'Autres'][i - 1],
+      category: [
+        categories.COMPETENCES,
+        categories.SUBJECT,
+        categories.CUSTOM,
+        categories.PREDEFINED,
+        categories.OTHER,
+      ][i - 1],
       configTargetProfile: {
         frameworks: [
           {


### PR DESCRIPTION
## 🌸 Problème
Il existe des seeds avec des category écrites en dure dans le code. Or, lors de la création d'un profil cible on utilise une liste de catégories prédéfinies qui sont ensuite traduites. De ce fait les traductions ne fonctionnent pas si les catégories ne correspondent pas à celles existantes

## 🌳 Proposition
Remplacer les catégories écrites en FR par les noms de catégories utilisées dans le code

## 🐝 Remarque
Avant : 
![image](https://github.com/user-attachments/assets/7b4e26bc-789a-448a-8614-f959251388d4)

Après : 
![image](https://github.com/user-attachments/assets/44e9539c-f43e-496e-b640-1ce3b3d8f0b2)



## 🤧 Pour tester
- Se connecter a PixOrga avec superadmin@example.net
- Aller sur la page de création d'une campagne
- Constater que les noms des catégories sont bien traduites
- 🐈‍⬛ 