### PR TITLE
[BUGFIX] MaDDo - Ne pas échouer la réplication si une nouvelle colonne est ajoutée dans la table source

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -5,7 +5,23 @@ export const replications = [
       await datamartKnex('sco_certification_results').delete();
     },
     from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result').select('*');
+      return datawarehouseKnex('data_export_parcoursup_certif_result').select(
+        'national_student_id',
+        'national_student_id',
+        'organization_uai',
+        'last_name',
+        'first_name',
+        'birthdate',
+        'status',
+        'pix_score',
+        'certification_date',
+        'competence_level',
+        'organization_uai',
+        'competence_name',
+        'competence_code',
+        'area_name',
+        'certification_courses_id',
+      );
     },
     to: ({ datamartKnex }, chunk) => {
       return datamartKnex('sco_certification_results').insert(chunk);
@@ -17,7 +33,23 @@ export const replications = [
       await datamartKnex('data_export_parcoursup_certif_result').delete();
     },
     from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result').select('*');
+      return datawarehouseKnex('data_export_parcoursup_certif_result').select(
+        'certification_code_verification',
+        'last_name',
+        'first_name',
+        'birthdate',
+        'status',
+        'pix_score',
+        'certification_date',
+        'competence_level',
+        'certification_code_verification',
+        'competence_name',
+        'competence_code',
+        'area_name',
+        'certification_courses_id',
+        'national_student_id',
+        'organization_uai',
+      );
     },
     to: ({ datamartKnex }, chunk) => {
       return datamartKnex('data_export_parcoursup_certif_result').insert(chunk);
@@ -29,7 +61,23 @@ export const replications = [
       await datamartKnex('certification_results').delete();
     },
     from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select('*');
+      return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select(
+        'national_student_id',
+        'national_student_id',
+        'organization_uai',
+        'last_name',
+        'first_name',
+        'birthdate',
+        'status',
+        'pix_score',
+        'certification_date',
+        'competence_level',
+        'organization_uai',
+        'competence_name',
+        'competence_code',
+        'area_name',
+        'certification_courses_id',
+      );
     },
     to: ({ datamartKnex }, chunk) => {
       return datamartKnex('certification_results').insert(chunk);
@@ -41,7 +89,23 @@ export const replications = [
       await datamartKnex('data_export_parcoursup_certif_result_code_validation').delete();
     },
     from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select('*');
+      return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select(
+        'certification_code_verification',
+        'last_name',
+        'first_name',
+        'birthdate',
+        'status',
+        'pix_score',
+        'certification_date',
+        'competence_level',
+        'certification_code_verification',
+        'competence_name',
+        'competence_code',
+        'area_name',
+        'certification_courses_id',
+        'national_student_id',
+        'organization_uai',
+      );
     },
     to: ({ datamartKnex }, chunk) => {
       return datamartKnex('data_export_parcoursup_certif_result_code_validation').insert(chunk);


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Si une nouvelle colonne est ajoutée dans une table répliquée par la mise à disposition de donnée, celle-ci échoue car elle ne trouve pas la colonne destination correspondante.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Extraire uniquement les colonnes à répliquer.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS.

## 🤧 Pour tester
Lancer un job de réplication. 

1. Récupérer un token avec le scope réplication : 
```shell
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11939.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

2. Lancer une réplication : 
```
curl -X POST https://pix-api-maddo-review-pr11939.osc-fr1.scalingo.io/api/replications/sco_certification_results -H "Authorization: Bearer $ACCESS_TOKEN"
```

-> Les données souhaitées ont bien été répliquées. 

