### PR TITLE
[FEATURE] Modifier le wording du lien pour interpréter les résultats de la certification sur Pix App (PIX-17380).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -633,7 +633,7 @@
       "issued-on": "Delivered on",
       "jury-info": "Notes from the examining body are not displayed on the verification page of your certificate.",
       "jury-title": "Notes from the examining body",
-      "learn-about-certification-results": "Learn more about my Pix Certification results",
+      "learn-about-certification-results": "How to interpret the results?",
       "professionalizing-warning": "The Pix certificate is recognised as professionalising by France Compétences upon reaching a minimum score of 120 pix.",
       "title": "Pix Certificate",
       "verification-code": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -643,7 +643,7 @@
         "title": "Código de comprobación",
         "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
       },
-      "learn-about-certification-results": "Comprender mis resultados de certificación Pix"
+      "learn-about-certification-results": "¿Cómo interpretar los resultados?"
     },
     "certification-ender": {
       "candidate": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -633,7 +633,7 @@
       "issued-on": "Délivré le",
       "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
       "jury-title": "Observations du jury",
-      "learn-about-certification-results": "Comprendre mes résultats de Certification Pix",
+      "learn-about-certification-results": "Comment interpréter les résultats ?",
       "professionalizing-warning": "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix",
       "title": "Certificat Pix",
       "verification-code": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -643,7 +643,7 @@
         "title": "Verificatie code",
         "tooltip": "Geef deze code om een derde partij de echtheid van je certificaat te laten controleren"
       },
-      "learn-about-certification-results": "Inzicht in mijn Pix-certificeringsresultaten"
+      "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?"
     },
     "certification-ender": {
       "candidate": {


### PR DESCRIPTION
## 🌸 Problème

Le lien pour comprendre les résultats de la nouvelle certification est disponible sur deux pages sur Pix App : 
- la page du candidat, lorsqu'il est connecté sur son compte)
- la page de partage d'un certificat, après avoir donné le code de vérification

Le label de ce lien est le suivant : "Comprendre mes résultats de Certification Pix"

Le "mes résultats" n'est pas adapté lorsqu'on est sur la page de partage du certificat, car l'utilisateur une personne autre que le candidat.

## 🌳 Proposition

Modifier le wording pour du neutre.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
