### PR TITLE
[FEATURE] Renommage du bouton de téléchargement de certificat (PIX-17421).

### DIFF
--- a/mon-pix/app/components/attestations/card.gjs
+++ b/mon-pix/app/components/attestations/card.gjs
@@ -48,7 +48,7 @@ function getAttesttationIcon(type) {
       @iconBefore="download"
       class="attestation-card__button"
     >
-      {{t "pages.certificate.attestation"}}
+      {{t "pages.certificate.actions.download"}}
     </PixButton>
   </PixBlock>
 </template>

--- a/mon-pix/app/components/certifications/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/certifications/user-certifications-detail-header.hbs
@@ -53,7 +53,7 @@
     <div class="attestation-and-verification-code">
       <div class="attestation">
         <PixButton @triggerAction={{this.downloadAttestation}}>
-          {{t "pages.certificate.attestation"}}
+          {{t "pages.certificate.actions.download"}}
         </PixButton>
         {{#if this.attestationDownloadErrorMessage}}
           <p class="attestation__error-message">{{this.attestationDownloadErrorMessage}}</p>

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -247,7 +247,7 @@ module('Integration | Component | user certifications detail header', function (
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
+      await click(screen.getByRole('button', { name: t('pages.certificate.actions.download') }));
 
       // then
       sinon.assert.calledWith(fileSaverSaveStub, {
@@ -360,7 +360,7 @@ module('Integration | Component | user certifications detail header', function (
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
+      await click(screen.getByRole('button', { name: t('pages.certificate.actions.download') }));
 
       // then
       sinon.assert.calledWith(fileSaverSaveStub, {
@@ -460,7 +460,7 @@ module('Integration | Component | user certifications detail header', function (
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
+      await click(screen.getByRole('button', { name: t('pages.certificate.actions.download') }));
 
       // then
       assert.ok(screen.getByText('Une erreur est survenue. Veuillez recommencer ou contacter le support.'));

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -612,7 +612,9 @@
       "title": "Customised test"
     },
     "certificate": {
-      "attestation": "Download my certificate",
+      "actions": {
+        "download": "Download my certificate"
+      },
       "back-link": "Return to my certificates",
       "candidate-birth": "Born on {birthdate}",
       "candidate-birth-complete": "Born on {birthdate} in {birthplace}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -612,7 +612,9 @@
       "title": "Parcours"
     },
     "certificate": {
-      "attestation": "Télécharger mon attestation",
+      "actions": {
+        "download": "Télécharger mon certificat"
+      },
       "back-link": "Retour à mes certifications",
       "candidate-birth": "Né(e) le {birthdate}",
       "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",


### PR DESCRIPTION
## 🌸 Problème

Le bouton de téléchargement de certificat fait encore mention de l'`attestation` alors qu'il s'agit d'un `certificat`

## 🌳 Proposition

- On renomme le bouton

## 🐝 Remarques

- On réorganise le fichier de traductions avec l'ajout d'une section `actions` pour la page `certificate` afin de correspondre à ce qui est stipulé dans l'ADR `0011-organisation-fichier-trad.md`

## 🤧 Pour tester

- Sur pix-app, se connecter avec `certif-success@example.net`
- Aller sur la page d'un certificat
- Vérifier que le nommage du bouton fait désormais mention de `certificat`
