### PR TITLE
[TECH] Supprimer la dépendance à `ember-fetch` dans Pix App.

### DIFF
--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
-import fetch from 'fetch';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
-import fetch from 'fetch';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import fetch from 'fetch';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 import { createTranslatedApplicationError } from 'mon-pix/errors/factories/create-application-error';

--- a/mon-pix/app/services/file-saver.js
+++ b/mon-pix/app/services/file-saver.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import fetch from 'fetch';
 
 export default class FileSaver extends Service {
   _downloadFileForIEBrowser({ fileContent, fileName }) {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -55,7 +55,6 @@
         "ember-element-helper": "^0.8.6",
         "ember-eslint-parser": "^0.5.0",
         "ember-exam": "^9.0.0",
-        "ember-fetch": "^8.1.2",
         "ember-intl": "^7.0.0",
         "ember-keyboard": "^9.0.0",
         "ember-lifeline": "^7.0.0",
@@ -10397,16 +10396,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/acorn": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
-      "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -10931,13 +10920,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.6.tgz",
-      "integrity": "sha512-Zypm+LjYdWAzvuypZvDN0smUJrhOurcuBWhhMRBExqVLRvdjp3Z9mASxKyq19K+meZMshwjjy5S0lkm388zE4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -10966,30 +10948,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-dynamic-import": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-      "deprecated": "This is probably built in to whatever tool you're using. If you still need it... idk",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^5.0.0"
-      }
-    },
-    "node_modules/acorn-dynamic-import/node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -14139,84 +14097,6 @@
         "matcher-collection": "^1.0.0"
       }
     },
-    "node_modules/broccoli-templater": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-templater/-/broccoli-templater-2.0.2.tgz",
-      "integrity": "sha512-71KpNkc7WmbEokTQpGcbGzZjUIY1NSVa3GB++KFKAfx5SZPUozCOsBlSTwxcv8TLoCAqbBnsX5AQPgg6vJ2l9g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.1",
-        "fs-tree-diff": "^0.5.9",
-        "lodash.template": "^4.4.0",
-        "rimraf": "^2.6.2",
-        "walk-sync": "^0.3.3"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/broccoli-templater/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/broccoli-templater/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/broccoli-templater/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/broccoli-templater/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/broccoli-templater/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.24.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
@@ -14641,19 +14521,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -16408,19 +16275,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "time-zone": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/dayjs": {
@@ -22708,811 +22562,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-fetch": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
-      "integrity": "sha512-TVx24/jrvDIuPL296DV0hBwp7BWLcSMf0I8464KGz01sPytAB+ZAePbc9ooBTJDkKZEGFgatJa4nj3yF1S9Bpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "broccoli-concat": "^4.2.5",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-merge-trees": "^4.2.0",
-        "broccoli-rollup": "^2.1.1",
-        "broccoli-stew": "^3.0.0",
-        "broccoli-templater": "^2.0.1",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "caniuse-api": "^3.0.0",
-        "ember-cli-babel": "^7.23.1",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-cli-version-checker": "^5.1.2",
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/@babel/runtime": {
-      "version": "7.12.18",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/@types/node": {
-      "version": "9.6.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
-      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-fetch/node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/async-disk-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/async-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/async-disk-cache/node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-babel-transpiler": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
-      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/polyfill": "^7.11.5",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "broccoli-persistent-filter": "^2.2.1",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-babel-transpiler/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-funnel/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-persistent-filter/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-rollup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz",
-      "integrity": "sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^9.6.0",
-        "amd-name-resolver": "^1.2.0",
-        "broccoli-plugin": "^1.2.1",
-        "fs-tree-diff": "^0.5.2",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "magic-string": "^0.24.0",
-        "node-modules-path": "^1.0.1",
-        "rollup": "^0.57.1",
-        "symlink-or-copy": "^1.1.8",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/broccoli-source": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ember-cli-babel": {
-      "version": "7.26.11",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
-      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/helper-compilation-targets": "^7.12.0",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.13.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.13.0",
-        "@babel/polyfill": "^7.11.5",
-        "@babel/preset-env": "^7.16.5",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^3.2.0",
-        "broccoli-babel-transpiler": "^7.8.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-source": "^2.1.2",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^4.1.0",
-        "ensure-posix-path": "^1.0.2",
-        "fixturify-project": "^1.10.0",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^3.0.1",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.13.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ember-cli-babel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/find-babel-config": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
-      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^1.0.2",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/fixturify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
-      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/fixturify-project": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
-      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fixturify": "^1.2.0",
-        "tmp": "^0.0.33"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/magic-string": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
-      "integrity": "sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.1"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-fetch/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-fetch/node_modules/reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-fetch/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/rollup": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
-      "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/acorn": "^4.0.3",
-        "acorn": "^5.5.3",
-        "acorn-dynamic-import": "^3.0.0",
-        "date-time": "^2.1.0",
-        "is-reference": "^1.1.0",
-        "locate-character": "^2.0.5",
-        "pretty-ms": "^3.1.0",
-        "require-relative": "^0.8.7",
-        "rollup-pluginutils": "^2.0.1",
-        "signal-exit": "^3.0.2",
-        "sourcemap-codec": "^1.4.1"
-      },
-      "bin": {
-        "rollup": "bin/rollup"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/sync-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/walk-sync/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-fetch/node_modules/workerpool": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
-      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.3.4",
-        "object-assign": "4.1.1",
-        "rsvp": "^4.8.4"
       }
     },
     "node_modules/ember-functions-as-helper-polyfill": {
@@ -33779,16 +32828,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -34714,13 +33753,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/locate-character": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -34766,13 +33798,6 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
       "dev": true,
       "license": "MIT"
     },
@@ -34843,13 +33868,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -34870,27 +33888,6 @@
       "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -36225,52 +35222,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-gyp": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -36410,13 +35361,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-modules-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.2.tgz",
-      "integrity": "sha512-6Gbjq+d7uhkO7epaKi5DNgUJn7H0gEyA4Jg0Mo1uQOi3Rk50G83LtmhhFyw0LxnAFhtlspkiiw52ISP13qzcBg==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/node-notifier": {
       "version": "10.0.1",
@@ -43009,16 +41953,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha512-LpH1Cf5EYuVjkBvCDBYvkUPh+iv2bk3FHflxHkpCYT0/FZ1d3N3uJaLiHr4yGuMcFUhv6eAivitTvWZI4B/chg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -44083,19 +43017,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
-      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/printf": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/printf/-/printf-0.6.1.tgz",
@@ -45121,13 +44042,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -45381,23 +44295,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/route-recognizer": {
       "version": "0.3.4",
@@ -48578,16 +47475,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/time-zone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -49931,13 +48818,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -88,7 +88,6 @@
     "ember-element-helper": "^0.8.6",
     "ember-eslint-parser": "^0.5.0",
     "ember-exam": "^9.0.0",
-    "ember-fetch": "^8.1.2",
     "ember-intl": "^7.0.0",
     "ember-keyboard": "^9.0.0",
     "ember-lifeline": "^7.0.0",

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -19,6 +19,9 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
         const screen = await visit('/connexion/oidc-partner?code=code&state=state');
         await click(screen.getByLabelText(t('common.cgu.label')));
         await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+        // eslint-disable-next-line ember/no-settled-after-test-helper
+        await settled();
+
         await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
 
         // when

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -2,7 +2,7 @@
 
 import { visit } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn, settled } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -93,6 +93,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
         await click(screen.getByRole('checkbox', { name: t('common.cgu.label') }));
         await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+        // eslint-disable-next-line ember/no-settled-after-test-helper
+        await settled();
 
         // then
         assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);

--- a/mon-pix/tests/integration/components/challenge/content-test.js
+++ b/mon-pix/tests/integration/components/challenge/content-test.js
@@ -11,12 +11,9 @@ module('Integration | Component | Challenge | Content', function (hooks) {
 
   let screen;
 
-  hooks.before(function () {
-    sinon.stub(window, 'fetch');
-  });
-
   hooks.beforeEach(async function () {
     // given
+    sinon.stub(window, 'fetch');
     const router = this.owner.lookup('service:router');
     router.transitionTo = sinon.stub();
 
@@ -53,6 +50,10 @@ module('Integration | Component | Challenge | Content', function (hooks) {
   @resetAllChallengeInfo={{this.fakeFunction}}
 />`,
     );
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
   });
 
   module('on challenge skip', function () {

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
-import * as fetch from 'fetch';
 import { SessionStorageEntry } from 'mon-pix//utils/session-storage-entry';
 import { ApplicationError } from 'mon-pix/errors/application-error';
 import { module, test } from 'qunit';
@@ -38,7 +37,7 @@ module('Unit | Route | login-oidc', function (hooks) {
 
     module('when no code exists in queryParams', function (hooks) {
       hooks.beforeEach(function () {
-        sinon.stub(fetch, 'default').resolves({
+        sinon.stub(window, 'fetch').resolves({
           json: sinon.stub().resolves({ redirectTarget: 'https://oidc/connexion' }),
         });
         const oidcPartner = {

--- a/mon-pix/tests/unit/services/file-saver-test.js
+++ b/mon-pix/tests/unit/services/file-saver-test.js
@@ -1,5 +1,4 @@
 import { setupTest } from 'ember-qunit';
-import * as fetch from 'fetch';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -36,7 +35,7 @@ module('Unit | Service | file-saver', function (hooks) {
     module('when options are given', function (hooks) {
       let fetchAPIStub;
       hooks.beforeEach(function () {
-        fetchAPIStub = sinon.stub(fetch, 'default').resolves({
+        fetchAPIStub = sinon.stub(window, 'fetch').resolves({
           ok: true,
           headers: {
             get: sinon.stub().returns(`attachment; filename=${responseFileName}`),


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

`ember-fetch` est déprécié en faveur du `fetch` natif.
Cette dépendance obsolète nous empêche de migrer vers `vite`.

Tous les détails sont dans cette RFC : https://rfcs.emberjs.com/id/1065-remove-ember-fetch

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On supprime la dépendance `ember-fetch` et on utilise `fetch` directement.
Dans les tests, on stubbe désormais `window.fetch`.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On a constaté au passage qu'un test unitaire était dépendant d'un autre pour fonctionner correctement, on en a profité pour corriger ce comportement.

## 🤧 Pour tester

CI verte = 😃 

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
