### PR TITLE
[TECH] Migrer les feature toggles des layouts vers le nouveau système (PIX-17339)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -23,4 +23,10 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'pix-orga', 'team-prescription'],
   },
+  isPixAdminNewSidebarEnabled: {
+    description: 'Display the new sidebar for Pix Admin',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['frontend', 'pix-admin'],
+  },
 };

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -29,4 +29,10 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'pix-admin'],
   },
+  isPixAppNewLayoutEnabled: {
+    description: 'Display the new layout for Pix App',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['frontend', 'pix-app'],
+  },
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -875,11 +875,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIXAPP_NEW_LAYOUT_ENABLED=false
 
-# Enable new sidebar for Pix Admin
-# type: boolean
-# default: false
-# FT_PIX_ADMIN_NEW_SIDEBAR_ENABLED=false
-
 # =====
 # CPF
 # =====

--- a/api/sample.env
+++ b/api/sample.env
@@ -870,11 +870,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_SELF_ACCOUNT_DELETION=false
 
-# Enable new PixApp layout
-# type: boolean
-# default: false
-# FT_PIXAPP_NEW_LAYOUT_ENABLED=false
-
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -303,7 +303,6 @@ const configuration = (function () {
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
-      isPixAdminNewSidebarEnabled: toBoolean(process.env.FT_PIX_ADMIN_NEW_SIDEBAR_ENABLED),
       isPixAppNewLayoutEnabled: toBoolean(process.env.FT_PIXAPP_NEW_LAYOUT_ENABLED),
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
       isSelfAccountDeletionEnabled: toBoolean(process.env.FT_SELF_ACCOUNT_DELETION),

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -303,7 +303,6 @@ const configuration = (function () {
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
-      isPixAppNewLayoutEnabled: toBoolean(process.env.FT_PIXAPP_NEW_LAYOUT_ENABLED),
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
       isSelfAccountDeletionEnabled: toBoolean(process.env.FT_SELF_ACCOUNT_DELETION),
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),


### PR DESCRIPTION
## 🌸 Problème

Nos feature toggles pour le layout de Pix admin et de Pix app sont sous l'ancienne version. Or, on ne sait pas trop quand on pourra les retirer.

## 🌳 Proposition

Passer les 2 feature toggles sous le nouveau système.

## 🐝 Remarques

Cette PR a 2 objectifs, le passage des 2 ft au nouveau mode et une estimation du temps nécessaire à ce passage.

## 🤧 Pour tester

- Prendre une grande inspiration (ça va être long),
#### Pour Pix app ✅ 
- Exécuter la commande pour obtenir la valeur actuelle du feature toggle:
```shell
scalingo -a pix-api-review-pr11953 run npm run toggles -- --key isPixAppNewLayoutEnabled
```
- Constater que le feature toggle est setté à false,
- Se rendre sur Pix app et se connecter avec le compte superadmin@example.net,
- Constater qu'il s'agit de l'ancien layout,
- Modifier le feature toggle sur true avec cette commande:
```shell
scalingo -a pix-api-review-pr11953 run npm run toggles -- --key isPixAppNewLayoutEnabled --value true
```
- Raffraîchir la page de Pix app,
- Constater que la nouvelle nav apparaît.
#### Pour Pix admin ✅ 
- Exécuter la commande pour obtenir la valeur actuelle du feature toggle:
```shell
scalingo -a pix-api-review-pr11953 run npm run toggles -- --key isPixAdminNewSidebarEnabled
```
- Constater que le feature toggle est setté à false,
- Se rendre sur Pix admin et se connecter avec le compte superadmin@example.net,
- Constater qu'il s'agit de l'ancien layout,
- Modifier le feature toggle sur true avec cette commande:
```shell
scalingo -a pix-api-review-pr11953 run npm run toggles -- --key isPixAdminNewSidebarEnabled --value true
```
- Raffraîchir la page de Pix admin,
- Constater que la nouvelle nav apparaît.