### PR TITLE
[FEATURE] Borner le script de rattrapage des live alert par date (PIX-17051).

### DIFF
--- a/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
+++ b/api/tests/integration/scripts/certification/fix-validated-live-alert-certification-challenge-ids_test.js
@@ -9,7 +9,12 @@ describe('Integration | Scripts | Certification | fix-validated-live-alert-certi
       it('should fix the capacities challenges ids', async function () {
         // given
         const certificationCourseId = 321;
-        const options = { dryRun: false, batchSize: 10, startingFromDate: new Date(2024, 10, 4) };
+        const options = {
+          dryRun: false,
+          batchSize: 10,
+          startingFromDate: new Date(2024, 10, 4),
+          stopAtDate: new Date(2024, 10, 6),
+        };
         const logger = {
           info: sinon.stub(),
           debug: sinon.stub(),


### PR DESCRIPTION
## 🌸 Problème

Le script de rattrapage des live alerts est... long, car il vérifie des millions d'enregistrements.

## 🌳 Proposition

Permettre de borner le script par date pour pouvoir maitriser les durées de lancement.

## 🐝 Remarques

## 🤧 Pour tester

* Faire passer une certification à un élève, qu'importe le résultat
* Lancer le script (voir la commande ci-dessous) en faisant varier les dates pour vérifier
  * Si la date de votre certif-course n'est pas compris dans les bornes : le script passe passe pas dessus
  * Si oui : le script le  prend en compte 
  * `node scripts/certification/fix-validated-live-alert-certification-challenge-ids.js --batchSize=1000 --delayBetweenBatch=100 --dryRun=true --startingFromDate=YYY-MM-DD --stopAtDate=YYYY-MM-DD`
  * version one-off `scalingo -a "pix-api-review-pr11910" run "node scripts/certification/fix-validated-live-alert-certification-challenge-ids.js --batchSize=1000 --delayBetweenBatch=100 --dryRun=true  --startingFromDate=YYY-MM-DD --stopAtDate=YYYY-MM-DD"`
