### PR TITLE
[TECH] Créer un feature toggle pour la nouvelle page d'analyse de campagne (PIX-17025)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -17,4 +17,10 @@ export default {
     defaultValue: false,
     tags: ['team-certification'],
   },
+  shouldDisplayNewAnalysisPage: {
+    description: 'Display the new page for campaign analysis',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['frontend', 'pix-orga', 'team-prescription'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -35,6 +35,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'setup-ecosystem-before-start': false,
+            'should-display-new-analysis-page': false,
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') shouldDisplayNewAnalysisPage;
+}


### PR DESCRIPTION
## 🌸 Problème

On a besoin d'un feature toggle pour la future page d'analyse des résultats de campagne sur PIx orga.

## 🌳 Proposition

Ajouter un feature toggle avec comme valeur par défaut false.

## 🐝 Remarques

On utilise le nouveau système des feature toggles.

## 🤧 Pour tester

- Se connecter à la RA:
```shell
scalingo -a pix-api-review-pr11922 run bash
```
- Exécuter la commande permettant de lister l'ensemble des feature toggles:
```shell
npm run toggles -- --list
```
- Constater la présence du feature toggle shouldDisplayNewAnalysisPage,
- Afficher uniquement le feature toggle:
```shell
npm run toggles -- --key shouldDisplayNewAnalysisPage
````