### PR TITLE
[TECH] Tests e2e de gestion des élèves sco avec Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,10 +188,6 @@ workflows:
           context: Pix
           requires:
             - mon_pix_build
-      # - mon_pix_e2e_playwright_test:
-      #     context: Pix
-      #     requires:
-      #       - mon_pix_build
 
       - orga_build:
           context: Pix
@@ -209,6 +205,10 @@ workflows:
           context: Pix
           requires:
             - orga_build
+      # - orga_e2e_playwright_test:
+      #     context: Pix
+      #     requires:
+      #       - orga_build
 
       - certif_install:
           context: Pix
@@ -950,11 +950,11 @@ jobs:
 
   # Temporary disabled until e2e tests are migrated to Playwright
   #
-  # mon_pix_e2e_playwright_test:
+  # orga_e2e_playwright_test:
   #   executor:
   #     name: node-redis-postgres-s3-docker-medium
   #   working_directory: ~/pix/high-level-tests/e2e-playwright
-  #   parallelism: 2
+  #   parallelism: 1
   #   steps:
   #     - attach_workspace:
   #         at: ~/pix
@@ -980,6 +980,9 @@ jobs:
   #         keys:
   #           - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
   #     - run:
+  #         name: Install Playwright Browser
+  #         command: npx playwright install --with-deps chromium
+  #     - run:
   #         name: Install Pix API
   #         working_directory: ~/pix/api
   #         command: npm ci
@@ -997,19 +1000,16 @@ jobs:
   #           MAILING_ENABLED: 'false'
   #           AUTH_SECRET: 'secret'
   #     - run:
-  #         name: Start Pix App
-  #         working_directory: ~/pix/mon-pix
+  #         name: Start Pix Orga
+  #         working_directory: ~/pix/orga
   #         command: npx ember server --path=./dist --proxy=http://localhost:3000
   #         background: true
   #     - run:
-  #         name: Install Playwright Browser
-  #         command: npx playwright install --with-deps chromium
-  #     - run:
   #         name: Run Pix App e2e tests (with sharding)
-  #         command: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --project=pix-app --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+  #         command: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --project=pix-orga --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
   #         environment:
   #           PIX_API_PORT: 3000
-  #           PIX_APP_URL: http://localhost:4200
+  #           PIX_ORGA_URL: http://localhost:4201
   #           DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
   #           AUTH_SECRET: 'secret'
   #     - store_test_results:

--- a/high-level-tests/e2e-playwright/pix-orga/migration.md
+++ b/high-level-tests/e2e-playwright/pix-orga/migration.md
@@ -1,38 +1,47 @@
+**Auth setup**
+
 - [x] Login
+
+**Homepage**
+
+- [ ] (NEW) Changer d'organisation
+- [ ] Logout
 
 **Onboarding**
 
 - [x] Invitation et Signup (rejoindre une organisation)
 - [x] Invitation et Signin (authentifié ou non)
-- [ ] Logout
 
 **student-sco**
 
-- [ ] Accès d'un admin vs accès d'une membre
-- [ ] Je veux changer le mot de passe d'un élève
-- [ ] Je veux créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
+- [x] Je veux changer le mot de passe d'un élève
+- [x] Je veux créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
+- [x] (NEW) Aucune action n'est disponible sur un élève non réconcilié
 
 **student-sup**
 
-- [ ] Accès d'un admin vs accès d'une membre
 - [ ] J'affiche la liste des élèves
 
 **campaign-evaluation**
 
 - [ ] Création d'une campagne d'évaluation
+- [ ] Modification d'une campagne d'évaluation
 - [ ] Je consulte le détail d'une campagne d'évaluation
 
 **campaign-profile**
 
 - [ ] Création d'une campagne de profil
+- [ ] Modification d'une campagne de profil
 - [ ] Je consulte le détail d'une campagne de profil
 
 **campaign-management**
 
 - [ ] Duplication
 - [ ] Archivage / désarchivage
-- [ ] Modification
 
 **member-management**
 
+- [ ] (NEW) Actions non disponibles pour un membre
+- [ ] (NEW) Actions disponibles pour un admin
 - [ ] J'envoie une invitation à rejoindre Pix Orga
+- [ ] (NEW) Modification du rôle d'un membre

--- a/high-level-tests/e2e-playwright/pix-orga/onboarding-invitations.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/onboarding-invitations.test.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { useLoggedUser } from '../helpers/auth.ts';
-import { databaseBuilder } from '../helpers/db.ts';
-import { test } from '../helpers/fixtures.ts';
+import { useLoggedUser } from '../helpers/auth.js';
+import { databaseBuilder } from '../helpers/db.js';
+import { test } from '../helpers/fixtures.js';
 
 test('A new user joins a new organization from an invitation link', async function ({ page }) {
   const invitation = databaseBuilder.factory.buildOrganizationInvitation();
@@ -11,7 +11,7 @@ test('A new user joins a new organization from an invitation link', async functi
   await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
   await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
 
-  test.step('signup user', async () => {
+  await test.step('signup user', async () => {
     await page.getByRole('textbox', { name: 'Prénom' }).fill('mini');
     await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('pixou');
     await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill('minipixou@example.net');
@@ -34,7 +34,7 @@ test('An existing user joins a new organization from an invitation link', async 
   await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
   await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
 
-  test.step('signin user', async () => {
+  await test.step('signin user', async () => {
     await page.getByRole('button', { name: 'Se connecter' }).click();
     await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill(user.email);
     await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');
@@ -58,7 +58,7 @@ test.describe('When user is already authenticated to Pix Orga', () => {
     await page.goto(`/rejoindre?invitationId=${invitation.id}&code=${invitation.code}`);
     await expect(page.getByText('Vous êtes invité(e) à')).toBeVisible();
 
-    test.step('signin user', async () => {
+    await test.step('signin user', async () => {
       await page.getByRole('button', { name: 'Se connecter' }).click();
       await page.getByRole('textbox', { name: 'Adresse e-mail' }).fill(user.email);
       await page.getByRole('textbox', { name: 'Mot de passe' }).fill('pix123');

--- a/high-level-tests/e2e-playwright/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/sco-students-management.test.ts
@@ -1,0 +1,115 @@
+import { expect } from '@playwright/test';
+
+import { useLoggedUser } from '../helpers/auth.js';
+import { databaseBuilder } from '../helpers/db.js';
+import { test } from '../helpers/fixtures.js';
+
+const loggedUserId = useLoggedUser('pix-orga');
+
+test('Students management for a sco organization', async ({ page }) => {
+  const { learnerPixAuth, learnerGarAuth, learnerNotLinked } = await _buildTestData();
+
+  await page.goto('/');
+  await page.getByRole('heading', { name: 'Campagnes' }).waitFor();
+
+  await page.getByRole('link', { name: 'Élèves' }).click();
+  await expect(page.getByRole('heading', { name: 'Élèves (3)' })).toBeVisible();
+
+  await test.step('Changes password of a learner having a PIX authentication method', async () => {
+    const row = page.getByRole('row').filter({ hasText: learnerPixAuth.lastName });
+    await row.getByRole('button', { name: 'Afficher les actions' }).click();
+    await row.getByRole('button', { name: 'Gérer le compte' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Gestion du compte Pix de l’élève' });
+    await expect(dialog.getByRole('textbox', { name: 'Adresse e-mail' })).toHaveValue(learnerPixAuth.email);
+    await expect(dialog.getByRole('textbox', { name: 'Identifiant' })).toHaveValue(learnerPixAuth.username);
+
+    await dialog.getByRole('button', { name: 'Réinitialiser le mot de passe' }).click();
+    await expect(dialog.getByText('Nouveau mot de passe à usage unique')).toBeVisible();
+    await expect(dialog.getByRole('textbox', { name: 'Nouveau mot de passe à usage unique' })).toHaveValue(
+      /[a-zA-Z0-9]{8}/,
+    );
+    await dialog.getByRole('button', { name: 'Fermer' }).click();
+  });
+
+  await test.step('Creates a username for a learner having a GAR authentication method', async () => {
+    const row = page.getByRole('row').filter({ hasText: learnerGarAuth.lastName });
+    await row.getByRole('button', { name: 'Afficher les actions' }).click();
+    await row.getByRole('button', { name: 'Gérer le compte' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Gestion du compte Pix de l’élève' });
+    await expect(dialog.getByText('Médiacentre')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Ajouter l’identifiant' }).click();
+    await expect(dialog.getByRole('textbox', { name: 'Identifiant' })).toHaveValue('billy.garuser0508');
+    await expect(dialog.getByText('Nouveau mot de passe à usage unique')).toBeVisible();
+    await expect(dialog.getByRole('textbox', { name: 'Nouveau mot de passe à usage unique' })).toHaveValue(
+      /[a-zA-Z0-9]{8}/,
+    );
+    await dialog.getByRole('button', { name: 'Fermer' }).click();
+  });
+
+  await test.step('No action available for learner not linked to a user', async () => {
+    const row = page.getByRole('row').filter({ hasText: learnerNotLinked.lastName });
+    await expect(row.getByRole('button', { name: 'Afficher les actions' })).not.toBeVisible();
+  });
+});
+
+async function _buildTestData() {
+  // SCO organization
+  const organization = databaseBuilder.factory.buildOrganization({
+    type: 'SCO',
+    isManagingStudents: true,
+    identityProviderForCampaigns: 'GAR',
+  });
+
+  // Member of the organization
+  const member = databaseBuilder.factory.buildUser.withMembership({
+    id: loggedUserId,
+    organizationId: organization.id,
+    role: 'MEMBER',
+  });
+  const legalDocument = databaseBuilder.factory.buildLegalDocumentVersion({ type: 'TOS', service: 'pix-orga' });
+  databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+    legalDocumentVersionId: legalDocument.id,
+    userId: member.id,
+  });
+
+  // Learner with no user linked
+  const learnerNotLinked = databaseBuilder.factory.buildOrganizationLearner({
+    organizationId: organization.id,
+    lastName: 'NoUser',
+    userId: null,
+  });
+
+  // Learner linked to user with PIX authentication method
+  const learnerPixAuth = databaseBuilder.factory.buildUser.withRawPassword({
+    lastName: 'PixUser',
+    email: 'pix@user.com',
+    username: 'pix.user',
+  });
+  databaseBuilder.factory.buildOrganizationLearner({
+    organizationId: organization.id,
+    firstName: learnerPixAuth.firstName,
+    lastName: learnerPixAuth.lastName,
+    userId: learnerPixAuth.id,
+  });
+
+  // Learner linked to user with GAR authentication method
+  const learnerGarAuth = databaseBuilder.factory.buildUser({ lastName: 'GarUser', username: null, email: null });
+  databaseBuilder.factory.buildOrganizationLearner({
+    organizationId: organization.id,
+    firstName: learnerGarAuth.firstName,
+    lastName: learnerGarAuth.lastName,
+    userId: learnerGarAuth.id,
+  });
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    firstName: learnerGarAuth.firstName,
+    lastName: learnerGarAuth.lastName,
+    userId: learnerGarAuth.id,
+  });
+
+  await databaseBuilder.commit();
+
+  return { learnerPixAuth, learnerGarAuth, learnerNotLinked };
+}


### PR DESCRIPTION
## 🌸 Problème

Sur la mise en place des tests e2e avec Playwright, on souhaite migrer les tests e2e de Pix Orga dans un premier temps.

## 🌳 Proposition

Migration des tests de gestion des élèves:
- Changer le mot de passe d'un élève
- Créer un identifiant pour un élève ayant la méthode de connexion Mediacentre
- (Nouveau test) Aucune action n'est disponible sur un élève non réconcilié

Pour le moment, le test e2e playwright ont été désactivés dans la CI avant d'être mergé sur la branche dev. Voici leur exécution pour cette PR: https://app.circleci.com/pipelines/github/1024pix/pix/115100/workflows/dde8f061-9aad-4042-b460-c19b4e550fc9/jobs/1285648
