### PR TITLE
[TECH] Ajouter le dossier oublié des scripts de devcomp aux review automatiques (PIX-17430)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
+/api/scripts/modulix/ @1024pix/team-devcomp
 /api/src/devcomp/application/ @1024pix/team-devcomp
 /api/src/devcomp/domain/ @1024pix/team-devcomp
 /api/src/devcomp/infrastructure/datasources/conversion/ @1024pix/team-devcomp


### PR DESCRIPTION
## 🌸 Problème

On a fait du nettoyage des dossier à faire en review par Devcomp dans une PR précédente, mais le dossier /api/scripts/modulix/ qui n'était pas présent n'a pas été rajouté.

## 🌳 Proposition

Ajouter ce dossier au CODEOWNERS.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

Pas de testes possible, mais ça marchera.
