### PR TITLE
[FEATURE] Autoriser les applications clientes à demander plusieurs scopes dans un même token (PIX-17247).

### DIFF
--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -82,7 +82,7 @@ export async function validateClientApplication(decodedAccessToken) {
     isValid: true,
     credentials: {
       client_id: decodedAccessToken.client_id,
-      scope: decodedAccessToken.scope,
+      scope: decodedAccessToken.scope.split(/\s/g),
       source: decodedAccessToken.source,
     },
   };

--- a/api/src/identity-access-management/domain/usecases/authenticate-application.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-application.js
@@ -44,7 +44,11 @@ async function _checkClientSecret(application, clientSecret, cryptoService) {
 }
 
 function _checkAppScope(application, scope) {
-  if (!application.scopes.includes(scope)) {
-    throw new ApplicationScopeNotAllowedError('The scope is invalid.');
+  const requestedScopes = scope.split(/\s/g);
+
+  for (const requestedScope of requestedScopes) {
+    if (!application.scopes.includes(requestedScope)) {
+      throw new ApplicationScopeNotAllowedError('The scope is invalid.');
+    }
   }
 }

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -32,6 +32,14 @@ function createAccessTokenForSaml({ userId, audience }) {
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds, audience });
 }
 
+/**
+ * @param {string} clientId
+ * @param {string} source
+ * @param {string | string[]} scope
+ * @param {string} secret
+ * @param {number | string} expiresIn
+ * @returns {string}
+ */
 function createAccessTokenFromApplication(
   clientId,
   source,
@@ -43,7 +51,7 @@ function createAccessTokenFromApplication(
     {
       client_id: clientId,
       source,
-      scope,
+      scope: Array.isArray(scope) ? scope.join(' ') : scope,
     },
     secret,
     { expiresIn },

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -505,7 +505,8 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     let options;
     const OSMOSE_CLIENT_ID = 'test-apimOsmoseClientId';
     const OSMOSE_CLIENT_SECRET = 'test-apimOsmoseClientSecret';
-    const SCOPE = 'organizations-certifications-result';
+    const SCOPE1 = 'organizations-certifications-result';
+    const SCOPE2 = 'another-scope';
 
     beforeEach(async function () {
       server = await createServer();
@@ -523,7 +524,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         name: 'osmose',
         clientId: OSMOSE_CLIENT_ID,
         clientSecret: OSMOSE_CLIENT_SECRET,
-        scopes: [SCOPE],
+        scopes: [SCOPE1, SCOPE2],
       });
       await databaseBuilder.commit();
     });
@@ -534,7 +535,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         grant_type: 'client_credentials',
         client_id: OSMOSE_CLIENT_ID,
         client_secret: OSMOSE_CLIENT_SECRET,
-        scope: SCOPE,
+        scope: `${SCOPE1} ${SCOPE2}`,
       });
 
       // when
@@ -555,7 +556,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         grant_type: 'client_credentials',
         client_id: 'NOT REGISTRED',
         client_secret: OSMOSE_CLIENT_SECRET,
-        scope: SCOPE,
+        scope: SCOPE1,
       });
 
       // when
@@ -575,7 +576,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         grant_type: 'client_credentials',
         client_id: OSMOSE_CLIENT_ID,
         client_secret: 'invalid secret',
-        scope: SCOPE,
+        scope: SCOPE1,
       });
 
       // when
@@ -589,13 +590,13 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       });
     });
 
-    it('should return a 403 when scope is not allowed', async function () {
+    it('should return a 403 when at least one scope is not allowed', async function () {
       // given
       options.payload = querystring.stringify({
         grant_type: 'client_credentials',
         client_id: OSMOSE_CLIENT_ID,
         client_secret: OSMOSE_CLIENT_SECRET,
-        scope: 'invalid scope',
+        scope: `invalid-scope ${SCOPE1}`,
       });
 
       // when

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -42,7 +42,11 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         method: 'GET',
         url: `/api/campaigns/${campaign.id}/participations`,
         headers: {
-          authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
+          authorization: generateValidRequestAuthorizationHeaderForApplication(
+            clientId,
+            'pix-client',
+            'campaigns meta',
+          ),
         },
       };
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -136,7 +136,7 @@ function generateAuthenticatedUserRequestHeaders({
   };
 }
 
-function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope) {
+function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope = '') {
   const accessToken = tokenService.createAccessTokenFromApplication(
     clientId,
     source,

--- a/api/tests/unit/infrastructure/authentication_test.js
+++ b/api/tests/unit/infrastructure/authentication_test.js
@@ -273,7 +273,13 @@ describe('Unit | Infrastructure | Authentication', function () {
         const h = { authenticated: sinon.stub() };
         const decodedAccessToken = {
           client_id: 'client_id',
-          scope: 'scope',
+          scope: 'scope1 scope2',
+          source: 'source',
+        };
+
+        const expectedCredentials = {
+          client_id: 'client_id',
+          scope: ['scope1', 'scope2'],
           source: 'source',
         };
         tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
@@ -286,7 +292,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         await authenticate(request, h);
 
         // then
-        expect(h.authenticated).to.have.been.calledWithExactly({ credentials: decodedAccessToken });
+        expect(h.authenticated).to.have.been.calledWithExactly({ credentials: expectedCredentials });
       });
     });
 


### PR DESCRIPTION
## 🌸 Problème

Actuellement, les applications clientes ne peuvent demander qu'un unique scope par token, ce qui rend fastidieux l'appel à plusieurs ressources de notre API.

## 🌳 Proposition

Respecter la [RFC 8693 OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693.html#name-scope-scopes-claim) : 

> The value of the scope claim is a JSON string containing a space-separated list of scopes associated with the token 

Nous avons alors permis de demander plusieurs scope les fournissant dans une string séparée par des espaces.
Au moment de récupérer les credentials pour les fournir à Hapi.js nous les repassons dans un tableau : cf: [nos échanges avec eux](https://github.com/hapijs/hapi/pull/4544).

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Demander plusieurs scope : ici `meta` et `campaigns` : 
```bash
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11891.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns' | jq -r .access_token)
```

Appeler la route qui autorise uniquement le scope `meta` : 

```bash
curl https://pix-api-maddo-review-pr11891.osc-fr1.scalingo.io/api/organizations -H "Authorization: Bearer $ACCESS_TOKEN"
```

Appeler la route qui autorise uniquement le scope `campaigns` : 

```bash
curl https://pix-api-maddo-review-pr11891.osc-fr1.scalingo.io/api/campaigns/104771/participations -H "Authorization: Bearer $ACCESS_TOKEN"
```
