### PR TITLE
[BUGFIX] Quelques menues corrections suite au recettage des nouveaux gabarits (PIX-17255).

### DIFF
--- a/mon-pix/app/components/certification-banners/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/certification-banners/congratulations-certification-banner.hbs
@@ -4,19 +4,22 @@
   </p>
   {{yield to="eligibleComplementaryCertifications"}}
   <div class="congratulations-banner__links">
-    <a
-      href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
+    <PixButtonLink
+      @href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
       class="congratulations-banner-links__link"
       target="_blank"
+      @variant="transparent-dark"
       rel="noopener noreferrer"
     >
       {{t "pages.certification-joiner.congratulation-banner.link.text"}}
       <PixIcon @name="openNew" @plainIcon={{true}} @title={{t "navigation.external-link-title"}} />
-    </a>
-    <LinkTo @route="authenticated.user-certifications" class="congratulations-banner-links__link">{{t
-        "pages.certification-start.link-to-user-certification"
-      }}
+    </PixButtonLink>
+    <PixButtonLink
+      @route="authenticated.user-certifications"
+      @variant="transparent-dark"
+      class="congratulations-banner-links__link"
+    >{{t "pages.certification-start.link-to-user-certification"}}
       <PixIcon @name="eye" @plainIcon={{true}} @ariaHidden={{true}} />
-    </LinkTo>
+    </PixButtonLink>
   </div>
 </div>

--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -4,7 +4,7 @@
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
     <div class="hexagon-score-content__pix-total">
       1024
-      <PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
+      <PixTooltip @isLight={{true}} @isWide={{true}} @position="left" @id="hexagon-score-tooltip">
         <:triggerElement>
           <button
             aria-label={{t "pages.profile.total-score-helper.label"}}

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -237,17 +237,13 @@
     </div>
   </:content>
   <:footer>
-    <ul class="scorecard-details-reset-modal__footer">
-      <li>
-        <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
-          {{t "common.actions.cancel"}}
-        </PixButton>
-      </li>
-      <li>
-        <PixButton id="pix-modal-footer__button-reset" @variant="error" @triggerAction={{this.reset}}>
-          {{t "pages.competence-details.actions.reset.label"}}
-        </PixButton>
-      </li>
-    </ul>
+    <div class="scorecard-details-reset-modal__footer">
+      <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
+        {{t "common.actions.cancel"}}
+      </PixButton>
+      <PixButton id="pix-modal-footer__button-reset" @variant="error" @triggerAction={{this.reset}}>
+        {{t "pages.competence-details.actions.reset.label"}}
+      </PixButton>
+    </div>
   </:footer>
 </PixModal>

--- a/mon-pix/app/components/training/header.hbs
+++ b/mon-pix/app/components/training/header.hbs
@@ -1,8 +1,8 @@
-<div class="background-banner-v2">
-  <div class="user-trainings-banner">
-    <h1 class="user-trainings-banner__title">{{t "pages.user-trainings.title"}}</h1>
-    <p class="user-trainings-banner__description">
+<section class="global-page-header">
+  <div class="global-page-header__left-content">
+    <h1 class="global-page-header__title">{{t "pages.user-trainings.title"}}</h1>
+    <p class="global-page-header__description">
       {{t "pages.user-trainings.description"}}
     </p>
   </div>
-</div>
+</section>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,5 +1,5 @@
 <li>
-  <article class="tutorial-card" role="article">
+  <PixBlock class="tutorial-card" role="article">
     <div class="tutorial-card__content">
       <h4 class="tutorial-card-content__title">
         <a
@@ -40,5 +40,5 @@
         </ul>
       {{/if}}
     </div>
-  </article>
+  </PixBlock>
 </li>

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -90,7 +90,6 @@
 
   @include breakpoints.device-is('tablet') {
     flex-direction: row;
-    width: 55%;
   }
 }
 
@@ -107,7 +106,6 @@
   @extend %pix-body-m;
 
   @include breakpoints.device-is('tablet') {
-    width: 45%;
     margin-bottom: 0;
   }
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -113,3 +113,10 @@
     margin-block: var(--pix-spacing-4x);
   }
 }
+
+/** Reset modal **/
+.scorecard-details-reset-modal__footer {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  justify-content: flex-end;
+}

--- a/mon-pix/app/styles/components/ui/_page-header.scss
+++ b/mon-pix/app/styles/components/ui/_page-header.scss
@@ -6,7 +6,7 @@
   gap: var(--pix-spacing-6x);
   justify-content: space-between;
   padding-bottom: var(--pix-spacing-6x);
-  border-bottom: 1px solid var(--pix-neutral-100);
+  border-bottom: 1px solid rgb(var(--pix-primary-100-inline), 0.8);
   margin-block: var(--pix-spacing-6x) var(--pix-spacing-8x);
 }
 

--- a/mon-pix/app/styles/components/ui/_page-header.scss
+++ b/mon-pix/app/styles/components/ui/_page-header.scss
@@ -7,7 +7,7 @@
   justify-content: space-between;
   padding-bottom: var(--pix-spacing-6x);
   border-bottom: 1px solid var(--pix-neutral-100);
-  margin-block: var(--pix-spacing-10x) var(--pix-spacing-8x);
+  margin-block: var(--pix-spacing-6x) var(--pix-spacing-8x);
 }
 
 .global-page-header__left-content {

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -81,6 +81,7 @@ img {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  margin-bottom: var(--pix-spacing-10x);
 }
 
 .global-page-container__streched-content {

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -22,7 +22,7 @@ img {
   gap: var(--pix-spacing-6x);
   align-items: center;
   justify-content: flex-end;
-  padding-bottom: var(--pix-spacing-4x);
+  padding-bottom: var(--pix-spacing-3x);
 
   &__user-pix-score {
     display: flex;

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -21,7 +21,7 @@
     @extend %pix-body-m;
 
     margin: 0;
-    padding: var(--pix-spacing-2x) 0 var(--pix-spacing-8x);
+    padding: var(--pix-spacing-2x) 0;
     color: var(--pix-neutral-500);
   }
 }

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.user-account.title")}}
 
 {{#if this.isPixAppNewLayoutEnabled}}
-  <main id="main" class="main user-account" role="main">
+  <main id="main" class="main user-account global-page-container" role="main">
     <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>
 
     <div class="user-account__container">

--- a/mon-pix/tests/acceptance/user-trainings-test.js
+++ b/mon-pix/tests/acceptance/user-trainings-test.js
@@ -38,11 +38,11 @@ module('Acceptance | mes-formations', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/mes-formations');
-      assert.dom('.user-trainings-banner__title').exists();
-      assert.ok(find('.user-trainings-banner__title').textContent.includes('Mes formations'));
-      assert.dom('.user-trainings-banner__description').exists();
+      assert.dom('.global-page-header__title').exists();
+      assert.ok(find('.global-page-header__title').textContent.includes('Mes formations'));
+      assert.dom('.global-page-header__description').exists();
       assert.ok(
-        find('.user-trainings-banner__description').textContent.includes(
+        find('.global-page-header__description').textContent.includes(
           'Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.',
         ),
       );

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -339,7 +339,7 @@
       "skills": "Compétences",
       "start-certification": "Certification",
       "trainings": "Mes formations",
-      "tutorials": "Mes tutos"
+      "tutorials": "Mes tutoriels"
     },
     "mobile-button-title": "Ouvrir le menu",
     "nav-bar": {
@@ -2224,7 +2224,7 @@
         "reset-aria-label": "Réinitialiser et désélectionner tous les filtres",
         "see-results": "Voir les résultats"
       },
-      "title": "Tutoriels"
+      "title": "Mes tutoriels"
     }
   }
 }


### PR DESCRIPTION
## 🌸 Problème 🌳 Proposition
Prise en compte de retours suite à la recette des nouveaux gabarits
- Commun à toute les pages : 24px (6x) entre titre et top nav au lieu de 40px (10x)
- Commun à toute les pages : divider dans la description en primary 100, 0.8 opacity
- Footer commun à toute les pagesspacing de 40px (10x) entre content et footer
- Titre page parcours : Mes parcours
- wording description : Retrouvez ici les parcours d’évaluations que l’on vous a invités à réaliser.
- page certification, utiliser composant bouton dans le header
- page compétence : modal remise à zéro cassé graphiquement
- supprimer le fond bleu sur la page “verifier un certificat”
- page mes formation supprimer le fond bleu et alligner sur le nouveau gabarit

## 🤧 Pour tester
- Vérifier les points sus-cités
