### PR TITLE
[FEATURE] Appliquer le variant 'admin' à la navigation PixAdmin (PIX-17224)

### DIFF
--- a/admin/app/templates/authenticated.hbs
+++ b/admin/app/templates/authenticated.hbs
@@ -1,5 +1,5 @@
 {{#if this.shouldDisplayNewSidebar}}
-  <PixAppLayout @variant="primary">
+  <PixAppLayout @variant="admin">
     <:navigation>
       <Layout::Sidebar />
     </:navigation>


### PR DESCRIPTION
## 🌸 Problème
La navigation de PixAdmin applique le variant dédié à PixApp

## 🌳 Proposition
Appliquer le variant 'admin'

## 🤧 Pour tester
Vérifier que le variant admin est bien visible sur PixAdmin