### PR TITLE
[FEATURE] Ajouter le champ moduleId au script get-modules-csv (PIX-17219)

### DIFF
--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -8,6 +8,7 @@ export async function getModulesListAsCsv(modules) {
     data: modules,
     delimiter: '\t',
     fileHeaders: [
+      { label: 'ModuleId', value: 'id' },
       { label: 'ModuleSlug', value: 'slug' },
       { label: 'ModuleTitle', value: 'title' },
       { label: 'ModuleLevel', value: 'details.level' },

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -409,7 +409,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     // Then
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
-      .equal(`\ufeff"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
-"bac-a-sable"\t"Bac à sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
+      .equal(`\ufeff"ModuleId"\t"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Bac à sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
   });
 });

--- a/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
@@ -43,7 +43,7 @@ describe('Unit | Scripts | Get Modules as CSV', function () {
       // when
       const result = _getTotalElementsCount(grains);
 
-      //then
+      // then
       expect(result).to.equal(3);
     });
 
@@ -82,7 +82,7 @@ describe('Unit | Scripts | Get Modules as CSV', function () {
       // when
       const result = _getTotalElementsCount(grains);
 
-      //then
+      // then
       expect(result).to.equal(2);
     });
 


### PR DESCRIPTION
## 🌸 Problème

On va utiliser le champ moduleId et on en a besoin dans le cadre de ce script.

## 🌳 Proposition

Ajouter ce champ aux colones dans le script.

## 🐝 Remarques

Modifications minimalistes dans le teste unitaire pour rajouter des espaces pour certains then.

## 🤧 Pour tester

- Lancer le script depuis l'api:
```shell
scalingo -a pix-api-review-pr11977 run node scripts/modulix/get-modules-csv.js
```
- Constater que la colone moduleId est présente.