### PR TITLE
[FEATURE] Donner accès aux compétences du candidat sur le modèle du certificat V3 (PIX-17338).

### DIFF
--- a/api/src/certification/results/domain/models/ResultCompetenceTree.js
+++ b/api/src/certification/results/domain/models/ResultCompetenceTree.js
@@ -1,5 +1,5 @@
-import { ResultCompetence } from '../../../../certification/results/domain/models/ResultCompetence.js';
 import { Area } from '../../../../shared/domain/models/Area.js';
+import { ResultCompetence } from './ResultCompetence.js';
 
 const NOT_PASSED_LEVEL = -1;
 const NOT_PASSED_SCORE = 0;

--- a/api/src/certification/results/domain/models/V3CertificationAttestation.js
+++ b/api/src/certification/results/domain/models/V3CertificationAttestation.js
@@ -13,6 +13,8 @@ export class V3CertificationAttestation {
    * @param {string} props.pixScore
    * @param {GlobalCertificationLevel} props.[globalLevel] - auto calculated
    * @param {string} props.verificationCode
+   * @param {Array<ResultCompetenceTree>} props.resultCompetenceTree
+   * @param {AlgorithmEngineVersion} props.algorithmEngineVersion
    */
   constructor({
     id,
@@ -24,6 +26,8 @@ export class V3CertificationAttestation {
     deliveredAt,
     pixScore,
     verificationCode,
+    resultCompetenceTree,
+    algorithmEngineVersion,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -36,5 +40,7 @@ export class V3CertificationAttestation {
     this.globalLevel = new GlobalCertificationLevel({ score: pixScore });
     this.verificationCode = verificationCode;
     this.maxReachableScore = MAX_REACHABLE_SCORE;
+    this.resultCompetenceTree = resultCompetenceTree;
+    this.algorithmEngineVersion = algorithmEngineVersion;
   }
 }

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -152,6 +152,7 @@ function _selectCertificationAttestations() {
       verificationCode: 'certification-courses.verificationCode',
       certificationCenter: 'sessions.certificationCenter',
       maxReachableLevelOnCertificationDate: 'certification-courses.maxReachableLevelOnCertificationDate',
+      algorithmEngineVersion: 'certification-courses.version',
       pixScore: 'assessment-results.pixScore',
       assessmentResultId: 'assessment-results.id',
       competenceMarks: knex.raw(`
@@ -273,6 +274,7 @@ async function _toDomainForCertificationAttestation({ certificationCourseDTO, co
   ) {
     return new V3CertificationAttestation({
       ...certificationCourseDTO,
+      resultCompetenceTree: (await featureToggles.get('isV3CertificationPageEnabled')) ? resultCompetenceTree : [],
     });
   }
 

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,4 +1,5 @@
 import { V3CertificationAttestation } from '../../../../../../src/certification/results/domain/models/V3CertificationAttestation.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 
 const buildV3CertificationAttestation = function ({
   id = 1,
@@ -10,6 +11,8 @@ const buildV3CertificationAttestation = function ({
   deliveredAt = new Date('2018-10-03T01:02:03Z'),
   pixScore = 123,
   verificationCode = 'P-SOMECODE',
+  resultCompetenceTree = null,
+  algorithmEngineVersion = AlgorithmEngineVersion.V3,
 } = {}) {
   return new V3CertificationAttestation({
     id,
@@ -21,6 +24,8 @@ const buildV3CertificationAttestation = function ({
     deliveredAt,
     pixScore,
     verificationCode,
+    resultCompetenceTree,
+    algorithmEngineVersion,
   });
 };
 


### PR DESCRIPTION
## 🌸 Problème
La nouvelle page V3 du certificat est en cours d'implémentation. Nous souhaitons y ajouter les compétences passées par le candidat mais nous ne retournons pas les infos dans le nouveau modèle V3 du certificat

## 🌳 Proposition

Retourner les compétences, en protégeant via le FT.

## 🤧 Pour tester
les tests passent