### PR TITLE
[BUGFIX] Définir une largeur max pour le global container (PIX-17251).

### DIFF
--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -68,6 +68,7 @@ img {
   width: 100%;
   margin-inline: auto;
   padding-inline: var(--pix-spacing-4x);
+  max-width: 80rem;
 
   @include breakpoints.device-is('desktop') {
     padding-inline: var(--pix-spacing-6x);

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -4,7 +4,7 @@
   <DataProtectionPolicyInformationBanner />
 </div>
 <Global::AppLayout>
-  <main id="main" class="main" role="main">
+  <main id="main" class="main global-page-container" role="main">
     <CampaignCodeForm
       @isUserAuthenticatedByPix={{this.isUserAuthenticatedByPix}}
       @isUserAuthenticatedByGAR={{this.isUserAuthenticatedByGAR}}


### PR DESCRIPTION
## 🌸 Problème
Un problème d'affichage a été constaté en prod depuis le retrait d'une largeur maximale sur le global container défini dans les layouts.

## 🌳 Proposition
Rétablir la largeur et ainsi ramener la paix au sein de la galaxie Pix.

## 🤧 Pour tester
- Se connecter sur Pix App
- Constater que le Global Container (dans lequel s'affichent les bandeaux et les compétences) fait 80rem.
