### PR TITLE
[FEATURE] Ajouter un script de normalisation suite au passage de la limite de blocage de 50 à 30 (PIX-16105)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -780,8 +780,8 @@ TEST_REDIS_URL=redis://localhost:6379
 # Default number of failure before the user is blocked
 # presence: optional
 # type: number
-# default: 50
-# LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=50
+# default: 30
+# LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=30
 
 # Disconnection duration after which a warning email is sent
 # presence: optional

--- a/api/src/identity-access-management/scripts/normalize-more-than-30-failures-blocked-users.script.js
+++ b/api/src/identity-access-management/scripts/normalize-more-than-30-failures-blocked-users.script.js
@@ -1,0 +1,28 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+
+const BLOCKING_LIMIT_FAILURE_COUNT = 30;
+const USER_LOGINS_TABLE_NAME = 'user-logins';
+
+export class NormalizeMoreThan30failuresBlockedUsersScript extends Script {
+  constructor() {
+    super({
+      description: 'This script normalizes user-logins records wrt the 30 failures updated blocking limit.',
+      permanent: false,
+    });
+  }
+  async handle({ logger }) {
+    const updatedUserLoginIds = await knex(USER_LOGINS_TABLE_NAME)
+      .where('failureCount', '>=', BLOCKING_LIMIT_FAILURE_COUNT)
+      .update({
+        blockedAt: new Date(),
+        failureCount: BLOCKING_LIMIT_FAILURE_COUNT,
+      })
+      .returning('id');
+
+    logger.info(`user-logins updated records: ${updatedUserLoginIds.length}`);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, NormalizeMoreThan30failuresBlockedUsersScript);


### PR DESCRIPTION
## 🌸 Problème

Suite à la décision de bloquer un compte définitivement après `30` tentatives, pour avoir des valeurs cohérentes, on doit normaliser le comptes Pix dont les tentatives sont au-dessus de `30` (inclus). 

## 🌳 Proposition

Les enregistrements de `user-logins` à normaliser sont ceux pour lesquels `failureCount >= 30`.

Pour ces enregistrements  il faut : 

* ajouter une date `blockedAt`
* modifier le `failureCount` à `30`

## 🐝 Remarques

Cette PR contient un petit commit sur `api/sample.env` pour être cohérent avec le fichier `api/src/shared/config.js`.

## 🤧 Pour tester

1. S'organiser pour disposer d'enregistrements avec `failureCount >= 30`. Exemple de commandes SQL pour mettre à jour des enregistrements existants (remplacer les `id` de l'exemple par des `id` de `user-logins` existants) : 
   ```sql
   update "user-logins" set "failureCount"=30 where id in (101999, 104669);
   update "user-logins" set "failureCount"=35 where id in (101773);
   update "user-logins" set "failureCount"=50 where id in (102668, 104668);
   ```

2. Lancer le script : 
   ```shell
   node src/identity-access-management/scripts/normalize-more-than-30-failures-blocked-users.script.js
   ```

3. Vérifier que **tous ces enregistrements avec `failureCount >= 30`** ont 
   * une date `blockedAt` correspond au moment de l'exécution du script
   * un `failureCount` à la valeur `30`
