### PR TITLE
[TECH]  ajoute une contrainte d'unicité pour `campaignParticipationId` sur `knowledge-element-snapshot` (pix-17358)

### DIFF
--- a/api/db/migrations/20250403142506_add-campaign-participation-id-unicity-constraint-on-snapshot.js
+++ b/api/db/migrations/20250403142506_add-campaign-participation-id-unicity-constraint-on-snapshot.js
@@ -1,0 +1,40 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+const COLUMN_NAME = 'campaignParticipationId';
+const CONSTRAINT_NAME = 'one_snapshot_by_campaignParticipationId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  const result = await knex.raw(
+    `select constraint_name
+                   from information_schema.constraint_column_usage
+                   where table_name = :tableName  and constraint_name = :constraintName`,
+    {
+      tableName: TABLE_NAME,
+      constraintName: CONSTRAINT_NAME,
+    },
+  );
+
+  if (result.rowCount === 1) {
+    return;
+  }
+  await knex.raw('ALTER TABLE :tableName: ADD CONSTRAINT :constraintName: UNIQUE (:columnName:)', {
+    tableName: TABLE_NAME,
+    constraintName: CONSTRAINT_NAME,
+    columnName: COLUMN_NAME,
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropUnique(COLUMN_NAME, CONSTRAINT_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Il existe des fois où un snashot peut être créer 2 fois pour la même participation.

## 🌳 Proposition

On ajoute une contrainte d'unicité pour éviter cela
## 🐝 Remarques

Cette contrainte a été déjà ajouté en prod, d’où la vérification de son existance dans le up

## 🤧 Pour tester

- se connecter sur scalingo 
- lancer la commande `npm run db:rollback:latest` pour supprimer la contrainte
- lancer le script d'ajout de contrainte 
```bash
node src/prescription/scripts/add-unicity-constraint-knwoledge-element-snapshots.js --dryRun false
``` 
- lancer la commande `npm run db:migrate` pour jouer la contrainte
