### PR TITLE
[FEATURE] Rendre le processus d'authentifcation OIDC plus résistant aux retours arrière (PIX-13945)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -21,7 +21,7 @@ async function authenticateOidcUser(request, h) {
   await request.yar.commit(h);
 
   if (sessionState === null) {
-    throw new BadRequestError('Required cookie "state" is missing');
+    throw new BadRequestError('Required "state" is missing in session', 'MISSING_OIDC_STATE');
   }
 
   const result = await usecases.authenticateOidcUser({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -333,9 +333,6 @@ function _mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.UnexpectedUserAccountError) {
     return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }
-  if (error instanceof SharedDomainErrors.AlreadyExistingEntityError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
-  }
   if (error instanceof SharedDomainErrors.AlreadyExistingMembershipError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -65,7 +65,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       expect(request.yar.commit).to.have.been.calledOnce;
     });
 
-    context('when state cookie is missing', function () {
+    context('when state is missing in session', function () {
       it('returns a BadRequestError', async function () {
         // given
         request.yar.get.returns(null);
@@ -75,7 +75,8 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
 
         // then
         expect(error).to.be.an.instanceOf(BadRequestError);
-        expect(error.message).to.equal('Required cookie "state" is missing');
+        expect(error.code).to.equal('MISSING_OIDC_STATE');
+        expect(error.message).to.equal('Required "state" is missing in session');
       });
     });
 
@@ -103,7 +104,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
 
         // then
         expect(error).to.be.an.instanceOf(UnauthorizedError);
-        expect(error.message).to.equal("L'utilisateur n'a pas de compte Pix");
         expect(error.code).to.equal('SHOULD_VALIDATE_CGU');
         expect(error.meta).to.deep.equal({
           authenticationKey,

--- a/junior/tests/acceptance/access-school-test.js
+++ b/junior/tests/acceptance/access-school-test.js
@@ -4,6 +4,7 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest, t } from '../../tests/helpers';
 import identifyLearner from '../helpers/identify-learner';
+import { unabortedVisit } from '../helpers/unaborted-visit';
 
 module('Acceptance | School', function (hooks) {
   setupApplicationTest(hooks);
@@ -13,14 +14,10 @@ module('Acceptance | School', function (hooks) {
 
   module('When the user is not identified', function () {
     test('should redirect to organization-code', async function (assert) {
-      try {
-        await visit('/');
-      } catch (error) {
-        const { message } = error;
-        if (message !== 'TransitionAborted') {
-          throw error;
-        }
-      }
+      // when
+      await unabortedVisit('/');
+
+      // then
       assert.strictEqual(currentURL(), '/organization-code');
     });
 
@@ -141,16 +138,7 @@ module('Acceptance | School', function (hooks) {
         this.server.create('school');
 
         // when
-        //Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch 🤯
-        //https://github.com/emberjs/ember-test-helpers/issues/332
-        try {
-          await visit('/schools/MINIPIXOU/students');
-        } catch (error) {
-          const { message } = error;
-          if (message !== 'TransitionAborted') {
-            throw error;
-          }
-        }
+        await unabortedVisit('/schools/MINIPIXOU/students');
 
         // then
         assert.strictEqual(currentURL(), '/schools/MINIPIXOU');
@@ -160,15 +148,13 @@ module('Acceptance | School', function (hooks) {
 
   module('When the user is identified', function () {
     test('should display mission page', async function (assert) {
+      // given
       identifyLearner(this.owner);
-      try {
-        await visit('/');
-      } catch (error) {
-        const { message } = error;
-        if (message !== 'TransitionAborted') {
-          throw error;
-        }
-      }
+
+      // when
+      await unabortedVisit('/');
+
+      // then
       assert.strictEqual(currentURL(), '/');
     });
 

--- a/junior/tests/acceptance/start-mission-test.js
+++ b/junior/tests/acceptance/start-mission-test.js
@@ -1,9 +1,10 @@
-import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { clickByText } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import { setupApplicationTest, t } from '../helpers';
 import identifyLearner from '../helpers/identify-learner';
+import { unabortedVisit } from '../helpers/unaborted-visit';
 
 module('Acceptance | Start mission', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,15 +17,9 @@ module('Acceptance | Start mission', function (hooks) {
       this.server.create('challenge');
 
       // when
-      try {
-        await visit(`/missions/${mission.id}`);
-        await clickByText(t('pages.missions.start-page.start-mission'));
-      } catch (error) {
-        const { message } = error;
-        if (message !== 'TransitionAborted') {
-          throw error;
-        }
-      }
+      await unabortedVisit(`/missions/${mission.id}`);
+      await clickByText(t('pages.missions.start-page.start-mission'));
+
       // then
       assert.strictEqual(currentURL(), `/assessments/1/challenges`);
     });
@@ -42,15 +37,9 @@ module('Acceptance | Start mission', function (hooks) {
       this.server.create('challenge');
 
       // when
-      try {
-        await visit(`/missions/${mission.id}`);
-        await clickByText(t('pages.missions.start-page.start-mission'));
-      } catch (error) {
-        const { message } = error;
-        if (message !== 'TransitionAborted') {
-          throw error;
-        }
-      }
+      await unabortedVisit(`/missions/${mission.id}`);
+      await clickByText(t('pages.missions.start-page.start-mission'));
+
       // then
       assert.strictEqual(currentURL(), `/missions/1/introduction`);
     });
@@ -65,15 +54,9 @@ module('Acceptance | Start mission', function (hooks) {
       this.server.create('challenge');
 
       // when
-      try {
-        await visit(`/missions/${mission.id}/introduction`);
-        await clickByText(t('pages.missions.introduction-page.start-mission'));
-      } catch (error) {
-        const { message } = error;
-        if (message !== 'TransitionAborted') {
-          throw error;
-        }
-      }
+      await unabortedVisit(`/missions/${mission.id}/introduction`);
+      await clickByText(t('pages.missions.introduction-page.start-mission'));
+
       // then
       assert.strictEqual(currentURL(), '/assessments/1/challenges');
     });

--- a/junior/tests/helpers/unaborted-visit.js
+++ b/junior/tests/helpers/unaborted-visit.js
@@ -1,0 +1,20 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { settled } from '@ember/test-helpers';
+
+// Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch en attendant l'évolution attendue dans Ember :
+// https://github.com/emberjs/ember-test-helpers/issues/332
+export async function unabortedVisit(url) {
+  try {
+    await visit(url);
+  } catch (error) {
+    if (!_isEmberTransitionAborted(error)) {
+      throw error;
+    }
+
+    await settled();
+  }
+}
+
+function _isEmberTransitionAborted(error) {
+  return error.message == 'TransitionAborted';
+}

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -34,6 +34,15 @@ export default class LoginOidcRoute extends Route {
       return;
     }
 
+    // Preventing OIDC authentication replay errors when doing history back and reload
+    // when the user is already authenticated with the same OIDC Provider.
+    if (this.session.isAuthenticated) {
+      if (identityProvider.code == this.session.data.authenticated.identityProviderCode) {
+        this.router.transitionTo('authenticated');
+        return;
+      }
+    }
+
     if (!queryParams.code) {
       transition.abort();
       await this._makeOidcAuthenticationRequest(identityProvider);

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -64,30 +64,6 @@ export default class LoginOidcRoute extends Route {
     this.session.set('data.nextURL', undefined);
   }
 
-  async _handleOidcCallbackRequest(code, state, iss, identityProviderSlug) {
-    try {
-      await this.session.authenticate('authenticator:oidc', {
-        code,
-        state,
-        iss,
-        identityProviderSlug,
-        hostSlug: 'token',
-      });
-    } catch (response) {
-      const apiError = get(response, 'errors[0]');
-      const error = new JSONApiError(apiError.detail, apiError);
-
-      const shouldValidateCgu = error.code === 'SHOULD_VALIDATE_CGU';
-
-      if (shouldValidateCgu && error.meta.authenticationKey) {
-        oidcUserAuthenticationStorage.set(error.meta);
-        return { shouldValidateCgu, identityProviderSlug };
-      }
-
-      throw error;
-    }
-  }
-
   async _makeOidcAuthenticationRequest(identityProviderSlug) {
 
     // Storing the `attemptedTransition` in the localstorage so when the user returns after
@@ -111,5 +87,29 @@ export default class LoginOidcRoute extends Route {
     );
     const { redirectTarget } = await response.json();
     this.location.replace(redirectTarget);
+  }
+
+  async _handleOidcCallbackRequest(code, state, iss, identityProviderSlug) {
+    try {
+      await this.session.authenticate('authenticator:oidc', {
+        code,
+        state,
+        iss,
+        identityProviderSlug,
+        hostSlug: 'token',
+      });
+    } catch (response) {
+      const apiError = get(response, 'errors[0]');
+      const error = new JSONApiError(apiError.detail, apiError);
+
+      const shouldValidateCgu = error.code === 'SHOULD_VALIDATE_CGU';
+
+      if (shouldValidateCgu && error.meta.authenticationKey) {
+        oidcUserAuthenticationStorage.set(error.meta);
+        return { shouldValidateCgu, identityProviderSlug };
+      }
+
+      throw error;
+    }
   }
 }

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -113,6 +113,11 @@ export default class LoginOidcRoute extends Route {
       const apiError = get(response, 'errors[0]');
       const error = new JSONApiError(apiError.detail, apiError);
 
+      if (error.code == 'MISSING_OIDC_STATE') {
+        this.router.transitionTo('authentication.login');
+        return;
+      }
+
       const shouldValidateCgu = error.code === 'SHOULD_VALIDATE_CGU';
       if (shouldValidateCgu && error.meta.authenticationKey) {
         oidcUserAuthenticationStorage.set(error.meta);

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -94,7 +94,7 @@ export default class LoginOidcRoute extends Route {
     );
     const { redirectTarget: authorizationUrl } = await response.json();
 
-    this.location.replace(authorizationUrl);
+    this.location.assign(authorizationUrl);
   }
 
   async _handleOidcCallbackRequest({ identityProvider, code, state, iss }) {

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -27,14 +27,15 @@ export default class LoginOidcRoute extends Route {
       throw error;
     }
 
+    const identityProviderSlug = transition.to.params.identity_provider_slug;
+    const identityProvider = this.oidcIdentityProviders[identityProviderSlug];
+    if (!identityProvider) {
+      return this.router.replaceWith('authentication.login');
+    }
+
     if (!queryParams.code) {
       this._cleanSession();
-
-      const identityProviderSlug = transition.to.params.identity_provider_slug;
-      const isSupportedIdentityProvider = this.oidcIdentityProviders[identityProviderSlug] ?? null;
-      if (isSupportedIdentityProvider) return this._handleRedirectRequest(identityProviderSlug);
-
-      return this.router.replaceWith('authentication.login');
+      return this._handleRedirectRequest(identityProviderSlug);
     }
   }
 

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -34,7 +34,6 @@ export default class LoginOidcRoute extends Route {
     }
 
     if (!queryParams.code) {
-      this._cleanSession();
       return this._makeOidcAuthenticationRequest(identityProviderSlug);
     }
   }
@@ -60,11 +59,8 @@ export default class LoginOidcRoute extends Route {
     });
   }
 
-  _cleanSession() {
-    this.session.set('data.nextURL', undefined);
-  }
-
   async _makeOidcAuthenticationRequest(identityProviderSlug) {
+    this.session.set('data.nextURL', undefined);
 
     // Storing the `attemptedTransition` in the localstorage so when the user returns after
     // the login they can be sent to the initial destination.

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -35,7 +35,7 @@ export default class LoginOidcRoute extends Route {
 
     if (!queryParams.code) {
       this._cleanSession();
-      return this._handleRedirectRequest(identityProviderSlug);
+      return this._makeOidcAuthenticationRequest(identityProviderSlug);
     }
   }
 
@@ -44,7 +44,7 @@ export default class LoginOidcRoute extends Route {
 
     const identityProviderSlug = params.identity_provider_slug;
     if (queryParams.code) {
-      return this._handleCallbackRequest(queryParams.code, queryParams.state, queryParams.iss, identityProviderSlug);
+      return this._handleOidcCallbackRequest(queryParams.code, queryParams.state, queryParams.iss, identityProviderSlug);
     }
   }
 
@@ -64,7 +64,7 @@ export default class LoginOidcRoute extends Route {
     this.session.set('data.nextURL', undefined);
   }
 
-  async _handleCallbackRequest(code, state, iss, identityProviderSlug) {
+  async _handleOidcCallbackRequest(code, state, iss, identityProviderSlug) {
     try {
       await this.session.authenticate('authenticator:oidc', {
         code,
@@ -88,7 +88,7 @@ export default class LoginOidcRoute extends Route {
     }
   }
 
-  async _handleRedirectRequest(identityProviderSlug) {
+  async _makeOidcAuthenticationRequest(identityProviderSlug) {
 
     // Storing the `attemptedTransition` in the localstorage so when the user returns after
     // the login they can be sent to the initial destination.

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -88,17 +88,14 @@ export default class LoginOidcRoute extends Route {
   }
 
   async _handleRedirectRequest(identityProviderSlug) {
-    /**
-     * Store the `attemptedTransition` in the localstorage so when the user returns after
-     * the login he can be sent to the initial destination.
-     */
-    if (this.session.get('attemptedTransition')) {
-      /**
-       * There is two types of intent in transition (see: https://github.com/tildeio/router.js/blob/9b3d00eb923e0bbc34c44f08c6de1e05684b907a/ARCHITECTURE.md#transitionintent)
-       * When the route is accessed by url (/campagnes/:code), the url is provided
-       * When the route is accessed by the submit of the campaign code, the route name (campaigns.access) and contexts ([Campaign]) are provided
-       */
 
+    // Storing the `attemptedTransition` in the localstorage so when the user returns after
+    // the login they can be sent to the initial destination.
+    if (this.session.get('attemptedTransition')) {
+      // There is two types of intent in transition (see: https://github.com/tildeio/router.js/blob/9b3d00eb923e0bbc34c44f08c6de1e05684b907a/ARCHITECTURE.md#transitionintent)
+      // When the route is accessed by url (/campagnes/:code), the url is provided.
+      // When the route is accessed by the submit of the campaign code,
+      // the route name (campaigns.access) and contexts ([Campaign]) are provided.
       let { url } = this.session.get('attemptedTransition.intent');
       const { name, contexts } = this.session.get('attemptedTransition.intent');
       if (!url) {

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -30,7 +30,7 @@ export default class LoginOidcRoute extends Route {
     if (!queryParams.code) {
       this._cleanSession();
 
-      const identityProviderSlug = transition.to.params.identity_provider_slug.toString();
+      const identityProviderSlug = transition.to.params.identity_provider_slug;
       const isSupportedIdentityProvider = this.oidcIdentityProviders[identityProviderSlug] ?? null;
       if (isSupportedIdentityProvider) return this._handleRedirectRequest(identityProviderSlug);
 

--- a/mon-pix/app/services/error-messages.js
+++ b/mon-pix/app/services/error-messages.js
@@ -56,20 +56,14 @@ export default class ErrorMessagesService extends Service {
     let i18nKey;
     let formatOptionsFn;
     let formatOptions;
-    let formattedGenericErrorDetails;
     if (mapping) {
       ({ i18nKey, formatOptionsFn } = mapping);
       formatOptions = formatOptionsFn && formatOptionsFn(error);
     } else {
       i18nKey = 'common.error';
-      formattedGenericErrorDetails = error.detail && ` (${error.detail})`;
     }
 
-    let message = this.intl.t(i18nKey, formatOptions);
-    if (formattedGenericErrorDetails) {
-      message += formattedGenericErrorDetails;
-    }
-
+    const message = this.intl.t(i18nKey, formatOptions);
     return message;
   }
 }

--- a/mon-pix/app/services/location.js
+++ b/mon-pix/app/services/location.js
@@ -2,6 +2,6 @@ import Service from '@ember/service';
 
 export default class LocationService extends Service {
   replace(url) {
-    return location.replace(url);
+    window.location.replace(url);
   }
 }

--- a/mon-pix/app/services/location.js
+++ b/mon-pix/app/services/location.js
@@ -4,4 +4,8 @@ export default class LocationService extends Service {
   replace(url) {
     window.location.replace(url);
   }
+
+  assign(url) {
+    window.location.assign(url);
+  }
 }

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -46,6 +46,8 @@ export default class OidcIdentityProviders extends Service {
 
   async load() {
     const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
-    oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
+    oidcIdentityProviders.forEach((oidcIdentityProvider) => {
+      this[oidcIdentityProvider.id] = oidcIdentityProvider;
+    });
   }
 }

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -44,7 +44,7 @@ export default function (config) {
           attributes: {
             code: 'OIDC_PARTNER',
             'organization-name': 'Partenaire OIDC',
-            slug: 'partenaire-oidc',
+            slug: 'oidc-partner',
             'should-close-session': false,
             source: 'oidc-externe',
             'is-visible': true,

--- a/mon-pix/tests/acceptance/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/acceptance/authentication/login-or-register-oidc-test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click, currentURL } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -16,10 +16,9 @@ module('Acceptance | Login or register oidc', function (hooks) {
     module('when accessing "login-or-register-oidc" page', function () {
       test('displays the page with "Français" as selected language', async function (assert) {
         // when
-        const screen = await visit('/connexion/oidc-partner?code=oidc_example_code&state=auth_session_state');
+        const screen = await visit('/connexion/oidc?identityProviderSlug=oidc-partner');
 
         // then
-        assert.strictEqual(currentURL(), '/connexion/oidc?identityProviderSlug=oidc-partner');
         assert.dom(screen.getByRole('button', { name: 'Sélectionnez une langue' })).exists();
       });
     });
@@ -27,7 +26,7 @@ module('Acceptance | Login or register oidc', function (hooks) {
     module('when user select "English" as his language', function () {
       test('displays the page with "English" as selected language', async function (assert) {
         // given
-        const screen = await visit('/connexion/oidc-partner?code=oidc_example_code&state=auth_session_state');
+        const screen = await visit('/connexion/oidc?identityProviderSlug=oidc-partner');
 
         // when
         await click(screen.getByRole('button', { name: 'Sélectionnez une langue' }));

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -8,6 +8,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntl from '../../helpers/setup-intl';
+import { unabortedVisit } from '../../helpers/unaborted-visit';
 
 module('Acceptance | OIDC | authentication flow', function (hooks) {
   setupApplicationTest(hooks);
@@ -120,21 +121,3 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
     });
   });
 });
-
-// Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch en attendant l'évolution attendue dans Ember :
-// https://github.com/emberjs/ember-test-helpers/issues/332
-async function unabortedVisit(url) {
-  try {
-    await visit(url);
-  } catch (error) {
-    if (!_isEmberTransitionAborted(error)) {
-      throw error;
-    }
-
-    await settled();
-  }
-}
-
-function _isEmberTransitionAborted(error) {
-  return error.message == 'TransitionAborted';
-}

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -59,7 +59,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         await clickByLabel('Je commence');
 
         // then
-        sinon.assert.called(replaceLocationStub);
         assert.strictEqual(currentURL(), '/connexion/oidc-partner');
         assert.ok(true);
       });
@@ -182,7 +181,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           await clickByLabel('Je commence');
 
           // then
-          sinon.assert.called(replaceLocationStub);
           assert.strictEqual(currentURL(), '/connexion/oidc-partner');
           assert.ok(true);
         });

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -60,7 +60,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
         // then
         assert.strictEqual(currentURL(), '/connexion/oidc-partner');
-        assert.ok(true);
       });
 
       test('should redirect to login or register oidc page', async function (assert) {
@@ -182,7 +181,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
           // then
           assert.strictEqual(currentURL(), '/connexion/oidc-partner');
-          assert.ok(true);
         });
       });
     });

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -23,16 +23,17 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
   module('Start a campaign that belongs to an external provider', function () {
     module('When user is not logged in', function (hooks) {
-      let replaceLocationStub;
+      let assignLocationStub;
 
       hooks.beforeEach(function () {
-        replaceLocationStub = sinon.stub().resolves();
+        assignLocationStub = sinon.stub().resolves();
         this.owner.register(
           'service:location',
           Service.extend({
-            replace: replaceLocationStub,
+            assign: assignLocationStub,
           }),
         );
+
         campaign = server.create('campaign', { identityProvider: 'OIDC_PARTNER' });
       });
 
@@ -58,8 +59,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         // when
         await clickByLabel('Je commence');
 
+        await settled();
+
         // then
-        assert.strictEqual(currentURL(), '/connexion/oidc-partner');
+        assert.ok(assignLocationStub.calledWith('https://oidc/connexion/oauth2/authorize'));
       });
 
       test('should redirect to login or register oidc page', async function (assert) {
@@ -100,7 +103,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
     });
 
     module('When user is logged in', function (hooks) {
-      let replaceLocationStub;
+      let assignLocationStub;
 
       hooks.beforeEach(async function () {
         const prescritUser = server.create('user', 'withEmail', {
@@ -108,11 +111,11 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           lastTermsOfServiceValidatedAt: null,
         });
         await authenticateByEmail(prescritUser);
-        replaceLocationStub = sinon.stub().resolves();
+        assignLocationStub = sinon.stub().resolves();
         this.owner.register(
           'service:location',
           Service.extend({
-            replace: replaceLocationStub,
+            assign: assignLocationStub,
           }),
         );
         campaign = server.create('campaign', { identityProvider: 'OIDC_PARTNER' });
@@ -179,8 +182,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           // when
           await clickByLabel('Je commence');
 
+          await settled();
+
           // then
-          assert.strictEqual(currentURL(), '/connexion/oidc-partner');
+          assert.ok(assignLocationStub.calledWith('https://oidc/connexion/oauth2/authorize'));
         });
       });
     });

--- a/mon-pix/tests/helpers/service-stubs.js
+++ b/mon-pix/tests/helpers/service-stubs.js
@@ -22,6 +22,7 @@ export function stubSessionService(owner, sessionData = {}) {
   const userIdForLearnerAssociation = sessionData.userIdForLearnerAssociation;
   const userId = isAuthenticated ? sessionData.userId || 123 : null;
   const source = isAuthenticated ? sessionData.source || 'pix' : null;
+  const identityProviderCode = sessionData.identityProviderCode;
 
   class SessionStub extends Service {
     constructor() {
@@ -34,6 +35,10 @@ export function stubSessionService(owner, sessionData = {}) {
         this.data = {
           authenticated: { user_id: userId, source, access_token: 'access_token!' },
         };
+
+        if (identityProviderCode) {
+          Object.assign(this.data.authenticated, { identityProviderCode });
+        }
       } else {
         this.data = {};
       }

--- a/mon-pix/tests/helpers/unaborted-visit.js
+++ b/mon-pix/tests/helpers/unaborted-visit.js
@@ -1,0 +1,20 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { settled } from '@ember/test-helpers';
+
+// Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch en attendant l'évolution attendue dans Ember :
+// https://github.com/emberjs/ember-test-helpers/issues/332
+export async function unabortedVisit(url) {
+  try {
+    await visit(url);
+  } catch (error) {
+    if (!_isEmberTransitionAborted(error)) {
+      throw error;
+    }
+
+    await settled();
+  }
+}
+
+function _isEmberTransitionAborted(error) {
+  return error.message == 'TransitionAborted';
+}

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
@@ -126,7 +126,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         });
       });
 
-      test('displays an error message with details', async function (assert) {
+      test('displays an error message but not with the details', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
         const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
@@ -140,7 +140,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.register();
 
         // then
-        assert.strictEqual(component.registerErrorMessage, `${t('common.error')} (some detail)`);
+        assert.strictEqual(component.registerErrorMessage, `${t('common.error')}`);
       });
 
       test('displays a default error message', async function (assert) {


### PR DESCRIPTION
## 🌸 Problème

Lorsque l’utilisateur s’authentifie auprès d'un SSO OIDC avec succès, il arrive sur la page d’accueil de Pix. Si l’utilisateur décide de cliquer sur le bouton précèdent de son navigateur alors plusieurs cas de figure problématiques peuvent se produire altérant le parcours utilisateur. Des problèmes peuvent aussi survenir lors d’allers et retours et en faisant des `CTRL + R`.

## 🌳 Proposition

La proposition consiste en plusieurs changements : 
1. La correction d'une race condition lors de la phase de redirection du navigateur de l'utilisateur vers l'authorizationUrl,
2. Lorsque l'utilisateur est déjà authentifié (par Pix), passer outre l'authentification OIDC et rediriger l'utilisateur vers la route `authenticated` (route qui correspond à un utilisateur authentifié), mais sans passer outre la ré-authentification OIDC si l'utilisateur participe à une campagne d'une orga associée à un SSO particulier et que l'utilisateur n’a pas été authentifié par ce SSO,
3. Lorsque l'utilisateur n'est pas authentifié (par Pix), gérer l’erreur `MISSING_OIDC_STATE` en redirigeant l'utilisateur vers la route `authentication.login` (route qui correspond à la page de connexion).

:information_source: Certains SSO refusent qu'on revienne en arrière sur leur page de connexion. Au niveau de Pix on ne peut rien y faire. En fait c'est même la bonne pratique en terme de sécurité. Par contre là où ces SSO pourraient s'améliorer, c'est en ayant alors une page avec une présentation et un texte plus adaptés aux utilisateurs finaux pour mieux expliquer le pourquoi.

## 🐝 Remarques

RAS

## 🤧 Pour tester

### Tests simples sans campagne

1. Se connecter avec les différents SSO, et avec son navigateur faire des retours arrière et des rechargements de page.,
2. Constater que l'utilisateur ne se voit plus présenter de page avec le message `Required cookie "state" is missing` ou `Required "state" is missing in session` et que le parcours utilisateur est logique et fluide.

### Tests complexes avec campagne

1. Créer une orga liée à un SSO1,
2. Créer une campagne pour cette orga,
3. Authentifier un utilisateur auprès d'un SSO2,
4. Avec cet utilisateur aller à l'URL pour accéder à la campagne de l'orga (l'URL de campagne est de la forme `/campagnes/{CODE}`),
5. Constater que l'utilisateur est obligé de s'authentifier auprès du SSO1 (c'est à dire le SSO1 associé à l'orga).

:warning: Pour le cas d'utilisation des orgas associées à un SSO particulier, le comportement n'a pas l'air de bien fonctionner tel qu'il est sur `dev` et tel que déployé en production. Donc si vous trouvez que le fonctionnement que vous rencontrerez dans cette partie est peu satisfaisant, faites les mêmes manipulations sur la recette pour comparer et valider qu'il y a/qu'il n'y a pas de régression.
