### PR TITLE
[FEATURE] Ajout du taux de couverture par tube dans le endpoint `/api/campaigns/:id/participations` [PIX-17280].

### DIFF
--- a/api/datamart/datamart-builder/datamart-buffer.js
+++ b/api/datamart/datamart-builder/datamart-buffer.js
@@ -1,10 +1,17 @@
+const INITIAL_ID = 100000;
+
 const datamartBuffer = {
   objectsToInsert: [],
+  nextId: INITIAL_ID,
 
   pushInsertable({ tableName, values }) {
     this.objectsToInsert.push({ tableName, values });
 
     return values;
+  },
+
+  getNextId() {
+    return this.nextId++;
   },
 
   purge() {

--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -43,11 +43,13 @@ class DatamartBuilder {
   async clean() {
     let rawQuery = '';
 
-    ['data_export_parcoursup_certif_result', 'data_export_parcoursup_certif_result_code_validation'].forEach(
-      (tableName) => {
-        rawQuery += `DELETE FROM ${tableName};`;
-      },
-    );
+    [
+      'data_export_parcoursup_certif_result',
+      'data_export_parcoursup_certif_result_code_validation',
+      'campaign_participation_tube_reached_levels',
+    ].forEach((tableName) => {
+      rawQuery += `DELETE FROM ${tableName};`;
+    });
 
     try {
       await this.knex.raw(rawQuery);

--- a/api/datamart/datamart-builder/factory/build-campaign-participation-tube-reached-level.js
+++ b/api/datamart/datamart-builder/factory/build-campaign-participation-tube-reached-level.js
@@ -1,0 +1,25 @@
+import { datamartBuffer } from '../datamart-buffer.js';
+
+export function buildCampaignParticipationTubeReachedLevel({
+  id = datamartBuffer.getNextId(),
+  tubeId = 'tube1wd1nle2n11e2',
+  campaignParticipationId = 1000,
+  reachedLevel = 4,
+} = {}) {
+  datamartBuffer.pushInsertable({
+    tableName: 'campaign_participation_tube_reached_levels',
+    values: {
+      id,
+      tube_id: tubeId,
+      campaign_participation_id: campaignParticipationId,
+      reached_level: reachedLevel,
+    },
+  });
+
+  return {
+    id,
+    tubeId,
+    campaignParticipationId,
+    reachedLevel,
+  };
+}

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -8,6 +8,7 @@ class CampaignParticipation {
     campaignId,
     userId,
     organizationLearnerId,
+    tubesReachedLevel,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -18,7 +19,16 @@ class CampaignParticipation {
     this.userId = userId;
     this.status = status;
     this.organizationLearnerId = organizationLearnerId;
+    this.tubesReachedLevel = tubesReachedLevel?.map((tubeReachedLevel) => new TubeReachedLevel(tubeReachedLevel));
   }
 }
 
 export { CampaignParticipation };
+
+class TubeReachedLevel {
+  constructor({ id, name, level }) {
+    this.id = id;
+    this.name = name;
+    this.level = level;
+  }
+}

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -1,8 +1,10 @@
+import { knex as knexDatamart } from '../../../../datamart/knex-database-connection.js';
 import { knex } from '../../../../db/knex-database-connection.js';
+import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 
 export async function findByCampaignId(campaignId) {
-  const rawCampaigns = await knex
+  const rawCampaignParticipations = await knex
     .select(
       'id',
       'createdAt',
@@ -18,9 +20,47 @@ export async function findByCampaignId(campaignId) {
     .from('campaign-participations')
     .where('campaignId', campaignId)
     .orderBy('id');
-  return rawCampaigns.map(toDomain);
+
+  const reachedLevelByTubes = await knexDatamart('campaign_participation_tube_reached_levels')
+    .select('*')
+    .whereIn(
+      'campaign_participation_id',
+      rawCampaignParticipations.map(({ id }) => id),
+    );
+
+  const tubeIds = new Set(reachedLevelByTubes.map(({ tube_id }) => tube_id));
+  const tubes = await tubeRepository.findByRecordIds(tubeIds);
+
+  return rawCampaignParticipations.map((rawCampaigns) => toDomain(rawCampaigns, reachedLevelByTubes, tubes));
 }
 
-function toDomain(rawCampaignParticipation) {
-  return new CampaignParticipation(rawCampaignParticipation);
+function toDomain(rawCampaignParticipation, rawReachedLevelByTubes, tubes) {
+  const tubeNamesById = _getTubeNamesById(tubes);
+
+  const campaignParticipationReachedLevels = rawReachedLevelByTubes
+    .filter(({ campaign_participation_id }) => rawCampaignParticipation.id === campaign_participation_id)
+    .map(({ reached_level, tube_id }) => ({
+      id: tube_id,
+      name: tubeNamesById[tube_id],
+      level: reached_level,
+    }));
+
+  return new CampaignParticipation({
+    id: rawCampaignParticipation.id,
+    createdAt: rawCampaignParticipation.createdAt,
+    participantExternalId: rawCampaignParticipation.participantExternalId,
+    status: rawCampaignParticipation.status,
+    sharedAt: rawCampaignParticipation.sharedAt,
+    campaignId: rawCampaignParticipation.campaignId,
+    userId: rawCampaignParticipation.userId,
+    organizationLearnerId: rawCampaignParticipation.organizationLearnerId,
+    tubesReachedLevel: campaignParticipationReachedLevels.length ? campaignParticipationReachedLevels : undefined,
+  });
+}
+
+function _getTubeNamesById(tubes) {
+  return tubes.reduce((acc, curr) => {
+    acc[curr.id] = curr.name;
+    return acc;
+  }, {});
 }

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -3,6 +3,7 @@ import { CampaignParticipationStatuses } from '../../../../src/prescription/shar
 import {
   createMaddoServer,
   databaseBuilder,
+  datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
 } from '../../../test-helper.js';
@@ -36,6 +37,60 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         status: CampaignParticipationStatuses.STARTED,
       });
 
+      const participation1ReachedLevels = [
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation1.id,
+          tubeId: 'tube1',
+          reachedLevel: 2,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation1.id,
+          tubeId: 'tube2',
+          reachedLevel: 0,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation1.id,
+          tubeId: 'tube3',
+          reachedLevel: 6,
+        }),
+      ];
+
+      const participation2ReachedLevels = [
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation2.id,
+          tubeId: 'tube1',
+          reachedLevel: 1,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation2.id,
+          tubeId: 'tube2',
+          reachedLevel: 2,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: participation2.id,
+          tubeId: 'tube3',
+          reachedLevel: 4,
+        }),
+      ];
+
+      const tubeNameById = Object.fromEntries(
+        [
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube1',
+            name: '@superTube',
+          }),
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube2',
+            name: '@gigaTube',
+          }),
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube3',
+            name: '@megaTube',
+          }),
+        ].map(({ id, name }) => [id, name]),
+      );
+
+      await datamartBuilder.commit();
       await databaseBuilder.commit();
 
       const options = {
@@ -52,8 +107,22 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal([
-        new CampaignParticipation(participation1),
-        new CampaignParticipation(participation2),
+        new CampaignParticipation({
+          ...participation1,
+          tubesReachedLevel: participation1ReachedLevels.map(({ tubeId, reachedLevel }) => ({
+            id: tubeId,
+            name: tubeNameById[tubeId],
+            level: reachedLevel,
+          })),
+        }),
+        new CampaignParticipation({
+          ...participation2,
+          tubesReachedLevel: participation2ReachedLevels.map(({ tubeId, reachedLevel }) => ({
+            id: tubeId,
+            name: tubeNameById[tubeId],
+            level: reachedLevel,
+          })),
+        }),
       ]);
     });
   });

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
@@ -1,6 +1,7 @@
 import { CampaignParticipation } from '../../../../../src/maddo/domain/models/CampaignParticipation.js';
 import { findByCampaignId } from '../../../../../src/maddo/infrastructure/repositories/campaign-participation-repository.js';
-import { databaseBuilder, expect } from '../../../../test-helper.js';
+import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { databaseBuilder, datamartBuilder, expect } from '../../../../test-helper.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | campaign-participation', function () {
   describe('#findByCampaignId', function () {
@@ -11,11 +12,58 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign-partici
 
       const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign1.id });
       databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign2.id });
-      const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign1.id });
+      const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign1.id,
+        status: CampaignParticipationStatuses.TO_SHARE,
+      });
+
+      const participation1ReachedLevels = [
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: campaignParticipation1.id,
+          tubeId: 'tube1',
+          reachedLevel: 2,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: campaignParticipation1.id,
+          tubeId: 'tube2',
+          reachedLevel: 0,
+        }),
+        datamartBuilder.factory.buildCampaignParticipationTubeReachedLevel({
+          campaignParticipationId: campaignParticipation1.id,
+          tubeId: 'tube3',
+          reachedLevel: 6,
+        }),
+      ];
+
+      const tubeNameById = Object.fromEntries(
+        [
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube1',
+            name: '@superTube',
+          }),
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube2',
+            name: '@gigaTube',
+          }),
+          databaseBuilder.factory.learningContent.buildTube({
+            id: 'tube3',
+            name: '@megaTube',
+          }),
+        ].map(({ id, name }) => [id, name]),
+      );
+
+      await datamartBuilder.commit();
       await databaseBuilder.commit();
 
       const expectedCampaignParticipations = [
-        new CampaignParticipation(campaignParticipation1),
+        new CampaignParticipation({
+          ...campaignParticipation1,
+          tubesReachedLevel: participation1ReachedLevels.map(({ tubeId, reachedLevel }) => ({
+            id: tubeId,
+            name: tubeNameById[tubeId],
+            level: reachedLevel,
+          })),
+        }),
         new CampaignParticipation(campaignParticipation3),
       ];
 


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
La récupération des participations à une campagne donnée n'inclut pas le taux de couverture.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On ajoute le taux de couverture calculé et stocké dans la table `campaign_participation_tube_reached_levels` (dans le datamart).

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
