### PR TITLE
[BUGFIX] Corriger l'affichage des modales sur Pix Certif.

### DIFF
--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -3,7 +3,6 @@
 .add-issue-report-modal {
   min-width: 850px;
   max-width: 850px;
-  margin: 100px auto;
   overflow: visible;
 
   /* to fix in pix UI */

--- a/certif/app/styles/components/new-candidate-modal.scss
+++ b/certif/app/styles/components/new-candidate-modal.scss
@@ -1,7 +1,9 @@
 .new-candidate-modal {
+  top: 0;
   min-width: 576px;
   max-width: 576px;
   margin: 100px auto;
+  transform: translateX(-50%);
 
   &__form {
     display: flex;


### PR DESCRIPTION
## 🌸 Problème

Lors de la montée de version de Pix UI https://github.com/1024pix/pix/pull/11955 on a pas vu les soucis d'affichage des modales

## 🌳 Proposition
En attendant un fix coté Pix ui, on surchage la classe de la modale de certification pour corriger l'affichage

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
