### PR TITLE
[TECH] Ajout de métriques sur le pool de connexion pour toutes les connexions de base de données.

### DIFF
--- a/api/db/database-connection.js
+++ b/api/db/database-connection.js
@@ -84,4 +84,21 @@ export class DatabaseConnection {
     const rows = resultSet.rows;
     return _.map(rows, 'table_name');
   }
+
+  getPoolMetrics() {
+    if (!this.knex.client.pool) {
+      return {};
+    }
+
+    return {
+      [this.#name]: {
+        used: this.knex.client.pool.numUsed(),
+        free: this.knex.client.pool.numFree(),
+        pendingAcquires: this.knex.client.pool.numPendingAcquires(),
+        pendingCreates: this.knex.client.pool.numPendingCreates(),
+        min: this.knex.client.pool.min,
+        max: this.knex.client.pool.max,
+      },
+    };
+  }
 }

--- a/api/db/database-connections.js
+++ b/api/db/database-connections.js
@@ -18,6 +18,13 @@ class DatabaseConnections {
   async checkStatuses() {
     return Promise.all(this.#connections.map((connection) => connection.checkStatus()));
   }
+
+  getPoolMetrics() {
+    const pools = this.#connections.reduce((acc, current) => {
+      return { ...acc, ...current.getPoolMetrics() };
+    }, {});
+    return { pools };
+  }
 }
 
 export const databaseConnections = new DatabaseConnections();

--- a/api/server.js
+++ b/api/server.js
@@ -3,6 +3,7 @@ import Hapi from '@hapi/hapi';
 import { parse } from 'neoqs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
+import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
 import { routes } from './lib/routes.js';
@@ -192,15 +193,9 @@ const enableLegacyOpsMetrics = async function (server) {
   const oppsy = new Oppsy(server);
 
   oppsy.on('ops', (data) => {
-    const knexPool = knex.client.pool;
     server.log(['ops'], {
       ...data,
-      knexPool: {
-        used: knexPool.numUsed(),
-        free: knexPool.numFree(),
-        pendingAcquires: knexPool.numPendingAcquires(),
-        pendingCreates: knexPool.numPendingCreates(),
-      },
+      ...databaseConnections.getPoolMetrics(),
     });
   });
 

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -3,6 +3,7 @@ import Hapi from '@hapi/hapi';
 import { parse } from 'neoqs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
+import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
 import { authentication } from './lib/infrastructure/authentication.js';
 import * as parcoursupRoutes from './src/certification/results/application/parcoursup-route.js';
@@ -145,15 +146,9 @@ const enableLegacyOpsMetrics = async function (server) {
   const oppsy = new Oppsy(server);
 
   oppsy.on('ops', (data) => {
-    const knexPool = knex.client.pool;
     server.log(['ops'], {
       ...data,
-      knexPool: {
-        used: knexPool.numUsed(),
-        free: knexPool.numFree(),
-        pendingAcquires: knexPool.numPendingAcquires(),
-        pendingCreates: knexPool.numPendingCreates(),
-      },
+      ...databaseConnections.getPoolMetrics(),
     });
   });
 

--- a/api/tests/integration/infrastructure/database-connection_test.js
+++ b/api/tests/integration/infrastructure/database-connection_test.js
@@ -42,4 +42,46 @@ describe('Integration | Infrastructure | database-connection', function () {
       await expect(datawarehouseDatabaseConnection.prepare()).to.be.fulfilled;
     });
   });
+
+  describe('#getPoolMetrics', function () {
+    it('should return pool metrics', async function () {
+      // given
+      const { environment } = config;
+      const databaseConnection = new DatabaseConnection(liveKnexConfigs[environment]);
+
+      // when
+      const poolMetrics = databaseConnection.getPoolMetrics();
+
+      // then
+      expect(poolMetrics).to.deep.equal({
+        live: {
+          used: 0,
+          free: 0,
+          pendingAcquires: 0,
+          pendingCreates: 0,
+          min: 1,
+          max: 4,
+        },
+      });
+    });
+
+    it('should not return metrics when connection is not defined', async function () {
+      // given
+      const databaseConnection = new DatabaseConnection({
+        name: 'not-existing-pg',
+        client: 'postgresql',
+        connection: undefined,
+        pool: {
+          min: 1,
+          max: 2,
+        },
+      });
+
+      // when
+      const poolMetrics = databaseConnection.getPoolMetrics();
+
+      // then
+      expect(poolMetrics).to.deep.equal({});
+    });
+  });
 });


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Actuellement, seules les métriques du pool de connexion de la base de données live sont envoyées via oopsy.
Avec l'ajout de connexions au datamart et au datawarehouse, nous n'avons pas de visibilité sur ces pools de connexion.

## 🌳 Proposition

On ajoute les données pour toutes les "database-connection" instanciées dans l'application.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

Cela ne fonctionne pas pour les workers, qui n'utilisent pas `hapi`.

Des changements sont à prévoir / synchroniser pour les captains dans les dashboards DD.


## 🤧 Pour tester

Sur les applications `api` et `maddo` :

Activer les métriques via la variable d'environnement `LOG_OPS_METRICS`.
Vérifier que les logs de type "ops" contiennent les données des pools de connexions des différentes connexions aux bases de données.


<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
