### PR TITLE
[TECH] Réduit la violation de contexte restreint entre évaluation et devcomp

### DIFF
--- a/api/src/devcomp/domain/usecases/find-tutorials.js
+++ b/api/src/devcomp/domain/usecases/find-tutorials.js
@@ -1,28 +1,20 @@
 import _ from 'lodash';
 
-// TODO Bounded context violation
-import { Scorecard } from '../../../evaluation/domain/models/Scorecard.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/KnowledgeElement.js';
 
 const findTutorials = async function ({
-  authenticatedUserId,
-  scorecardId,
+  userId,
+  competenceId,
   knowledgeElementRepository,
   skillRepository,
   tubeRepository,
   tutorialRepository,
   locale,
 }) {
-  // TODO replace scorecardId by competenceId
-  const { userId, competenceId } = Scorecard.parseId(scorecardId);
-
-  // TODO refactor to extract this guard to controller
-  if (parseInt(authenticatedUserId) !== parseInt(userId)) {
-    throw new UserNotAuthorizedToAccessEntityError();
-  }
-
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
+    userId,
+    competenceId,
+  });
   const invalidatedDirectKnowledgeElements = _getInvalidatedDirectKnowledgeElements(knowledgeElements);
 
   if (invalidatedDirectKnowledgeElements.length === 0) {

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -1,5 +1,6 @@
 import { usecases as devCompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { scorecardController } from '../../../../../src/evaluation/application/scorecards/scorecard-controller.js';
+import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import * as requestResponseUtils from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
@@ -54,16 +55,16 @@ describe('Unit | Controller | scorecard-controller', function () {
 
   describe('#findTutorials', function () {
     const tutorials = [];
-
-    beforeEach(function () {
-      sinon
-        .stub(devCompUsecases, 'findTutorials')
-        .withArgs({ authenticatedUserId, scorecardId, locale })
-        .resolves(tutorials);
-    });
+    const competenceId = 13;
+    const userId = authenticatedUserId;
+    const scorecard = { userId, competenceId };
 
     it('should call the expected usecase', async function () {
-      // given
+      sinon
+        .stub(devCompUsecases, 'findTutorials')
+        .withArgs({ userId: authenticatedUserId, competenceId, locale })
+        .resolves(tutorials);
+      sinon.stub(Scorecard, 'parseId').withArgs(scorecardId).resolves(scorecard);
       const tutorialSerializer = {
         serialize: sinon.stub(),
       };


### PR DESCRIPTION
## 🌸 Problème

Le cas d'usage de recherche de tutoriel utilise le `Scorecard` pour retrouver l'id de compétence et vérifier que le user est bien celui authentifié...

## 🌳 Proposition

- Déplacer la vérification que l'utilisateur authentifié est bien celui lié au `Scorecard` dans le controller
- Utiliser uniquement un id de compétence en paramètre pour trouver un tutoriel 

## 🐝 Remarques

:warning: À merger après #11859 


## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
