### PR TITLE
[FEATURE] Créer l'API interne pour mettre à disposition les données des participations par campagne (PIX-17351)

### DIFF
--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -15,353 +15,378 @@
 
 ## CampaignApi
 
-* [CampaignApi](#module_CampaignApi)
-    * [~save(campaign)](#module_CampaignApi..save) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
-    * [~get(campaignId)](#module_CampaignApi..get) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-    * [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-    * [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
-    * [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
-    * [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
-    * [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
-    * [~PageDefinition](#module_CampaignApi..PageDefinition) : <code>object</code>
-    * [~CampaignListPayload](#module_CampaignApi..CampaignListPayload) : <code>object</code>
-    * [~Pagination](#module_CampaignApi..Pagination) : <code>object</code>
-    * [~CampaignListResponse](#module_CampaignApi..CampaignListResponse) : <code>object</code>
+- [CampaignApi](#module_CampaignApi)
+  - [~save(campaign)](#module_CampaignApi..save) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
+  - [~get(campaignId)](#module_CampaignApi..get) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+  - [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+  - [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
+  - [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
+  - [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
+  - [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
+  - [~PageDefinition](#module_CampaignApi..PageDefinition) : <code>object</code>
+  - [~CampaignListPayload](#module_CampaignApi..CampaignListPayload) : <code>object</code>
+  - [~Pagination](#module_CampaignApi..Pagination) : <code>object</code>
+  - [~CampaignListResponse](#module_CampaignApi..CampaignListResponse) : <code>object</code>
 
 <a name="module_CampaignApi..save"></a>
 
 ### CampaignApi~save(campaign) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
+
 **Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Throws**:
 
 - <code>UserNotAuthorizedToCreateCampaignError</code> to be improved to handle different error types
 
-
-| Param | Type |
-| --- | --- |
-| campaign | <code>CampaignPayload</code> | 
+| Param    | Type                         |
+| -------- | ---------------------------- |
+| campaign | <code>CampaignPayload</code> |
 
 <a name="module_CampaignApi..get"></a>
 
 ### CampaignApi~get(campaignId) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-| Param | Type |
-| --- | --- |
-| campaignId | <code>number</code> | 
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
+
+| Param      | Type                |
+| ---------- | ------------------- |
+| campaignId | <code>number</code> |
 
 <a name="module_CampaignApi..update"></a>
 
 ### CampaignApi~update(payload) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-| Param | Type |
-| --- | --- |
-| payload | <code>UpdateCampaignPayload</code> | 
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
+
+| Param   | Type                               |
+| ------- | ---------------------------------- |
+| payload | <code>UpdateCampaignPayload</code> |
 
 <a name="module_CampaignApi..findAllForOrganization"></a>
 
 ### CampaignApi~findAllForOrganization(payload) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-| Param | Type |
-| --- | --- |
-| payload | <code>CampaignListPayload</code> | 
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
+
+| Param   | Type                             |
+| ------- | -------------------------------- |
+| payload | <code>CampaignListPayload</code> |
 
 <a name="module_CampaignApi..CampaignPayload"></a>
 
 ### CampaignApi~CampaignPayload : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| name | <code>string</code> | 
-| title | <code>string</code> | 
-| targetProfileId | <code>number</code> | 
-| organizationId | <code>number</code> | 
-| creatorId | <code>number</code> | 
-| customLandingPageText | <code>string</code> | 
+| Name                  | Type                |
+| --------------------- | ------------------- |
+| name                  | <code>string</code> |
+| title                 | <code>string</code> |
+| targetProfileId       | <code>number</code> |
+| organizationId        | <code>number</code> |
+| creatorId             | <code>number</code> |
+| customLandingPageText | <code>string</code> |
 
 <a name="module_CampaignApi..UserNotAuthorizedToCreateCampaignError"></a>
 
 ### CampaignApi~UserNotAuthorizedToCreateCampaignError : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| message | <code>string</code> | 
+| Name    | Type                |
+| ------- | ------------------- |
+| message | <code>string</code> |
 
 <a name="module_CampaignApi..UpdateCampaignPayload"></a>
 
 ### CampaignApi~UpdateCampaignPayload : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| campaignId | <code>number</code> | 
-| name | <code>string</code> | 
-| title | <code>string</code> | 
-| customLandingPageText | <code>string</code> | 
+| Name                  | Type                |
+| --------------------- | ------------------- |
+| campaignId            | <code>number</code> |
+| name                  | <code>string</code> |
+| title                 | <code>string</code> |
+| customLandingPageText | <code>string</code> |
 
 <a name="module_CampaignApi..PageDefinition"></a>
 
 ### CampaignApi~PageDefinition : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| size | <code>number</code> | 
-| number | <code>Page</code> | 
+| Name   | Type                |
+| ------ | ------------------- |
+| size   | <code>number</code> |
+| number | <code>Page</code>   |
 
 <a name="module_CampaignApi..CampaignListPayload"></a>
 
 ### CampaignApi~CampaignListPayload : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| organizationId | <code>number</code> | 
-| page | <code>PageDefinition</code> | 
+| Name           | Type                        |
+| -------------- | --------------------------- |
+| organizationId | <code>number</code>         |
+| page           | <code>PageDefinition</code> |
+| withCoverRate  | <code>boolean</code>        |
 
 <a name="module_CampaignApi..Pagination"></a>
 
 ### CampaignApi~Pagination : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| page | <code>number</code> | 
-| pageSize | <code>number</code> | 
-| rowCount | <code>number</code> | 
-| pageCount | <code>number</code> | 
+| Name      | Type                |
+| --------- | ------------------- |
+| page      | <code>number</code> |
+| pageSize  | <code>number</code> |
+| rowCount  | <code>number</code> |
+| pageCount | <code>number</code> |
 
 <a name="module_CampaignApi..CampaignListResponse"></a>
 
 ### CampaignApi~CampaignListResponse : <code>object</code>
+
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| models | <code>Array.&lt;CampaignListItem&gt;</code> | 
-| meta | <code>Pagination</code> | 
+| Name   | Type                                        |
+| ------ | ------------------------------------------- |
+| models | <code>Array.&lt;CampaignListItem&gt;</code> |
+| meta   | <code>Pagination</code>                     |
 
 <a name="module_OrganizationLearnerApi"></a>
 
 ## OrganizationLearnerApi
 
-* [OrganizationLearnerApi](#module_OrganizationLearnerApi)
-    * [~find(payload)](#module_OrganizationLearnerApi..find) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
-    * [~get(organizationLearnerId)](#module_OrganizationLearnerApi..get) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
-    * [~PageDefinition](#module_OrganizationLearnerApi..PageDefinition) : <code>object</code>
-    * [~FilterDefinition](#module_OrganizationLearnerApi..FilterDefinition) : <code>object</code>
-    * [~OrganizationLearnerListPayload](#module_OrganizationLearnerApi..OrganizationLearnerListPayload) : <code>object</code>
-    * [~Pagination](#module_OrganizationLearnerApi..Pagination) : <code>object</code>
-    * [~OrganizationLearner](#module_OrganizationLearnerApi..OrganizationLearner) : <code>object</code>
-    * [~OrganizationLearnerListResponse](#module_OrganizationLearnerApi..OrganizationLearnerListResponse) : <code>object</code>
+- [OrganizationLearnerApi](#module_OrganizationLearnerApi)
+  - [~find(payload)](#module_OrganizationLearnerApi..find) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
+  - [~get(organizationLearnerId)](#module_OrganizationLearnerApi..get) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
+  - [~PageDefinition](#module_OrganizationLearnerApi..PageDefinition) : <code>object</code>
+  - [~FilterDefinition](#module_OrganizationLearnerApi..FilterDefinition) : <code>object</code>
+  - [~OrganizationLearnerListPayload](#module_OrganizationLearnerApi..OrganizationLearnerListPayload) : <code>object</code>
+  - [~Pagination](#module_OrganizationLearnerApi..Pagination) : <code>object</code>
+  - [~OrganizationLearner](#module_OrganizationLearnerApi..OrganizationLearner) : <code>object</code>
+  - [~OrganizationLearnerListResponse](#module_OrganizationLearnerApi..OrganizationLearnerListResponse) : <code>object</code>
 
 <a name="module_OrganizationLearnerApi..find"></a>
 
 ### OrganizationLearnerApi~find(payload) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
+
 Récupère les organization-learners pour une organization. Par défaut, ces organizations-learners sont triés par prénom puis par nom.
 Si le params 'page' est présent, les organization-learners seront paginés
 Si le params 'filter' est présent, les organization-learners seront filtrés
 
-**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
+**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)
 
-| Param | Type |
-| --- | --- |
-| payload | <code>OrganizationLearnerListPayload</code> | 
+| Param   | Type                                        |
+| ------- | ------------------------------------------- |
+| payload | <code>OrganizationLearnerListPayload</code> |
 
 <a name="module_OrganizationLearnerApi..get"></a>
 
 ### OrganizationLearnerApi~get(organizationLearnerId) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
-**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 
-| Param | Type |
-| --- | --- |
-| organizationLearnerId | <code>number</code> | 
+**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)
+
+| Param                 | Type                |
+| --------------------- | ------------------- |
+| organizationLearnerId | <code>number</code> |
 
 <a name="module_OrganizationLearnerApi..PageDefinition"></a>
 
 ### OrganizationLearnerApi~PageDefinition : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| size | <code>number</code> | 
-| number | <code>Page</code> | 
+| Name   | Type                |
+| ------ | ------------------- |
+| size   | <code>number</code> |
+| number | <code>Page</code>   |
 
 <a name="module_OrganizationLearnerApi..FilterDefinition"></a>
 
 ### OrganizationLearnerApi~FilterDefinition : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| divisions | <code>Array.&lt;string&gt;</code> | 
-| name | <code>string</code> | 
+| Name      | Type                              |
+| --------- | --------------------------------- |
+| divisions | <code>Array.&lt;string&gt;</code> |
+| name      | <code>string</code>               |
 
 <a name="module_OrganizationLearnerApi..OrganizationLearnerListPayload"></a>
 
 ### OrganizationLearnerApi~OrganizationLearnerListPayload : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Propery**: <code>(FilterDefinition\|undefined)</code> filter  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| organizationId | <code>number</code> | 
-| page | <code>PageDefinition</code> \| <code>undefined</code> | 
+| Name           | Type                                                  |
+| -------------- | ----------------------------------------------------- |
+| organizationId | <code>number</code>                                   |
+| page           | <code>PageDefinition</code> \| <code>undefined</code> |
 
 <a name="module_OrganizationLearnerApi..Pagination"></a>
 
 ### OrganizationLearnerApi~Pagination : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| page | <code>number</code> | 
-| pageSize | <code>number</code> | 
-| rowCount | <code>number</code> | 
-| pageCount | <code>number</code> | 
+| Name      | Type                |
+| --------- | ------------------- |
+| page      | <code>number</code> |
+| pageSize  | <code>number</code> |
+| rowCount  | <code>number</code> |
+| pageCount | <code>number</code> |
 
 <a name="module_OrganizationLearnerApi..OrganizationLearner"></a>
 
 ### OrganizationLearnerApi~OrganizationLearner : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| id | <code>number</code> | 
-| firstName | <code>string</code> | 
-| lastName | <code>string</code> | 
-| division | <code>string</code> | 
-| organizationId | <code>number</code> | 
+| Name           | Type                |
+| -------------- | ------------------- |
+| id             | <code>number</code> |
+| firstName      | <code>string</code> |
+| lastName       | <code>string</code> |
+| division       | <code>string</code> |
+| organizationId | <code>number</code> |
 
 <a name="module_OrganizationLearnerApi..OrganizationLearnerListResponse"></a>
 
 ### OrganizationLearnerApi~OrganizationLearnerListResponse : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| organizationLearners | <code>Array.&lt;OrganizationLearner&gt;</code> | 
-| pagination | <code>Pagination</code> \| <code>undefined</code> | 
+| Name                 | Type                                              |
+| -------------------- | ------------------------------------------------- |
+| organizationLearners | <code>Array.&lt;OrganizationLearner&gt;</code>    |
+| pagination           | <code>Pagination</code> \| <code>undefined</code> |
 
 <a name="module_OrganizationLearnerWithParticipationsApi"></a>
 
 ## OrganizationLearnerWithParticipationsApi
 
-* [OrganizationLearnerWithParticipationsApi](#module_OrganizationLearnerWithParticipationsApi)
-    * [~find(payload)](#module_OrganizationLearnerWithParticipationsApi..find) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
-    * [~FindPayload](#module_OrganizationLearnerWithParticipationsApi..FindPayload) : <code>object</code>
-    * [~OrganizationLearner](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearner) : <code>object</code>
-    * [~Organization](#module_OrganizationLearnerWithParticipationsApi..Organization) : <code>object</code>
-    * [~CampaignParticipation](#module_OrganizationLearnerWithParticipationsApi..CampaignParticipation) : <code>object</code>
-    * [~OrganizationLearnerWithParticipations](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations) : <code>object</code>
+- [OrganizationLearnerWithParticipationsApi](#module_OrganizationLearnerWithParticipationsApi)
+  - [~find(payload)](#module_OrganizationLearnerWithParticipationsApi..find) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
+  - [~FindPayload](#module_OrganizationLearnerWithParticipationsApi..FindPayload) : <code>object</code>
+  - [~OrganizationLearner](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearner) : <code>object</code>
+  - [~Organization](#module_OrganizationLearnerWithParticipationsApi..Organization) : <code>object</code>
+  - [~CampaignParticipation](#module_OrganizationLearnerWithParticipationsApi..CampaignParticipation) : <code>object</code>
+  - [~OrganizationLearnerWithParticipations](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations) : <code>object</code>
 
 <a name="module_OrganizationLearnerWithParticipationsApi..find"></a>
 
 ### OrganizationLearnerWithParticipationsApi~find(payload) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
+
 Récupère les organizations-learners avec leurs participations à partir d'une liste d'ids d'utilisateurs
 
-**Kind**: inner method of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
+**Kind**: inner method of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)
 
-| Param | Type |
-| --- | --- |
-| payload | <code>FindPayload</code> | 
+| Param   | Type                     |
+| ------- | ------------------------ |
+| payload | <code>FindPayload</code> |
 
 <a name="module_OrganizationLearnerWithParticipationsApi..FindPayload"></a>
 
 ### OrganizationLearnerWithParticipationsApi~FindPayload : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| userIds | <code>Array.&lt;number&gt;</code> | 
+| Name    | Type                              |
+| ------- | --------------------------------- |
+| userIds | <code>Array.&lt;number&gt;</code> |
 
 <a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearner"></a>
 
 ### OrganizationLearnerWithParticipationsApi~OrganizationLearner : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| id | <code>number</code> | 
-| MEFCode | <code>string</code> | 
+| Name    | Type                |
+| ------- | ------------------- |
+| id      | <code>number</code> |
+| MEFCode | <code>string</code> |
 
 <a name="module_OrganizationLearnerWithParticipationsApi..Organization"></a>
 
 ### OrganizationLearnerWithParticipationsApi~Organization : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| isManagingStudents | <code>boolean</code> | 
-| tags | <code>Array.&lt;string&gt;</code> | 
-| type | <code>string</code> | 
+| Name               | Type                              |
+| ------------------ | --------------------------------- |
+| isManagingStudents | <code>boolean</code>              |
+| tags               | <code>Array.&lt;string&gt;</code> |
+| type               | <code>string</code>               |
 
 <a name="module_OrganizationLearnerWithParticipationsApi..CampaignParticipation"></a>
 
 ### OrganizationLearnerWithParticipationsApi~CampaignParticipation : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| targetProfileId | <code>number</code> | 
+| Name            | Type                |
+| --------------- | ------------------- |
+| targetProfileId | <code>number</code> |
 
 <a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations"></a>
 
 ### OrganizationLearnerWithParticipationsApi~OrganizationLearnerWithParticipations : <code>object</code>
+
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name | Type |
-| --- | --- |
-| organizationLearner | <code>OrganizationLearner</code> | 
-| organization | <code>Organization</code> | 
-| campaignParticipations | <code>Array.&lt;CampaignParticipation&gt;</code> | 
+| Name                   | Type                                             |
+| ---------------------- | ------------------------------------------------ |
+| organizationLearner    | <code>OrganizationLearner</code>                 |
+| organization           | <code>Organization</code>                        |
+| campaignParticipations | <code>Array.&lt;CampaignParticipation&gt;</code> |
 
 <a name="module_TargetProfileApi"></a>
 
 ## TargetProfileApi
 
-* [TargetProfileApi](#module_TargetProfileApi)
-    * [~getByOrganizationId(organizationId)](#module_TargetProfileApi..getByOrganizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
-    * [~getById(id)](#module_TargetProfileApi..getById) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+- [TargetProfileApi](#module_TargetProfileApi)
+  - [~getByOrganizationId(organizationId)](#module_TargetProfileApi..getByOrganizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
+  - [~getById(id)](#module_TargetProfileApi..getById) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
 
 <a name="module_TargetProfileApi..getByOrganizationId"></a>
 
 ### TargetProfileApi~getByOrganizationId(organizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
-**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
 
-| Param | Type |
-| --- | --- |
-| organizationId | <code>number</code> | 
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)
+
+| Param          | Type                |
+| -------------- | ------------------- |
+| organizationId | <code>number</code> |
 
 <a name="module_TargetProfileApi..getById"></a>
 
 ### TargetProfileApi~getById(id) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
-**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
 
-| Param | Type |
-| --- | --- |
-| id | <code>number</code> | 
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)
 
-
+| Param | Type                |
+| ----- | ------------------- |
+| id    | <code>number</code> |

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -102,6 +102,7 @@ export const update = async (payload) => {
  * @type {object}
  * @property {number} organizationId
  * @property {PageDefinition} page
+ * @property {boolean} withCoverRate
  */
 
 /**
@@ -131,6 +132,7 @@ export const findAllForOrganization = async (payload) => {
   const { models: campaigns, meta } = await usecases.findPaginatedFilteredOrganizationCampaigns({
     organizationId: payload.organizationId,
     page: payload.page,
+    withCoverRate: payload.withCoverRate ?? false,
   });
 
   const campaignsList = campaigns.map((campaign) => new CampaignListItem(campaign));

--- a/api/src/prescription/campaign/application/api/models/CampaignListItem.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignListItem.js
@@ -1,5 +1,5 @@
 export class CampaignListItem {
-  constructor({ id, name, createdAt, archivedAt, type, code, targetProfileName }) {
+  constructor({ id, name, createdAt, archivedAt, type, code, targetProfileName, tubes }) {
     this.id = id;
     this.name = name;
     this.createdAt = createdAt;
@@ -7,5 +7,6 @@ export class CampaignListItem {
     this.type = type;
     this.code = code;
     this.targetProfileName = targetProfileName;
+    this.tubes = tubes;
   }
 }

--- a/api/src/prescription/campaign/application/api/models/CampaignListItem.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignListItem.js
@@ -1,8 +1,11 @@
 export class CampaignListItem {
-  constructor({ id, name, createdAt, archivedAt }) {
+  constructor({ id, name, createdAt, archivedAt, type, code, targetProfileName }) {
     this.id = id;
     this.name = name;
     this.createdAt = createdAt;
     this.archivedAt = archivedAt;
+    this.type = type;
+    this.code = code;
+    this.targetProfileName = targetProfileName;
   }
 }

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-filtered-organization-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-filtered-organization-campaigns.js
@@ -13,7 +13,7 @@ const findPaginatedFilteredOrganizationCampaigns = withTransaction(async functio
   knowledgeElementSnapshotRepository,
   withCoverRate,
 }) {
-  const campaignReports = campaignReportRepository.findPaginatedFilteredByOrganizationId({
+  const campaignReports = await campaignReportRepository.findPaginatedFilteredByOrganizationId({
     organizationId,
     filter,
     page,
@@ -38,6 +38,7 @@ const findPaginatedFilteredOrganizationCampaigns = withTransaction(async functio
     });
     campaignReport.setCoverRate(campaignResultLevelPerTubesAndCompetences);
   }
+  return campaignReports;
 });
 
 export { findPaginatedFilteredOrganizationCampaigns };

--- a/api/src/prescription/campaign/domain/usecases/find-paginated-filtered-organization-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/find-paginated-filtered-organization-campaigns.js
@@ -1,11 +1,43 @@
-const findPaginatedFilteredOrganizationCampaigns = function ({
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { CampaignResultLevelsPerTubesAndCompetences } from '../models/CampaignResultLevelsPerTubesAndCompetences.js';
+
+const findPaginatedFilteredOrganizationCampaigns = withTransaction(async function ({
+  locale,
   userId,
   organizationId,
   filter,
   page,
   campaignReportRepository,
+  campaignParticipationRepository,
+  learningContentRepository,
+  knowledgeElementSnapshotRepository,
+  withCoverRate,
 }) {
-  return campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page, userId });
-};
+  const campaignReports = campaignReportRepository.findPaginatedFilteredByOrganizationId({
+    organizationId,
+    filter,
+    page,
+    userId,
+  });
+
+  if (!withCoverRate) {
+    return campaignReports;
+  }
+
+  for (const campaignReport of campaignReports.models) {
+    const campaignParticipationIds = await campaignParticipationRepository.getSharedParticipationIds(campaignReport.id);
+
+    const knowledgeElementsByParticipation =
+      await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(campaignParticipationIds);
+
+    const learningContent = await learningContentRepository.findByCampaignId(campaignReport.id, locale);
+    const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
+      campaignId: campaignReport.id,
+      learningContent,
+      knowledgeElementsByParticipation,
+    });
+    campaignReport.setCoverRate(campaignResultLevelPerTubesAndCompetences);
+  }
+});
 
 export { findPaginatedFilteredOrganizationCampaigns };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -125,6 +125,7 @@ const findPaginatedFilteredByOrganizationId = async function ({ organizationId, 
       'users.id AS ownerId',
       'users.firstName AS ownerFirstName',
       'users.lastName AS ownerLastName',
+      'target-profiles.name AS targetProfileName',
       knex.raw(
         'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) OVER (partition by "campaigns"."id") AS "participationsCount"',
       ),
@@ -133,6 +134,7 @@ const findPaginatedFilteredByOrganizationId = async function ({ organizationId, 
       ),
     )
     .join('users', 'users.id', 'campaigns.ownerId')
+    .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
     .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where('campaigns.organizationId', organizationId)
     .whereNull('campaigns.deletedAt')
@@ -153,7 +155,7 @@ const findPaginatedFilteredByOrganizationId = async function ({ organizationId, 
 
 function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName, isOwnedByMe }, userId) {
   if (name) {
-    qb.whereILike('name', `%${name}%`);
+    qb.whereILike('campaigns.name', `%${name}%`);
   }
   if (ongoing) {
     qb.whereNull('campaigns.archivedAt');

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -84,6 +84,10 @@ class CampaignReport {
     this.stages = stageCollection.stages;
   }
 
+  setCoverRate(campaignResultLevelsPerTubesAndCompetences) {
+    this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube;
+  }
+
   computeAverageResult(masteryRates) {
     const totalMasteryRates = masteryRates.length;
     if (totalMasteryRates > 0) {

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -23,7 +23,9 @@ class CampaignReport {
     badges = [],
     stages = [],
     multipleSendings,
+    targetProfileName,
   } = {}) {
+    this.targetProfileName = targetProfileName;
     this.id = id;
     this.name = name;
     this.code = code;

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -21,14 +21,16 @@ describe('Integration | Application | campaign-api', function () {
       const organizationId = databaseBuilder.factory.buildOrganization().id;
 
       databaseBuilder.factory.buildCampaign({ organizationId });
-      databaseBuilder.factory.buildCampaign({ organizationId });
+      const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
       databaseBuilder.factory.buildCampaign();
 
       await databaseBuilder.commit();
 
-      const result = await campaignApi.findAllForOrganization({ organizationId, page: { size: 1, number: 1 } });
+      const result = await campaignApi.findAllForOrganization({ organizationId, page: { size: 1, number: 2 } });
 
       expect(result.models.length).to.be.equal(1);
+      expect(result.models[0].id).to.deep.equal(campaignId2);
+      expect(result.meta.pageCount).to.equal(2);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -1,0 +1,87 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | find-paginated-filtered-organization-campaigns', function () {
+  context('when cover rate is false', function () {
+    it('should return paginated campaign reports for a given organization without cover rate', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildCampaign({ organizationId });
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      await databaseBuilder.commit();
+      // when
+      const result = await usecases.findPaginatedFilteredOrganizationCampaigns({
+        locale: 'fr',
+        organizationId,
+        page: { number: 1, size: 4 },
+        userId,
+      });
+
+      //then
+      expect(result.models[0]).to.be.an.instanceof(CampaignReport);
+      expect(result.models[0].tubes).to.be.undefined;
+    });
+  });
+  context('when cover rate is true', function () {
+    it('should return paginated campaign reports for a given organization with cover rate', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+
+      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+
+      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+
+      const tubeId = databaseBuilder.factory.learningContent.buildTube({ competenceId }).id;
+
+      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId, status: 'actif' }).id;
+
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId });
+
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+      const participationUser = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+      });
+
+      const ke = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId,
+        userId: participationUser.userId,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participationUser.id,
+        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+      });
+
+      await databaseBuilder.commit();
+      // when
+      const result = await usecases.findPaginatedFilteredOrganizationCampaigns({
+        locale: 'fr',
+        organizationId,
+        page: { number: 1, size: 4 },
+        userId,
+        withCoverRate: true,
+      });
+
+      //then
+      expect(result.models[0]).to.be.an.instanceof(CampaignReport);
+      expect(result.models[0].tubes[0]).to.deep.equal({
+        id: 'tubeIdA',
+        competenceId: 'competenceIdA',
+        practicalTitle: 'practicalTitle FR Tube A',
+        practicalDescription: 'practicalDescription FR Tube A',
+        maxLevel: 2,
+        meanLevel: 2,
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -208,6 +208,7 @@ describe('Unit | API | Campaigns', function () {
       const organizationId = Symbol('organizationId');
       const page = Symbol('page');
       const meta = Symbol('meta');
+      const targetProfileName = Symbol('targetProfileName');
       const campaignInformation1 = domainBuilder.buildCampaignReport({
         id: 777,
         code: 'SOMETHING',
@@ -216,6 +217,7 @@ describe('Unit | API | Campaigns', function () {
         customLandingPageText: 'Rooooooooooooar',
         createdAt: new Date('2020-01-01'),
         archivedAt: new Date('2023-01-01'),
+        targetProfileName,
       });
       const campaignInformation2 = domainBuilder.buildCampaignReport({
         id: 666,
@@ -225,6 +227,7 @@ describe('Unit | API | Campaigns', function () {
         customLandingPageText: 'pshh pshh pshhh pshhh',
         createdAt: new Date('2020-01-01'),
         archivedAt: new Date('2023-01-01'),
+        targetProfileName,
       });
 
       const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
@@ -243,6 +246,7 @@ describe('Unit | API | Campaigns', function () {
       expect(firstCampaignListItem.name).to.be.equal(campaignInformation1.name);
       expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
       expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
+      expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -204,54 +204,84 @@ describe('Unit | API | Campaigns', function () {
   });
 
   describe('#findAllForOrganization', function () {
-    it('should return paginated campaign list from organizationId', async function () {
-      const organizationId = Symbol('organizationId');
-      const page = Symbol('page');
-      const meta = Symbol('meta');
-      const targetProfileName = Symbol('targetProfileName');
-      const coverRate = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
+    context('when withCoverRate is false or not filled in', function () {
+      it('should return paginated campaign list from organizationId without cover rate', async function () {
+        const organizationId = Symbol('organizationId');
+        const page = Symbol('page');
+        const meta = Symbol('meta');
+        const targetProfileName = Symbol('targetProfileName');
 
-      const campaignInformation1 = domainBuilder.buildCampaignReport({
-        id: 777,
-        code: 'SOMETHING',
-        name: 'Godzilla',
-        title: 'is Biohazard',
-        customLandingPageText: 'Rooooooooooooar',
-        createdAt: new Date('2020-01-01'),
-        archivedAt: new Date('2023-01-01'),
-        targetProfileName,
+        const campaignInformation1 = domainBuilder.buildCampaignReport({
+          id: 777,
+          code: 'SOMETHING',
+          name: 'Godzilla',
+          title: 'is Biohazard',
+          customLandingPageText: 'Rooooooooooooar',
+          createdAt: new Date('2020-01-01'),
+          archivedAt: new Date('2023-01-01'),
+          targetProfileName,
+        });
+
+        const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
+        getCampaignStub
+          .withArgs({ organizationId, page, withCoverRate: false })
+          .resolves({ models: [campaignInformation1], meta });
+
+        // when
+        const result = await campaignApi.findAllForOrganization({ organizationId, page });
+
+        // then
+        const firstCampaignListItem = result.models[0];
+        expect(result.meta).to.be.equal(meta);
+        expect(firstCampaignListItem).not.to.be.instanceOf(CampaignReport);
+        expect(firstCampaignListItem.id).to.be.equal(campaignInformation1.id);
+        expect(firstCampaignListItem.name).to.be.equal(campaignInformation1.name);
+        expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
+        expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
+        expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
+        expect(firstCampaignListItem.tubes).to.be.undefined;
       });
+    });
+    context('when withCoverRate is true', function () {
+      it('should return paginated campaign list from organizationId with cover rate', async function () {
+        const organizationId = Symbol('organizationId');
+        const page = Symbol('page');
+        const meta = Symbol('meta');
+        const targetProfileName = Symbol('targetProfileName');
+        const coverRate = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
 
-      campaignInformation1.setCoverRate(coverRate);
-      const campaignInformation2 = domainBuilder.buildCampaignReport({
-        id: 666,
-        code: 'SOMETHING',
-        name: 'Monarch',
-        title: 'is a butterfly',
-        customLandingPageText: 'pshh pshh pshhh pshhh',
-        createdAt: new Date('2020-01-01'),
-        archivedAt: new Date('2023-01-01'),
-        targetProfileName,
+        const campaignInformation1 = domainBuilder.buildCampaignReport({
+          id: 777,
+          code: 'SOMETHING',
+          name: 'Godzilla',
+          title: 'is Biohazard',
+          customLandingPageText: 'Rooooooooooooar',
+          createdAt: new Date('2020-01-01'),
+          archivedAt: new Date('2023-01-01'),
+          targetProfileName,
+        });
+
+        campaignInformation1.setCoverRate(coverRate);
+
+        const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
+        getCampaignStub
+          .withArgs({ organizationId, page, withCoverRate: true })
+          .resolves({ models: [campaignInformation1], meta });
+
+        // when
+        const result = await campaignApi.findAllForOrganization({ organizationId, page, withCoverRate: true });
+
+        // then
+        const firstCampaignListItem = result.models[0];
+        expect(result.meta).to.be.equal(meta);
+        expect(firstCampaignListItem).not.to.be.instanceOf(CampaignReport);
+        expect(firstCampaignListItem.id).to.be.equal(campaignInformation1.id);
+        expect(firstCampaignListItem.name).to.be.equal(campaignInformation1.name);
+        expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
+        expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
+        expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
+        expect(firstCampaignListItem.tubes).to.be.equal(coverRate.levelsPerTube);
       });
-
-      const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
-      getCampaignStub
-        .withArgs({ organizationId, page })
-        .resolves({ models: [campaignInformation1, campaignInformation2], meta });
-
-      // when
-      const result = await campaignApi.findAllForOrganization({ organizationId, page });
-
-      // then
-      const firstCampaignListItem = result.models[0];
-      expect(result.meta).to.be.equal(meta);
-      expect(firstCampaignListItem).not.to.be.instanceOf(CampaignReport);
-      expect(firstCampaignListItem.id).to.be.equal(campaignInformation1.id);
-      expect(firstCampaignListItem.name).to.be.equal(campaignInformation1.name);
-      expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
-      expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
-      expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
-      expect(firstCampaignListItem.tubes).to.be.equal(campaignInformation1.tubes);
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -209,6 +209,8 @@ describe('Unit | API | Campaigns', function () {
       const page = Symbol('page');
       const meta = Symbol('meta');
       const targetProfileName = Symbol('targetProfileName');
+      const coverRate = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
+
       const campaignInformation1 = domainBuilder.buildCampaignReport({
         id: 777,
         code: 'SOMETHING',
@@ -219,6 +221,8 @@ describe('Unit | API | Campaigns', function () {
         archivedAt: new Date('2023-01-01'),
         targetProfileName,
       });
+
+      campaignInformation1.setCoverRate(coverRate);
       const campaignInformation2 = domainBuilder.buildCampaignReport({
         id: 666,
         code: 'SOMETHING',
@@ -247,6 +251,7 @@ describe('Unit | API | Campaigns', function () {
       expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
       expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
       expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
+      expect(firstCampaignListItem.tubes).to.be.equal(campaignInformation1.tubes);
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -1,4 +1,5 @@
 import { findPaginatedFilteredOrganizationCampaigns } from '../../../../../../src/prescription/campaign/domain/usecases/find-paginated-filtered-organization-campaigns.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | find-paginated-filtered-organization-campaigns', function () {
@@ -6,6 +7,8 @@ describe('Unit | Domain | Use Cases | find-paginated-filtered-organization-camp
 
   beforeEach(function () {
     campaignReportRepository.findPaginatedFilteredByOrganizationId = sinon.stub();
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((callback) => callback());
   });
 
   describe('#findPaginatedFilteredOrganizationCampaigns', function () {
@@ -18,7 +21,11 @@ describe('Unit | Domain | Use Cases | find-paginated-filtered-organization-camp
       const page = { number: 1, size: 3 };
 
       // when
-      const promise = findPaginatedFilteredOrganizationCampaigns({ organizationId, page, campaignReportRepository });
+      const promise = findPaginatedFilteredOrganizationCampaigns({
+        organizationId,
+        page,
+        campaignReportRepository,
+      });
 
       // then
       return promise.then((campaigns) => {

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -1,76 +1,13 @@
 import { expect } from 'chai';
 
-import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
 import * as serializer from '../../../../../../../src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
-import { KnowledgeElementCollection } from '../../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
-import { KnowledgeElement } from '../../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { domainBuilder } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-competences-serializer', function () {
   describe('#serialize', function () {
-    let learningContent, keData;
-
-    beforeEach(function () {
-      const framework = domainBuilder.buildFramework({ id: 'frameworkId', name: 'frameworkName' });
-      const skill1 = domainBuilder.buildSkill({
-        id: 'recSkillWeb1',
-        tubeId: 'tube1',
-        difficulty: 1,
-      });
-      const tube1 = domainBuilder.buildTube({
-        id: 'tube1',
-        competenceId: 'competence1',
-        skills: [skill1],
-        practicalTitle: 'tube 1',
-        practicalDescription: 'tube 1 description',
-      });
-
-      const competence1 = domainBuilder.buildCompetence({
-        id: 'competence1',
-        areaId: 'recArea1',
-        tubes: [tube1],
-        name: 'compétence 1',
-        description: 'description compétence 1',
-      });
-
-      const area = domainBuilder.buildArea({ id: 'recArea1', frameworkId: framework.id });
-      const thematic1 = domainBuilder.buildThematic({
-        id: 'thematic1',
-        competenceId: 'competence1',
-        tubeIds: ['tube1'],
-      });
-
-      competence1.thematics = [thematic1];
-      area.competences = [competence1];
-      framework.areas = [area];
-
-      learningContent = domainBuilder.buildLearningContent([framework]);
-
-      const user1ke1 = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.VALIDATED,
-        skillId: skill1.id,
-        userId: 1,
-      });
-
-      const user2ke1 = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.INVALIDATED,
-        skillId: skill1.id,
-        userId: 2,
-      });
-
-      keData = {
-        participationId1: new KnowledgeElementCollection([user1ke1]).latestUniqNonResetKnowledgeElements,
-        participationId2: new KnowledgeElementCollection([user2ke1]).latestUniqNonResetKnowledgeElements,
-      };
-    });
-
     it('should convert CampaignResultLevelPerTubesAndCompentences acquisitions statistics into JSON API data', function () {
       const campaignId = 1;
-      const model = new CampaignResultLevelsPerTubesAndCompetences({
-        campaignId: 1,
-        learningContent,
-        knowledgeElementsByParticipation: keData,
-      });
+      const model = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
       const json = serializer.serialize(model);
 
       expect(json).to.deep.equal({

--- a/api/tests/tooling/domain-builder/factory/build-campaign-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-report.js
@@ -45,6 +45,7 @@ const buildCampaignReport = function ({
     ownerFirstName,
     ownerLastName,
     targetProfileId,
+    targetProfileName,
     participationsCount,
     sharedParticipationsCount,
     averageResult,

--- a/api/tests/tooling/domain-builder/factory/build-campaign-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-report.js
@@ -18,6 +18,7 @@ const buildCampaignReport = function ({
   ownerFirstName = 'Un prénom',
   ownerLastName = 'Un nom',
   targetProfileId = 3,
+  targetProfileName = 'targetProfile',
   participationsCount = 5,
   sharedParticipationsCount = 2,
   averageResult = 0.4,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -211,6 +211,7 @@ import {
 } from './identity-access-management/build-lti-platform-registration.js';
 import { buildUserLogin } from './identity-access-management/build-user-login.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
+import { buildCampaignResultLevelsPerTubesAndCompetences as boundedContextCampaignBuildCampaignResultLevelsPerTubesAndCompetences } from './prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js';
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
 import { buildStageCollection as buildStageCollectionForUserCampaignResults } from './user-campaign-results/build-stage-collection.js';
@@ -282,6 +283,8 @@ const certification = {
 const prescription = {
   campaign: {
     buildCampaign: boundedContextCampaignBuildCampaign,
+    buildCampaignResultLevelsPerTubesAndCompetences:
+      boundedContextCampaignBuildCampaignResultLevelsPerTubesAndCompetences,
   },
   campaignParticipation: {
     buildCampaignParticipation: boundedContextCampaignParticipationBuildCampaignParticipation,

--- a/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
@@ -1,0 +1,71 @@
+import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { buildArea } from '../../build-area.js';
+import { buildCompetence } from '../../build-competence.js';
+import { buildFramework } from '../../build-framework.js';
+import { buildKnowledgeElement } from '../../build-knowledge-element.js';
+import { buildLearningContent } from '../../build-learning-content.js';
+import { buildSkill } from '../../build-skill.js';
+import { buildThematic } from '../../build-thematic.js';
+import { buildTube } from '../../build-tube.js';
+
+function buildCampaignResultLevelsPerTubesAndCompetences() {
+  const framework = buildFramework({ id: 'frameworkId', name: 'frameworkName' });
+  const skill1 = buildSkill({
+    id: 'recSkillWeb1',
+    tubeId: 'tube1',
+    difficulty: 1,
+  });
+  const tube1 = buildTube({
+    id: 'tube1',
+    competenceId: 'competence1',
+    skills: [skill1],
+    practicalTitle: 'tube 1',
+    practicalDescription: 'tube 1 description',
+  });
+
+  const competence1 = buildCompetence({
+    id: 'competence1',
+    areaId: 'recArea1',
+    tubes: [tube1],
+    name: 'compétence 1',
+    description: 'description compétence 1',
+  });
+
+  const area = buildArea({ id: 'recArea1', frameworkId: framework.id });
+  const thematic1 = buildThematic({
+    id: 'thematic1',
+    competenceId: 'competence1',
+    tubeIds: ['tube1'],
+  });
+
+  competence1.thematics = [thematic1];
+  area.competences = [competence1];
+  framework.areas = [area];
+
+  const learningContent = buildLearningContent([framework]);
+
+  const user1ke1 = buildKnowledgeElement({
+    status: KnowledgeElement.StatusType.VALIDATED,
+    skillId: skill1.id,
+    userId: 1,
+  });
+
+  const user2ke1 = buildKnowledgeElement({
+    status: KnowledgeElement.StatusType.INVALIDATED,
+    skillId: skill1.id,
+    userId: 2,
+  });
+
+  const keData = {
+    participationId1: new KnowledgeElementCollection([user1ke1]).latestUniqNonResetKnowledgeElements,
+    participationId2: new KnowledgeElementCollection([user2ke1]).latestUniqNonResetKnowledgeElements,
+  };
+  return new CampaignResultLevelsPerTubesAndCompetences({
+    campaignId: 1,
+    learningContent,
+    knowledgeElementsByParticipation: keData,
+  });
+}
+export { buildCampaignResultLevelsPerTubesAndCompetences };

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -39,6 +39,20 @@ describe('Unit | Domain | Models | CampaignReport', function () {
     });
   });
 
+  describe('#setCoverRate', function () {
+    it('should set cover rate', function () {
+      // given
+      const campaignResultLevelsPerTubesAndCompetences =
+        domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
+      const campaignReport = domainBuilder.buildCampaignReport();
+
+      // when
+      campaignReport.setCoverRate(campaignResultLevelsPerTubesAndCompetences);
+      // then
+      expect(campaignReport.tubes).to.deep.equal(campaignResultLevelsPerTubesAndCompetences.levelsPerTube);
+    });
+  });
+
   describe('#setTargetProfileInformation', function () {
     it('should define target profile informations', function () {
       const targetProfileForSpecifier = {


### PR DESCRIPTION
## 🌸 Problème

Les données concernant les participations à une campagne doivent être mises à disposition aux partenaires qui le demandent.

## 🌳 Proposition
On enrichit une méthode existante sur CampaignsApi pour créer une API interne à l'usage de Team-Maddo.

## 🐝 Remarques

## 🤧 Pour tester
