### PR TITLE
[BUGFIX] Fixer les problèmes liés à l'overflow dans le PixTable (pix-17313)

### DIFF
--- a/orga/app/components/campaign/badges.gjs
+++ b/orga/app/components/campaign/badges.gjs
@@ -13,7 +13,7 @@ const isAcquired = (badge, acquiredBadges = []) => {
 
 <template>
   {{#each @badges as |badge|}}
-    <PixTooltip @id="badge-tooltip-{{badge.id}}">
+    <PixTooltip @id="badge-tooltip-{{badge.id}}" @position="bottom">
       <:triggerElement>
         <img
           src={{badge.imageUrl}}

--- a/orga/app/components/campaign/charts/campaign-badge-acquisitions.gjs
+++ b/orga/app/components/campaign/charts/campaign-badge-acquisitions.gjs
@@ -28,7 +28,7 @@ export default class CampaignBadgeAcquisitions extends Component {
       <ul class="badge-acquisitions__list">
         {{#each this.data as |badgeAcquisition|}}
           <li class="badge-acquisitions__list-item">
-            <PixTooltip @id="badge-tooltip-{{badgeAcquisition.badge.id}}" @position="left" @isInline={{true}}>
+            <PixTooltip @id="badge-tooltip-{{badgeAcquisition.badge.id}}" position="bottom" @isInline={{true}}>
               <:triggerElement>
                 <img
                   src={{badgeAcquisition.badge.imageUrl}}

--- a/orga/app/components/campaign/results/evolution-header.gjs
+++ b/orga/app/components/campaign/results/evolution-header.gjs
@@ -1,17 +1,24 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { t } from 'ember-intl';
-
-import TooltipWithIcon from '../../ui/tooltip-with-icon';
 
 <template>
   <span class="evolution-header">
-
     {{t "pages.campaign-results.table.column.evolution"}}
-
-    <TooltipWithIcon
-      @iconName="help"
-      @content={{@tooltipContent}}
-      @ariaHiddenIcon={{true}}
-      class="tooltip-with-icon-small"
-    />
+    <PixTooltip @id="evolution-tooltip" @position="left" @isInline={{true}}>
+      <:triggerElement>
+        <PixIcon
+          @name="help"
+          @plainIcon={{true}}
+          aria-hidden="true"
+          tabindex="0"
+          aria-label={{t "components.certificability-tooltip.aria-label"}}
+          aria-describedby="evolution-tooltip"
+        />
+      </:triggerElement>
+      <:tooltip>
+        {{@tooltipContent}}
+      </:tooltip>
+    </PixTooltip>
   </span>
 </template>

--- a/orga/app/components/certificability/tooltip.gjs
+++ b/orga/app/components/certificability/tooltip.gjs
@@ -16,9 +16,13 @@ export default class Tooltip extends Component {
     return this.intl.t('components.certificability-tooltip.from-collect-notice');
   }
 
+  get position() {
+    return this.args.position ? this.args.position : 'bottom-left';
+  }
+
   <template>
     <div class="certificability-tooltip">
-      <PixTooltip @id="column-is-certifiable-informations" @position="top-left" @isWide={{true}}>
+      <PixTooltip @id="column-is-certifiable-informations" @position={{this.position}} @isWide={{true}}>
         <:triggerElement>
           <PixIcon
             @name="help"

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -59,7 +59,7 @@ function getMissionResultColor(result) {
               <div class="organization-participant__align-element">
                 {{t "pages.missions.mission.table.result.headers.step" (indexNumber index)}}
 
-                <PixTooltip @id="tooltip-{{index}}" @isInline={{true}}>
+                <PixTooltip @id="tooltip-{{index}}" @position="left" @isInline={{true}}>
                   <:triggerElement>
                     <PixIcon
                       @name="help"


### PR DESCRIPTION

## 🌸 Problème

Depuis l'intégration de PixTable dans PixOrga, les éléments flottants comme les tooltips sont tronqués.

## 🌳 Proposition

- Trop compliqué de toucher au contexte d'empilement sans toucher à tout le template
- Ember-velcro : modification du comportement de la tooltip de PixUI donc pas idéal
-> Solution retenue : revoir la position des tooltips

## 🤧 Pour tester
Vérifier que les tooltips suivantes s'affichent correctement : 
- Se connecter sur PixOrga, aller sur l'organisationPix1D et vérifier les tooltips "étape 1" / "étape 2" de la page du détail d'une mission, onglet "Résultats"
- Se connecter sur la SCO SIECLE et vérifier les tooltips de la page "Résultats" pour une campagne à badge (tooltip de la colonne "Evolution" + tooltip des badges)