### PR TITLE
[FEATURE] Ajouter les attributs d'archivage d'un centre de certification (PIX-16748)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center.js
+++ b/api/db/database-builder/factory/build-certification-center.js
@@ -9,6 +9,8 @@ const buildCertificationCenter = function ({
   updatedAt,
   isV3Pilot = false,
   isScoBlockedAccessWhitelist = false,
+  archivedAt = null,
+  archivedBy = null,
 } = {}) {
   const values = {
     id,
@@ -19,6 +21,8 @@ const buildCertificationCenter = function ({
     updatedAt,
     isV3Pilot,
     isScoBlockedAccessWhitelist,
+    archivedAt,
+    archivedBy,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-centers',

--- a/api/db/migrations/20250401070307_add_archive_attributes_columns_to_certification_centers.js
+++ b/api/db/migrations/20250401070307_add_archive_attributes_columns_to_certification_centers.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'certification-centers';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.timestamp('archivedAt');
+    table.bigInteger('archivedBy').references('users.id').index();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('archivedAt');
+    table.dropColumn('archivedBy');
+  });
+};
+
+export { down, up };

--- a/api/tests/tooling/domain-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center.js
@@ -9,6 +9,8 @@ const buildCertificationCenter = function ({
   updatedAt,
   habilitations = [],
   isV3Pilot = false,
+  archivedAt,
+  archivedBy,
 } = {}) {
   return new CertificationCenter({
     id,
@@ -19,6 +21,8 @@ const buildCertificationCenter = function ({
     createdAt,
     habilitations,
     isV3Pilot,
+    archivedAt,
+    archivedBy,
   });
 };
 


### PR DESCRIPTION
## 🌸 Problème

Nous souhaitons identifier les centre de certifications archivés et quel utilisateur les a archivés.


## 🌳 Proposition

Sur la table certification-centers ajouter les colonnes:
archivedAt : timestamp - With time zone, nullable
archivedBy : bigint - Foreign key sur users(id), nullable


## 🐝 Remarques

Si dans le database builder les attributs `archivedAt` et `archivedBy` sont déclarés sans affectation, elles sont `undefined`, ce qui crée des erreurs dans certains tests qui font des requêtes comme : 
`await knex('certification-centers').select().where({ id: center.id }).first();` (qui renvoie des valeurs `null` pour ces colonnes).
L'affectation de la valeur `null` à ces colonnes se fait également dans le` databaseBuilder.buildOrganization();`

## 🤧 Pour tester

- faire une migration
```
npm run db:migrate
```
- Se connecter sur la db:
- Vérifier le schéma de chaque colone ajoutée
- faire un rollback
```shell

npm run db:rollback:latest

````
- Vérifier que les colonnes ont disparu des tables.
