### PR TITLE
[TECH] Créer une migration pour supprimer la contrainte userId et snappedAt dans la table knowledge-element-snapshots et rendre ces 2 colones nullables (PIX-17211)

### DIFF
--- a/api/db/migrations/20250402075613_update-knowledge-element-snapshots-table.js
+++ b/api/db/migrations/20250402075613_update-knowledge-element-snapshots-table.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer('userId').nullable().alter();
+    table.dateTime('snappedAt').nullable().alter();
+    table.dropUnique(['userId', 'snappedAt']);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer('userId').notNullable().alter();
+    table.dateTime('snappedAt').notNullable().alter();
+    table.unique(['userId', 'snappedAt']);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

On souhaite supprimer la contrainte du couple userId et snappedAt dans la table knowledge-element-snapshots et rendre les 2 colone nullable.

## 🌳 Proposition

Créer la migration nécessaire avec up et down.

## 🐝 Remarques

Aucune donnée ne sera affecté par la migration, ni avant, ni apprès.

## 🤧 Pour tester

- Se connecter à la Review app,
```shell
scalingo -a pix-api-review-pr11936 psql-console
```
- Entrer cette commande:
```sql
\d "knowledge-element-snapshots";
```
- Vérifier qu'on obtient ce résultat:
```
                                              Table "public.knowledge-element-snapshots"
         Column          |           Type           | Collation | Nullable |                          Default                          
-------------------------+--------------------------+-----------+----------+-----------------------------------------------------------
 id                      | integer                  |           | not null | nextval('"knowledge-element-snapshots_id_seq"'::regclass)
 userId                  | integer                  |           |          | 
 snappedAt               | timestamp with time zone |           |          | 
 snapshot                | jsonb                    |           | not null | 
 campaignParticipationId | integer                  |           |          | 
Indexes:
    "knowledge-element-snapshots_pkey" PRIMARY KEY, btree (id)
    "knowledge_element_snapshots_campaignparticipationid_index" btree ("campaignParticipationId")
Foreign-key constraints:
    "knowledge_element_snapshots_campaignparticipationid_foreign" FOREIGN KEY ("campaignParticipationId") REFERENCES "campaign-participations"(id)
```