### PR TITLE
[BUGFIX] Corriger la scrollbar sur le composant transitoire (PIX-17402)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -29,6 +29,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds, participantCoun
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
       participantCount,
+      completionDistribution: { started: participantCount },
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },

--- a/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-shared-results-modal.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/evaluation-shared-results-modal.scss
@@ -10,7 +10,7 @@
   left: 0;
   z-index: 1000;
   padding: 0;
-  overflow-y: hidden;
+  overflow: hidden;
   text-align: center; // Used to center horizontally the inline-block modal content
   // we inline the pix-neutral-800 value
   background-color: rgb(37 56 88 / 50%);
@@ -40,7 +40,7 @@
   width: 100%;
   height: 100%;
   padding: var(--pix-spacing-4x);
-  overflow: hidden;
+  overflow: auto;
   color: var(--pix-neutral-800);
   text-align: center;
   vertical-align: middle; // Centered vertically with the .evaluation-shared-results-modal__overlay::after which is 100% height
@@ -64,8 +64,6 @@
       width: initial;
       height: initial;
     }
-
-
   }
 
   &__title {
@@ -103,7 +101,7 @@
 
 @include breakpoints.device-is('tablet') {
   .evaluation-shared-results-modal {
-      padding: 48px 80px;
+    padding: 48px 80px;
 
     &__header {
       padding-top: 0;


### PR DESCRIPTION
## 🌸 Problème

Sur un petit format d'écran, le composant transitoire n'affiche pas la scrollbar. Cela empêche d'afficher tout le contenu.

## 🌳 Proposition

Corriger cela.

## 🐝 Remarques

C'était causé par l'héritage de l'overflow sur la modale.

## 🤧 Pour tester
1. Se connecter en tant qu'une personne de devcomp (voir https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/18907137/Seeds+Review+app+Integration+et+local#Utilisateurs%3A)
2. Accéder à une des 2 campagnes (préférence pour `EDUMULTIP` pour pouvoir renvoyer les résultats)
3. Envoyer ses résultats
4. Constater que la Modale est scrollbar en cas de device trop petit.