### PR TITLE
[FEATURE] Suppression du détail sur les raisons d'un échec d'authentification

### DIFF
--- a/api/src/authorization/domain/errors.js
+++ b/api/src/authorization/domain/errors.js
@@ -8,10 +8,4 @@ class AdminMemberError extends DomainError {
   }
 }
 
-class ApplicationWithInvalidClientSecretError extends DomainError {
-  constructor(message = 'The client secret is invalid.') {
-    super(message);
-  }
-}
-
-export { AdminMemberError, ApplicationWithInvalidClientSecretError };
+export { AdminMemberError };

--- a/api/src/identity-access-management/domain/usecases/register-lti-platform.js
+++ b/api/src/identity-access-management/domain/usecases/register-lti-platform.js
@@ -4,7 +4,7 @@ import { config } from '../../../shared/config.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { InvalidLtiPlatformRegistrationError } from '../errors.js';
 
-const logger = child('iam:lti', { event: SCOPES.LTI });
+const logger = child('iam:lti', { event: SCOPES.IAM });
 
 function ltiMessage(type) {
   return Joi.object({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -223,18 +223,14 @@ function _mapToHttpError(error) {
     return new HttpErrors.ServiceUnavailableError(error.message);
   }
 
-  if (error instanceof SharedDomainErrors.ApplicationWithInvalidClientIdError) {
-    return new HttpErrors.UnauthorizedError('The client ID is invalid.');
-  }
-
   if (error instanceof SharedDomainErrors.CertificationCandidatesError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
   if (error instanceof SharedDomainErrors.AuthenticationMethodAlreadyExistsError) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
-  if (error instanceof SharedDomainErrors.ApplicationWithInvalidClientSecretError) {
-    return new HttpErrors.UnauthorizedError('The client secret is invalid.');
+  if (error instanceof SharedDomainErrors.ApplicationWithInvalidCredentialsError) {
+    return new HttpErrors.UnauthorizedError('The client ID and/or secret are invalid.');
   }
   if (error instanceof SharedDomainErrors.MissingAttributesError) {
     return new HttpErrors.UnprocessableEntityError(error.message);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -572,14 +572,8 @@ class AlreadyExistingMembershipError extends DomainError {
   }
 }
 
-class ApplicationWithInvalidClientIdError extends DomainError {
+class ApplicationWithInvalidCredentialsError extends DomainError {
   constructor(message = 'The client ID or secret are invalid.') {
-    super(message);
-  }
-}
-
-class ApplicationWithInvalidClientSecretError extends DomainError {
-  constructor(message = 'The client secret is invalid.') {
     super(message);
   }
 }
@@ -1031,8 +1025,7 @@ export {
   AlreadyRegisteredUsernameError,
   AlreadySharedCampaignParticipationError,
   ApplicationScopeNotAllowedError,
-  ApplicationWithInvalidClientIdError,
-  ApplicationWithInvalidClientSecretError,
+  ApplicationWithInvalidCredentialsError,
   AssessmentEndedError,
   AssessmentNotCompletedError,
   AssessmentResultNotCreatedError,

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -48,7 +48,7 @@ export function child(section, bindings, options) {
 
 export const SCOPES = {
   LEARNING_CONTENT: 'learningcontent',
-  LTI: 'lti',
+  IAM: 'iam',
 };
 
 function messageFormatCompact(log, messageKey, _logLevel, { colors }) {

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -565,7 +565,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       // then
       expect(response.result.errors[0]).to.deep.equal({
         title: 'Unauthorized',
-        detail: 'The client ID is invalid.',
+        detail: 'The client ID and/or secret are invalid.',
         status: '401',
       });
     });
@@ -585,7 +585,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       // then
       expect(response.result.errors[0]).to.deep.equal({
         title: 'Unauthorized',
-        detail: 'The client secret is invalid.',
+        detail: 'The client ID and/or secret are invalid.',
         status: '401',
       });
     });

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-application_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-application_test.js
@@ -3,8 +3,7 @@ import { authenticateApplication } from '../../../../../src/identity-access-mana
 import { config } from '../../../../../src/shared/config.js';
 import {
   ApplicationScopeNotAllowedError,
-  ApplicationWithInvalidClientIdError,
-  ApplicationWithInvalidClientSecretError,
+  ApplicationWithInvalidCredentialsError,
 } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
@@ -23,7 +22,7 @@ describe('Unit | Usecase | authenticate-application', function () {
 
       const err = await catchErr(authenticateApplication)({ ...payload, clientApplicationRepository });
 
-      expect(err).to.be.instanceOf(ApplicationWithInvalidClientIdError);
+      expect(err).to.be.instanceOf(ApplicationWithInvalidCredentialsError);
     });
   });
 
@@ -54,7 +53,7 @@ describe('Unit | Usecase | authenticate-application', function () {
 
         const err = await catchErr(authenticateApplication)({ ...payload, clientApplicationRepository, cryptoService });
 
-        expect(err).to.be.instanceOf(ApplicationWithInvalidClientSecretError);
+        expect(err).to.be.instanceOf(ApplicationWithInvalidCredentialsError);
       });
     });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -692,20 +692,12 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Erreur, vous devez changer votre mot de passe.');
     });
 
-    it('responds Unauthorized when a ApplicationWithInvalidClientSecretError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.ApplicationWithInvalidClientSecretError());
+    it('responds Unauthorized when a ApplicationWithInvalidCredentialsError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.ApplicationWithInvalidCredentialsError());
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
-      expect(responseDetail(response)).to.equal('The client secret is invalid.');
-    });
-
-    it('responds Unauthorized when a ApplicationWithInvalidClientIdError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.ApplicationWithInvalidClientIdError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
-      expect(responseDetail(response)).to.equal('The client ID is invalid.');
+      expect(responseDetail(response)).to.equal('The client ID and/or secret are invalid.');
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
2 erreurs différentes sont retournées par l'authentification des applications en cas d'échec. Ces erreurs indiquent s'il s'agit d'un client inconnu, ou d'un mot de passe erroné.
Retourner ces informations est une mauvaise pratique de sécurité, car elles peuvent être exploitées par un attaquant pour craquer des comptes utilisateurs.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Retourner une erreur générique en cas d'erreur d'authentification.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Le détail de l'erreur est cependant loggué pour permettre d'aider les partenaires en cas de problèmes d'authentification.

## 🤧 Pour tester

Activer les logs.

### Erreurs d'authentification

Echouer une authentification applicative avec un clientId inconnu : 

```
curl -X 'POST' \
  'https://api-pr11974.review.pix.fr/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursu&client_secret=bidule&scope=parcoursup'
```

-> L'erreur retournée est générique (401).
-> Un log indique qu'une authentification a échoué pour le clientId `parcoursu`

Echouer une authentification applicative avec un mot de passe erroné : 

```
curl -X 'POST' \
  'https://api-pr11974.review.pix.fr/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursup&client_secret=bad-password&scope=parcoursup'
```

-> L'erreur retournée est générique (401).
-> Un log indique qu'une authentification a échoué pour le clientId `parcoursup` car le mot de passe était erroné.

### Non régression

Echouer une authentification applicative avec un scope inadapté :

```
curl -X 'POST' \
  'https://api-pr11974.review.pix.fr/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursup&client_secret=parcoursup-secret-de-trente-deux-caracteres&scope=not-allowed-scope'
```

-> L'erreur retournée indique le scope non autorisé (403).

Réussir une authentification cliente :
```
curl -X 'POST' \
  'https://api-pr11974.review.pix.fr/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=parcoursup&client_secret=parcoursup-secret-de-trente-deux-caracteres&scope=parcoursup'
```

Un token d'authentification est bien retourné.

