### PR TITLE
[BUGFIX] Réparer les réplications parcoursup

### DIFF
--- a/api/datamart/migrations/20250403125002_remove_useless_columns.js
+++ b/api/datamart/migrations/20250403125002_remove_useless_columns.js
@@ -1,0 +1,31 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable('data_export_parcoursup_certif_result_code_validation', function (table) {
+    table.dropColumn('national_student_id');
+    table.dropColumn('organization_uai');
+  });
+
+  await knex.schema.alterTable('certification_results', function (table) {
+    table.dropColumn('national_student_id');
+    table.dropColumn('organization_uai');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable('data_export_parcoursup_certif_result_code_validation', function (table) {
+    table.string('national_student_id');
+  });
+
+  await knex.schema.alterTable('certification_results', function (table) {
+    table.string('national_student_id');
+  });
+};
+
+export { down, up };

--- a/api/datamart/seeds/cases/verification-code/verification-code-only.js
+++ b/api/datamart/seeds/cases/verification-code/verification-code-only.js
@@ -22,8 +22,6 @@ export default function () {
   const studentBase = {
     certification_courses_id: generateCertifCourseId(),
     certification_code_verification: generateVerificationCode(),
-    organization_uai: null,
-    national_student_id: null,
     last_name: faker.person.lastName(),
     first_name: generateFirstName(),
     birthdate: getFormattedBirthdate(),

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -7,7 +7,6 @@ export const replications = [
     from: ({ datawarehouseKnex }) => {
       return datawarehouseKnex('data_export_parcoursup_certif_result').select(
         'national_student_id',
-        'national_student_id',
         'organization_uai',
         'last_name',
         'first_name',
@@ -16,7 +15,6 @@ export const replications = [
         'pix_score',
         'certification_date',
         'competence_level',
-        'organization_uai',
         'competence_name',
         'competence_code',
         'area_name',
@@ -34,7 +32,8 @@ export const replications = [
     },
     from: ({ datawarehouseKnex }) => {
       return datawarehouseKnex('data_export_parcoursup_certif_result').select(
-        'certification_code_verification',
+        'national_student_id',
+        'organization_uai',
         'last_name',
         'first_name',
         'birthdate',
@@ -42,13 +41,10 @@ export const replications = [
         'pix_score',
         'certification_date',
         'competence_level',
-        'certification_code_verification',
         'competence_name',
         'competence_code',
         'area_name',
         'certification_courses_id',
-        'national_student_id',
-        'organization_uai',
       );
     },
     to: ({ datamartKnex }, chunk) => {
@@ -62,9 +58,7 @@ export const replications = [
     },
     from: ({ datawarehouseKnex }) => {
       return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select(
-        'national_student_id',
-        'national_student_id',
-        'organization_uai',
+        'certification_code_verification',
         'last_name',
         'first_name',
         'birthdate',
@@ -72,7 +66,6 @@ export const replications = [
         'pix_score',
         'certification_date',
         'competence_level',
-        'organization_uai',
         'competence_name',
         'competence_code',
         'area_name',
@@ -98,13 +91,10 @@ export const replications = [
         'pix_score',
         'certification_date',
         'competence_level',
-        'certification_code_verification',
         'competence_name',
         'competence_code',
         'area_name',
         'certification_courses_id',
-        'national_student_id',
-        'organization_uai',
       );
     },
     to: ({ datamartKnex }, chunk) => {


### PR DESCRIPTION
## 🌸 Problème

Les réplications parcoursup ne passent pas pour plusieurs raisons : 
- le schéma que nous avons dans le datamart a une colonne en plus 
- et dû à cette erreur de schéma, nous sélectionnons une colonne en trop dans le datawarehouse dans les réplications

## 🌳 Proposition

Nous corrigeons les deux erreurs commises. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Passer la variable PG_BOSS_CONNECTION à 1 et redémarrer le container web

Récupérer un token 
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr11957.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer les réplications
```
for replicationName in "sco_certification_results" "certification_results" "data_export_parcoursup_certif_result" "data_export_parcoursup_certif_result_code_validation"; do; curl -X POST "https://pix-api-maddo-review-pr11957.osc-fr1.scalingo.io/api/replications/$replicationName" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"; done
```