### PR TITLE
[BUGFIX] Augmentation du délai maximum du job de réplication (MADDO). 

### DIFF
--- a/api/src/maddo/application/jobs/replication-job-controller.js
+++ b/api/src/maddo/application/jobs/replication-job-controller.js
@@ -1,14 +1,13 @@
 import { knex as datamartKnex } from '../../../../datamart/knex-database-connection.js';
 import { knex as datawarehouseKnex } from '../../../../datawarehouse/knex-database-connection.js';
 import { JobController, JobGroup } from '../../../shared/application/jobs/job-controller.js';
-import { JobExpireIn } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ReplicationJob } from '../../domain/models/ReplicationJob.js';
 import { extractTransformAndLoadData } from '../../domain/usecases/extract-transform-and-load-data.js';
 import * as replicationRepository from '../../infrastructure/repositories/replication-repository.js';
 
 export class ReplicationJobController extends JobController {
   constructor() {
-    super(ReplicationJob.name, { jobGroup: JobGroup.MADDO, expireIn: JobExpireIn.FOUR_HOURS });
+    super(ReplicationJob.name, { jobGroup: JobGroup.MADDO });
   }
 
   async handle({

--- a/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
+++ b/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
@@ -1,4 +1,12 @@
-import { JobRepository, JobRetry } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import {
+  JobExpireIn,
+  JobRepository,
+  JobRetry,
+} from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ReplicationJob } from '../../../domain/models/ReplicationJob.js';
 
-export const replicationJobRepository = new JobRepository({ name: ReplicationJob.name, retry: JobRetry.FEW_RETRY });
+export const replicationJobRepository = new JobRepository({
+  name: ReplicationJob.name,
+  retry: JobRetry.FEW_RETRY,
+  expireIn: JobExpireIn.FOUR_HOURS,
+});


### PR DESCRIPTION
## 🌸 Problème

Des erreurs ont été commises dans #11985

## 🌳 Proposition

Utiliser au bon endroit l'option expireIn

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Lancer un job : 

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12003.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

```
curl -X POST https://pix-api-maddo-review-pr12003.osc-fr1.scalingo.io/api/replications/sco_certification_results -H "Authorization: Bearer $ACCESS_TOKEN"
```

Se connecter à la base : 

```
scalingo -a pix-api-review-pr12003 pgsql-console
```

```
select expirein from pgboss.job where name = 'ReplicationJob' order by createdon desc; 
```

Constater que la valeur correspond à 04:00:00
