### PR TITLE
[TECH] Supprimer les colones userId et snappedAt de knowledge-element-snapshots (PIX-17212)

### DIFF
--- a/api/db/migrations/20250404132619_remove-userId-and-snappedAt-columns-from-knowledge-element-snapshots-table.js
+++ b/api/db/migrations/20250404132619_remove-userId-and-snappedAt-columns-from-knowledge-element-snapshots-table.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+const COLUMN_NAMES = ['userId', 'snappedAt'];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    COLUMN_NAMES.forEach((columnName) => {
+      table.dropColumn(columnName);
+    });
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAMES[0]);
+    table.dateTime(COLUMN_NAMES[1]);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Dans la pr #11965 on a cessé d'utiliser userId et snappedAt dans la table knowledge-element-snapshots. On a donc plus besoin de ces colones.

## 🌳 Proposition

Créer une migration pour retirer les 2 colones.

## 🐝 Remarques

Cette pr ne doit passer qu'une fois que l'autre sera mergée.

## 🤧 Pour tester
- Se connecter à la ra:
```shell
scalingo -a pix-api-review-pr11970 psql-console
```
- Obtenir le schema de la table knowledge-element-snapshots et constater que les colones userId et snappedAt n'y sont plus,
```sql
\d "knowledge-element-snapshots";
- Rollback la migration dans un autre onglet de terminal:
```shell
scalingo -a pix-api-review-pr11970 run npm run db:rollback:latest
```
- Réexécuter la commande en sql et constater que userId et snappedAt sont de retour, le premier un nombre, le second une date.