### PR TITLE
[FEATURE] Autoriser un participant avec une participation précédente supprimée à re-participer (PIX-15809)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipant.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipant.js
@@ -94,10 +94,6 @@ class CampaignParticipant {
       );
     }
 
-    if (this.previousCampaignParticipationForUser?.isDeleted) {
-      throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
-    }
-
     if (['STARTED', 'TO_SHARE'].includes(this.previousCampaignParticipationForUser?.status)) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
@@ -574,8 +574,9 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         );
       });
 
-      it('throws a ForbiddenAccess exception when the previous participation is deleted', async function () {
+      it('not throws a ForbiddenAccess exception when the previous participation is deleted', async function () {
         const userIdentity = { id: 1 };
+
         const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation({
           multipleSendings: true,
           externalIdLabel: null,
@@ -593,10 +594,15 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             hasParticipated: false,
           },
         });
-        const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
-        expect(error).to.be.an.instanceof(ForbiddenAccess);
-        expect(error.message).to.equal('Vous ne pouvez pas repasser la campagne');
+        campaignParticipant.start({ participantExternalId: null });
+
+        expect(campaignParticipant.campaignParticipation).to.deep.include({
+          campaignId: campaignToStartParticipation.id,
+          status: 'STARTED',
+          userId: userIdentity.id,
+          organizationLearnerId: null,
+        });
       });
 
       describe('and isReset param is true', function () {


### PR DESCRIPTION
## 🌸 Problème

Ce bout de code ne sera plus fonctionnel car la suppression d'une participation anonymisera cette dernière. Nous ne pourrons donc plus vérifier ce cas.

## 🌳 Proposition

Supprimer cette condition

## 🐝 Remarques

J'ai laissé le test car j'ai testé que ça ne throw pas.

## 🤧 Pour tester

- participer à une campagne via Pix
- supprimer la participation via PixOrga
- re-participer à la campagne avec le même utilisateur via Pix
