### PR TITLE
[TECH] Utiliser les paliers acquis pour afficher les statistiques sur la page d'analyse (PIX-17297)

### DIFF
--- a/api/src/evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js
+++ b/api/src/evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js
@@ -1,64 +1,4 @@
-/**
- * This service compares available and acquired stages for a campaign participation.
- */
-class StagesAndAcquiredStagesComparison {
-  /**
-   * @type {Stage[]}
-   */
-  #acquiredStages = [];
-
-  /**
-   * @type {number}
-   */
-  #totalNumberOfStages;
-
-  /**
-   * @param {Stage[]} availableStages
-   * @param {StageAcquisition[]} stageAcquisitions
-   */
-  constructor(availableStages, stageAcquisitions) {
-    this.#totalNumberOfStages = availableStages.length;
-    this.#acquiredStages = availableStages
-      .sort(this.#sortByLevelOrThreshold)
-      .filter((availableStage) => stageAcquisitions.find(({ stageId }) => stageId === availableStage.id));
-  }
-
-  /**
-   * @param {Stage} previousStage
-   * @param {Stage} currentStage
-   *
-   * @returns {-1, 0, 1}
-   */
-  #sortByLevelOrThreshold(previousStage, currentStage) {
-    if (currentStage.isFirstSkill) {
-      return previousStage.isZeroStage ? -1 : 1;
-    }
-    return currentStage.level
-      ? previousStage.level - currentStage.level
-      : previousStage.threshold - currentStage.threshold;
-  }
-
-  /**
-   * @returns {number}
-   */
-  get reachedStageNumber() {
-    return this.#acquiredStages.length;
-  }
-
-  /**
-   * @returns {number}
-   */
-  get totalNumberOfStages() {
-    return this.#totalNumberOfStages;
-  }
-
-  /**
-   * @returns {Stage}
-   */
-  get reachedStage() {
-    return this.#acquiredStages[this.#acquiredStages.length - 1];
-  }
-}
+import { StageAcquisitionCollection } from '../../../../shared/domain/models/user-campaign-results/StageAcquisitionCollection.js';
 
 /**
  * Compare stages and stages acquisitions to
@@ -69,7 +9,7 @@ class StagesAndAcquiredStagesComparison {
  * @returns {{reachedStage: Stage, reachedStageNumber: number, totalNumberOfStages: number}}
  */
 export const compare = (availableStages, stageAcquisitions) => {
-  const stageComparison = new StagesAndAcquiredStagesComparison(availableStages, stageAcquisitions);
+  const stageComparison = new StageAcquisitionCollection(availableStages, stageAcquisitions);
 
   return {
     reachedStageNumber: stageComparison.reachedStageNumber,

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -7,6 +7,8 @@ import * as campaignRepository from '../../../../../src/prescription/campaign/in
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeRepository from '../../../../evaluation/infrastructure/repositories/badge-repository.js';
+import * as stageAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js';
+import * as stageRepository from '../../../../evaluation/infrastructure/repositories/stage-repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
@@ -107,6 +109,8 @@ const dependencies = {
   organizationMembershipRepository: campaignRepositories.organizationMembershipRepository,
   organizationRepository,
   placementProfileService,
+  stageRepository,
+  stageAcquisitionRepository,
   stageCollectionRepository,
   targetProfileRepository: campaignRepositories.targetProfileRepository, // TODO
   tutorialRepository,

--- a/api/src/shared/domain/models/user-campaign-results/StageAcquisitionCollection.js
+++ b/api/src/shared/domain/models/user-campaign-results/StageAcquisitionCollection.js
@@ -1,0 +1,60 @@
+class StageAcquisitionCollection {
+  /**
+   * @type {Stage[]}
+   */
+  #acquiredStages = [];
+
+  /**
+   * @type {number}
+   */
+  #totalNumberOfStages;
+
+  /**
+   * @param {Stage[]} availableStages
+   * @param {StageAcquisition[]} stageAcquisitions
+   */
+  constructor(availableStages, stageAcquisitions) {
+    this.#totalNumberOfStages = availableStages.length;
+    this.#acquiredStages = availableStages
+      .sort(this.#sortByLevelOrThreshold)
+      .filter((availableStage) => stageAcquisitions.find(({ stageId }) => stageId === availableStage.id));
+  }
+
+  /**
+   * @param {Stage} previousStage
+   * @param {Stage} currentStage
+   *
+   * @returns {-1, 0, 1}
+   */
+  #sortByLevelOrThreshold(previousStage, currentStage) {
+    if (currentStage.isFirstSkill) {
+      return previousStage.isZeroStage ? -1 : 1;
+    }
+    return currentStage.level
+      ? previousStage.level - currentStage.level
+      : previousStage.threshold - currentStage.threshold;
+  }
+
+  /**
+   * @returns {number}
+   */
+  get reachedStageNumber() {
+    return this.#acquiredStages.length;
+  }
+
+  /**
+   * @returns {number}
+   */
+  get totalNumberOfStages() {
+    return this.#totalNumberOfStages;
+  }
+
+  /**
+   * @returns {Stage}
+   */
+  get reachedStage() {
+    return this.#acquiredStages[this.#acquiredStages.length - 1];
+  }
+}
+
+export { StageAcquisitionCollection };

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import {
   NoStagesForCampaign,
   UserNotAuthorizedToAccessEntityError,
@@ -48,17 +49,25 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
     await mockLearningContent(learningContentObjects);
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
     organizationId = databaseBuilder.factory.buildOrganization().id;
     userId = databaseBuilder.factory.buildUser().id;
+
     databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+    // build stages
+
     stage1 = databaseBuilder.factory.buildStage({
       targetProfileId,
-      threshold: 0,
       prescriberTitle: 'title',
+      isFirstSkill: true,
       prescriberDescription: 'desc',
     });
     stage2 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 30 });
     stage3 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 70 });
+
+    // build campaign and campaign skills
+
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
     databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
     databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId2' });
@@ -102,30 +111,6 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
   });
 
   context('when the campaign manage stages', function () {
-    it('should return participations counts by stages', async function () {
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0 });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.31 });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.72 });
-      await databaseBuilder.commit();
-
-      // when
-      const result = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
-
-      // then
-      expect(result).to.deep.equal([
-        {
-          id: stage1.id,
-          value: 1,
-          title: stage1.prescriberTitle,
-          description: stage1.prescriberDescription,
-          reachedStage: 1,
-          totalStage: 3,
-        },
-        { id: stage2.id, value: 1, title: null, description: null, reachedStage: 2, totalStage: 3 },
-        { id: stage3.id, value: 1, title: null, description: null, reachedStage: 3, totalStage: 3 },
-      ]);
-    });
-
     it('should set to 0 all participation counts when no participations', async function () {
       await databaseBuilder.commit();
 
@@ -144,6 +129,66 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
         },
         { id: stage2.id, value: 0, title: null, description: null, reachedStage: 2, totalStage: 3 },
         { id: stage3.id, value: 0, title: null, description: null, reachedStage: 3, totalStage: 3 },
+      ]);
+    });
+
+    it('should return participations counts by stages', async function () {
+      // create campaign participations
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        status: CampaignParticipationStatuses.TO_SHARE,
+      }); // this participation should not be taken into account
+      const participation3 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+      const participation4 = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+      // create stages acquisitions
+
+      // for participation 1
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: participation1.id,
+        stageId: stage1.id,
+      });
+
+      // for participation 2
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: participation2.id,
+        stageId: stage2.id,
+      });
+
+      // for participation 3
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: participation3.id,
+        stageId: stage1.id,
+      });
+
+      // for participation 4
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: participation4.id,
+        stageId: stage2.id,
+      }); // this acquisition should not be counted as it is not the highest stage acquired
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: participation4.id,
+        stageId: stage3.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.getCampaignParticipationsCountByStage({ userId, campaignId });
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          id: stage1.id,
+          value: 2,
+          title: stage1.prescriberTitle,
+          description: stage1.prescriberDescription,
+          reachedStage: 1,
+          totalStage: 3,
+        },
+        { id: stage2.id, value: 0, title: null, description: null, reachedStage: 2, totalStage: 3 },
+        { id: stage3.id, value: 1, title: null, description: null, reachedStage: 3, totalStage: 3 },
       ]);
     });
   });

--- a/api/tests/shared/unit/domain/models/StageAcquisitionCollection_test.js
+++ b/api/tests/shared/unit/domain/models/StageAcquisitionCollection_test.js
@@ -1,0 +1,92 @@
+import { Stage } from '../../../../../src/evaluation/domain/models/Stage.js';
+import { StageAcquisitionCollection } from '../../../../../src/shared/domain/models/user-campaign-results/StageAcquisitionCollection.js';
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Domain | Models | Stages acquisition', function () {
+  context('Stages are defined by thresholds', function () {
+    let availableStages;
+    let stagesAcquisitions;
+    let stageAcquisitionCollection;
+
+    before(function () {
+      availableStages = [
+        { id: 50, threshold: 30 },
+        { id: 10, threshold: null, level: null, isFirstSkill: true },
+        { id: 40, threshold: 0 },
+        { id: 1, threshold: 10 },
+        { id: 2, threshold: 20 },
+        { id: 4, threshold: 40 },
+        { id: 6, threshold: 60 },
+        { id: 5, threshold: 50 },
+      ].map(domainBuilder.buildStage);
+
+      stagesAcquisitions = [
+        { id: 3, stageId: 50 },
+        { id: 2, stageId: 2 },
+        { id: 1, stageId: 1 },
+        { id: 4, stageId: 10 },
+        { id: 5, stageId: 40 },
+      ].map(domainBuilder.buildStageAcquisition);
+
+      stageAcquisitionCollection = new StageAcquisitionCollection(availableStages, stagesAcquisitions);
+    });
+
+    describe('totalNumberOfStages', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.totalNumberOfStages).to.deep.equal(availableStages.length);
+      });
+    });
+    describe('reachedStageNumber', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.reachedStageNumber).to.deep.equal(5);
+      });
+    });
+    describe('reachedStage', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.reachedStage).to.be.an.instanceOf(Stage);
+        expect(stageAcquisitionCollection.reachedStage.id).to.deep.equal(50);
+      });
+    });
+  });
+  context('Stages are defined by levels', function () {
+    let availableStages;
+    let stagesAcquisitions;
+    let stageAcquisitionCollection;
+
+    before(function () {
+      availableStages = [
+        { id: 4, level: 2 },
+        { id: 1, level: 5 },
+        { id: 6, level: 3 },
+        { id: 5, level: 8 },
+        { id: 2, level: 1 },
+        { id: 50, level: 0 },
+      ].map(domainBuilder.buildStage);
+
+      stagesAcquisitions = [
+        { id: 3, stageId: 4 },
+        { id: 1, stageId: 50 },
+      ].map(domainBuilder.buildStageAcquisition);
+
+      stageAcquisitionCollection = new StageAcquisitionCollection(availableStages, stagesAcquisitions);
+    });
+
+    describe('totalNumberOfStages', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.totalNumberOfStages).to.deep.equal(availableStages.length);
+      });
+    });
+    describe('reachedStageNumber', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.reachedStageNumber).to.deep.equal(2);
+      });
+    });
+    describe('reachedStage', function () {
+      it('should return the correct number of stages', function () {
+        expect(stageAcquisitionCollection.reachedStage).to.be.an.instanceOf(Stage);
+        expect(stageAcquisitionCollection.reachedStage.id).to.deep.equal(4);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Actuellement on calcule l'obtention des paliers a la volée pour afficher les statistiques sur la page d'analyse d'une campagne. Or grâce au travail entrepris par la défunte équipe @1024pix/team-evaluation 💞  l'acquisition des paliers est désormais stockée en base. 

## 🌳 Proposition

Utiliser les acquisitions en base pour afficher et calculer les statistiques de répartition des participations par palier atteint.
![image](https://github.com/user-attachments/assets/06d6a8a5-8806-43dc-bdb7-c5bf4ce1fad3)

## 🐝 Remarques

J'ai utilisé le usecase d'acquisition dans les seeds pour obtenir des données cohérentes 🤷🏼.

## 🤧 Pour tester

Se rendre sur la [page d'analyse d'une campagne](https://orga-pr11996.review.pix.fr/campagnes/104871/resultats-evaluation).
La répartition par stage doit être cohérente avec les le palier moyen affiche au dessus et les paliers atteints dans le tableau en dessous 🕵🏼 .
