### PR TITLE
[BUGFIX] Corriger des erreurs suite à la montée de version Pix UI sur Pix Certif (PIX-17429).

### DIFF
--- a/certif/app/components/members-table.gjs
+++ b/certif/app/components/members-table.gjs
@@ -98,6 +98,7 @@ export default class MembersTable extends Component {
                     <:triggerElement>
                       <PixIconButton
                         @ariaLabel={{t 'pages.team.members.actions.edit-role'}}
+                        @plainIcon={{true}}
                         @iconName='edit'
                         @triggerAction={{fn @onChangeMemberRoleButtonClicked member}}
                       />
@@ -113,6 +114,7 @@ export default class MembersTable extends Component {
                       <PixIconButton
                         @ariaLabel={{t 'pages.team.members.actions.remove-membership'}}
                         @iconName='delete'
+                        @plainIcon={{true}}
                         @triggerAction={{fn @onRemoveMemberButtonClicked member}}
                       />
                     </:triggerElement>
@@ -129,6 +131,7 @@ export default class MembersTable extends Component {
                       <PixIconButton
                         @ariaLabel={{t 'pages.team.members.actions.leave-certification-center'}}
                         @iconName='delete'
+                        @plainIcon={{true}}
                         @triggerAction={{@onLeaveCertificationCenterButtonClicked}}
                       />
                     </:triggerElement>

--- a/certif/app/styles/components/finalization-confirmation-modal.scss
+++ b/certif/app/styles/components/finalization-confirmation-modal.scss
@@ -3,7 +3,6 @@
 .finalization-confirmation-modal {
   min-width: 578px;
   max-width: 578px;
-  margin: 315px auto;
 
   &__warning {
     font-weight: 500;

--- a/certif/app/styles/components/select-referer-modal.scss
+++ b/certif/app/styles/components/select-referer-modal.scss
@@ -1,8 +1,6 @@
 @use 'pix-design-tokens/typography';
 
 .select-referer-modal {
-  width: 35%;
-
   &__title {
     color: var(--pix-neutral-900);
 

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -65,6 +65,14 @@
   &__menu {
     border-left: 1px solid var(--pix-neutral-100);
     padding: var(--pix-spacing-2x);
+
+    .pix-icon-button {
+      color: var(--pix-neutral-0);
+
+      &:hover {
+        color: var(--pix-neutral-800);
+      }
+    }
   }
 
   .dropdown__content {

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -34,7 +34,7 @@
   &__date {
     margin-right: 40px;
     padding-right: 40px;
-    border-right: 1px solid var(--pix-neutral-20);
+    border-right: 1px solid var(--pix-neutral-500);
   }
 
   &__text {

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -128,6 +128,20 @@
   &__clipboard-button {
     margin-left: 4px;
   }
+
+  .pix-icon-button {
+    &:hover {
+      background-color: var(--pix-neutral-0);
+      &:active {
+        color: var(--pix-neutral-0);
+      }
+    }
+    &:focus {
+      &:hover {
+        background-color: var(--pix-neutral-800);
+      }
+    }
+  }
 }
 
 .session-details-buttons {


### PR DESCRIPTION
## 🌸 Problème

Depuis la récente montée de version de Pix UI, on a rencontré plusieurs problèmes : 
- en retirant les background des boutons PixIconButton, le bouton dans l’espace surveillant apparaît en sombre alors que le fond l’est aussi, on perd énormément en contraste.
- en ajoutant le PixOverlay dans les modales, ça à décalé certains à qui on imposait des margin en dur.

<img width="822" alt="Capture d’écran 2025-04-09 à 15 30 42" src="https://github.com/user-attachments/assets/948d0980-3bff-40e9-9f84-1b7cfe3f1825" />

<img width="1722" alt="Capture d’écran 2025-04-09 à 15 43 29" src="https://github.com/user-attachments/assets/06c40a2e-8f9e-4808-bc79-a0c3eca914ab" />

## 🌳 Proposition

Changer la couleur en surchargeant le composant Pix UI, correction temporaire en attendant une variante sur Pix UI

## 🤧 Pour tester

- se connecter sur Pix Certif avec certif-pro@example.net
- Créer une session
- Aller dans l'espace surveillant

<img width="847" alt="Capture d’écran 2025-04-09 à 15 33 46" src="https://github.com/user-attachments/assets/18580d8a-9909-49ec-a60e-aa4c47cbc538" />

<img width="1722" alt="Capture d’écran 2025-04-09 à 15 49 14" src="https://github.com/user-attachments/assets/c6463d17-ae36-4a24-999b-814a4bd695bd" />


