### PR TITLE
[FEATURE] MaDDo Parcoursup - Utiliser les tables génériques de résultats de certif (PIX-17323)

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -43,11 +43,9 @@ class DatamartBuilder {
   async clean() {
     let rawQuery = '';
 
-    ['data_export_parcoursup_certif_result', 'data_export_parcoursup_certif_result_code_validation'].forEach(
-      (tableName) => {
-        rawQuery += `DELETE FROM ${tableName};`;
-      },
-    );
+    ['certification_results', 'sco_certification_results'].forEach((tableName) => {
+      rawQuery += `DELETE FROM ${tableName};`;
+    });
 
     try {
       await this.knex.raw(rawQuery);

--- a/api/datamart/datamart-builder/factory/build-certification-result-code-validation.js
+++ b/api/datamart/datamart-builder/factory/build-certification-result-code-validation.js
@@ -28,7 +28,7 @@ const buildCertificationResultCodeValidation = function ({
   };
 
   datamartBuffer.pushInsertable({
-    tableName: 'data_export_parcoursup_certif_result_code_validation',
+    tableName: 'certification_results',
     values,
   });
 };

--- a/api/datamart/datamart-builder/factory/build-certification-result.js
+++ b/api/datamart/datamart-builder/factory/build-certification-result.js
@@ -30,7 +30,7 @@ const buildCertificationResult = function ({
   };
 
   datamartBuffer.pushInsertable({
-    tableName: 'data_export_parcoursup_certif_result',
+    tableName: 'sco_certification_results',
     values,
   });
 

--- a/api/datamart/seeds/populate-sco-datamart.js
+++ b/api/datamart/seeds/populate-sco-datamart.js
@@ -9,7 +9,7 @@ import { chunkify } from './cases/tools.js';
 const NUMBER_OF_SEEDS = Number(process.env.DATAMART_NUMBER_OF_SEEDS) || 100;
 
 const insertScoDatamart = async (knex) => {
-  const scoDatamart = 'data_export_parcoursup_certif_result';
+  const scoDatamart = 'sco_certification_results';
 
   logger.info('Start Case 1 : INE ok');
   await chunkify({ numberOfSeeds: NUMBER_OF_SEEDS, knex, datamart: scoDatamart, generateFn: caseINEok });

--- a/api/datamart/seeds/populate-verification-code-datamart.js
+++ b/api/datamart/seeds/populate-verification-code-datamart.js
@@ -6,7 +6,7 @@ const NUMBER_OF_SEEDS = Number(process.env.DATAMART_NUMBER_OF_SEEDS) || 100;
 
 const insertGeneralPublicDatamart = async (knex) => {
   logger.info('Start Case 6 : Verification code OK');
-  const generalPublicDatamart = 'data_export_parcoursup_certif_result_code_validation';
+  const generalPublicDatamart = 'certification_results';
   await chunkify({
     numberOfSeeds: NUMBER_OF_SEEDS,
     knex,

--- a/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-parcoursup-repository.js
@@ -19,7 +19,7 @@ const getByOrganizationUAI = async ({ organizationUai, lastName, firstName, birt
 };
 
 const _getBySearchParams = async (searchParams) => {
-  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result')
+  const certificationResultDto = await datamartKnex('sco_certification_results')
     .select({
       national_student_id: 'national_student_id',
       organization_uai: 'organization_uai',
@@ -58,7 +58,7 @@ const _getBySearchParams = async (searchParams) => {
 };
 
 const getByVerificationCode = async ({ verificationCode }) => {
-  const certificationResultDto = await datamartKnex('data_export_parcoursup_certif_result_code_validation')
+  const certificationResultDto = await datamartKnex('certification_results')
     .select({
       last_name: 'last_name',
       first_name: 'first_name',


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les tables utilisées pour la mise à disposition de données de certification pour parcoursup ont des noms typés "parcoursup" alors qu'elles contiennent des données de résultat de certification génériques.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Utiliser des noms de table plus génériques.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Les 2 paires de tables sont actuellement répliquées dans le datamart pour gérer la transition.

## 🤧 Pour tester

Accéder aux données "parcoursup" via les endpoint Maddo.

Récupérer un token 
```shell
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11952.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursup&client_secret=parcoursup-secret-de-trente-deux-caracteres&scope=parcoursup' | jq -r .access_token)
```

Appeler une des routes dédiées : 
```shell
curl -X POST https://pix-api-maddo-review-pr11952.osc-fr1.scalingo.io/api/application/parcoursup/certification/search -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" -d '{ "ine": "123456789AB"}'
```

