### PR TITLE
[FEATURE] ajoute la route pour récupérer les niveaux par sujet et competence (Pix-17023)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -23,6 +23,7 @@ import * as organizationRepository from '../../../../shared/infrastructure/repos
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
+import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
@@ -42,6 +43,7 @@ import { participantResultsSharedRepository } from '../../infrastructure/reposit
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
 import * as poleEmploiSendingRepository from '../../infrastructure/repositories/pole-emploi-sending-repository.js';
+
 /**
  * @typedef { import ('../../../../shared/infrastructure/repositories/area-repository.js')} AreaRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/assessment-repository.js')} AssessmentRepository
@@ -60,7 +62,8 @@ import * as poleEmploiSendingRepository from '../../infrastructure/repositories/
  * @typedef { import ('../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js')} CompareStagesAndAcquiredStages
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/competence-evaluation-repository.js')} CompetenceEvaluationRepository
  * @typedef { import ('../../../../shared/infrastructure/repositories/competence-repository.js')} CompetenceRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
+ * @typedef { import ('../../../../shared/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
+ * @typedef { import ('../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js')} KnowledgeElementSnapshotRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/organization-learner-repository.js')} OrganizationLearnerRepository
  * @typedef { import ('../../infrastructure/repositories/participant-result-repository.js')} ParticipantResultRepository
@@ -106,6 +109,7 @@ const dependencies = {
   competenceEvaluationRepository,
   competenceRepository,
   knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
+  knowledgeElementSnapshotRepository,
   learningContentRepository,
   organizationLearnerRepository,
   organizationRepository,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-analysis-repository.js
@@ -1,14 +1,12 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING } from '../../../../../src/shared/infrastructure/constants.js';
 import { CampaignAnalysis } from '../../../campaign/domain/read-models/CampaignAnalysis.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
-import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
-const { SHARED } = CampaignParticipationStatuses;
+import * as campaignParticipationRepository from './campaign-participation-repository.js';
 
 const getCampaignAnalysis = async function (campaignId, campaignLearningContent, tutorials) {
-  const campaignParticipationIds = await _getSharedParticipationsId(campaignId);
+  const campaignParticipationIds = await campaignParticipationRepository.getSharedParticipationIds(campaignId);
   const campaignParticipationIdsChunks = _.chunk(campaignParticipationIds, CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
   const participantCount = campaignParticipationIds.length;
 
@@ -58,11 +56,3 @@ const getCampaignParticipationAnalysis = async function (
 };
 
 export { getCampaignAnalysis, getCampaignParticipationAnalysis };
-
-async function _getSharedParticipationsId(campaignId) {
-  const results = await knex('campaign-participations')
-    .pluck('id')
-    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
-
-  return results;
-}

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -13,7 +13,7 @@ import { KnowledgeElementCollection } from '../../../shared/domain/models/Knowle
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
 
-const { TO_SHARE } = CampaignParticipationStatuses;
+const { TO_SHARE, SHARED } = CampaignParticipationStatuses;
 
 const { pick } = lodash;
 
@@ -260,6 +260,15 @@ function _rowToResult(row) {
   };
 }
 
+async function getSharedParticipationIds(campaignId) {
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn('campaign-participations')
+    .pluck('id')
+    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
+
+  return results;
+}
+
 export {
   batchUpdate,
   findOneByCampaignIdAndUserId,
@@ -270,6 +279,7 @@ export {
   getCampaignParticipationsForOrganizationLearner,
   getCodeOfLastParticipationToProfilesCollectionCampaignForUser,
   getLocked,
+  getSharedParticipationIds,
   hasAssessmentParticipations,
   isRetrying,
   remove,

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -1,6 +1,7 @@
 import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as campaignAnalysisSerializer from '../../campaign-participation/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as campaignResultLevelsPerTubesAndCompetencesSerializer from '../infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import * as divisionSerializer from '../infrastructure/serializers/jsonapi/division-serializer.js';
 import * as groupSerializer from '../infrastructure/serializers/jsonapi/group-serializer.js';
 import * as presentationStepsSerializer from '../infrastructure/serializers/jsonapi/presentation-steps-serializer.js';
@@ -42,11 +43,25 @@ const getPresentationSteps = async function (
   return dependencies.presentationStepsSerializer.serialize(presentationSteps);
 };
 
+const getLevelPerTubesAndCompetences = async function (
+  request,
+  h,
+  dependencies = { campaignResultLevelsPerTubesAndCompetencesSerializer },
+) {
+  const { campaignId } = request.params;
+  const locale = extractLocaleFromRequest(request);
+  const campaignAnalysis = await usecases.getResultLevelsPerTubesAndCompetences({
+    campaignId,
+    locale,
+  });
+  return dependencies.campaignResultLevelsPerTubesAndCompetencesSerializer.serialize(campaignAnalysis);
+};
 const campaignController = {
   division,
   getAnalysis,
   getGroups,
   getPresentationSteps,
+  getLevelPerTubesAndCompetences,
 };
 
 export { campaignController };

--- a/api/src/prescription/campaign/application/campaign-route.js
+++ b/api/src/prescription/campaign/application/campaign-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { identifiersType as prescriptionIdentifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { campaignController } from './campaign-controller.js';
@@ -54,6 +55,20 @@ const register = async function (server) {
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
             "- Récupération de l'analyse de la campagne par son id",
         ],
+        tags: ['api', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{campaignId}/level-per-tubes-and-competences',
+      config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        handler: campaignController.getLevelPerTubesAndCompetences,
         tags: ['api', 'campaign'],
       },
     },

--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -1,0 +1,94 @@
+import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
+
+class CampaignResultLevelsPerTubesAndCompetences {
+  #difficultyBySkillId;
+  #tubesWithLevels;
+
+  constructor({ campaignId, learningContent, knowledgeElementsByParticipation } = {}) {
+    this.id = campaignId;
+    this.learningContent = learningContent;
+    this.knowledgeElementSnapshots = Object.values(knowledgeElementsByParticipation);
+    this.#difficultyBySkillId = learningContent.skills.reduce(
+      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
+      {},
+    );
+    this.#tubesWithLevels = this.#getTubesWithLevels(learningContent.tubes);
+  }
+
+  #getTubesWithLevels(tubes) {
+    const maxTubeLevels = tubes.map((tube) => {
+      const participationsReachedLevels = this.#computeParticipationsReachedLevelForTube(tube);
+      const meanLevel = average(participationsReachedLevels);
+
+      const maxLevel = tube.getHardestSkill().difficulty;
+
+      return {
+        id: tube.id,
+        competenceId: tube.competenceId,
+        practicalTitle: tube.practicalTitle,
+        practicalDescription: tube.practicalDescription,
+        maxLevel,
+        meanLevel,
+      };
+    });
+    return maxTubeLevels;
+  }
+
+  get levelsPerTube() {
+    return this.#tubesWithLevels;
+  }
+
+  get levelsPerCompetence() {
+    const maxCompetenceLevels = this.learningContent.competences.map((competence) => {
+      const tubes = this.#tubesWithLevels.filter((tube) => tube.competenceId === competence.id);
+      const averageTubesMaxReachableLevel = averageBy(tubes, 'maxLevel');
+      const averageTubesMeanReachedLevel = averageBy(tubes, 'meanLevel');
+
+      return {
+        id: competence.id,
+        index: competence.index,
+        name: competence.name,
+        description: competence.description,
+        maxLevel: averageTubesMaxReachableLevel,
+        meanLevel: averageTubesMeanReachedLevel,
+      };
+    });
+    return maxCompetenceLevels;
+  }
+
+  get maxReachableLevel() {
+    return averageBy(this.levelsPerTube, 'maxLevel');
+  }
+
+  get meanReachedLevel() {
+    return averageBy(this.levelsPerTube, 'meanLevel');
+  }
+
+  #computeParticipationsReachedLevelForTube(tube) {
+    const skillIdsForTube = tube.skills.map((skill) => skill.id);
+    return this.knowledgeElementSnapshots.map((knowledgeElements) =>
+      this.#computeParticipationReachedLevelForTube(skillIdsForTube, knowledgeElements),
+    );
+  }
+
+  #computeParticipationReachedLevelForTube(skillIds, knowledgeElements) {
+    const validatedKe = knowledgeElements
+      .filter((ke) => skillIds.includes(ke.skillId))
+      .filter((ke) => ke.status === KnowledgeElement.StatusType.VALIDATED);
+
+    if (validatedKe.length === 0) {
+      return 0;
+    }
+    return Math.max(...validatedKe.map((knowledgeElement) => this.#difficultyBySkillId[knowledgeElement.skillId]));
+  }
+}
+
+const averageBy = (collection, propName) => {
+  if (!propName) {
+    return collection.reduce((acc, value) => value + acc, 0) / collection.length;
+  }
+  return collection.reduce((acc, item) => acc + item[propName], 0) / collection.length;
+};
+const average = (collection) => averageBy(collection);
+
+export { CampaignResultLevelsPerTubesAndCompetences };

--- a/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
+++ b/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
@@ -1,0 +1,24 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../models/CampaignResultLevelsPerTubesAndCompetences.js';
+
+const getResultLevelsPerTubesAndCompetences = async ({
+  campaignId,
+  locale,
+  campaignParticipationRepository,
+  learningContentRepository,
+  knowledgeElementSnapshotRepository,
+}) => {
+  const campaignParticipationIds = await campaignParticipationRepository.getSharedParticipationIds(campaignId);
+
+  const knowledgeElementsByParticipation =
+    await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(campaignParticipationIds);
+
+  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
+
+  return new CampaignResultLevelsPerTubesAndCompetences({
+    campaignId,
+    learningContent,
+    knowledgeElementsByParticipation,
+  });
+};
+
+export { getResultLevelsPerTubesAndCompetences };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
@@ -1,0 +1,21 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (results) {
+  return new Serializer('campaign-result-levels-per-tubes-and-competences', {
+    attributes: ['levelsPerTube', 'levelsPerCompetence', 'maxReachableLevel', 'meanReachedLevel'],
+    levelsPerCompetence: {
+      ref: 'id',
+      includes: true,
+      attributes: ['index', 'name', 'description', 'maxLevel', 'meanLevel'],
+    },
+    levelsPerTube: {
+      ref: 'id',
+      includes: true,
+      attributes: ['competenceId', 'practicalTitle', 'practicalDescription', 'maxLevel', 'meanLevel'],
+    },
+  }).serialize(results);
+};
+
+export { serialize };

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -1,0 +1,115 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | get-result-levels-per-tubes-and-competences', function () {
+  let campaignId;
+
+  beforeEach(async function () {
+    const learningContentData = {
+      frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
+      areas: [{ id: 'recArea1', frameworkId: 'frameworkId', competenceIds: ['recCompetence1'] }],
+      competences: [
+        {
+          id: 'recCompetence1',
+          name_i18n: { fr: 'name FR Compétence 1', en: 'name EN Compétence 1' },
+          description_i18n: { fr: 'description FR Compétence 1', en: 'description EN Compétence 1' },
+          index: '1.1',
+          skillIds: ['recSkillWeb1', 'recSkillWeb2', 'recSkillUrl1', 'recSkillUrl2'],
+          areaId: 'recArea1',
+          origin: 'Pix',
+        },
+      ],
+      thematics: [],
+      tubes: [
+        {
+          id: 'recTube1',
+          name: '@tubeWeb1',
+          title: 'Title recTube1',
+          description: 'recTube1 description',
+          practicalTitle_i18n: { fr: 'Tube 1 fr title', en: 'Tube 1 en title' },
+          practicalDescription_i18n: { fr: 'recTube1 fr description', en: 'recTube1 en description' },
+          competenceId: 'recCompetence1',
+          skillIds: ['recSkillWeb1', 'recSkillWeb2'],
+        },
+      ],
+      skills: [
+        {
+          id: 'recSkillWeb1',
+          name: '@web1',
+          tubeId: 'recTube1',
+          status: 'actif',
+          level: 1,
+          competenceId: 'recCompetence1',
+        },
+      ],
+      challenges: [],
+    };
+    await databaseBuilder.factory.learningContent.build(learningContentData);
+
+    campaignId = databaseBuilder.factory.buildCampaign({
+      type: CampaignTypes.ASSESSMENT,
+    }).id;
+
+    const firstParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+    const secondParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+    learningContentData.skills.forEach((skill) => {
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: skill.id });
+    });
+
+    const user1ke1 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.VALIDATED,
+      skillId: learningContentData.skills[0].id,
+      userId: firstParticipation.userId,
+    });
+    const user2ke1 = databaseBuilder.factory.buildKnowledgeElement({
+      status: KnowledgeElement.StatusType.INVALIDATED,
+      skillId: learningContentData.skills[0].id,
+      userId: secondParticipation.userId,
+    });
+
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({
+      campaignParticipationId: firstParticipation.id,
+      snapshot: new KnowledgeElementCollection([user1ke1]).toSnapshot(),
+    });
+    databaseBuilder.factory.buildKnowledgeElementSnapshot({
+      campaignParticipationId: secondParticipation.id,
+      snapshot: new KnowledgeElementCollection([user2ke1]).toSnapshot(),
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should return a CampaignResultLevelsPerTubesAndCompetences', async function () {
+    const result = await usecases.getResultLevelsPerTubesAndCompetences({ campaignId, locale: LOCALE.FRENCH_SPOKEN });
+
+    expect(result).instanceOf(CampaignResultLevelsPerTubesAndCompetences);
+    expect(result.maxReachableLevel).to.equal(1);
+    expect(result.meanReachedLevel).to.equal(0.5);
+    expect(result.levelsPerCompetence).to.deep.equal([
+      {
+        description: 'description FR Compétence 1',
+        id: 'recCompetence1',
+        index: '1.1',
+        maxLevel: 1,
+        meanLevel: 0.5,
+        name: 'name FR Compétence 1',
+      },
+    ]);
+    expect(result.levelsPerTube).to.deep.equal([
+      {
+        competenceId: 'recCompetence1',
+        id: 'recTube1',
+        maxLevel: 1,
+        meanLevel: 0.5,
+        practicalDescription: 'recTube1 fr description',
+        practicalTitle: 'Tube 1 fr title',
+      },
+    ]);
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
@@ -99,4 +99,40 @@ describe('Unit | Application | Controller | Campaign', function () {
       expect(response).to.equal(expectedResults);
     });
   });
+
+  describe('#getLevelPerTubesAndCompetences', function () {
+    const campaignId = 1;
+    const locale = FRENCH_SPOKEN;
+    let campaignResultLevelsPerTubesAndCompetencesSerializerStub;
+
+    beforeEach(function () {
+      sinon.stub(usecases, 'getResultLevelsPerTubesAndCompetences');
+      campaignResultLevelsPerTubesAndCompetencesSerializerStub = {
+        serialize: sinon.stub(),
+      };
+    });
+
+    it('should return expected results', async function () {
+      // given
+      const resultLevels = Symbol('resultLevels');
+      const expectedResults = Symbol('results');
+      usecases.getResultLevelsPerTubesAndCompetences.withArgs({ campaignId, locale }).resolves(resultLevels);
+      campaignResultLevelsPerTubesAndCompetencesSerializerStub.serialize
+        .withArgs(resultLevels)
+        .returns(expectedResults);
+
+      const request = {
+        params: { campaignId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignController.getLevelPerTubesAndCompetences(request, hFake, {
+        campaignResultLevelsPerTubesAndCompetencesSerializer: campaignResultLevelsPerTubesAndCompetencesSerializerStub,
+      });
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-route_test.js
@@ -1,5 +1,6 @@
 import { campaignController } from '../../../../../src/prescription/campaign/application/campaign-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Router | campaign-router ', function () {
@@ -81,6 +82,42 @@ describe('Unit | Application | Router | campaign-router ', function () {
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('GET /api/campaigns/{campaignId}/level-per-tubes-and-competences', function () {
+    describe('User is not authorized to access campaign', function () {
+      it('should return 403', async function () {
+        // given
+        sinon
+          .stub(campaignController, 'getLevelPerTubesAndCompetences')
+          .callsFake((request, h) => h.response('ok').code(200));
+        sinon
+          .stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/campaigns/1/level-per-tubes-and-competences');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('Wrong campaign id', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/campaigns/wrongId/level-per-tubes-and-competences');
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -1,0 +1,182 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', function () {
+  describe('compute', function () {
+    let learningContent, keData;
+
+    beforeEach(function () {
+      const framework = domainBuilder.buildFramework({ id: 'frameworkId', name: 'frameworkName' });
+      const skill1 = domainBuilder.buildSkill({
+        id: 'recSkillWeb1',
+        tubeId: 'tube1',
+        difficulty: 1,
+      });
+      const skill2 = domainBuilder.buildSkill({
+        id: 'recSkillWeb2',
+        tubeId: 'tube1',
+        difficulty: 2,
+      });
+      const skill3 = domainBuilder.buildSkill({
+        id: 'recSkillUrl1',
+        tubeId: 'tube2',
+        difficulty: 3,
+      });
+      const skill4 = domainBuilder.buildSkill({
+        id: 'recSkillUrl2',
+        tubeId: 'tube2',
+        difficulty: 4,
+      });
+
+      const tube1 = domainBuilder.buildTube({
+        id: 'tube1',
+        competenceId: 'competence1',
+        skills: [skill1, skill2],
+        practicalTitle: 'tube 1',
+        practicalDescription: 'tube 1 description',
+      });
+      const tube2 = domainBuilder.buildTube({
+        id: 'tube2',
+        competenceId: 'competence2',
+        skills: [skill3, skill4],
+        practicalTitle: 'tube 2',
+        practicalDescription: 'tube 2 description',
+      });
+
+      const competence1 = domainBuilder.buildCompetence({
+        id: 'competence1',
+        areaId: 'recArea1',
+        tubes: [tube1],
+        name: 'compétence 1',
+        description: 'description compétence 1',
+      });
+      const competence2 = domainBuilder.buildCompetence({
+        id: 'competence2',
+        areaId: 'recArea1',
+        tubes: [tube2],
+        name: 'compétence 2',
+        description: 'description compétence 2',
+      });
+
+      const area = domainBuilder.buildArea({ id: 'recArea1', frameworkId: framework.id });
+      const thematic1 = domainBuilder.buildThematic({
+        id: 'thematic1',
+        competenceId: 'competence1',
+        tubeIds: ['tube1'],
+      });
+      const thematic2 = domainBuilder.buildThematic({
+        id: 'thematic2',
+        competenceId: 'competence2',
+        tubeIds: ['tube2'],
+      });
+      competence1.thematics = [thematic1];
+      competence2.thematics = [thematic2];
+      area.competences = [competence1, competence2];
+      framework.areas = [area];
+
+      learningContent = domainBuilder.buildLearningContent([framework]);
+
+      const user1ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillWeb1',
+        userId: 1,
+      });
+      const user1ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: 'recSkillWeb2',
+        userId: 1,
+      });
+
+      const user2ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl1',
+        userId: 2,
+      });
+
+      const user2ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl2',
+        userId: 2,
+      });
+
+      keData = {
+        participationId1: new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
+        participationId2: new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+      };
+    });
+
+    it('should get max level per tube', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+
+      expect(campaignResult.levelsPerTube).deep.equal([
+        {
+          id: 'tube1',
+          competenceId: 'competence1',
+          practicalTitle: 'tube 1',
+          practicalDescription: 'tube 1 description',
+          maxLevel: 2,
+          meanLevel: 0.5,
+        },
+        {
+          id: 'tube2',
+          competenceId: 'competence2',
+          practicalTitle: 'tube 2',
+          practicalDescription: 'tube 2 description',
+          maxLevel: 4,
+          meanLevel: 2,
+        },
+      ]);
+    });
+
+    it('should get max level per competence', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+
+      expect(campaignResult.levelsPerCompetence).deep.equal([
+        {
+          id: 'competence1',
+          index: '1.1',
+          name: 'compétence 1',
+          description: 'description compétence 1',
+          maxLevel: 2,
+          meanLevel: 0.5,
+        },
+        {
+          id: 'competence2',
+          index: '1.1',
+          name: 'compétence 2',
+          description: 'description compétence 2',
+          maxLevel: 4,
+          meanLevel: 2,
+        },
+      ]);
+    });
+
+    it('should compute the maximum reachable level', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      expect(campaignResult.maxReachableLevel).equal(3);
+    });
+
+    it('should compute the mean reached level', function () {
+      const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      expect(campaignResult.meanReachedLevel).equal(1.25);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
+import { KnowledgeElementCollection } from '../../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-competences-serializer', function () {
+  describe('#serialize', function () {
+    let learningContent, keData;
+
+    beforeEach(function () {
+      const framework = domainBuilder.buildFramework({ id: 'frameworkId', name: 'frameworkName' });
+      const skill1 = domainBuilder.buildSkill({
+        id: 'recSkillWeb1',
+        tubeId: 'tube1',
+        difficulty: 1,
+      });
+      const tube1 = domainBuilder.buildTube({
+        id: 'tube1',
+        competenceId: 'competence1',
+        skills: [skill1],
+        practicalTitle: 'tube 1',
+        practicalDescription: 'tube 1 description',
+      });
+
+      const competence1 = domainBuilder.buildCompetence({
+        id: 'competence1',
+        areaId: 'recArea1',
+        tubes: [tube1],
+        name: 'compétence 1',
+        description: 'description compétence 1',
+      });
+
+      const area = domainBuilder.buildArea({ id: 'recArea1', frameworkId: framework.id });
+      const thematic1 = domainBuilder.buildThematic({
+        id: 'thematic1',
+        competenceId: 'competence1',
+        tubeIds: ['tube1'],
+      });
+
+      competence1.thematics = [thematic1];
+      area.competences = [competence1];
+      framework.areas = [area];
+
+      learningContent = domainBuilder.buildLearningContent([framework]);
+
+      const user1ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: skill1.id,
+        userId: 1,
+      });
+
+      const user2ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: skill1.id,
+        userId: 2,
+      });
+
+      keData = {
+        participationId1: new KnowledgeElementCollection([user1ke1]).latestUniqNonResetKnowledgeElements,
+        participationId2: new KnowledgeElementCollection([user2ke1]).latestUniqNonResetKnowledgeElements,
+      };
+    });
+
+    it('should convert CampaignResultLevelPerTubesAndCompentences acquisitions statistics into JSON API data', function () {
+      const campaignId = 1;
+      const model = new CampaignResultLevelsPerTubesAndCompetences({
+        campaignId: 1,
+        learningContent,
+        knowledgeElementsByParticipation: keData,
+      });
+      const json = serializer.serialize(model);
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'campaign-result-levels-per-tubes-and-competences',
+          id: `${campaignId}`,
+          attributes: {
+            'max-reachable-level': 1,
+            'mean-reached-level': 0.5,
+          },
+          relationships: {
+            'levels-per-competence': {
+              data: [
+                {
+                  id: 'competence1',
+                  type: 'levelsPerCompetences',
+                },
+              ],
+            },
+            'levels-per-tube': {
+              data: [
+                {
+                  id: 'tube1',
+                  type: 'levelsPerTubes',
+                },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              'competence-id': 'competence1',
+              'max-level': 1,
+              'mean-level': 0.5,
+              'practical-description': 'tube 1 description',
+              'practical-title': 'tube 1',
+            },
+            id: 'tube1',
+            type: 'levelsPerTubes',
+          },
+          {
+            attributes: {
+              description: 'description compétence 1',
+              index: '1.1',
+              'max-level': 1,
+              'mean-level': 0.5,
+              name: 'compétence 1',
+            },
+            id: 'competence1',
+            type: 'levelsPerCompetences',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-learning-content.js
@@ -16,7 +16,7 @@ buildLearningContent.withSimpleContent = () => {
   const skill = buildSkill({ id: 'skillId', tubeId: 'tubeId' });
   const tube = buildTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
   const area = buildArea({ id: 'areaId', frameworkId: framework.id });
-  const competence = buildCompetence({ id: 'competenceId', area, tubes: [tube] });
+  const competence = buildCompetence({ id: 'competenceId', areaId: area.id, tubes: [tube] });
   const thematic = buildThematic({ id: 'thematicId', competenceId: 'competenceId', tubeIds: ['tubeId'] });
   competence.thematics = [thematic];
   area.competences = [competence];


### PR DESCRIPTION
## 🌸 Problème

Dans le cadre de l'épix sur la refonte de la page analyse, on a besoin d'afficher les infos de niveaux atteints / niveaux max atteignable par tubes ou compétences.

## 🌳 Proposition

On ajoute une nouvelle route qui à terme remplacera la route `/api/campaigns/{campaignId}/analyses` et qui renvois les donnée attendu (avec la description de chaque tube et compétences)

## 🐝 Remarques

Valider avec le team data que le calcul des niveaux moyen max et atteints sont ok

## 🤧 Pour tester

```
ACCESS_TOKEN=$(curl -s 'https://pix-api-review-pr11948.osc-fr1.scalingo.io/api/token' --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123&scope=pix-orga' | jq -r .access_token);

curl -H "Authorization: Bearer $ACCESS_TOKEN" https://orga-pr11948.review.pix.fr/api/campaigns/xxx/level_by_tubes_and_competences
```
