### PR TITLE
[BUGFIX] Réparer les tables des listes de sessions (PIX-17279).

### DIFF
--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -1,11 +1,21 @@
 import Controller from '@ember/controller';
 
 export default class ListController extends Controller {
-  get sessionsWithRequiredActionCount() {
-    return this.model.v2Sessions.length;
+  // v2
+  get v2SessionsToBePublishedCount() {
+    return this.model.v2SessionsToBePublished.length;
   }
 
-  get sessionsWithRequiredActionCountVersion3() {
-    return this.model.v3Sessions.length;
+  get v2SessionsWithRequiredActionCount() {
+    return this.model.v2SessionsWithRequiredAction.length;
+  }
+
+  // v3
+  get v3SessionsToBePublishedCount() {
+    return this.model.v3SessionsToBePublished.length;
+  }
+
+  get v3SessionsWithRequiredActionCount() {
+    return this.model.v3SessionsWithRequiredAction.length;
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -21,7 +21,7 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
   }
 
   get hasSessionsToProcess() {
-    return this.model.length;
+    return Boolean(this.model?.length);
   }
 
   @action toggleAssignedSessionsDisplay() {

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
@@ -5,18 +6,43 @@ export default class AuthenticatedSessionsListRoute extends Route {
   @service store;
 
   async model() {
-    const v3Sessions = await this.store.query('with-required-action-session', {
+    const v3SessionsWithRequiredAction = await this.store.query('with-required-action-session', {
       filter: {
         version: 3,
       },
     });
 
-    const v2Sessions = await this.store.query('with-required-action-session', {
+    const v3SessionsToBePublished = await this.store.query('to-be-published-session', {
+      filter: {
+        version: 3,
+      },
+    });
+
+    const v2SessionsWithRequiredAction = await this.store.query('with-required-action-session', {
       filter: {
         version: 2,
       },
     });
 
-    return { v2Sessions, v3Sessions };
+    const v2SessionsToBePublished = await this.store.query('to-be-published-session', {
+      filter: {
+        version: 2,
+      },
+    });
+
+    const refreshModel = this.refreshModel;
+
+    return {
+      v3SessionsWithRequiredAction,
+      v3SessionsToBePublished,
+      v2SessionsWithRequiredAction,
+      v2SessionsToBePublished,
+      refreshModel,
+    };
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import trim from 'lodash/trim';
-import { FINALIZED } from 'pix-admin/models/session';
 
 export default class AuthenticatedSessionsAllRoute extends Route {
   @service store;
@@ -49,7 +48,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
       controller.certificationCenterName = null;
       controller.certificationCenterExternalId = null;
       controller.certificationCenterType = null;
-      controller.status = FINALIZED;
+      controller.status = null;
       controller.version = null;
     }
   }

--- a/admin/app/routes/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/routes/authenticated/sessions/list/to-be-published.js
@@ -11,21 +11,13 @@ export default class AuthenticatedSessionsListToBePublishedRoute extends Route {
 
   model(_, transition) {
     if (transition.to.queryParams.version === '3') {
-      return this.store.query('to-be-published-session', {
-        filter: {
-          version: 3,
-        },
-      });
+      return this.modelFor('authenticated.sessions.list').v3SessionsToBePublished;
     }
-    return this.store.query('to-be-published-session', {
-      filter: {
-        version: 2,
-      },
-    });
+    return this.modelFor('authenticated.sessions.list').v2SessionsToBePublished;
   }
 
   @action
   refreshModel() {
-    this.refresh();
+    this.modelFor('authenticated.sessions.list').refreshModel();
   }
 }

--- a/admin/app/routes/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/routes/authenticated/sessions/list/with-required-action.js
@@ -7,8 +7,8 @@ export default class AuthenticatedSessionsWithRequiredActionListRoute extends Ro
 
   model(_, transition) {
     if (transition.to.queryParams.version === '3') {
-      return this.modelFor('authenticated.sessions.list').v3Sessions;
+      return this.modelFor('authenticated.sessions.list').v3SessionsWithRequiredAction;
     }
-    return this.modelFor('authenticated.sessions.list').v2Sessions;
+    return this.modelFor('authenticated.sessions.list').v2SessionsWithRequiredAction;
   }
 }

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -8,20 +8,22 @@
     <PixTabs @variant="primary" @ariaLabel="Navigation de la section sessions" class="navigation">
       <LinkTo @route="authenticated.sessions.list.with-required-action" @query={{hash version=3}}>
         {{t "pages.sessions.list.required-actions.v3"}}
-        ({{this.sessionsWithRequiredActionCountVersion3}})
+        ({{this.v3SessionsWithRequiredActionCount}})
       </LinkTo>
       <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=3}}>
         {{t "pages.sessions.list.to-be-published.v3"}}
+        ({{this.v3SessionsToBePublishedCount}})
       </LinkTo>
       <LinkTo @route="authenticated.sessions.list.all">
         {{t "pages.sessions.list.all"}}
       </LinkTo>
       <LinkTo @route="authenticated.sessions.list.with-required-action" @query={{hash version=2}}>
         {{t "pages.sessions.list.required-actions.v2"}}
-        ({{this.sessionsWithRequiredActionCount}})
+        ({{this.v2SessionsWithRequiredActionCount}})
       </LinkTo>
       <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=2}}>
         {{t "pages.sessions.list.to-be-published.v2"}}
+        ({{this.v2SessionsToBePublishedCount}})
       </LinkTo>
     </PixTabs>
     <section class="page-section">

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -16,36 +16,41 @@ module('Unit | Route | authenticated/sessions/list', function (hooks) {
   });
 
   module('#model', function () {
-    test('it should fetch the list of sessions with required action', async function (assert) {
+    test('it should fetch the sessions lists', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated/sessions/list');
-      const v2Sessions = [
-        {
-          certificationCenterName: 'Centre SCO des Anne-Solo',
-          finalizedAt: '2020-04-15T15:00:34.000Z',
-        },
-      ];
 
-      const v3Sessions = [
-        {
-          certificationCenterName: 'Centre SCO v3',
-          finalizedAt: '2020-04-15T15:00:34.000Z',
-        },
-      ];
+      const v2SessionWithRequiredAction = [Symbol('v2SessionWithRequiredAction')];
+      const v2SessionToBePublished = [Symbol('v2SessionToBePublished')];
+
       const queryStub = sinon.stub();
-      queryStub.withArgs('with-required-action-session', { filter: { version: 2 } }).resolves(v2Sessions);
-      queryStub.withArgs('with-required-action-session', { filter: { version: 3 } }).resolves(v3Sessions);
+      queryStub
+        .withArgs('with-required-action-session', { filter: { version: 2 } })
+        .resolves(v2SessionWithRequiredAction);
+      queryStub.withArgs('to-be-published-session', { filter: { version: 2 } }).resolves(v2SessionToBePublished);
+
+      const v3SessionsWithRequiredAction = [Symbol('v3SessionWithRequiredAction')];
+      const v3SessionToBePublished = [Symbol('v3SessionToBePublished')];
+
+      queryStub
+        .withArgs('with-required-action-session', { filter: { version: 3 } })
+        .resolves(v3SessionsWithRequiredAction);
+      queryStub.withArgs('to-be-published-session', { filter: { version: 3 } }).resolves(v3SessionToBePublished);
 
       store.query = queryStub;
 
       // when
-      const result = await route.model();
+      const { refreshModel, ...result } = await route.model();
 
       // then
       assert.deepEqual(result, {
-        v2Sessions,
-        v3Sessions,
+        v2SessionsToBePublished: v2SessionToBePublished,
+        v2SessionsWithRequiredAction: v2SessionWithRequiredAction,
+        v3SessionsToBePublished: v3SessionToBePublished,
+        v3SessionsWithRequiredAction: v3SessionsWithRequiredAction,
       });
+
+      assert.strictEqual(typeof refreshModel, 'function');
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
@@ -229,7 +229,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         assert.deepEqual(controller.id, null);
         assert.deepEqual(controller.certificationCenterName, null);
         assert.deepEqual(controller.certificationCenterType, null);
-        assert.deepEqual(controller.status, 'finalized');
+        assert.deepEqual(controller.status, null);
         assert.deepEqual(controller.version, null);
       });
     });

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
@@ -1,4 +1,3 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -6,27 +5,19 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/sessions/list/to-be-published', function (hooks) {
   setupTest(hooks);
 
-  let store;
-  hooks.beforeEach(function () {
-    class StoreStub extends Service {
-      query = null;
-    }
-    this.owner.register('service:store', StoreStub);
-    store = this.owner.lookup('service:store');
-  });
-
   module('#model', function () {
     module('when filtering on V2 sessions', function () {
       test('it should fetch the list of sessions to be published', async function (assert) {
         // given
         const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
-        const v2Sessions = [
+        const v2SessionsToBePublished = [
           {
             certificationCenterName: 'Centre SCO des Anne-Solo',
             finalizedAt: '2020-04-15T15:00:34.000Z',
           },
         ];
-        const queryStub = sinon.stub();
+        route.modelFor = sinon.stub().returns({ v2SessionsToBePublished });
+
         const _ = sinon.stub();
         const transition = {
           to: {
@@ -36,14 +27,11 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
           },
         };
 
-        queryStub.withArgs('to-be-published-session', { filter: { version: 2 } }).resolves(v2Sessions);
-        store.query = queryStub;
-
         // when
         const result = await route.model(_, transition);
         // then
 
-        assert.deepEqual(result, v2Sessions);
+        assert.deepEqual(result, v2SessionsToBePublished);
       });
     });
 
@@ -51,13 +39,14 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
       test('it should fetch the list of sessions to be published', async function (assert) {
         // given
         const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
-        const v3Sessions = [
+        const v3SessionsToBePublished = [
           {
             certificationCenterName: 'Centre V3',
             finalizedAt: '2020-08-20T18:00:00.000Z',
           },
         ];
-        const queryStub = sinon.stub();
+        route.modelFor = sinon.stub().returns({ v3SessionsToBePublished });
+
         const _ = sinon.stub();
         const transition = {
           to: {
@@ -67,14 +56,11 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
           },
         };
 
-        queryStub.withArgs('to-be-published-session', { filter: { version: 3 } }).resolves(v3Sessions);
-        store.query = queryStub;
-
         // when
         const result = await route.model(_, transition);
-        // then
 
-        assert.deepEqual(result, v3Sessions);
+        // then
+        assert.deepEqual(result, v3SessionsToBePublished);
       });
     });
   });


### PR DESCRIPTION
## 🌸 Problème

Lorsque je suis dans PixAdmin, je peux voir la liste des toutes les sessions.

Puis une fois que je navigue dans un autre onglet, et que je reviens sur “toutes les sessions”, le tableau n'affiche plus que les sessions finalisées.

## 🌳 Proposition

Par défaut, la route "toutes les sessions" venait ajouter la query-param `status=finalized`.

➡ Éviter d'avoir des query-params sur cette route.

## 🐝 Remarques

Je me suis aussi permis d'ajouter des compteurs sur les onglets "à publier".

## 🤧 Pour tester

- Aller sur PixAdmin en RA
- Visiter la page "Sessions de certif"
- ☑️ Confirmer que tout se passe bien
