### PR TITLE
[FEATURE] Ne récupérer que les certifs v3 lors du téléchargement des certifs d'une classe (PIX-17435).

### DIFF
--- a/api/src/certification/results/application/certification-attestation-controller.js
+++ b/api/src/certification/results/application/certification-attestation-controller.js
@@ -107,7 +107,9 @@ const downloadCertificationAttestationsForDivision = async function (
     division,
   });
 
-  if (attestations.every((attestation) => attestation instanceof V3CertificationAttestation)) {
+  if (attestations.some((attestation) => attestation instanceof V3CertificationAttestation)) {
+    const v3Certificates = attestations.filter((certificate) => certificate instanceof V3CertificationAttestation);
+
     const normalizedDivision = normalizeAndRemoveAccents(division);
 
     const translatedFileName = i18n.__('certification-confirmation.file-name', {
@@ -117,7 +119,7 @@ const downloadCertificationAttestationsForDivision = async function (
     return h
       .response(
         dependencies.v3CertificationAttestationPdf.generate({
-          certificates: attestations,
+          certificates: v3Certificates,
           i18n,
         }),
       )

--- a/api/tests/certification/results/unit/application/certification-attestation-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-attestation-controller_test.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import { certificationAttestationController } from '../../../../../src/certification/results/application/certification-attestation-controller.js';
 import { usecases } from '../../../../../src/certification/results/domain/usecases/index.js';
+import { SESSIONS_VERSIONS } from '../../../../../src/certification/shared/domain/models/SessionVersion.js';
 import { LANGUAGES_CODE } from '../../../../../src/shared/domain/services/language-service.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
@@ -232,13 +233,16 @@ describe('Certification | Results | Unit | Application | Controller | certificat
       clock.restore();
     });
 
-    describe('when attestations are for v3', function () {
-      it('should return division attestations in PDF binary format', async function () {
+    describe('when there are at least one v3 attestation', function () {
+      it('should return only v3 division attestations in PDF binary format', async function () {
         // given
         const userId = 1;
         const i18n = getI18n();
 
         const v3CertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation();
+        const v2CertificationAttestation = domainBuilder.buildCertificationAttestation({
+          version: SESSIONS_VERSIONS.V2,
+        });
         const generatedPdf = Symbol('Stream');
 
         const organizationId = domainBuilder.buildOrganization().id;
@@ -257,7 +261,7 @@ describe('Certification | Results | Unit | Application | Controller | certificat
             division,
             organizationId,
           })
-          .resolves([v3CertificationAttestation, v3CertificationAttestation]);
+          .resolves([v3CertificationAttestation, v3CertificationAttestation, v2CertificationAttestation]);
 
         const generatePdfStub = {
           generate: sinon.stub().returns(generatedPdf),


### PR DESCRIPTION
## 🌸 Problème

Pour les classes qui contiennent à la fois des candidats ayant passé une certification v2 et des candidats ayant passé une certification v3, les établissements ont des messages d’erreur lorsqu’ils tentent de télécharger les certificats .pdf.

## 🌳 Proposition

Dès lors qu’il y a au moins une certification v3 dans une classe, le téléchargement ne doit comprendre que les certificats pdf des certifications v3.

## 🐝 Remarques

Pour les candidats qui ont passé une v2 dans cette classe, ils devront aller chercher leur certificat pdf dans Pix App ou bien la demander au support/métier certif qui pourra le récupérer dans Pix Admin.

## 🤧 Pour tester

Ce qu'on peut voir sur certif avec l'utilisateur `sco-managing-students-v3@example.net` :

<img width="731" alt="image" src="https://github.com/user-attachments/assets/e298c942-34e8-4b9f-a62c-6c90e5e092ff" />

Sur Orga, avec le même utilisateur, télécharger les attestations de la classe 6ème.
Dans le PDF généré, il ne devrait n'y avoir que 2 pages (correspondant aux 2 participants des candidats en v3).
