### PR TITLE
[BUGFIX] Augmentation du délai maximum du job de réplication (MADDO).

### DIFF
--- a/api/src/maddo/application/jobs/replication-job-controller.js
+++ b/api/src/maddo/application/jobs/replication-job-controller.js
@@ -1,13 +1,14 @@
 import { knex as datamartKnex } from '../../../../datamart/knex-database-connection.js';
 import { knex as datawarehouseKnex } from '../../../../datawarehouse/knex-database-connection.js';
 import { JobController, JobGroup } from '../../../shared/application/jobs/job-controller.js';
+import { JobExpireIn } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ReplicationJob } from '../../domain/models/ReplicationJob.js';
 import { extractTransformAndLoadData } from '../../domain/usecases/extract-transform-and-load-data.js';
 import * as replicationRepository from '../../infrastructure/repositories/replication-repository.js';
 
 export class ReplicationJobController extends JobController {
   constructor() {
-    super(ReplicationJob.name, { jobGroup: JobGroup.MADDO });
+    super(ReplicationJob.name, { jobGroup: JobGroup.MADDO, expireIn: JobExpireIn.FOUR_HOURS });
   }
 
   async handle({


### PR DESCRIPTION
## 🌸 Problème

Le job de réplication de données entre le datawarehouse et le datamart prend plus de 15 minutes (qui est le temps maximum par défaut).

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌳 Proposition

En attendant de savoir comment traiter proprement l'arrêt du job qui dépasse le temps imparti, on fixe la durée maximum à 4h afin de connaitre la durée d'un job en succès.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

A venir.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
