### PR TITLE
[FEATURE] Créer le FT pour le nouveau certificat en ligne V3 (PIX-17328).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -39,6 +39,6 @@ export default {
     description: 'Used to enable new certification page for V3',
     type: 'boolean',
     defaultValue: false,
-    tags: ['frontend', 'team-certification'],
+    tags: ['frontend', 'pix-app', 'team-certification'],
   },
 };

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -35,4 +35,10 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'pix-app'],
   },
+  isV3CertificationPageEnabled: {
+    description: 'Used to enable new certification page for V3',
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['frontend', 'team-certification'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -39,6 +39,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'show-experimental-missions': false,
             'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,
+            'is-v3-certification-page-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## 🌸 Problème

Un nouveau certificat en ligne, pour les v3, va être implémenter. Il ne faut pas que ce chantier soit visible par les utilisateurs.

## 🌳 Proposition

Créer un FT (back + front)

## 🤧 Pour tester

tester sur la RA, la présence du `is-v3-certification-page-enabled` à true dans la console /feature-toggles

commande => `npm run toggles -- --key=isV3CertificationPageEnabled --value=true`