### PR TITLE
[TECH] Ne plus demander de reviews de devcomp à la modification du référentiel (PIX-17006)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,17 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
-/api/src/devcomp/ @1024pix/team-devcomp
+/api/src/devcomp/application/ @1024pix/team-devcomp
+/api/src/devcomp/domain/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/conversion/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/learning-content/samples/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/learning-content/.gitignore @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/datasources/learning-content/readme.md @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/factories/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/repositories/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/serializers/ @1024pix/team-devcomp
+/api/src/devcomp/infrastructure/utils/ @1024pix/team-devcomp
+/api/src/devcomp/routes.js @1024pix/team-devcomp
 /api/tests/devcomp/ @1024pix/team-devcomp
 
 /mon-pix/app/components/module/ @1024pix/team-devcomp


### PR DESCRIPTION
## 🌸 Problème

Lorsqu'on fait une modification dans le référentiel de devcomp, une review est automatiquement demandée à l'équipe, ce qui n'est pas toujours nécessaire.

## 🌳 Proposition

Modifier le code owner pour inclure uniquement les dossiers nécessaires et le bac à sable.

## 🐝 Remarques

Peut-on écrire de manière plus rapide?