### PR TITLE
[FEATURE] Ajustements des marges et couleurs de fond après la mise à jour de la nav du Pix -Admin (PIX-17276)

### DIFF
--- a/admin/app/components/certification-centers/invitations-action.gjs
+++ b/admin/app/components/certification-centers/invitations-action.gjs
@@ -61,7 +61,7 @@ export default class CertificationCenterInvitationsAction extends Component {
   <template>
     <section class="page-section certification-center-invitations">
       <form>
-        <h2 class="certification-center-invitations__heading">Inviter un membre</h2>
+        <h2 class="page-section__header">Inviter un membre</h2>
         <div class="certification-center-invitations-form-container">
           <PixInput
             @id="userEmailToInvite"

--- a/admin/app/components/certification-centers/invitations-action.scss
+++ b/admin/app/components/certification-centers/invitations-action.scss
@@ -1,13 +1,4 @@
 /* stylelint-disable selector-class-pattern */
-.certification-center-invitations {
-  display: flex;
-  justify-content: space-around;
-}
-
-.certification-center-invitations__heading {
-  margin-bottom: var(--pix-spacing-4x);
-  font-size: 1.125rem;
-}
 
 .certification-center-invitations-form-container {
   display: flex;

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.gjs
@@ -16,7 +16,7 @@ export default class BadgesList extends Component {
 
   <template>
     <section class="page-section">
-      <h2 class="complementary-certification-details__badges-title">
+      <h2 class="complementary-certification-details__badges-title page-section__header">
         {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
       </h2>
       <PixTable

--- a/admin/app/components/complementary-certifications/target-profiles/history.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/history.gjs
@@ -6,7 +6,7 @@ import { t } from 'ember-intl';
 
 <template>
   <section class="page-section">
-    <h2 class="complementary-certification-details__history-title">
+    <h2 class="complementary-certification-details__history-title page-section__header">
       {{t "components.complementary-certifications.target-profiles.history-list.title"}}
     </h2>
     <PixTable

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -1,9 +1,9 @@
 /* stylelint-disable selector-class-pattern */
 #certification-center-get-page {
 
-  .page-section__header {
-    justify-content: space-around;
-  }
+  /* .page-section__header {
+    justify-content: space-around; //suppression de l'alignement center des titres et sous-titres des sections
+  }*/ 
 
   .certification-center {
 

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -1,16 +1,18 @@
 /* stylelint-disable selector-class-pattern */
 #certification-center-get-page {
 
-  /* .page-section__header {
-    justify-content: space-around; //suppression de l'alignement center des titres et sous-titres des sections
-  }*/ 
+  .page-section__header {
+    margin-top: var(--pix-spacing-6x);
+    margin-bottom: 0;
+    padding-top: var(--pix-spacing-3x);
+    padding-bottom: var(--pix-spacing-2x);
+    border-top: 1px solid var(--pix-neutral-100);
+  }
 
   .certification-center {
 
     &__section {
       display: flex;
-      justify-content: center;
-      max-height: 38px;
 
       input {
         width: 310px;

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -77,13 +77,8 @@
     }
   }
 
-  .page-section__header {
-    justify-content: space-around;
-  }
-
   .organization__forms-section {
     display: flex;
-    justify-content: space-around;
 
     h2 {
       font-size: 1.125rem;

--- a/admin/app/styles/components/trainings/training-target-profiles-tab.scss
+++ b/admin/app/styles/components/trainings/training-target-profiles-tab.scss
@@ -1,17 +1,8 @@
 /* stylelint-disable selector-class-pattern */
 .training-target-profiles {
-  .page-section__header {
-    justify-content: center;
-  }
-
   label {
     font-weight: bold;
     font-size: 1.125rem;
-  }
-
-  .training__forms-section {
-    display: flex;
-    justify-content: space-around;
   }
 
   .training__form {

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -35,7 +35,11 @@
       &__header {
         display: flex;
         align-items: center;
-        margin-bottom: 20px;
+        margin-top: var(--pix-spacing-6x);
+        margin-bottom: 0;
+        padding-top: var(--pix-spacing-3x);
+        padding-bottom: var(--pix-spacing-2x);
+        border-top: 1px solid var(--pix-neutral-100);
       }
 
       h2, &__title {

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -6,9 +6,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: var(--pix-spacing-2x) var(--pix-spacing-4x) 0 var(--pix-spacing-4x);
     padding-bottom: var(--pix-spacing-6x);
-    border-bottom: 1px solid var(--pix-neutral-100);
 
     .page-actions {
       display: flex;
@@ -29,19 +27,10 @@
     }
   }
 
-  .page-header {
-    margin-top: var(--pix-spacing-4x);
-  }
-
   .page-body {
     inset: 60px 0 0 80px;
-    padding: var(--pix-spacing-2x);
 
     .page-section {
-      margin-bottom: 10px;
-      padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
-      background: var(--pix-neutral-0);
-      border-radius: 5px;
 
       &__header {
         display: flex;

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -5,7 +5,7 @@
       <header class="page-section__header">
         <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
       </header>
-      <div class="training__forms-section">
+      <div>
         <form class="training__sub-form form" {{on "submit" this.attachTargetProfiles}}>
           <PixInput
             @value={{this.targetProfilesToAttach}}


### PR DESCRIPTION
## 🌸 Problème
Depuis la mise à jour de la nav sur Pix Admin, certains fonds et marges ne sont plus nécessaires autour du contenu (car déjà présent dans PixLayout)

## 🌳 Proposition
- supprimer le fond blanc sur .page .page-body .page-section
- supprimer padding sur .page .page-body .page-section
- supprimer border-radius sur .page .page-body .page-section
- supprimer margin-bottom sur .page .page-body .page-section
- supprimer padding sur .page .page-body
- supprimer border-bottom sur .page header
- supprimer margin sur .page header
- supprimer margin-top sur .page header

## 🤧 Pour tester

Vérifier la suppression des éléments listés au dessus