### PR TITLE
[BUGFIX] Permettre le calcul du résultat des campagnes de type exam (PIX-17268)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -159,7 +159,7 @@ PGBOSS_CONNECTION_POOL_MAX_SIZE=
 #
 # presence: optional
 # type: Boolean
-# default: `false`
+  # default: `false`
 # sample: START_JOB_IN_WEB_PROCESS=true
 START_JOB_IN_WEB_PROCESS=
 

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -38,7 +38,6 @@ import { participationResultCalculationJobRepository } from '../../infrastructur
 import { participationSharedJobRepository } from '../../infrastructure/repositories/jobs/participation-shared-job-repository.js';
 import { participationStartedJobRepository } from '../../infrastructure/repositories/jobs/participation-started-job-repository.js';
 import * as participantResultRepository from '../../infrastructure/repositories/participant-result-repository.js';
-import { participantResultsSharedRepository } from '../../infrastructure/repositories/participant-results-shared-repository.js';
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
 import * as poleEmploiSendingRepository from '../../infrastructure/repositories/pole-emploi-sending-repository.js';
@@ -115,7 +114,7 @@ const dependencies = {
   participationsForUserManagementRepository,
   participationSharedJobRepository,
   participationStartedJobRepository,
-  participantResultsSharedRepository,
+  participantResultsSharedRepository: campaignRepositories.participantResultsSharedRepository,
   poleEmploiNotifier: requirePoleEmploiNotifier(),
   poleEmploiSendingRepository,
   stageAcquisitionRepository,

--- a/api/src/prescription/campaign-participation/domain/usecases/save-computed-campaign-participation-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/save-computed-campaign-participation-result.js
@@ -8,8 +8,8 @@ const saveComputedCampaignParticipationResult = async function ({
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   if (!campaignParticipation.isShared) throw new CantCalculateCampaignParticipationResultError();
 
-  const participantResultsShared = await participantResultsSharedRepository.get(campaignParticipationId);
-  return participantResultsSharedRepository.save(participantResultsShared);
+  const participantResultsShared = await participantResultsSharedRepository.get({ campaignParticipationId });
+  return participantResultsSharedRepository.save({ participantResultsShared });
 };
 
 export { saveComputedCampaignParticipationResult };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/index.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/index.js
@@ -1,13 +1,19 @@
 import * as organizationFeatureAPI from '../../../../organizational-entities/application/api/organization-features-api.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import * as campaignsAPI from '../../../campaign/application/api/campaigns-api.js';
+import * as knowledgeElementSnapshotAPI from '../../../campaign/application/api/knowledge-element-snapshots-api.js';
 import * as campaignParticipantRepository from './campaign-participant-repository.js';
+import * as participantResultsSharedRepository from './participant-results-shared-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   campaignParticipantRepository,
+  participantResultsSharedRepository,
 };
 
 const dependencies = {
   organizationFeatureAPI,
+  knowledgeElementSnapshotAPI,
+  campaignsAPI,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js
@@ -6,34 +6,41 @@ import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastru
 import { ParticipantResultsShared } from '../../domain/models/ParticipantResultsShared.js';
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
 
-const participantResultsSharedRepository = {
-  async save(participantResultShared) {
-    await knex('campaign-participations').update(participantResultShared).where({ id: participantResultShared.id });
-  },
-
-  async get(campaignParticipationId) {
-    const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationId({
-      campaignParticipationId,
-    });
-    const knowledgeElements = await knowledgeElementSnapshotRepository.findByCampaignParticipationIds([
-      campaignParticipationId,
-    ]);
-    const competences = await competenceRepository.listPixCompetencesOnly();
-    const { userId, sharedAt, id } = await campaignParticipationRepository.get(campaignParticipationId);
-
-    const [placementProfile] = await placementProfileService.getPlacementProfilesWithSnapshotting({
-      participations: [{ userId, sharedAt, campaignParticipationId: id }],
-      competences,
-      allowExcessPixAndLevels: false,
-    });
-
-    return new ParticipantResultsShared({
-      campaignParticipationId,
-      knowledgeElements: knowledgeElements[campaignParticipationId],
-      skillIds,
-      placementProfile,
-    });
-  },
+const save = async function ({ participantResultsShared }) {
+  await knex('campaign-participations').update(participantResultsShared).where({ id: participantResultsShared.id });
 };
 
-export { participantResultsSharedRepository };
+const get = async function ({ campaignParticipationId, campaignsAPI, knowledgeElementSnapshotAPI }) {
+  let knowledgeElements;
+  const campaign = await campaignsAPI.getByCampaignParticipationId(campaignParticipationId);
+  const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationId({
+    campaignParticipationId,
+  });
+
+  if (campaign.isExam) {
+    const results = await knowledgeElementSnapshotAPI.getByParticipation(campaignParticipationId);
+
+    knowledgeElements = results.knowledgeElements;
+  } else {
+    const results = await knowledgeElementSnapshotRepository.findByCampaignParticipationIds([campaignParticipationId]);
+
+    knowledgeElements = results[campaignParticipationId];
+  }
+  const competences = await competenceRepository.listPixCompetencesOnly();
+  const { userId, sharedAt, id } = await campaignParticipationRepository.get(campaignParticipationId);
+
+  const [placementProfile] = await placementProfileService.getPlacementProfilesWithSnapshotting({
+    participations: [{ userId, sharedAt, campaignParticipationId: id }],
+    competences,
+    allowExcessPixAndLevels: false,
+  });
+
+  return new ParticipantResultsShared({
+    campaignParticipationId,
+    knowledgeElements,
+    skillIds,
+    placementProfile,
+  });
+};
+
+export { get, save };

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-results-shared-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-results-shared-repository_test.js
@@ -1,4 +1,4 @@
-import { participantResultsSharedRepository } from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/participant-results-shared-repository.js';
+import { repositories } from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/index.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../../../src/shared/domain/constants.js';
 import { databaseBuilder, expect, knex, mockLearningContent } from '../../../../../test-helper.js';
@@ -22,7 +22,7 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         isCertifiable: true,
       };
 
-      await participantResultsSharedRepository.save(participantResultsShared);
+      await repositories.participantResultsSharedRepository.save({ participantResultsShared });
 
       const campaignParticipation = await knex('campaign-participations').where({ id: 1 }).first();
 
@@ -61,7 +61,7 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           isCertifiable: true,
         };
 
-        await participantResultsSharedRepository.save(participantResultsShared);
+        await repositories.participantResultsSharedRepository.save({ participantResultsShared });
 
         const campaignParticipation1 = await knex('campaign-participations').where({ id: 1 }).first();
         const campaignParticipation2 = await knex('campaign-participations').where({ id: 2 }).first();
@@ -104,7 +104,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         await mockLearningContent(learningContent);
 
         //when
-        const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+        const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+          campaignParticipationId: participation.id,
+        });
 
         expect(participantResultsShared.masteryRate).to.equals(4 / (16 * MAX_REACHABLE_PIX_BY_COMPETENCE));
         expect(participantResultsShared.id).to.equal(participation.id);
@@ -144,7 +146,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         await mockLearningContent(learningContent);
 
         //when
-        const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+        const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+          campaignParticipationId: participation.id,
+        });
 
         expect(participantResultsShared.isCertifiable).to.be.false;
       });
@@ -181,7 +185,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         await mockLearningContent(learningContent);
 
         //when
-        const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+        const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+          campaignParticipationId: participation.id,
+        });
 
         expect(participantResultsShared.isCertifiable).to.be.true;
       });
@@ -212,7 +218,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         await mockLearningContent(learningContent);
 
         //when
-        const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+        const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+          campaignParticipationId: participation.id,
+        });
 
         expect(participantResultsShared.masteryRate).to.equals(1);
         expect(participantResultsShared.id).to.equal(participation.id);
@@ -245,7 +253,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           await mockLearningContent(learningContent);
 
           //when
-          const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+          const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+            campaignParticipationId: participation.id,
+          });
           expect(participantResultsShared.masteryRate).to.equals(1);
           expect(participantResultsShared.id).to.equal(participation.id);
           expect(participantResultsShared.pixScore).to.equals(4);
@@ -278,7 +288,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
           await mockLearningContent(learningContent);
 
           //when
-          const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+          const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+            campaignParticipationId: participation.id,
+          });
 
           expect(participantResultsShared.id).to.equal(participation.id);
           expect(participantResultsShared.masteryRate).to.equals(2 / 3);
@@ -321,7 +333,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         await mockLearningContent(learningContent);
 
         //when
-        const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+        const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+          campaignParticipationId: participation.id,
+        });
 
         expect(participantResultsShared.isCertifiable).to.be.null;
       });
@@ -342,7 +356,9 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
       await mockLearningContent(learningContent);
 
       //when
-      const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
+      const participantResultsShared = await repositories.participantResultsSharedRepository.get({
+        campaignParticipationId: participation.id,
+      });
 
       expect(participantResultsShared.masteryRate).to.equals(1);
     });


### PR DESCRIPTION
## 🌸 Problème

On a oublié de calculer le résulstat des campagnes de type exam au partage. "oups"

## 🌳 Proposition

Le calculer ( personne n'a rien vu 👀 )

## 🐝 Remarques

Je ne suis pas satisfait du Fix, mais je pense que ça va dans la globalité des API Internes etc... il faudra certainement mettre à plat ce gros repository qui fait bien trop de chose que juste remonter de la données 🤔 

## 🤧 Pour tester

Faire une campagne de Type Exam et vérifier que son score n'est pas à 0 une fois la participation partagé ET avoir fait un bon gros F5 sur la page de résultat