### PR TITLE
[FEATURE] Améliorer le style de la page de vérification de certif (PIX-17278).

### DIFF
--- a/mon-pix/app/components/certification-verification-code-form.gjs
+++ b/mon-pix/app/components/certification-verification-code-form.gjs
@@ -1,5 +1,3 @@
-import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCode from '@1024pix/pix-ui/components/pix-code';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
@@ -56,41 +54,39 @@ export default class CertificationVerificationCodeForm extends Component {
   }
 
   <template>
-    <PixBackgroundHeader id="main">
-      <PixBlock class="fill-in-certificate-verification-code">
-        <h1 class="fill-in-certificate-verification-code__title">
-          {{t "pages.fill-in-certificate-verification-code.first-title"}}
-        </h1>
+    <section class="global-page-header">
+      <h1 class="global-page-header__title">
+        {{t "pages.fill-in-certificate-verification-code.first-title"}}
+      </h1>
 
-        <p class="fill-in-certificate-verification-code__description">
-          {{t "pages.fill-in-certificate-verification-code.description"}}
-        </p>
+      <p class="global-page-header__description">
+        {{t "pages.fill-in-certificate-verification-code.description"}}
+      </p>
+    </section>
 
-        <form class="fill-in-certificate-verification-code__form" autocomplete="off">
-          <PixCode
-            @length="10"
-            @requiredLabel={{t "common.forms.mandatory"}}
-            @subLabel={{t "pages.fill-in-certificate-verification-code.sub-label"}}
-            @value={{this.certificateVerificationCode}}
-            @validationStatus={{this.status}}
-            @errorMessage={{this.errorMessage}}
-            {{on "keyup" this.clearErrors}}
-            {{on "input" this.handleVerificationCodeInput}}
-          >
-            <:label>{{t "pages.fill-in-certificate-verification-code.label"}}</:label>
-          </PixCode>
+    <form class="fill-in-certificate-verification-code__form" autocomplete="off">
+      <PixCode
+        @length="10"
+        @requiredLabel={{t "common.forms.mandatory"}}
+        @subLabel={{t "pages.fill-in-certificate-verification-code.sub-label"}}
+        @value={{this.certificateVerificationCode}}
+        @validationStatus={{this.status}}
+        @errorMessage={{this.errorMessage}}
+        {{on "keyup" this.clearErrors}}
+        {{on "input" this.handleVerificationCodeInput}}
+      >
+        <:label>{{t "pages.fill-in-certificate-verification-code.label"}}</:label>
+      </PixCode>
 
-          <PixButton @type="submit" @triggerAction={{this.checkCertificate}} class="form__actions">
-            {{t "pages.fill-in-certificate-verification-code.verify"}}
-          </PixButton>
+      <PixButton @type="submit" @triggerAction={{this.checkCertificate}}>
+        {{t "pages.fill-in-certificate-verification-code.verify"}}
+      </PixButton>
 
-          {{#if @apiErrorMessage}}
-            <PixNotificationAlert @type="error" @withIcon={{true}}>
-              {{@apiErrorMessage}}
-            </PixNotificationAlert>
-          {{/if}}
-        </form>
-      </PixBlock>
-    </PixBackgroundHeader>
+      {{#if @apiErrorMessage}}
+        <PixNotificationAlert @type="error" @withIcon={{true}}>
+          {{@apiErrorMessage}}
+        </PixNotificationAlert>
+      {{/if}}
+    </form>
   </template>
 }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -1,37 +1,20 @@
-@use 'pix-design-tokens/breakpoints';
-@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/colors';
 
-.fill-in-certificate-verification-code {
-  width: 75%;
-  margin: 0 auto var(--pix-spacing-8x);
-  padding: var(--pix-spacing-12x) var(--pix-spacing-6x);
+.fill-in-certificate-verification-code__form {
+  margin-bottom: var(--pix-spacing-12x);
+  text-align: center;
 
-  @extend %pix-body-m;
+  input {
+    background-color: var(--pix-neutral-0);
 
-  @include breakpoints.device-is('tablet') {
-    padding: var(--pix-spacing-12x) 60px;
-  }
-
-  &__title {
-    text-align: center;
-
-    @extend %pix-title-m;
-  }
-
-  &__description {
-    margin: var(--pix-spacing-6x) 0;
-    color: var(--pix-neutral-500);
-    line-height: 1.375rem;
-    text-align: center;
-  }
-
-  &__form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    .form__actions {
-      margin: var(--pix-spacing-6x) 0;
+    @media (max-width: 25rem) {
+      height: 14vw;
+      font-size: 8vw;
     }
+  }
+
+  [type="submit"] {
+    display: inline-flex;
+    margin-top: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.fill-in-certificate-verification-code.title")}}
 
 <Global::AppLayout>
-  <main role="main">
+  <main id="main" role="main" class="global-page-container">
     <CertificationVerificationCodeForm
       @checkCertificate={{this.checkCertificate}}
       @apiErrorMessage={{this.apiErrorMessage}}

--- a/mon-pix/tests/integration/components/certification-verification-code-form-test.gjs
+++ b/mon-pix/tests/integration/components/certification-verification-code-form-test.gjs
@@ -19,7 +19,11 @@ module('Integration | Component | certification verification code form', functio
     assert
       .dom(screen.getByRole('heading', { name: t('pages.fill-in-certificate-verification-code.first-title') }))
       .exists();
-    assert.dom(screen.getByText(t('pages.fill-in-certificate-verification-code.description'))).exists();
+    assert
+      .dom(
+        screen.getByText(t('pages.fill-in-certificate-verification-code.description'), { collapseWhitespace: false }),
+      )
+      .exists();
     assert.dom(screen.getByRole('textbox', { name: 'Code de vérification * Exemple: P-XXXXXXXX' })).exists();
     assert.dom(screen.getByRole('button', { name: t('pages.fill-in-certificate-verification-code.verify') })).exists();
   });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1343,7 +1343,7 @@
       "warning-message-logout": "Se déconnecter"
     },
     "fill-in-certificate-verification-code": {
-      "description": "La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le \"code de vérification\" du certificat Pix à vérifier.",
+      "description": "La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le \"code de vérification\" du certificat Pix à vérifier.",
       "errors": {
         "missing-code": "Merci de renseigner le code de vérification.",
         "not-found": "Il n'y a pas de certificat Pix correspondant.",


### PR DESCRIPTION
## 🌸 Problème

![image](https://github.com/user-attachments/assets/1286bed1-4ab8-4c98-92ee-40bec6f67978)

Le responsive de la page n'était pas bon.
Aussi, le style n'était pas viable pour la nouvelle navigation.

## 🌳 Proposition

Adapter le style de la page pour qu'il corresponde aux nouveaux design adaptés à la nouvelle nav.

## 🤧 Pour tester

Visiter [en RA](https://app-pr11911.review.pix.fr/verification-certificat) la page `/verification-certificat`
