### PR TITLE
[TECH] Suppression de la contrainte de non nullité sur la colonne isV3Pilot (PIX-17292).

### DIFF
--- a/api/db/migrations/20250401065347_remove-not-null-constraint-on-isV3Pilot-column.js
+++ b/api/db/migrations/20250401065347_remove-not-null-constraint-on-isV3Pilot-column.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'isV3Pilot';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table
+      .boolean(COLUMN_NAME)
+      .defaultTo(true)
+      .nullable()
+      .comment('DEPRECATED, this column will be unused soon')
+      .alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).notNull().comment('').alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

La colonne `isV3Pilot` située dans la table `certification-centers` en BDD n'est plus nécessaire et sera bientôt supprimée.
Or cette colonne dispose d'une contrainte de non-nullité.

## 🌳 Proposition

Afin de garantir la rétro-compatibilité lors de la suppression du code, nous retirons la contrainte de non nullité sur la colonne.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

✅ Tests verts.
