### PR TITLE
[FEATURE] Documenter les routes de mise à disposition de données (PIX-17258).

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { responseObjectErrorDoc } from '../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { getCampaignParticipations } from './campaigns-controller.js';
 import { isCampaignInJurisdictionPreHandler, organizationPreHandler } from './pre-handlers.js';
 
@@ -18,8 +19,29 @@ const register = async function (server) {
         },
         pre: [organizationPreHandler, isCampaignInJurisdictionPreHandler],
         handler: getCampaignParticipations,
-        notes: ['- Retourne les résultats de la campagne donnée.'],
+        description: 'Lister les résultats d’une campagne',
+        notes: [
+          'Retourne les résultats de la campagne avec l’identifiant `campaignId`.',
+          '**Cette route nécessite le scope campaigns.**',
+        ],
         tags: ['api', 'campaigns', 'maddo'],
+        response: {
+          failAction: 'log',
+          status: {
+            200: Joi.object({
+              id: Joi.number().description('ID de la participation à la campagne'),
+              createdAt: Joi.date().description('Date de début de participation'),
+              participantExternalId: Joi.string().description('Identifiant Externe rempli en début de participation'),
+              status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
+              sharedAt: Joi.date().description('Date de participation'),
+              campaignId: Joi.number().description('ID de la campagne liée à la participation'),
+              userId: Joi.number().description('ID utilisateur du participant'),
+              organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
+            }).label('CampaignParticipation'),
+            401: responseObjectErrorDoc,
+            403: responseObjectErrorDoc,
+          },
+        },
       },
     },
   ]);

--- a/api/src/maddo/application/replications-routes.js
+++ b/api/src/maddo/application/replications-routes.js
@@ -18,7 +18,11 @@ const register = async function (server) {
           }),
         },
         handler: replicate,
-        notes: ['- Permet à une application de lancer une réplication entre le datawarehouse et le datamart'],
+        description: 'Lancer un job de réplication.',
+        notes: [
+          'Permet à une application de lancer une réplication entre le datawarehouse et le datamart.',
+          '**Cette route nécessite le scope replication.**',
+        ],
         tags: ['api', 'replications'],
       },
     },

--- a/api/src/shared/application/healthcheck/index.js
+++ b/api/src/shared/application/healthcheck/index.js
@@ -8,7 +8,7 @@ const register = async function (server) {
       config: {
         auth: false,
         handler: healthcheckController.get,
-        tags: ['api'],
+        tags: ['api', 'healthcheck'],
       },
     },
     {
@@ -17,7 +17,7 @@ const register = async function (server) {
       config: {
         auth: false,
         handler: healthcheckController.checkDbStatus,
-        tags: ['api'],
+        tags: ['api', 'healthcheck'],
       },
     },
     {
@@ -26,7 +26,7 @@ const register = async function (server) {
       config: {
         auth: false,
         handler: healthcheckController.checkRedisStatus,
-        tags: ['api'],
+        tags: ['api', 'healthcheck'],
       },
     },
     {

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -86,6 +86,7 @@ class PixAPI extends PixOpenApiBaseDefinition {
   constructor() {
     super({ endpoint: '/api' });
     this.swaggerConfiguration.grouping = 'tags';
+    this.swaggerConfiguration.tagsGroupingFilter = (tag) => !['api', 'maddo'].includes(tag);
   }
 }
 

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -34,7 +34,7 @@ class PixOpenApiBaseDefinition {
      */
     this.swaggerConfiguration = {
       OAS: 'v3.0',
-      routeTag: 'api',
+      routeTag: (tags) => tags.includes('api') && !tags.includes('healthcheck'),
       info: {
         title: 'Welcome to the Pix api catalog',
         version: packageJSON.version,


### PR DESCRIPTION
## 🌸 Problème

Notre swagger contient les schémas de validation de payload et de params, mais ne contient pas les retours.

## 🌳 Proposition

Ajouter le schéma des réponses. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Se rendre sur /api/documentation et constater que les routes sont documentées. 