### PR TITLE
[TECH] Corrige un test sur PixOrga qui casse en local et pas sur la CI.

### DIFF
--- a/orga/tests/integration/components/participant/assessment/results-test.js
+++ b/orga/tests/integration/components/participant/assessment/results-test.js
@@ -43,6 +43,7 @@ module('Integration | Component | Participant::Assessment::Results', function (h
 
     // then
     assert.ok(screen.getByRole('cell', { name: 'Compétence 1' }));
-    assert.ok(screen.getByRole('cell', { name: /50%/ }));
+    // For some reason getByRole does not work locally but is ok in CI
+    assert.ok(screen.getAllByText('50%')[0]);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Il y a un test d'intégration sur le composant ParticipantAssessmentResults qui casse systématiquement.

## 🌳 Proposition

Faire passer le test en local.

## 🐝 Remarques

En cherchant dans la base de code, j'ai trouvé d'autres commentaires qui explique avoir rencontré le même genre de problème avec &nbsp;. Je n'ai pas trouvé de lien vers une source spécifique.

## 🤧 Pour tester

Récupérer la branche en local et vérifier que les tests du composant sont passants 🍏 
