### PR TITLE
[FEATURE] Ne pas afficher l'heure sur les dates de dernier accès dans PIX Admin (PIX-17281)

### DIFF
--- a/admin/app/components/certification-centers/membership-item.gjs
+++ b/admin/app/components/certification-centers/membership-item.gjs
@@ -72,6 +72,12 @@ export default class CertificationCentersMembershipItemComponent extends Compone
       </:cell>
     </PixTableColumn>
     <PixTableColumn @context={{@context}}>
+      <:header>Date de rattachement</:header>
+      <:cell>
+        {{dayjsFormat @certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{@context}}>
       <:header>Rôle</:header>
       <:cell>
         <MembershipItemRole
@@ -86,16 +92,10 @@ export default class CertificationCentersMembershipItemComponent extends Compone
       <:header>Dernier accès</:header>
       <:cell>
         {{#if @certificationCenterMembership.lastAccessedAt}}
-          {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD-MM-YYYY - HH:mm:ss"}}
+          {{dayjsFormat @certificationCenterMembership.lastAccessedAt "DD-MM-YYYY"}}
         {{else}}
           {{t "components.certification-centers.membership-item.no-last-connection-date-info"}}
         {{/if}}
-      </:cell>
-    </PixTableColumn>
-    <PixTableColumn @context={{@context}}>
-      <:header>Date de rattachement</:header>
-      <:cell>
-        {{dayjsFormat @certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
       </:cell>
     </PixTableColumn>
     <PixTableColumn @context={{@context}}>

--- a/admin/app/components/organizations/member-item.gjs
+++ b/admin/app/components/organizations/member-item.gjs
@@ -13,7 +13,7 @@ export default class MemberItem extends Component {
     if (!this.args.organizationMembership.lastAccessedAt) {
       return this.intl.t('components.organizations.member-items.no-last-connection-date-info');
     }
-    return dayjs(this.args.organizationMembership.lastAccessedAt).format('DD/MM/YYYY HH:mm');
+    return dayjs(this.args.organizationMembership.lastAccessedAt).format('DD/MM/YYYY');
   }
 
   <template>

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -51,9 +51,7 @@ module('Integration | Component |  certification-centers/membership-item', funct
       );
 
       // then
-      const expectedLastAccessDate = dayjs(certificationCenterMembership.lastAccessedAt).format(
-        'DD-MM-YYYY - HH:mm:ss',
-      );
+      const expectedLastAccessedAtDate = dayjs(certificationCenterMembership.lastAccessedAt).format('DD-MM-YYYY');
       const expectedCreationDate = dayjs(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
 
       assert.dom(screen.getByRole('link', { name: certificationCenterMembership.id })).exists();
@@ -61,7 +59,7 @@ module('Integration | Component |  certification-centers/membership-item', funct
       assert.dom(screen.getByRole('cell', { name: user.lastName })).exists();
       assert.dom(screen.getByRole('cell', { name: user.email })).exists();
       assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
-      assert.dom(screen.getByRole('cell', { name: expectedLastAccessDate })).exists();
+      assert.dom(screen.getByRole('cell', { name: expectedLastAccessedAtDate })).exists();
       assert.dom(screen.getByRole('cell', { name: expectedCreationDate })).exists();
       assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
       assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();

--- a/admin/tests/integration/components/organizations/member-item-test.gjs
+++ b/admin/tests/integration/components/organizations/member-item-test.gjs
@@ -43,7 +43,7 @@ module('Integration | Component | MemberItem', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'Doe' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'toto@example.net' })).exists();
-    assert.dom(screen.getByRole('cell', { name: dayjs(now).format('DD/MM/YYYY HH:mm') })).exists();
+    assert.dom(screen.getByRole('cell', { name: dayjs(now).format('DD/MM/YYYY') })).exists();
   });
   module('if there is no last access date', function () {
     test('displays default last access date', async function (assert) {


### PR DESCRIPTION
## 🌸 Problème

Petits ajustements dans pix Admin:

- Fiche d’une organisation > Equipe > on voit la date et l'heure dans la colonne “Dernier accès”

  - on ne devrait voir que la date (pas l'heure)

- Fiche d’un centre de certification > dans l’onglet Equipe > on voit la date et l'heure dans la colonne “Dernier accès” 

  - on ne devrait voir que la date (pas l'heure)

- Fiche d’un centre de certification > Equipe > Déplaçer “Date de rattachement” entre “Adresse e-mail “ et “Rôle”

## 🌳 Proposition

Effectuer ces changements


## 🤧 Pour tester

- Sur Pix Certif : accéder à deux centres de certification (en tant que [james-paledroits@example.net](mailto:james-paledroits@example.net) par exemple) 

- Sur Pix Orga : accéder à une ou deux organisations (en tant que [allorga@example.net](mailto:allorga@example.net) par exemple) 

- Sur Pix Admin ouvrir une session en tant que superAdmin, et vérifier les dates de dernières connexions au format DD/MM/AAAA ( **sans les heures** )  sur l'onglet Pix Certif de la page du premier utilisateur, puis sur l'onglet Pix Orga de la page du deuxième utilisateur