### PR TITLE
[FEATURE] Assurer l'intégrité des données enregistrées côté Model (PIX-17157)

### DIFF
--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -24,6 +24,12 @@ class PassageEventInstantiationError extends TypeError {
   }
 }
 
+class PassageEventWithElementInstantiationError extends TypeError {
+  constructor(message = 'A passage element event cannot be instantiated directly') {
+    super(message);
+  }
+}
+
 class PassageDoesNotExistError extends DomainError {
   constructor(message = 'The passage does not exist') {
     super(message);
@@ -48,6 +54,7 @@ export {
   ModuleInstantiationError,
   PassageDoesNotExistError,
   PassageEventInstantiationError,
+  PassageEventWithElementInstantiationError,
   PassageTerminatedError,
   UserNotAuthorizedToFindTrainings,
 };

--- a/api/src/devcomp/domain/models/passage-events/PassageEvent.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEvent.js
@@ -1,3 +1,4 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageEventInstantiationError } from '../../errors.js';
 
@@ -24,8 +25,16 @@ class PassageEvent {
     this.type = type;
     this.occurredAt = occurredAt;
     this.createdAt = createdAt;
-    this.passageId = passageId;
+    this.setPassageId(passageId);
     this.data = data;
+  }
+
+  setPassageId(passageId) {
+    if (typeof passageId !== 'number') {
+      throw new DomainError('The passageId should be a number');
+    }
+
+    this.passageId = passageId;
   }
 }
 

--- a/api/src/devcomp/domain/models/passage-events/PassageEvent.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEvent.js
@@ -23,7 +23,7 @@ class PassageEvent {
 
     this.id = id;
     this.type = type;
-    this.occurredAt = occurredAt;
+    this.setOccurredAt(occurredAt);
     this.createdAt = createdAt;
     this.setPassageId(passageId);
     this.data = data;
@@ -35,6 +35,14 @@ class PassageEvent {
     }
 
     this.passageId = passageId;
+  }
+
+  setOccurredAt(occurredAt) {
+    if (Object.prototype.toString.call(occurredAt) !== '[object Date]') {
+      throw new DomainError('The occurredAt property should be a Date object');
+    }
+
+    this.occurredAt = occurredAt;
   }
 }
 

--- a/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
@@ -11,8 +11,8 @@ import { PassageEvent } from './PassageEvent.js';
  * Subclasses should be named in past tense.
  */
 class PassageEventWithElement extends PassageEvent {
-  constructor({ id, type, occurredAt, createdAt, passageId, elementId } = {}) {
-    super({ id, type, occurredAt, createdAt, passageId, data: { elementId } });
+  constructor({ id, type, occurredAt, createdAt, passageId, elementId, data } = {}) {
+    super({ id, type, occurredAt, createdAt, passageId, data: { ...data, elementId } });
 
     if (this.constructor === PassageEventWithElement) {
       throw new PassageEventWithElementInstantiationError();

--- a/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
@@ -1,0 +1,26 @@
+import { assertHasUuidLength, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEventWithElementInstantiationError } from '../../errors.js';
+import { PassageEvent } from './PassageEvent.js';
+
+/**
+ * @abstract PassageElementEvent
+ * See PassageEvent for more info.
+ *
+ * This is the base class for all PassageElementEvent.
+ * It's syntaxic sugar for a `PassageEvent` that contains an element, it exists because lots of events happen on a element that we store in the `data` key..
+ * Subclasses should be named in past tense.
+ */
+class PassageEventWithElement extends PassageEvent {
+  constructor({ id, type, occurredAt, createdAt, passageId, elementId } = {}) {
+    super({ id, type, occurredAt, createdAt, passageId, data: { elementId } });
+
+    if (this.constructor === PassageEventWithElement) {
+      throw new PassageEventWithElementInstantiationError();
+    }
+
+    assertNotNullOrUndefined(elementId, 'The elementId property is required for a PassageEventWithElement');
+    assertHasUuidLength(elementId, 'The elementId property should be exactly 36 characters long');
+  }
+}
+
+export { PassageEventWithElement };

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -1,16 +1,14 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
-import { PassageEvent } from './PassageEvent.js';
+import { PassageElementEvent } from './PassageElementEvent.js';
 
 /**
  * @class FlashcardsStartedEvent
  *
  * A FlashcardsStartedEvent is generated when a set of Modulix flashcards is started and saved in DB.
  */
-class FlashcardsStartedEvent extends PassageEvent {
+class FlashcardsStartedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, elementId }) {
-    super({ id, type: 'FLASHCARDS_STARTED', occurredAt, createdAt, passageId, data: { elementId } });
-
-    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsStartedEvent');
+    super({ id, type: 'FLASHCARDS_STARTED', occurredAt, createdAt, passageId, elementId });
 
     this.elementId = elementId;
   }
@@ -21,12 +19,12 @@ class FlashcardsStartedEvent extends PassageEvent {
  *
  * A FlashcardsVersoSeenEvent is generated when a card's answer is seen and saved in DB.
  */
-class FlashcardsVersoSeenEvent extends PassageEvent {
+class FlashcardsVersoSeenEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
-    super({ id, type: 'FLASHCARDS_VERSO_SEEN', occurredAt, createdAt, passageId, data: { elementId, cardId } });
+    super({ id, type: 'FLASHCARDS_VERSO_SEEN', occurredAt, createdAt, passageId, elementId, data: { cardId } });
 
-    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsVersoSeenEvent');
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsVersoSeenEvent');
+
     this.elementId = elementId;
     this.cardId = cardId;
   }
@@ -37,7 +35,7 @@ class FlashcardsVersoSeenEvent extends PassageEvent {
  *
  * A FlashcardsCardAutoAssessedEvent is generated when an auto-assessment is given and saved in DB.
  */
-class FlashcardsCardAutoAssessedEvent extends PassageEvent {
+class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, elementId, cardId, autoAssessment }) {
     super({
       id,
@@ -45,12 +43,13 @@ class FlashcardsCardAutoAssessedEvent extends PassageEvent {
       occurredAt,
       createdAt,
       passageId,
-      data: { elementId, cardId, autoAssessment },
+      elementId,
+      data: { cardId, autoAssessment },
     });
 
-    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsCardAutoAssessedEvent');
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsCardAutoAssessedEvent');
     assertNotNullOrUndefined(autoAssessment, 'The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
+
     this.elementId = elementId;
     this.cardId = cardId;
     this.autoAssessment = autoAssessment;
@@ -62,7 +61,7 @@ class FlashcardsCardAutoAssessedEvent extends PassageEvent {
  *
  * A FlashcardsRectoReviewedEvent is generated when a card's question is reviewed and saved in DB.
  */
-class FlashcardsRectoReviewedEvent extends PassageEvent {
+class FlashcardsRectoReviewedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
     super({
       id,
@@ -70,10 +69,10 @@ class FlashcardsRectoReviewedEvent extends PassageEvent {
       occurredAt,
       createdAt,
       passageId,
-      data: { elementId, cardId },
+      elementId,
+      data: { cardId },
     });
 
-    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsRectoReviewedEvent');
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsRectoReviewedEvent');
 
     this.elementId = elementId;
@@ -86,11 +85,9 @@ class FlashcardsRectoReviewedEvent extends PassageEvent {
  *
  * A FlashcardsRetriedEvent is generated when a set of Modulix flashcards is retried and saved in DB.
  */
-class FlashcardsRetriedEvent extends PassageEvent {
+class FlashcardsRetriedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, elementId }) {
-    super({ id, type: 'FLASHCARDS_RETRIED', occurredAt, createdAt, passageId, data: { elementId } });
-
-    assertNotNullOrUndefined(elementId, 'The elementId is required for a FlashcardsRetriedEvent');
+    super({ id, type: 'FLASHCARDS_RETRIED', occurredAt, createdAt, passageId, elementId });
 
     this.elementId = elementId;
   }

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -61,7 +61,11 @@ class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsCardAutoAssessedEvent');
     assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
     assertNotNullOrUndefined(autoAssessment, 'The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
-    assertEnumValue(AutoAssessmentEnumValues, autoAssessment);
+    assertEnumValue(
+      AutoAssessmentEnumValues,
+      autoAssessment,
+      'The autoAssessment value must be one of these : [‘yes‘, ‘maybe‘, ‘no‘]',
+    );
 
     this.elementId = elementId;
     this.cardId = cardId;

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -1,5 +1,15 @@
-import { assertHasUuidLength, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
-import { PassageElementEvent } from './PassageElementEvent.js';
+import {
+  assertEnumValue,
+  assertHasUuidLength,
+  assertNotNullOrUndefined,
+} from '../../../../shared/domain/models/asserts.js';
+import { PassageEventWithElement } from './PassageEventWithElement.js';
+
+const AutoAssessmentEnumValues = Object.freeze({
+  YES: 'yes',
+  MAYBE: 'maybe',
+  NO: 'no',
+});
 
 /**
  * @class FlashcardsStartedEvent
@@ -51,6 +61,7 @@ class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsCardAutoAssessedEvent');
     assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
     assertNotNullOrUndefined(autoAssessment, 'The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
+    assertEnumValue(AutoAssessmentEnumValues, autoAssessment);
 
     this.elementId = elementId;
     this.cardId = cardId;

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -1,4 +1,4 @@
-import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { assertHasUuidLength, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageElementEvent } from './PassageElementEvent.js';
 
 /**
@@ -24,6 +24,7 @@ class FlashcardsVersoSeenEvent extends PassageEventWithElement {
     super({ id, type: 'FLASHCARDS_VERSO_SEEN', occurredAt, createdAt, passageId, elementId, data: { cardId } });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsVersoSeenEvent');
+    assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
 
     this.elementId = elementId;
     this.cardId = cardId;
@@ -48,6 +49,7 @@ class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
     });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsCardAutoAssessedEvent');
+    assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
     assertNotNullOrUndefined(autoAssessment, 'The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
 
     this.elementId = elementId;
@@ -74,6 +76,7 @@ class FlashcardsRectoReviewedEvent extends PassageEventWithElement {
     });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsRectoReviewedEvent');
+    assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
 
     this.elementId = elementId;
     this.cardId = cardId;

--- a/api/src/shared/domain/models/asserts.js
+++ b/api/src/shared/domain/models/asserts.js
@@ -18,3 +18,9 @@ export function assertInstanceOf(value, clazz) {
     throw new TypeError('Illegal value provided');
   }
 }
+
+export function assertHasUuidLength(value, errorMessage = 'Uuid value must be exactly 36 characters long') {
+  if (value.length !== 36) {
+    throw new DomainError(errorMessage);
+  }
+}

--- a/api/src/shared/domain/models/asserts.js
+++ b/api/src/shared/domain/models/asserts.js
@@ -6,10 +6,10 @@ export function assertNotNullOrUndefined(value, errorMessage = 'Ne doit pas êtr
   }
 }
 
-export function assertEnumValue(enumObject, value) {
+export function assertEnumValue(enumObject, value, errorMessage = 'Illegal enum value provided') {
   const isValidEnumValue = Object.keys(enumObject).some((key) => enumObject[key] === value);
   if (!isValidEnumValue) {
-    throw new TypeError('Illegal enum value provided');
+    throw new TypeError(errorMessage);
   }
 }
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -231,7 +231,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
 
         // then
         expect(error).to.be.instanceOf(TypeError);
-        expect(error.message).to.equal('Illegal enum value provided');
+        expect(error.message).to.equal('The autoAssessment value must be one of these : [‘yes‘, ‘maybe‘, ‘no‘]');
       });
     });
   });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -116,7 +116,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const passageId = 2;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
-      const autoAssessment = Symbol('yes');
+      const autoAssessment = 'yes';
 
       // when
       const flashcardsCardAutoAssessedEvent = new FlashcardsCardAutoAssessedEvent({
@@ -201,6 +201,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         // then
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
+      });
+    });
+
+    describe('when autoAssessment is not an acceptable value', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+        const cardId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8666';
+        const autoAssessment = 'wrong_value';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new FlashcardsCardAutoAssessedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              elementId,
+              cardId,
+              autoAssessment,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(TypeError);
+        expect(error.message).to.equal('Illegal enum value provided');
       });
     });
   });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -13,9 +13,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('date');
-      const createdAt = Symbol('date');
-      const passageId = Symbol('passage');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
       const elementId = Symbol('elementId');
 
       // when
@@ -35,9 +35,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = now;
+        const createdAt = now;
+        const passageId = 2;
 
         // when
         const error = catchErrSync(() => new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId }))();
@@ -53,9 +53,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('occurredAt');
-      const createdAt = Symbol('createdAt');
-      const passageId = Symbol('passage');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
       const elementId = Symbol('elementId');
       const cardId = Symbol('cardId');
 
@@ -83,9 +83,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = now;
+        const createdAt = now;
+        const passageId = 2;
 
         // when
         const error = catchErrSync(() => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId }))();
@@ -100,9 +100,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
         const elementId = Symbol('elementId');
 
         // when
@@ -121,9 +121,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('occurredAt');
-      const createdAt = Symbol('createdAt');
-      const passageId = Symbol('passage');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
       const elementId = Symbol('elementId');
       const cardId = Symbol('cardId');
       const autoAssessment = Symbol('yes');
@@ -153,9 +153,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = now;
+        const createdAt = now;
+        const passageId = 2;
 
         // when
         const error = catchErrSync(
@@ -172,9 +172,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
         const elementId = Symbol('elementId');
 
         // when
@@ -193,9 +193,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('occurredAt');
-      const createdAt = Symbol('createdAt');
-      const passageId = Symbol('passage');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
       const elementId = Symbol('elementId');
       const cardId = Symbol('cardId');
 
@@ -223,9 +223,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = now;
+        const createdAt = now;
+        const passageId = 2;
 
         // when
         const error = catchErrSync(() => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId }))();
@@ -240,9 +240,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
         const elementId = Symbol('elementId');
 
         // when
@@ -261,9 +261,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('occurredAt');
-      const createdAt = Symbol('createdAt');
-      const passageId = Symbol('passage');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
       const elementId = Symbol('elementId');
 
       // when
@@ -289,9 +289,9 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
-        const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const occurredAt = now;
+        const createdAt = now;
+        const passageId = 2;
 
         // when
         const error = catchErrSync(() => new FlashcardsRetriedEvent({ id, occurredAt, createdAt, passageId }))();

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -40,7 +40,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const createdAt = new Date();
       const passageId = 2;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
-      const cardId = Symbol('cardId');
+      const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
 
       // when
       const flashcardsCardAnswerSeenEvent = new FlashcardsVersoSeenEvent({
@@ -81,6 +81,30 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         expect(error.message).to.equal('The cardId is required for a FlashcardsVersoSeenEvent');
       });
     });
+
+    describe('when cardId is not a valid uuid', function () {
+      it('should throw an error', function () {
+        // given
+        const cardId = '00e0c3fa-d812-45c8-b0cc-f317004988f';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new FlashcardsVersoSeenEvent({
+              id: Symbol('id'),
+              occurredAt: new Date(),
+              createdAt: new Date(),
+              passageId: 2,
+              elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+              cardId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId property should be exactly 36 characters long');
+      });
+    });
   });
 
   describe('#FlashcardsCardAutoAssessedEvent', function () {
@@ -91,7 +115,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const createdAt = new Date();
       const passageId = 2;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
-      const cardId = Symbol('cardId');
+      const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
       const autoAssessment = Symbol('yes');
 
       // when
@@ -134,6 +158,30 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         expect(error.message).to.equal('The cardId is required for a FlashcardsCardAutoAssessedEvent');
       });
     });
+
+    describe('when cardId is not a valid uuid', function () {
+      it('should throw an error', function () {
+        // given
+        const cardId = '00e0c3fa-d812-45c8-b0cc-f317004988f';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new FlashcardsCardAutoAssessedEvent({
+              id: Symbol('id'),
+              occurredAt: new Date(),
+              createdAt: new Date(),
+              passageId: 2,
+              elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+              cardId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId property should be exactly 36 characters long');
+      });
+    });
   });
 
   describe('#FlashcardsRectoReviewedEvent', function () {
@@ -144,7 +192,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const createdAt = new Date();
       const passageId = 2;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
-      const cardId = Symbol('cardId');
+      const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
 
       // when
       const flashcardsCardQuestionReviewedEvent = new FlashcardsRectoReviewedEvent({
@@ -183,6 +231,30 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         // then
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The cardId is required for a FlashcardsRectoReviewedEvent');
+      });
+    });
+
+    describe('when cardId is not a valid uuid', function () {
+      it('should throw an error', function () {
+        // given
+        const cardId = 'not-a-valid-uuid';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new FlashcardsRectoReviewedEvent({
+              id: Symbol('id'),
+              occurredAt: new Date(),
+              createdAt: new Date(),
+              passageId: 2,
+              elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+              cardId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId property should be exactly 36 characters long');
       });
     });
   });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -182,6 +182,27 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         expect(error.message).to.equal('The cardId property should be exactly 36 characters long');
       });
     });
+
+    describe('when autoAssessment is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+        const cardId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8666';
+
+        // when
+        const error = catchErrSync(
+          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId, elementId, cardId }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The autoAssessment is required for a FlashcardsCardAutoAssessedEvent');
+      });
+    });
   });
 
   describe('#FlashcardsRectoReviewedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -16,7 +16,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
-      const elementId = Symbol('elementId');
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
       // when
       const flashcardsStartedEvent = new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId, elementId });
@@ -30,23 +30,6 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsStartedEvent.elementId).to.equal(elementId);
       expect(flashcardsStartedEvent.data).to.deep.equal({ elementId });
     });
-
-    describe('when elementId is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = now;
-        const createdAt = now;
-        const passageId = 2;
-
-        // when
-        const error = catchErrSync(() => new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId }))();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The elementId is required for a FlashcardsStartedEvent');
-      });
-    });
   });
 
   describe('#FlashcardsVersoSeenEvent', function () {
@@ -56,7 +39,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
-      const elementId = Symbol('elementId');
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = Symbol('cardId');
 
       // when
@@ -76,24 +59,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardAnswerSeenEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardAnswerSeenEvent.passageId).to.equal(passageId);
       expect(flashcardsCardAnswerSeenEvent.elementId).to.equal(elementId);
-      expect(flashcardsCardAnswerSeenEvent.data).to.deep.equal({ elementId, cardId });
-    });
-
-    describe('when elementId is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = now;
-        const createdAt = now;
-        const passageId = 2;
-
-        // when
-        const error = catchErrSync(() => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId }))();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The elementId is required for a FlashcardsVersoSeenEvent');
-      });
+      expect(flashcardsCardAnswerSeenEvent.data).to.deep.equal({ cardId, elementId });
     });
 
     describe('when cardId is not given', function () {
@@ -103,7 +69,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
-        const elementId = Symbol('elementId');
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
@@ -124,7 +90,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
-      const elementId = Symbol('elementId');
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = Symbol('cardId');
       const autoAssessment = Symbol('yes');
 
@@ -146,26 +112,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardAutoAssessedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardAutoAssessedEvent.passageId).to.equal(passageId);
       expect(flashcardsCardAutoAssessedEvent.elementId).to.equal(elementId);
-      expect(flashcardsCardAutoAssessedEvent.data).to.deep.equal({ elementId, cardId, autoAssessment });
-    });
-
-    describe('when elementId is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = now;
-        const createdAt = now;
-        const passageId = 2;
-
-        // when
-        const error = catchErrSync(
-          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId }),
-        )();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The elementId is required for a FlashcardsCardAutoAssessedEvent');
-      });
+      expect(flashcardsCardAutoAssessedEvent.data).to.deep.equal({ cardId, autoAssessment, elementId });
     });
 
     describe('when cardId is not given', function () {
@@ -175,7 +122,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
-        const elementId = Symbol('elementId');
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
@@ -196,7 +143,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
-      const elementId = Symbol('elementId');
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = Symbol('cardId');
 
       // when
@@ -216,24 +163,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardQuestionReviewedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardQuestionReviewedEvent.passageId).to.equal(passageId);
       expect(flashcardsCardQuestionReviewedEvent.elementId).to.equal(elementId);
-      expect(flashcardsCardQuestionReviewedEvent.data).to.deep.equal({ elementId, cardId });
-    });
-
-    describe('when elementId is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = now;
-        const createdAt = now;
-        const passageId = 2;
-
-        // when
-        const error = catchErrSync(() => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId }))();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The elementId is required for a FlashcardsRectoReviewedEvent');
-      });
+      expect(flashcardsCardQuestionReviewedEvent.data).to.deep.equal({ cardId, elementId });
     });
 
     describe('when cardId is not given', function () {
@@ -243,7 +173,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
-        const elementId = Symbol('elementId');
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
@@ -264,7 +194,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
-      const elementId = Symbol('elementId');
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
       // when
       const flashcardsRetriedEvent = new FlashcardsRetriedEvent({
@@ -283,23 +213,6 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsRetriedEvent.passageId).to.equal(passageId);
       expect(flashcardsRetriedEvent.elementId).to.equal(elementId);
       expect(flashcardsRetriedEvent.data).to.deep.equal({ elementId });
-    });
-
-    describe('when elementId is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = now;
-        const createdAt = now;
-        const passageId = 2;
-
-        // when
-        const error = catchErrSync(() => new FlashcardsRetriedEvent({ id, occurredAt, createdAt, passageId }))();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The elementId is required for a FlashcardsRetriedEvent');
-      });
     });
   });
 });

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -10,7 +10,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('date');
+      const occurredAt = new Date();
       const createdAt = Symbol('date');
       const passageId = 1234;
       const contentHash = Symbol('contentHash');
@@ -32,7 +32,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
       it('should throw an error', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date();
         const createdAt = Symbol('date');
         const passageId = 1234;
 
@@ -50,7 +50,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
     it('should init and keep attributes', function () {
       // given
       const id = Symbol('id');
-      const occurredAt = Symbol('date');
+      const occurredAt = new Date();
       const createdAt = Symbol('date');
       const passageId = 1234;
 

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -12,7 +12,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
       const id = Symbol('id');
       const occurredAt = Symbol('date');
       const createdAt = Symbol('date');
-      const passageId = Symbol('passage');
+      const passageId = 1234;
       const contentHash = Symbol('contentHash');
 
       // when
@@ -34,7 +34,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 1234;
 
         // when
         const error = catchErrSync(() => new PassageStartedEvent({ id, occurredAt, createdAt, passageId }))();
@@ -52,7 +52,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
       const id = Symbol('id');
       const occurredAt = Symbol('date');
       const createdAt = Symbol('date');
-      const passageId = Symbol('passage');
+      const passageId = 1234;
 
       // when
       const passageTerminatedEvent = new PassageTerminatedEvent({ id, occurredAt, createdAt, passageId });

--- a/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
@@ -1,0 +1,74 @@
+import { PassageEventWithElementInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { PassageEventWithElement } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEventWithElement.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', function () {
+  describe('#constructor', function () {
+    it('should not be able to create a PassageElementWithEvent directly', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = Symbol('date');
+      const passageId = 3;
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new PassageEventWithElement({
+            id,
+            type: 'PassageElementWithEvent',
+            occurredAt,
+            createdAt,
+            passageId,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(PassageEventWithElementInstantiationError);
+    });
+
+    it('should throw an error if elementId is not present', function () {
+      // given
+      class FakePassageEventWithElement extends PassageEventWithElement {}
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new FakePassageEventWithElement({
+            id: Symbol('id'),
+            type: 'PassageElementWithEvent',
+            occurredAt: new Date(),
+            createdAt: new Date(),
+            passageId: 123,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The elementId property is required for a PassageEventWithElement');
+    });
+
+    it('should throw an error if elementId is invalid', function () {
+      // given
+      class FakePassageEventWithElement extends PassageEventWithElement {}
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new FakePassageEventWithElement({
+            id: Symbol('id'),
+            type: 'PassageElementWithEvent',
+            occurredAt: new Date(),
+            createdAt: new Date(),
+            passageId: 123,
+            elementId: 'abcd',
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The elementId property should be exactly 36 characters long');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -67,13 +67,53 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       });
     });
 
+    describe('#setPassageId', function () {
+      it('should throw an error when passageId is a string', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({
+              id: 1,
+              type: 'FAKE',
+              occurredAt: new Date(),
+              createdAt: Symbol('date'),
+              passageId: 'blablabla',
+            });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The passageId should be a number');
+      });
+
+      it('sets passageId when it is valid', function () {
+        // given
+        const passageId = 2;
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE', occurredAt: new Date(), passageId });
+          }
+        }
+
+        // when
+        const fakeEvent = new FakeEvent();
+
+        // then
+        expect(fakeEvent.passageId).to.deep.equal(passageId);
+      });
+    });
+
     describe('if a passage event has minimal required attributes', function () {
       it('should create a PassageEvent and set id attribute', function () {
         // given
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
@@ -92,7 +132,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
@@ -111,7 +151,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
@@ -130,7 +170,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
@@ -149,7 +189,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
@@ -168,7 +208,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const id = Symbol('id');
         const occurredAt = Symbol('date');
         const createdAt = Symbol('date');
-        const passageId = Symbol('passage');
+        const passageId = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
             super({ id, type: 'FAKE', occurredAt, createdAt, passageId });

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -49,6 +49,24 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       });
     });
 
+    describe('if a passage event has a occurredAt that is not a Date', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE', passageId: 124, occurredAt: 'abcd' });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The occurredAt property should be a Date object');
+      });
+    });
+
     describe('if a passage event does not have a passageId', function () {
       it('should throw an error', function () {
         // given
@@ -111,7 +129,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set id attribute', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {
@@ -130,7 +148,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set type attribute', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {
@@ -149,7 +167,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set occurredAt attribute', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {
@@ -168,7 +186,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set createdAt attribute', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {
@@ -187,7 +205,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set passageId attribute', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {
@@ -206,7 +224,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       it('should create a PassageEvent and set data to undefined', function () {
         // given
         const id = Symbol('id');
-        const occurredAt = Symbol('date');
+        const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
         class FakeEvent extends PassageEvent {

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -59,7 +59,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   it('should save the passage and record passage started event', async function () {
     // given
     const moduleId = Symbol('moduleId');
-    const passageId = Symbol('passageId');
+    const passageId = 1234;
     const userId = Symbol('userId');
 
     const slug = 'les-adresses-email';

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -31,7 +31,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
     describe('when passage is found', function () {
       it('should not verify if passage is terminated', async function () {
         // given
-        const passageId = Symbol('passageId');
+        const passageId = 1234;
 
         const passage = {
           terminatedAt: Symbol('terminatedAt'),
@@ -53,7 +53,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
 
       it('should call terminate method and update passage and return it, then record an event', async function () {
         // given
-        const passageId = Symbol('passageId');
+        const passageId = 1234;
         const occurredAt = new Date('2025-01-01');
 
         const passageRepository = {

--- a/api/tests/shared/unit/domain/models/asserts_test.js
+++ b/api/tests/shared/unit/domain/models/asserts_test.js
@@ -1,9 +1,11 @@
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import {
   assertEnumValue,
+  assertHasUuidLength,
   assertInstanceOf,
   assertNotNullOrUndefined,
 } from '../../../../../src/shared/domain/models/asserts.js';
-import { expect } from '../../../../test-helper.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Models | asserts', function () {
   describe('#assertNotNullOrUndefined', function () {
@@ -68,6 +70,46 @@ describe('Unit | Shared | Models | asserts', function () {
 
         // When, Then
         expect(() => assertInstanceOf(aDate, Date)).not.to.throw();
+      });
+    });
+  });
+
+  describe('#assertHasUuidLength', function () {
+    describe('given invalid value', function () {
+      it('should throw', function () {
+        // given
+        const value = '00e0c3fa-d812-45c8-b0cc-f317004988f9d';
+
+        // when
+        const error = catchErrSync(() => assertHasUuidLength(value))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('Uuid value must be exactly 36 characters long');
+      });
+    });
+
+    describe('given invalid value and a custom error message', function () {
+      it('should throw withe the custom error message', function () {
+        // given
+        const value = '00e0c3fa-d812-45c8-b0cc-f317004988';
+
+        // when
+        const error = catchErrSync(() => assertHasUuidLength(value, 'NOPE'))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('NOPE');
+      });
+    });
+
+    describe('given valid value', function () {
+      it('should not throw', function () {
+        // given
+        const value = '00e0c3fa-d812-45c8-b0cc-f317004988f9';
+
+        // when/then
+        expect(() => assertHasUuidLength(value)).not.to.throw();
       });
     });
   });

--- a/api/tests/shared/unit/domain/models/asserts_test.js
+++ b/api/tests/shared/unit/domain/models/asserts_test.js
@@ -41,6 +41,21 @@ describe('Unit | Shared | Models | asserts', function () {
       });
     });
 
+    describe('given invalid value with custom error message', function () {
+      it('should throw', function () {
+        // given
+        const errorMessage = 'This is an error with my custom message';
+        const anEnum = { X: 'y' };
+
+        // When
+        const error = catchErrSync(() => assertEnumValue(anEnum, 'z', errorMessage))();
+
+        // Then
+        expect(error).to.be.instanceOf(TypeError);
+        expect(error.message).to.equal('This is an error with my custom message');
+      });
+    });
+
     describe('given valid values', function () {
       it('should not throw', function () {
         // given


### PR DESCRIPTION
## :egg: Problème

Il n'y a pas de validation lors de la création des évènements liés aux flashcards.

## :bowl_with_spoon: Proposition

Valider les propriétés suivantes :

- [x] `occurredAt`: a le format timestamp
- [x] `passageId`: a le format number
- [x] `elementId`: a la taille d'un uuid (36 caractères)
- [x] `cardId`: a la taille d'un uuid (36 caractères)
- [x] `autoAssessment`: a le format `enum`

## :milk_glass: Remarques

On aimerait profiter de cette PR pour proposer un refacto qui harmoniserait les constructeurs des classes héritant de`PassageEvent` car il nous semble qu'avoir des constructeurs différents à chaque fois cela alourdit inutilement le code.

On garde les deux points suivant pour un prochain ticket

- `passageId`: correspond à un `passage` existant en base
- `passageId`: correspond à un `passage` associé à l'utilisateur authentifié ou à un passage sans `userId` si l'utilisateur est anonyme

## :butter: Pour tester

Pas possible de tester pour l'instant car le code n'est pas utilisée fonctionnellement.
