### PR TITLE
[TECH] Ajouter les routes parcoursup dans l'API Maddo (PIX-17321)

### DIFF
--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -5,6 +5,7 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
+import * as parcoursupRoutes from './src/certification/results/application/parcoursup-route.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import * as campaignsRoutes from './src/maddo/application/campaigns-routes.js';
 import * as organizationsRoutes from './src/maddo/application/organizations-routes.js';
@@ -187,6 +188,7 @@ const setupRoutesAndPlugins = async function (server) {
     healthcheckRoutes,
     organizationsRoutes,
     replicationsRoutes,
+    parcoursupRoutes,
   ];
   const routesWithOptions = routes.map((route) => ({
     plugin: route,

--- a/api/tests/certification/results/acceptance/application/parcoursup-route_api_test.js
+++ b/api/tests/certification/results/acceptance/application/parcoursup-route_api_test.js
@@ -1,11 +1,11 @@
 import {
-  createMaddoServer,
+  createServer,
   datamartBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
 } from '../../../../test-helper.js';
 
-describe('Certification | Results | Acceptance | Application | parcoursup-route', function () {
+describe('Certification | Results | Acceptance | Application | API | parcoursup-route', function () {
   let server,
     ine,
     organizationUai,
@@ -19,7 +19,7 @@ describe('Certification | Results | Acceptance | Application | parcoursup-route'
     certificationResultData;
 
   beforeEach(async function () {
-    server = await createMaddoServer();
+    server = await createServer();
 
     PARCOURSUP_CLIENT_ID = 'test-parcoursupClientId';
     PARCOURSUP_SCOPE = 'parcoursup';


### PR DESCRIPTION
## 🌸 Problème

Nous souhaitons que tous les partenaires récupèrent des données via une API dédiée, l'API Maddo. Les routes de parcoursup sont uniquement disponibles sur l'API il n'est alors pas possible de changer l'endroit où pointe la gateway. 

## 🌳 Proposition

Ajouter les routes parcoursup sur l'API Maddo. 

## 🐝 Remarques

Nous avons copié le fichier de test pour montrer que les routes sont
encore disponibles dans l'API. Après la migration, elles pourront ne plus être importées dans l'API.

## 🤧 Pour tester

Récupérer un token 
```shell
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11945.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursup&client_secret=parcoursup-secret-de-trente-deux-caracteres&scope=parcoursup' | jq -r .access_token)
```

Appeler une des routes dédiées : 
```shell
curl -X POST https://pix-api-maddo-review-pr11945.osc-fr1.scalingo.io/api/application/parcoursup/certification/search -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" -d '{ "ine": "123456789AB"}'
```
