### PR TITLE
[TECH] Supprimer le FT showNewCampaignPresentationPage (PIX-17434).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -828,13 +828,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
 
-# Display the new campaign presentation page
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE=false
-
 # Consider experimental missions as active
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -309,7 +309,6 @@ const configuration = (function () {
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
-      showNewCampaignPresentationPage: toBoolean(process.env.FT_SHOW_NEW_CAMPAIGN_PRESENTATION_PAGE),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -37,7 +37,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'setup-ecosystem-before-start': false,
             'should-display-new-analysis-page': false,
             'show-experimental-missions': false,
-            'show-new-campaign-presentation-page': false,
             'show-new-result-page': false,
             'is-v3-certification-page-enabled': false,
           },

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -2,7 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
-  @attr('boolean') showNewCampaignPresentationPage;
   @attr('boolean') isPixAppNewLayoutEnabled;
   @attr('boolean') isPixCompanionEnabled;
   @attr('boolean') isQuestEnabled;

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -11,7 +11,6 @@ module('Unit | Service | feature-toggles', function (hooks) {
     const featureToggles = Object.create({
       isTextToSpeechButtonEnabled: false,
       isPixCompanionEnabled: false,
-      showNewCampaignPresentationPage: false,
     });
 
     let storeStub;
@@ -56,18 +55,6 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.false(featureToggleService.featureToggles.isPixCompanionEnabled);
-    });
-
-    test('it initializes the feature toggle showNewCampaignPresentationPage to false', async function (assert) {
-      // given
-      const featureToggleService = this.owner.lookup('service:featureToggles');
-      featureToggleService.set('store', storeStub);
-
-      // when
-      await featureToggleService.load();
-
-      // then
-      assert.false(featureToggleService.featureToggles.showNewCampaignPresentationPage);
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Ce feature-toggle n’est plus utilisé depuis la clôture de https://github.com/1024pix/pix/pull/10425 

## 🌳 Proposition

Supprimer l'usage de ce FT dans le code.

## 🤧 Pour tester

Tests toujours verts
