### PR TITLE
[TECH] Corrige les tests n'utilisant pas correctement l'assert throw.

### DIFF
--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -264,7 +264,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
             finalizedSessionRepository.get.resolves(domainBuilder.buildFinalizedSession());
 
             // when/then
-            expect(
+            expect(async () => {
               await publishSession({
                 sessionId: 'sessionId',
                 publishedAt: now,
@@ -272,12 +272,12 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
                 finalizedSessionRepository,
                 sessionRepository,
                 sharedSessionRepository,
-              }),
-            ).to.not.throw;
+              });
 
-            expect(certificationRepository.publishCertificationCourses).to.have.been.calledOnceWithExactly([
-              { pixCertificationStatus: null, isCancelled: true },
-            ]);
+              expect(certificationRepository.publishCertificationCourses).to.have.been.calledOnceWithExactly([
+                { pixCertificationStatus: null, isCancelled: true },
+              ]);
+            }).to.not.throw();
           });
         });
       });

--- a/api/tests/certification/shared/unit/domain/validators/session-validator_test.js
+++ b/api/tests/certification/shared/unit/domain/validators/session-validator_test.js
@@ -21,7 +21,9 @@ describe('Unit | Domain | Validators | session-validator', function () {
   describe('#validate', function () {
     context('when validation is successful', function () {
       it('should not throw any error', function () {
-        expect(sessionValidator.validate(session)).to.not.throw;
+        expect(() => {
+          sessionValidator.validate(session);
+        }).to.not.throw();
       });
     });
 
@@ -161,7 +163,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
   describe('#validateForMassSessionImport', function () {
     context('when validation is successful', function () {
       it('should not throw any error', function () {
-        expect(sessionValidator.validateForMassSessionImport(session, 1)).to.not.throw;
+        expect(() => sessionValidator.validateForMassSessionImport(session, 1)).to.not.throw();
       });
     });
 
@@ -271,7 +273,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
     context('when validating id', function () {
       context('when id not in submitted filters', function () {
         it('should not throw any error', function () {
-          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
+          expect(() => sessionValidator.validateAndNormalizeFilters({})).to.not.throw();
         });
       });
 
@@ -285,11 +287,11 @@ describe('Unit | Domain | Validators | session-validator', function () {
 
         context('when id is an integer', function () {
           it('accept a string containing an int', function () {
-            expect(sessionValidator.validateAndNormalizeFilters({ id: '123' })).to.not.throw;
+            expect(() => sessionValidator.validateAndNormalizeFilters({ id: '123' })).to.not.throw();
           });
 
           it('should not throw any error', function () {
-            expect(sessionValidator.validateAndNormalizeFilters({ id: 123 })).to.not.throw;
+            expect(() => sessionValidator.validateAndNormalizeFilters({ id: 123 })).to.not.throw();
           });
         });
       });
@@ -298,7 +300,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
     context('when validating certificationCenterName', function () {
       context('when certificationCenterName not in submitted filters', function () {
         it('should not throw any error', function () {
-          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
+          expect(() => sessionValidator.validateAndNormalizeFilters({})).to.not.throw();
         });
       });
 
@@ -315,7 +317,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
         context('when certificationCenterName is a string', function () {
           it('should not throw an error', async function () {
             const certificationCenterName = '   Coucou le dév qui lit ce message !   ';
-            expect(sessionValidator.validateAndNormalizeFilters({ certificationCenterName })).to.not.throw;
+            expect(() => sessionValidator.validateAndNormalizeFilters({ certificationCenterName })).to.not.throw();
             expect(
               sessionValidator.validateAndNormalizeFilters({ certificationCenterName }).certificationCenterName,
             ).to.equal(certificationCenterName.trim());
@@ -327,7 +329,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
     context('when validating status', function () {
       context('when status not in submitted filters', function () {
         it('should not throw any error', function () {
-          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
+          expect(() => sessionValidator.validateAndNormalizeFilters({})).to.not.throw();
         });
       });
 
@@ -348,10 +350,18 @@ describe('Unit | Domain | Validators | session-validator', function () {
 
         context('when status is in the statuses list', function () {
           it('should not throw an error', async function () {
-            expect(sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.CREATED })).to.not.throw;
-            expect(sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.FINALIZED })).to.not.throw;
-            expect(sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.IN_PROCESS })).to.not.throw;
-            expect(sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.PROCESSED })).to.not.throw;
+            expect(() =>
+              sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.CREATED }),
+            ).to.not.throw();
+            expect(() =>
+              sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.FINALIZED }),
+            ).to.not.throw();
+            expect(() =>
+              sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.IN_PROCESS }),
+            ).to.not.throw();
+            expect(() =>
+              sessionValidator.validateAndNormalizeFilters({ status: SESSION_STATUSES.PROCESSED }),
+            ).to.not.throw();
           });
         });
       });
@@ -360,7 +370,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
     context('when validating version', function () {
       context('when version not in submitted filters', function () {
         it('should not throw any error', function () {
-          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
+          expect(() => sessionValidator.validateAndNormalizeFilters({})).to.not.throw();
         });
       });
 
@@ -385,8 +395,8 @@ describe('Unit | Domain | Validators | session-validator', function () {
 
         context('when resultsSentToPrescriberAt is a number in the allowed list', function () {
           it('should not throw an error', async function () {
-            expect(sessionValidator.validateAndNormalizeFilters({ version: 2 })).to.not.throw;
-            expect(sessionValidator.validateAndNormalizeFilters({ version: 3 })).to.not.throw;
+            expect(() => sessionValidator.validateAndNormalizeFilters({ version: 2 })).to.not.throw();
+            expect(() => sessionValidator.validateAndNormalizeFilters({ version: 3 })).to.not.throw();
           });
         });
       });

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -47,13 +47,16 @@ describe('Integration | Repository | user-recommended-training-repository', func
       };
 
       // then
-      expect(await saveSameUserRecommendedTraining()).not.to.throw;
-      const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
-        .where({
-          id: userRecommendedTraining.id,
-        })
-        .first();
-      expect(updatedUserRecommendedTraining.updatedAt).to.be.above(userRecommendedTraining.updatedAt);
+      expect(async () => {
+        await saveSameUserRecommendedTraining();
+
+        const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
+          .where({
+            id: userRecommendedTraining.id,
+          })
+          .first();
+        expect(updatedUserRecommendedTraining.updatedAt).to.be.above(userRecommendedTraining.updatedAt);
+      }).not.to.throw();
     });
   });
 

--- a/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
@@ -346,7 +346,7 @@ describe('Unit | Service | ScorecardService', function () {
             campaignRepository,
           });
         };
-        expect(await call()).not.to.throw;
+        expect(call).not.to.throw();
       });
 
       // then

--- a/api/tests/integration/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/integration/scripts/helpers/csvHelpers_test.js
@@ -61,11 +61,12 @@ describe('Integration | Scripts | Helpers | csvHelpers.js', function () {
 
       // then
       expect(
-        await checkCsvHeader({
-          filePath: withValidHeaderFilePath,
-          requiredFieldNames,
-        }),
-      ).to.not.throw;
+        async () =>
+          await checkCsvHeader({
+            filePath: withValidHeaderFilePath,
+            requiredFieldNames,
+          }),
+      ).to.not.throw();
     });
   });
 });

--- a/api/tests/organizational-entities/unit/domain/validators/certification-center-creation.validator.test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/certification-center-creation.validator.test.js
@@ -18,7 +18,7 @@ describe('Unit | Organizational Entities | Domain | Validators | certification-c
         const certificationCenterCreationParams = { name: 'ACME', type: 'PRO' };
 
         // when/then
-        expect(certificationCenterCreationValidator.validate(certificationCenterCreationParams)).to.not.throw;
+        expect(() => certificationCenterCreationValidator.validate(certificationCenterCreationParams)).to.not.throw();
       });
     });
 
@@ -122,8 +122,9 @@ describe('Unit | Organizational Entities | Domain | Validators | certification-c
             const certificationCenterCreationParams = { name: 'ACME', type };
 
             // when/then
-            return expect(certificationCenterCreationValidator.validate(certificationCenterCreationParams)).to.not
-              .throw;
+            return expect(() =>
+              certificationCenterCreationValidator.validate(certificationCenterCreationParams),
+            ).to.not.throw();
           });
         });
       });

--- a/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
         const organizationCreationParams = { name: 'ACME', type: 'PRO', documentationUrl: 'https://kingArthur.com' };
 
         // when/then
-        expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
+        expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
       });
     });
 
@@ -95,7 +95,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             const organizationCreationParams = { name: 'ACME', type };
 
             // when/then
-            return expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
+            return expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
           });
         });
       });

--- a/api/tests/prescription/campaign-participation/unit/application/pole-emploi-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/pole-emploi-controller_test.js
@@ -59,7 +59,7 @@ describe('Unit | Controller | pole-emploi-controller', function () {
         const error = await catchErr(poleEmploiController.getSendings)(request, hFake, { poleEmploiService });
 
         //then
-        expect(error).to.throw;
+        expect(error).to.be.ok;
       });
     });
     context('when there are filters', function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -124,7 +124,6 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
         organizationRepository: organizationRepositoryStub,
       });
 
-      expect(error).to.throw;
       expect(error).to.be.an.instanceof(UserNotFoundError);
     });
 
@@ -141,7 +140,6 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
         organizationRepository: organizationRepositoryStub,
       });
 
-      expect(error).to.throw;
       expect(error).to.be.an.instanceof(NotFoundError);
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
@@ -61,53 +61,53 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
       context(`when campaign is of type ${campaign.type}`, function () {
         context('when validation is successful', function () {
           it('should not throw any error', function () {
-            expect(campaignUpdateValidator.validate(campaign)).to.not.throw;
+            expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
           });
 
           context('#title', function () {
             it('should resolve when is null', function () {
               // when/then
-              expect(
+              expect(() =>
                 campaignUpdateValidator.validate({
                   ...campaign,
                   title: MISSING_VALUE,
                 }),
-              ).to.not.throw;
+              ).to.not.throw();
             });
 
             it('should resolve when is not provided', function () {
               // when/then
-              expect(
+              expect(() =>
                 campaignUpdateValidator.validate({
                   ...campaign,
                   title: UNDEFINED_VALUE,
                 }),
-              ).to.not.throw;
+              ).to.not.throw();
             });
           });
 
           context('#customResultPageText', function () {
             it('should resolve when is null', function () {
               // when/then
-              expect(
+              expect(() =>
                 campaignUpdateValidator.validate({
                   ...campaign,
                   customResultPageText: MISSING_VALUE,
                 }),
-              ).to.not.throw;
+              ).to.not.throw();
             });
           });
 
           context('#customResultPageButtonText and #customResultPageButtonUrl', function () {
             it('should resolve when both are null', function () {
               // when/then
-              expect(
+              expect(() =>
                 campaignUpdateValidator.validate({
                   ...campaign,
                   customResultPageButtonText: MISSING_VALUE,
                   customResultPageButtonUrl: MISSING_VALUE,
                 }),
-              ).to.not.throw;
+              ).to.not.throw();
             });
           });
 
@@ -387,7 +387,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
         };
 
         // when/then
-        expect(campaignUpdateValidator.validate(campaign)).to.not.throw;
+        expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
       });
 
       it('should reject with error campaign type is ASSESSMENT and title has more than 50 char', function () {
@@ -460,7 +460,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
         };
 
         // when/then
-        expect(campaignUpdateValidator.validate(campaign)).to.not.throw;
+        expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
       });
     });
 
@@ -494,7 +494,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
         };
 
         // when/then
-        expect(campaignUpdateValidator.validate(campaign)).to.not.throw;
+        expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
       });
 
       it('should reject with error when customResultPageButtonText is not filled but customResultPageButtonUrl is', function () {
@@ -570,7 +570,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
         };
 
         // when/then
-        expect(campaignUpdateValidator.validate(campaign)).to.not.throw;
+        expect(() => campaignUpdateValidator.validate(campaign)).to.not.throw();
       });
 
       it('should reject with error when it is not a url', function () {

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -302,9 +302,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
           const secondLearnerAttributes = { ...learnerAttributes, group: 'cheese' };
 
-          const response = learnerSet.addLearners([learnerAttributes, secondLearnerAttributes]);
-
-          expect(response).to.not.throw;
+          expect(() => learnerSet.addLearners([learnerAttributes, secondLearnerAttributes])).to.not.throw();
         });
       });
       context('checkDateRule', function () {
@@ -321,8 +319,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
         it('when the date respect the format, should not throw an error', async function () {
           const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
 
-          const response = learnerSet.addLearners([{ ...learnerAttributes, birthdate: '2026-03-06' }]);
-          expect(response).to.not.throw;
+          expect(() => learnerSet.addLearners([{ ...learnerAttributes, birthdate: '2026-03-06' }])).to.not.throw();
         });
 
         it('should throw date error when the format is not respected', async function () {
@@ -365,8 +362,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
           const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
 
-          const response = learnerSet.addLearners([{ ...learnerAttributes, cycle: 'Cycle III' }]);
-          expect(response).to.not.throw;
+          expect(() => learnerSet.addLearners([{ ...learnerAttributes, cycle: 'Cycle III' }])).to.not.throw();
         });
 
         it('when the value DOES NOT correspond to the expectedValues, should throw an error', async function () {

--- a/api/tests/prescription/target-profile/unit/domain/validators/creation-command-validation_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/validators/creation-command-validation_test.js
@@ -34,7 +34,7 @@ describe('Unit | Domain | Validators | target-profile/creationCommandValidator',
         const targetProfileCreationCommand = validParams;
 
         // when/then
-        expect(creationCommandValidator.validate(targetProfileCreationCommand)).to.not.throw;
+        expect(() => creationCommandValidator.validate(targetProfileCreationCommand)).to.not.throw();
       });
     });
 

--- a/api/tests/shared/unit/application/validator/checkOrganizationHasFeature_test.js
+++ b/api/tests/shared/unit/application/validator/checkOrganizationHasFeature_test.js
@@ -16,15 +16,15 @@ describe('Unit | Application | Validator | checkOrganizationHasFeature', functio
         .withArgs({ organizationId, featureKey })
         .resolves(true);
 
-      // when
-      const response = await checkOrganizationHasFeatureUseCase.execute({
-        organizationId,
-        featureKey,
-        dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
-      });
-
-      // then
-      expect(response).to.not.throw;
+      // when & then
+      expect(
+        async () =>
+          await checkOrganizationHasFeatureUseCase.execute({
+            organizationId,
+            featureKey,
+            dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
+          }),
+      ).to.not.throw();
     });
   });
   context('When organization does not have feature enabled', function () {
@@ -48,7 +48,6 @@ describe('Unit | Application | Validator | checkOrganizationHasFeature', functio
       });
 
       // then
-      expect(response).to.throw;
       expect(response).to.be.an.instanceOf(OrganizationDoesNotHaveFeatureEnabledError);
     });
   });

--- a/api/tests/shared/unit/domain/validators/password-validator_test.js
+++ b/api/tests/shared/unit/domain/validators/password-validator_test.js
@@ -18,7 +18,7 @@ describe('Unit | Shared | Domain | Validator | password-validator', function () 
         password = 'Pix12345';
 
         // then
-        expect(passwordValidator.validate(password)).to.not.throw;
+        expect(() => passwordValidator.validate(password)).to.not.throw();
       });
     });
 

--- a/api/tests/shared/unit/domain/validators/user-validator_test.js
+++ b/api/tests/shared/unit/domain/validators/user-validator_test.js
@@ -27,7 +27,7 @@ describe('Unit | Shared | Domain | Validator | user-validator', function () {
 
       context('when validation is successful', function () {
         it('should not throw any error', function () {
-          expect(userValidator.validate({ user })).to.not.throw;
+          expect(() => userValidator.validate({ user })).to.not.throw();
         });
       });
 
@@ -251,7 +251,7 @@ describe('Unit | Shared | Domain | Validator | user-validator', function () {
 
       context('when validation is successful', function () {
         it('should not throw any error', function () {
-          expect(userValidator.validate({ user, cguRequired })).to.not.throw;
+          expect(() => userValidator.validate({ user, cguRequired })).to.not.throw();
         });
       });
 


### PR DESCRIPTION
## 🌸 Problème

L'assertion `throw` de chaijs est une fonction. Elle s'utilise comme suit : 

```js
expect(() => laFonctionQueJeVeuxTester()).not.to.throw() 
```

Si on oublie l'appel à la fonction comme suit : 

```js
expect(() => laFonctionQueJeVeuxTester()).not.to.throw
```

Le résultat sera que le code passé dans le `expect` ne sera tout simplement pas appelé et le test sera vert. Il y a quelques tests qui n'appelle pas correctement throw dans la base de code.

## 🌳 Proposition

Corriger les appels à throw dans nos tests.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

La CI est verte 🍏 
