### PR TITLE
[TECH] Modifier le lien de documentation dans l'espace surveillant sur Pix Certif (PIX-17385).

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -79,7 +79,7 @@ export default class Url extends Service {
   }
 
   get invigilatorDocumentationUrl() {
-    return 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f';
+    return 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX';
   }
 
   #isFrenchSpoken() {

--- a/certif/tests/integration/components/session-supervising/header-test.js
+++ b/certif/tests/integration/components/session-supervising/header-test.js
@@ -179,6 +179,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
           name: 'Documentation sur la gestion des signalements Ouverture dans une nouvelle fenêtre',
         }),
       )
-      .hasAttribute('href', 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');
+      .hasAttribute('href', 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX');
   });
 });

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -293,7 +293,7 @@ module('Unit | Service | url', function (hooks) {
       const invigilatorDocumentationUrl = service.invigilatorDocumentationUrl;
 
       // then
-      assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/S5LHayrjbM4Zn5f');
+      assert.strictEqual(invigilatorDocumentationUrl, 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX');
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

Sur Pix Certif, dans l'espace surveillant, une url dans un encart d'information donne accès à une documentation pour le surveillant. Cette url est cassé, il faut la remplacer.

## 🌳 Proposition

Modifier l'url par celle donnée par le métier

## 🤧 Pour tester
- se connecter sur Pix Certif
- Aller dans l'espace surveillant
- cliquer sur le lien
- constater que l'on arrive bien sur le doc