### PR TITLE
[TECH] Ajouter des élèves pour les seeds de Certif (cas sco managing student) (PIX-17252).

### DIFF
--- a/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
+++ b/api/db/seeds/data/team-certification/cases/simple-sco-managing-students-certification.js
@@ -38,7 +38,7 @@ export default async function simpleScoManagingStudentsCertificationCase({ datab
     id: SIMPLE_SCO_ORGANIZATION_MEMBER_ID,
     firstName: 'Sco',
     lastName: 'Organization Member',
-    email: 'simple-sco-organization-member@example.net',
+    email: 'sco-managing-students-v3@example.net',
     cgu: true,
     lang: 'fr',
     lastTermsOfServiceValidatedAt: new Date(),
@@ -93,13 +93,12 @@ export default async function simpleScoManagingStudentsCertificationCase({ datab
    */
   const scoUser = databaseBuilder.factory.buildUser.withRawPassword({
     id: SIMPLE_SCO_CERTIFICATION_USER_ID,
-    firstName: 'Sco',
-    lastName: 'Certifiable',
+    firstName: 'certifiable',
+    lastName: 'sco-user',
     email: 'certifiable-sco-user@example.net',
     cgu: true,
     lang: 'fr',
     lastTermsOfServiceValidatedAt: new Date(),
-    pixCertifTermsOfServiceAccepted: true,
   });
 
   await tooling.profile.createCertifiableProfile({
@@ -113,11 +112,53 @@ export default async function simpleScoManagingStudentsCertificationCase({ datab
     firstName: scoUser.firstName,
     lastName: scoUser.lastName,
     email: scoUser.email,
-    sex: scoUser.sex,
+    division: 'Terminal',
+    sex: 'F',
     birthdate: '2000-01-01',
     isCertifiable: true,
+    isDisabled: false,
     certifiableAt: new Date('2022-01-30'),
   });
+
+  for (let index = 0; index < 10; index++) {
+    const otherUser = databaseBuilder.factory.buildUser.withRawPassword({
+      firstName: `Élève-${index}`,
+      lastName: `Non certifiable`,
+      email: `non-certifiable-sco-user_${index}@example.net`,
+      cgu: true,
+      lang: 'fr',
+    });
+    databaseBuilder.factory.buildOrganizationLearner({
+      firstName: otherUser.firstName,
+      lastName: otherUser.lastName,
+      sex: 'M',
+      birthdate: '2000-01-01',
+      birthCity: null,
+      birthCityCode: '75115',
+      birthCountryCode: '100',
+      birthProvinceCode: null,
+      division: '6eme',
+      isDisabled: false,
+      organizationId: newOrga.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    databaseBuilder.factory.buildOrganizationLearner({
+      firstName: otherUser.firstName,
+      lastName: otherUser.lastName,
+      sex: 'M',
+      birthdate: '2000-01-01',
+      birthCity: null,
+      birthCityCode: '75115',
+      birthCountryCode: '100',
+      birthProvinceCode: null,
+      division: 'Terminal',
+      isDisabled: false,
+      organizationId: newOrga.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
 
   await databaseBuilder.commit();
 


### PR DESCRIPTION
## 🌸 Problème
Actuellement le cas SCO ne gère qu'un élève.

## 🌳 Proposition

Pour être plus proche du réel, on ajoute des élèves prêt à être inscrits.

## 🐝 Remarques

modifs sur le mail de l'utilisateur, plus facile à mémoriser (+ indication de la V3)

---

mise à jour de la doc après merge de cette PR.

## 🤧 Pour tester

se connecter avec sco-managing-students-v3@example.net sur Pix Certif
- Aller sur la session existante et inscrire des candidats

Vérifier la présence de 21 élèves (10 6ème et 10 Terminal (précisé comme non certifiable dans leurs noms), 1 6 ème certifiable qui porte son email dans son nom/prénom pour faciliter notre connexion à Pix App)
