### PR TITLE
[TECH] Prévenir les incompréhensions due aux expirations de jobs.  

### DIFF
--- a/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
+++ b/api/src/maddo/infrastructure/repositories/jobs/replication-job-repository.js
@@ -1,12 +1,7 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ReplicationJob } from '../../../domain/models/ReplicationJob.js';
 
 export const replicationJobRepository = new JobRepository({
   name: ReplicationJob.name,
   retry: JobRetry.FEW_RETRY,
-  expireIn: JobExpireIn.FOUR_HOURS,
 });

--- a/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
+++ b/api/src/prescription/learner-management/application/jobs/schedule-compute-organization-learners-certificability-job-controller.js
@@ -5,7 +5,6 @@ import { ComputeCertificabilityJob } from '../../../../prescription/learner-mana
 import { JobScheduleController } from '../../../../shared/application/jobs/job-schedule-controller.js';
 import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { JobExpireIn } from '../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import * as organizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { computeCertificabilityJobRepository } from '../../../learner-management/infrastructure/repositories/jobs/compute-certificability-job-repository.js';
@@ -16,7 +15,6 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobController extends Jo
   constructor() {
     super('ScheduleComputeOrganizationLearnersCertificabilityJob', {
       jobCron: config.features.scheduleComputeOrganizationLearnersCertificability.cron,
-      expireIn: JobExpireIn.FOUR_HOURS,
     });
   }
 

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportCommonOrganizationLearnersJob } from '../../../domain/models/ImportCommonOrganizationLearnersJob.js';
 
 class ImportCommonOrganizationLearnersJobRepository extends JobRepository {
   constructor() {
     super({
       name: ImportCommonOrganizationLearnersJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportOrganizationLearnersJob } from '../../../domain/models/ImportOrganizationLearnersJob.js';
 
 class ImportOrganizationLearnersJobRepository extends JobRepository {
   constructor() {
     super({
       name: ImportOrganizationLearnersJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportScoCsvOrganizationLearnersJob } from '../../../domain/models/ImportScoCsvOrganizationLearnersJob.js';
 
 class ImportScoCsvOrganizationLearnersJobRepository extends JobRepository {
   constructor() {
     super({
       name: ImportScoCsvOrganizationLearnersJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ImportSupOrganizationLearnersJob } from '../../../domain/models/ImportSupOrganizationLearnersJob.js';
 
 class ImportSupOrganizationLearnersJobRepository extends JobRepository {
   constructor() {
     super({
       name: ImportSupOrganizationLearnersJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateCommonOrganizationImportFileJob } from '../../../domain/models/ValidateCommonOrganizationImportFileJob.js';
 
 class ValidateCommonOrganizationImportFileJobRepository extends JobRepository {
   constructor() {
     super({
       name: ValidateCommonOrganizationImportFileJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateCsvOrganizationImportFileJob } from '../../../domain/models/ValidateCsvOrganizationImportFileJob.js';
 
 class ValidateCsvOrganizationImportFileJobRepository extends JobRepository {
   constructor() {
     super({
       name: ValidateCsvOrganizationImportFileJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js
@@ -1,15 +1,10 @@
-import {
-  JobExpireIn,
-  JobRepository,
-  JobRetry,
-} from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
 import { ValidateOrganizationImportFileJob } from '../../../domain/models/ValidateOrganizationImportFileJob.js';
 
 class ValidateOrganizationImportFileJobRepository extends JobRepository {
   constructor() {
     super({
       name: ValidateOrganizationImportFileJob.name,
-      expireIn: JobExpireIn.HIGH,
       retry: JobRetry.FEW_RETRY,
     });
   }

--- a/api/src/shared/application/jobs/job-controller.js
+++ b/api/src/shared/application/jobs/job-controller.js
@@ -14,7 +14,7 @@ export class JobController {
   constructor(jobName, options = {}) {
     this.jobName = jobName;
     this.jobGroup = options.jobGroup ?? JobGroup.DEFAULT;
-    this.expireIn = options.expireIn ?? JobExpireIn.DEFAULT;
+    this.expireIn = options.expireIn ?? JobExpireIn.INFINITE;
 
     this.#validate();
   }

--- a/api/src/shared/infrastructure/repositories/jobs/job-repository.js
+++ b/api/src/shared/infrastructure/repositories/jobs/job-repository.js
@@ -38,7 +38,7 @@ export class JobRepository {
 
     this.retry = config.retry || JobRetry.NO_RETRY;
 
-    this.expireIn = config.expireIn || JobExpireIn.DEFAULT;
+    this.expireIn = config.expireIn || JobExpireIn.INFINITE;
     this.priority = config.priority || JobPriority.DEFAULT;
 
     this.#validate();
@@ -130,7 +130,9 @@ export const JobRetry = Object.freeze({
  * @enum {string}
  */
 export const JobExpireIn = Object.freeze({
-  DEFAULT: '00:15:00',
-  HIGH: '00:30:00',
-  FOUR_HOURS: '04:00:00',
+  INFINITE: '48:00:00',
+  /*
+   pg-boss n'arrête pas les jobs expirés. De plus, il empile d'autres jobs par dessus et relance le job expiré, ce qui peut provoquer des états incohérents.
+   Par conséquent nous définissons 48 heures comme durée maximale, ce qui fait plus que la durée maximale d'un conteneur.
+   */
 });

--- a/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
+++ b/api/src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js
@@ -1,11 +1,10 @@
-import { JobExpireIn, JobRepository, JobRetry } from '../../../../infrastructure/repositories/jobs/job-repository.js';
+import { JobRepository, JobRetry } from '../../../../infrastructure/repositories/jobs/job-repository.js';
 
 class SendEmailJobRepository extends JobRepository {
   constructor() {
     super({
       name: 'SendEmailJob',
       retry: JobRetry.STANDARD_RETRY,
-      expireIn: JobExpireIn.HIGH,
     });
   }
 }

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-common-organization-learners-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ImportCommonOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportCommonOrganizationLearnersJob.js';
 import { importCommonOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-common-organization-learners-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importCommonOrganizationLearnersJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportCommonOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-organization-learners-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ImportOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportOrganizationLearnersJob.js';
 import { importOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-organization-learners-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importOrganizationLearnersJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ImportScoCsvOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportScoCsvOrganizationLearnersJob.js';
 import { importScoCsvOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-sco-csv-organization-learners-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importScoCsvOrganizationLearnersJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportScoCsvOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ImportSupOrganizationLearnersJob } from '../../../../../../../src/prescription/learner-management/domain/models/ImportSupOrganizationLearnersJob.js';
 import { importSupOrganizationLearnersJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/import-sup-organization-learners-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | importSupOrganizationLearnersJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | impo
 
       // then
       await expect(ImportSupOrganizationLearnersJob.name).to.have.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ValidateCommonOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateCommonOrganizationImportFileJob.js';
 import { validateCommonOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-common-organization-learners-import-file-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateCommonOrganizationImportFileJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCommonOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ValidateCsvOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateCsvOrganizationImportFileJob.js';
 import { validateCsvOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-csv-organization-learners-import-file-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateCsvOrganizationImportFileJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateCsvOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository_test.js
@@ -1,9 +1,6 @@
 import { ValidateOrganizationImportFileJob } from '../../../../../../../src/prescription/learner-management/domain/models/ValidateOrganizationImportFileJob.js';
 import { validateOrganizationImportFileJobRepository } from '../../../../../../../src/prescription/learner-management/infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js';
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Integration | Prescription | Infrastructure | Repository | Jobs | validateOrganizationImportFileJobRepository', function () {
@@ -16,7 +13,6 @@ describe('Integration | Prescription | Infrastructure | Repository | Jobs | vali
 
       // then
       await expect(ValidateOrganizationImportFileJob.name).to.have.been.performed.withJob({
-        expirein: JobExpireIn.HIGH,
         retrylimit: JobRetry.FEW_RETRY.retryLimit,
         retrydelay: JobRetry.FEW_RETRY.retryDelay,
         retrybackoff: JobRetry.FEW_RETRY.retryBackoff,

--- a/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/jobs/job-repository_test.js
@@ -24,7 +24,7 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
     await expect(name).to.have.been.performed.withJob({
       name,
       data: expectedParams,
-      expirein: '00:15:00',
+      expirein: '48:00:00',
       priority,
       retrydelay: 30,
       retrylimit: 10,
@@ -52,7 +52,7 @@ describe('Integration | Infrastructure | Repositories | Jobs | job-repository', 
     const name = 'JobTest';
     const expectedParams = [{ jobParam: 1 }, { jobParam: 2 }];
     const retry = JobRetry.STANDARD_RETRY;
-    const expireIn = JobExpireIn.HIGH;
+    const expireIn = JobExpireIn.INFINITE;
     const priority = JobPriority.HIGH;
 
     const job = new JobRepository({ name, retry, expireIn, priority });

--- a/api/tests/shared/unit/application/jobs/job-controller_test.js
+++ b/api/tests/shared/unit/application/jobs/job-controller_test.js
@@ -30,7 +30,7 @@ describe('Unit | Shared | Application | Jobs | JobController', function () {
     // given
     const jobName = 'jobName';
     const jobGroup = JobGroup.DEFAULT;
-    const expireIn = JobExpireIn.DEFAULT;
+    const expireIn = JobExpireIn.INFINITE;
 
     // when
     const controller = new JobController(jobName);

--- a/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/repositories/jobs/send-email.job-repository_test.js
@@ -1,7 +1,4 @@
-import {
-  JobExpireIn,
-  JobRetry,
-} from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { JobRetry } from '../../../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
 import { sendEmailJobRepository } from '../../../../../../../src/shared/mail/infrastructure/repositories/jobs/send-email.job-repository.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -9,6 +6,5 @@ describe('Unit | Email | Infrastructure | Jobs | SendEmailJobRepository', functi
   it('sets up the send email job configuration', function () {
     expect(sendEmailJobRepository.name).to.equal('SendEmailJob');
     expect(sendEmailJobRepository.retry).to.equal(JobRetry.STANDARD_RETRY);
-    expect(sendEmailJobRepository.expireIn).to.equal(JobExpireIn.HIGH);
   });
 });

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -152,7 +152,7 @@ describe('#registerJobs', function () {
       expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
         name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
         cron: '0 21 * * *',
-        options: { tz: 'Europe/Paris', expireIn: JobExpireIn.FOUR_HOURS },
+        options: { tz: 'Europe/Paris', expireIn: JobExpireIn.INFINITE },
       });
     });
 


### PR DESCRIPTION
## 🌸 Problème

Pg-boss utilise [Promise.race()](https://github.com/timgit/pg-boss/blob/9ee9ccd7a72dc076c2ef45fe7c243450f68bdf7d/src/manager.js#L27), pour définir si un job a son délai de traitement qui a expiré. 
Le problème est que `Promise.race` n'arrête pas les promesses en cours, il retourne juste la première promesse qui est terminée. Dans notre cas, lorsqu'un job expire, il est alors marqué comme expiré par pg-boss qui va le retenter plus tard, alors que le job continue en tâche de fond. 

Des ressources pour comprendre le souhait et l'usage de `expirein` par pg-boss :

https://github.com/timgit/pg-boss/issues/238
https://github.com/timgit/pg-boss/issues/102

## 🌳 Proposition

Utiliser une valeur complétement arbitraire et exagéré pour ne pas se soucier de la config `expireIn` qui peut causer plus de mal que de bien. 
Nous proposons de la mettre à 48h, car nous souhaitons déployer du code à un intervalle plus court que 24h, ce qui fait que la durée de vie d'un conteneur ne peut pas excéder le temps entre deux déploiements. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Faire une action qui ajoute un job 
Constater en base que le job a un `expirein` à `48:00:00`
