### PR TITLE
[BUGFIX] Couper les cellules avec des mots trop longs dans la liste des sessions certif (PIX-17378).

### DIFF
--- a/certif/app/components/sessions/session-list.gjs
+++ b/certif/app/components/sessions/session-list.gjs
@@ -112,7 +112,7 @@ export default class SessionList extends Component {
               </LinkTo>
             </:cell>
           </PixTableColumn>
-          <PixTableColumn @context={{context}}>
+          <PixTableColumn @context={{context}} class='table__column--hyphen'>
             <:header>
               {{t 'common.forms.session-labels.center-name'}}
             </:header>
@@ -120,7 +120,7 @@ export default class SessionList extends Component {
               {{sessionSummary.address}}
             </:cell>
           </PixTableColumn>
-          <PixTableColumn @context={{context}}>
+          <PixTableColumn @context={{context}} class='table__column--hyphen'>
             <:header>
               {{t 'common.forms.session-labels.room'}}
             </:header>

--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -8,6 +8,11 @@
     &--small {
       width: 10%;
     }
+
+    &--hyphen {
+      min-width: 15ch;
+      hyphens: auto;
+    }
   }
 
   &__empty {


### PR DESCRIPTION
## 🌸 Problème

![image](https://github.com/user-attachments/assets/eeed07f3-0e66-41f5-b210-2f083a85a622)

Si le nom du site et/ou de la salle sont trop longs, ils agrandissent trop le tableau et font que la page déborde.

## 🌳 Proposition

Permettre que ces cellules contiennent des traits-d'union pour couper les mots trop longs.

## 🐝 Remarques

On ne pourra pas faire de magie dans tous les cas, sur petit écran, il y a trop de colonnes pour que tout rentre.

## 🤧 Pour tester

Voir la liste des sessions de certif [en RA](https://certif-pr11991.review.pix.fr/sessions) avec `certif-pro@example.net`
