### PR TITLE
[BUGFIX] Ajouter la dependance manquante codeGenerator dans les injections de dépendances pour les usecases (PIX-17417)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as learnersApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import * as schoolRepository from '../../../school/infrastructure/repositories/school-repository.js';
+import * as codeGenerator from '../../../shared/domain/services/code-generator.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCenterRepository from '../../infrastructure/repositories/certification-center.repository.js';
@@ -34,6 +35,7 @@ const path = dirname(fileURLToPath(import.meta.url));
 
 const repositories = {
   organizationCreationValidator,
+  codeGenerator,
   centerRepository,
   certificationCenterRepository,
   certificationCenterForAdminRepository,

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -201,6 +201,16 @@ async function insertMultipleSendingFeatureForNewOrganization() {
   return feature.id;
 }
 
+async function insertPixJuniorFeatureForNewOrganization() {
+  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
+  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT);
+  databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER);
+  databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+    name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
+  });
+  await databaseBuilder.commit();
+}
+
 // Hapi
 const hFake = {
   response(source) {
@@ -367,6 +377,7 @@ export {
   HttpTestServer,
   insertMultipleSendingFeatureForNewOrganization,
   insertOrganizationUserWithRoleAdmin,
+  insertPixJuniorFeatureForNewOrganization,
   insertUserWithRoleCertif,
   insertUserWithRoleSuperAdmin,
   knex,


### PR DESCRIPTION
## 🌸 Problème

Dans le cadre de la migration de lib vers src, la dependance codeGenerator n'a pas été injecté dans le nouveau boundedContext.

## 🌳 Proposition

Ajouter la dépendance manquante

## 🐝 Remarques

On a posé un test et fait un peu de refacto pour que le tests utilise la version "injecté" du usecase.

## 🤧 Pour tester

- se connecter à pix admin
- créer une nouvelle orga PixJunior
