### PR TITLE
[TECH] Supprimer la mention attestation dans le nom du PDF de la certification (PIX-17409).

### DIFF
--- a/api/src/certification/results/application/certification-attestation-controller.js
+++ b/api/src/certification/results/application/certification-attestation-controller.js
@@ -86,7 +86,7 @@ const getCertificationPDFAttestationsForSession = async function (
     i18n,
   });
 
-  const fileName = `attestation-pix-session-${sessionId}.pdf`;
+  const fileName = `certification-pix-session-${sessionId}.pdf`;
   return h
     .response(buffer)
     .header('Content-Disposition', `attachment; filename=${fileName}`)

--- a/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-attestation-route_test.js
@@ -164,7 +164,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
             expect(response.statusCode).to.equal(200);
             expect(response.headers['content-type']).to.equal('application/pdf');
 
-            const filename = `filename=attestation-pix-20181201.pdf`;
+            const filename = `filename=certification-pix-20181201.pdf`;
             expect(response.headers['content-disposition']).to.include(filename);
 
             const fileFormat = response.result.substring(1, 4);
@@ -192,7 +192,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
           // then
           expect(response.statusCode).to.equal(200);
           expect(response.headers['content-type']).to.equal('application/pdf');
-          expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
+          expect(response.headers['content-disposition']).to.include('filename=certification-pix');
           expect(response.file).not.to.be.null;
         });
       });
@@ -219,7 +219,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.equal('application/pdf');
-        expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
+        expect(response.headers['content-disposition']).to.include('filename=certification-pix');
         expect(response.file).not.to.be.null;
       });
     });
@@ -252,7 +252,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.equal('application/pdf');
         expect(response.headers['content-disposition']).to.equal(
-          `attachment; filename=session-${sessionId}-attestation-pix-${dayjs(session.publishedAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=session-${sessionId}-certification-pix-${dayjs(session.publishedAt).format('YYYYMMDD')}.pdf`,
         );
         expect(response.file).not.to.be.null;
       });
@@ -405,7 +405,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.equal('application/pdf');
         expect(response.headers['content-disposition']).to.equal(
-          `attachment; filename=${organizationLearner.division.toLowerCase()}-attestation-pix-${dayjs(session.publishedAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=${organizationLearner.division.toLowerCase()}-certification-pix-${dayjs(session.publishedAt).format('YYYYMMDD')}.pdf`,
         );
         expect(response.file).not.to.be.null;
       });

--- a/api/tests/certification/results/unit/application/certification-attestation-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-attestation-controller_test.js
@@ -49,7 +49,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
         });
         expect(response.source).to.deep.equal(generatedPdf);
         expect(response.headers['Content-Disposition']).to.contains(
-          `attachment; filename=attestation-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=certification-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
         );
       });
     });
@@ -59,7 +59,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation();
         const attestationPDF = 'binary string';
-        const filename = 'attestation-pix-20181003.pdf';
+        const filename = 'certification-pix-20181003.pdf';
         const userId = 1;
         const i18n = Symbol('i18n');
 
@@ -143,7 +143,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
         });
         expect(response.source).to.deep.equal(generatedPdf);
         expect(response.headers['Content-Disposition']).to.contains(
-          `attachment; filename=session-${session.id}-attestation-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=session-${session.id}-certification-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
         );
       });
     });
@@ -214,7 +214,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
         // then
         expect(response.source).to.deep.equal(attestationPDF);
         expect(response.headers['Content-Disposition']).to.contains(
-          'attachment; filename=attestation-pix-session-12.pdf',
+          'attachment; filename=certification-pix-session-12.pdf',
         );
       });
     });
@@ -279,7 +279,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
         });
         expect(response.source).to.deep.equal(generatedPdf);
         expect(response.headers['Content-Disposition']).to.contains(
-          `attachment; filename=3eme-b-attestation-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=3eme-b-certification-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
         );
       });
     });

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -239,7 +239,7 @@
     "file-metadata": {
       "title": "Pix certification confirmation"
     },
-    "file-name": "pix-confirmation-{deliveredAt}.pdf",
+    "file-name": "pix-certification-{deliveredAt}.pdf",
     "from-birthplace": " in { birthplace }",
     "max-level": "(levels on { maxReachableLevelOnCertificationDate })",
     "max-reachable-level-indication": "* At the date of the successful completion of this certification, the number of acheivable pix was { maxReachableScore }, corresponding to a level { maxReachableLevelOnCertificationDate }."

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -236,7 +236,7 @@
   },
   "certification-confirmation": {
     "absolute-max-level-indication": "Cuando estén disponibles los 8 niveles del repositorio de píxeles, este número máximo será de 1024 píxeles.",
-    "file-name": "attestation-pix-{deliveredAt}.pdf",
+    "file-name": "certification-pix-{deliveredAt}.pdf",
     "file-metadata": {
       "title": "Pix certificacion confirmación"
     },

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -241,9 +241,9 @@
   "certification-confirmation": {
     "absolute-max-level-indication": "Lorsque les 8 niveaux du référentiel Pix seront disponibles, ce nombre maximum sera de 1024 pix.",
     "file-metadata": {
-      "title": "Attestation(s) de certification Pix"
+      "title": "Certification(s) Pix"
     },
-    "file-name": "attestation-pix-{deliveredAt}.pdf",
+    "file-name": "certification-pix-{deliveredAt}.pdf",
     "from-birthplace": " à { birthplace }",
     "max-level": "(niveaux sur { maxReachableLevelOnCertificationDate })",
     "max-reachable-level-indication": "* À la date d’obtention de cette certification, le nombre maximum de pix atteignable était de { maxReachableScore }, correspondant au niveau { maxReachableLevelOnCertificationDate }."

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -236,12 +236,12 @@
   },
   "certification-confirmation": {
     "absolute-max-level-indication": "Als de 8 niveaus van de Pix-opslagplaats beschikbaar zijn, zal dit maximumaantal 1024 pixels zijn.",
-    "file-name": "attest-pix-{geleverdbij}.pdf",
+    "file-name": "certificering-pix-{deliveredAt}.pdf",
     "file-metadata": {
-      "title": "Pix certification attest"
+      "title": "Pix certificering"
     },
-    "from-birthplace": "naar { geboorteplaats }",
-    "max-level": "(niveaus op { maxReachableLevelOnCertificationDate })",
+    "from-birthplace": "naar {birthplace}",
+    "max-level": "(niveaus op {maxReachableLevelOnCertificationDate})",
     "max-reachable-level-indication": "* Op de datum waarop deze certificering werd behaald, was het maximaal haalbare aantal pix { maxReachableScore }, wat overeenkomt met het niveau { maxReachableLevelOnCertificationDate }."
   },
   "certification-result-email": {


### PR DESCRIPTION
## 🌸 Problème

Le mot "attestation" n'est plus spécifique à la certification.

## 🌳 Proposition

Supprimer la mention dans le nom du PDF

## 🐝 Remarques

Un chantier plus gros est prévu pour supprimer ce mot dans les fichiers etc..

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
