### PR TITLE
[BUGFIX] Ne plus faire apparaître le menu lorsqu'un candidat entre en certification sur Pix App (PIX-17425).

### DIFF
--- a/mon-pix/app/components/certifications/start.gjs
+++ b/mon-pix/app/components/certifications/start.gjs
@@ -7,7 +7,7 @@ import CompanionBlocker from '../companion/blocker';
 <template>
   <CompanionBlocker>
     <main class="main" role="main">
-      <PixBackgroundHeader id="main">
+      <PixBackgroundHeader id="main" class="certification-start-page__header">
         <PixBlock @shadow="heavy" class="certification-start-page__block">
           <CertificationStarter @certificationCandidateSubscription={{@certificationCandidateSubscription}} />
         </PixBlock>

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -4,6 +4,7 @@
 @use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/fonts';
+@use 'pix-design-tokens/colors';
 
 .certification-starter {
   @include breakpoints.device-is('desktop') {
@@ -12,6 +13,10 @@
 }
 
 .certification-start-page {
+  &__header .pix-background-header__background {
+    background: colors.$pix-primary-certif-gradient;
+  }
+
   &__block {
     margin: var(--pix-spacing-3x) 0;
     padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);

--- a/mon-pix/app/templates/authenticated.hbs
+++ b/mon-pix/app/templates/authenticated.hbs
@@ -2,6 +2,4 @@
   <DataProtectionPolicyInformationBanner />
 </div>
 
-<Global::AppLayout @hasAttestationDetails={{gt this.model.attestationDetail.length 0}}>
-  {{outlet}}
-</Global::AppLayout>
+{{outlet}}

--- a/mon-pix/app/templates/authenticated/attestations.hbs
+++ b/mon-pix/app/templates/authenticated/attestations.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.attestations.title")}}
-
-<Attestations::Content />
+<Global::AppLayout>
+  <Attestations::Content />
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/certifications/join.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/join.hbs
@@ -1,12 +1,14 @@
 {{page-title (t "pages.certification-start.title")}}
 
-<main id="main" class="global-page-container" role="main">
-  {{#if this.model.isCertifiable}}
-    <PixBlock class="certification-start-page__block">
-      <CertificationBanners @certificationEligibility={{this.model}} @fullName={{this.currentUser.user.fullName}} />
-      <CertificationJoiner @onStepChange={{this.changeStep}} />
-    </PixBlock>
-  {{else}}
-    <CertificationNotCertifiable />
-  {{/if}}
-</main>
+<Global::AppLayout>
+  <main id="main" class="global-page-container" role="main">
+    {{#if this.model.isCertifiable}}
+      <PixBlock class="certification-start-page__block">
+        <CertificationBanners @certificationEligibility={{this.model}} @fullName={{this.currentUser.user.fullName}} />
+        <CertificationJoiner @onStepChange={{this.changeStep}} />
+      </PixBlock>
+    {{else}}
+      <CertificationNotCertifiable />
+    {{/if}}
+  </main>
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/certifications/resume.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/resume.hbs
@@ -1,1 +1,3 @@
-{{outlet}}
+<Global::AppLayout>
+  {{outlet}}
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/competences.hbs
+++ b/mon-pix/app/templates/authenticated/competences.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.competence-details.title")}}
-
-{{outlet}}
+<Global::AppLayout>
+  {{outlet}}
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/profile.hbs
+++ b/mon-pix/app/templates/authenticated/profile.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.profile.title")}}
-
-<ProfileContent @model={{@model}} />
+<Global::AppLayout>
+  <ProfileContent @model={{@model}} />
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/sitemap.hbs
+++ b/mon-pix/app/templates/authenticated/sitemap.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.sitemap.title")}}
-
-<Sitemap::Content @model={{@model}} />
+<Global::AppLayout>
+  <Sitemap::Content @model={{@model}} />
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -1,35 +1,36 @@
 {{page-title (t "pages.user-account.title")}}
+<Global::AppLayout>
+  {{#if this.isPixAppNewLayoutEnabled}}
+    <main id="main" class="main user-account global-page-container" role="main">
+      <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>
 
-{{#if this.isPixAppNewLayoutEnabled}}
-  <main id="main" class="main user-account global-page-container" role="main">
-    <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>
-
-    <div class="user-account__container">
-      <UserAccount::UserAccountNavigation
-        @class="user-account__navigation"
-        @canSelfDeleteAccount={{@model.accountInfo.canSelfDeleteAccount}}
-      />
-
-      <section class="user-account__section">
-        {{outlet}}
-      </section>
-    </div>
-  </main>
-{{else}}
-  <main id="main" class="main" role="main">
-    <PixBackgroundHeader class="user-account-legacy">
-      <h1 class="user-account-legacy__title">{{t "pages.user-account.title"}}</h1>
-
-      <div class="user-account-legacy__menu-and-content">
+      <div class="user-account__container">
         <UserAccount::UserAccountNavigation
-          @class="user-account-legacy__navigation"
+          @class="user-account__navigation"
           @canSelfDeleteAccount={{@model.accountInfo.canSelfDeleteAccount}}
         />
 
-        <PixBlock class="user-account-legacy__content">
+        <section class="user-account__section">
           {{outlet}}
-        </PixBlock>
+        </section>
       </div>
-    </PixBackgroundHeader>
-  </main>
-{{/if}}
+    </main>
+  {{else}}
+    <main id="main" class="main" role="main">
+      <PixBackgroundHeader class="user-account-legacy">
+        <h1 class="user-account-legacy__title">{{t "pages.user-account.title"}}</h1>
+
+        <div class="user-account-legacy__menu-and-content">
+          <UserAccount::UserAccountNavigation
+            @class="user-account-legacy__navigation"
+            @canSelfDeleteAccount={{@model.accountInfo.canSelfDeleteAccount}}
+          />
+
+          <PixBlock class="user-account-legacy__content">
+            {{outlet}}
+          </PixBlock>
+        </div>
+      </PixBackgroundHeader>
+    </main>
+  {{/if}}
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-certifications/get.hbs
+++ b/mon-pix/app/templates/authenticated/user-certifications/get.hbs
@@ -1,32 +1,34 @@
-<main id="main" class="global-page-container" role="main">
-  <PixButtonLink
-    @route="authenticated.user-certifications"
-    @variant="tertiary"
-    @iconBefore="arrowLeft"
-    class="user-certifications-page__previous-button"
-  >
-    {{t "pages.certificate.back-link"}}
-  </PixButtonLink>
+<Global::AppLayout>
+  <main id="main" class="global-page-container" role="main">
+    <PixButtonLink
+      @route="authenticated.user-certifications"
+      @variant="tertiary"
+      @iconBefore="arrowLeft"
+      class="user-certifications-page__previous-button"
+    >
+      {{t "pages.certificate.back-link"}}
+    </PixButtonLink>
 
-  <PixBlock class="user-certifications-page-get__header">
-    <Certifications::UserCertificationsDetailHeader @certification={{@model}} />
-  </PixBlock>
+    <PixBlock class="user-certifications-page-get__header">
+      <Certifications::UserCertificationsDetailHeader @certification={{@model}} />
+    </PixBlock>
 
-  <div class="user-certifications-page-get__details-body">
-    <Certifications::UserCertificationsDetailCompetencesList
-      @resultCompetenceTree={{@model.resultCompetenceTree}}
-      @maxReachableLevelOnCertificationDate={{this.model.maxReachableLevelOnCertificationDate}}
-    />
-    {{#if this.shouldDisplayDetailsSection}}
-      <Certifications::UserCertificationsDetailResult @certification={{@model}} />
-    {{/if}}
-  </div>
+    <div class="user-certifications-page-get__details-body">
+      <Certifications::UserCertificationsDetailCompetencesList
+        @resultCompetenceTree={{@model.resultCompetenceTree}}
+        @maxReachableLevelOnCertificationDate={{this.model.maxReachableLevelOnCertificationDate}}
+      />
+      {{#if this.shouldDisplayDetailsSection}}
+        <Certifications::UserCertificationsDetailResult @certification={{@model}} />
+      {{/if}}
+    </div>
 
-  <p class="user-certifications-page-get__note">
-    {{t
-      "pages.certificate.competences.information"
-      maxReachableLevelOnCertificationDate=this.model.maxReachableLevelOnCertificationDate
-      maxReachablePixCountOnCertificationDate=this.model.maxReachablePixCountOnCertificationDate
-    }}
-  </p>
-</main>
+    <p class="user-certifications-page-get__note">
+      {{t
+        "pages.certificate.competences.information"
+        maxReachableLevelOnCertificationDate=this.model.maxReachableLevelOnCertificationDate
+        maxReachablePixCountOnCertificationDate=this.model.maxReachablePixCountOnCertificationDate
+      }}
+    </p>
+  </main>
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-certifications/index.hbs
+++ b/mon-pix/app/templates/authenticated/user-certifications/index.hbs
@@ -1,8 +1,10 @@
-<main id="main" role="main" class="global-page-container">
-  <Ui::PageTitle>
-    <:title> {{t "pages.certifications-list.title"}}</:title>
-    <:subtitle>{{t "pages.user-tests.description"}}</:subtitle>
-  </Ui::PageTitle>
+<Global::AppLayout>
+  <main id="main" role="main" class="global-page-container">
+    <Ui::PageTitle>
+      <:title> {{t "pages.certifications-list.title"}}</:title>
+      <:subtitle>{{t "pages.user-tests.description"}}</:subtitle>
+    </Ui::PageTitle>
 
-  <UserCertificationsPanel @certifications={{@model}} />
-</main>
+    <UserCertificationsPanel @certifications={{@model}} />
+  </main>
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-dashboard.hbs
+++ b/mon-pix/app/templates/authenticated/user-dashboard.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.dashboard.title")}}
-
-<Dashboard::Content @model={{this.model}} />
+<Global::AppLayout>
+  <Dashboard::Content @model={{this.model}} />
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-tests.hbs
+++ b/mon-pix/app/templates/authenticated/user-tests.hbs
@@ -1,10 +1,11 @@
 {{page-title (t "pages.user-tests.title")}}
+<Global::AppLayout>
+  <main id="main" role="main" class="global-page-container">
+    <Ui::PageTitle>
+      <:title> {{t "pages.user-tests.title"}}</:title>
+      <:subtitle>{{t "pages.user-tests.description"}}</:subtitle>
+    </Ui::PageTitle>
 
-<main id="main" role="main" class="global-page-container">
-  <Ui::PageTitle>
-    <:title> {{t "pages.user-tests.title"}}</:title>
-    <:subtitle>{{t "pages.user-tests.description"}}</:subtitle>
-  </Ui::PageTitle>
-
-  <CampaignParticipationOverview::Grid @model={{this.model}} />
-</main>
+    <CampaignParticipationOverview::Grid @model={{this.model}} />
+  </main>
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-trainings.hbs
+++ b/mon-pix/app/templates/authenticated/user-trainings.hbs
@@ -1,24 +1,25 @@
 {{page-title (t "pages.user-trainings.title")}}
-
-<main id="main" class="main" role="main">
-  <Training::Header />
-  <div class="user-trainings-content">
-    {{#if @model.trainings.meta.pagination.rowCount}}
-      <div class="user-trainings-content__container">
-        <ul class="user-trainings-content__list">
-          {{#each @model.trainings as |training|}}
-            <li class="user-trainings-content-list__item">
-              <Training::Card @training={{training}} />
-            </li>
-          {{/each}}
-        </ul>
-        <PixPagination
-          @pagination={{@model.trainings.meta.pagination}}
-          @pageOptions={{this.pageOptions}}
-          @locale={{this.intl.primaryLocale}}
-          @isCondensed="true"
-        />
-      </div>
-    {{/if}}
-  </div>
-</main>
+<Global::AppLayout>
+  <main id="main" class="main" role="main">
+    <Training::Header />
+    <div class="user-trainings-content">
+      {{#if @model.trainings.meta.pagination.rowCount}}
+        <div class="user-trainings-content__container">
+          <ul class="user-trainings-content__list">
+            {{#each @model.trainings as |training|}}
+              <li class="user-trainings-content-list__item">
+                <Training::Card @training={{training}} />
+              </li>
+            {{/each}}
+          </ul>
+          <PixPagination
+            @pagination={{@model.trainings.meta.pagination}}
+            @pageOptions={{this.pageOptions}}
+            @locale={{this.intl.primaryLocale}}
+            @isCondensed="true"
+          />
+        </div>
+      {{/if}}
+    </div>
+  </main>
+</Global::AppLayout>

--- a/mon-pix/app/templates/authenticated/user-tutorials.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials.hbs
@@ -1,2 +1,4 @@
 {{page-title (t "pages.user-tutorials.title")}}
-{{outlet}}
+<Global::AppLayout>
+  {{outlet}}
+</Global::AppLayout>

--- a/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information-test.js
@@ -128,5 +128,49 @@ module('Acceptance | Certifications | Information', function (hooks) {
         assert.strictEqual(currentURL(), '/certifications/candidat/2');
       });
     });
+
+    module('when user validates instructions and redirect to the certification start page', function () {
+      test('should not display the menu', async function (assert) {
+        // given
+        server.create('certification-candidate-subscription', {
+          id: '2',
+          sessionId: 123,
+          eligibleSubscriptions: null,
+          nonEligibleSubscription: null,
+          sessionVersion: 3,
+        });
+        await authenticateByEmail(user);
+        const screen = await visit('/certifications');
+
+        // when
+        await fillCertificationJoiner({
+          sessionId: '123',
+          firstName: 'toto',
+          lastName: 'titi',
+          dayOfBirth: '01',
+          monthOfBirth: '01',
+          yearOfBirth: '2000',
+          t,
+        });
+
+        // then
+        assert.dom(screen.queryByRole('navigation', { name: t('navigation.main.label') })).doesNotExist();
+
+        // when
+        for (let i = 0; i < 4; i++) {
+          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+        }
+        await click(
+          screen.getByRole('checkbox', {
+            name: 'En cochant cette case, je reconnais avoir pris connaissance de ces règles et je m’engage à les respecter.',
+          }),
+        );
+        await click(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }));
+
+        // then
+        assert.strictEqual(currentURL(), '/certifications/candidat/2');
+        assert.dom(screen.queryByRole('navigation', { name: t('navigation.main.label') })).doesNotExist();
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/certifications/certification-ender-test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender-test.js
@@ -17,6 +17,14 @@ module('Integration | Component | Certifications | CertificationEnder', function
     assert.ok(screen.getByText(t('pages.certification-ender.candidate.title')));
   });
 
+  test('should not display the authenticated menu', async function (assert) {
+    // when
+    const screen = await renderScreen(hbs`<Certifications::CertificationEnder />`);
+
+    // then
+    assert.dom(screen.queryByRole('navigation', { name: t('navigation.main.label') })).doesNotExist();
+  });
+
   test('should display the certification number', async function (assert) {
     // given
     this.certificationNumber = 1234;


### PR DESCRIPTION
## 🌸 Problème

Actuellement on constate que la modification du menu sur Pix App à entraîné des erreurs d'affichage sur les pages lié à la certification.
En effet les pages d'instructions et de fin de certification présentes un menu visible, or le candidat entre dans un tunnel lors de sa certification, il n'est pas censé le voir.

## 🌳 Proposition

Les pages d'instruction, de code candidat et de fin de certification étant authenticated, ils profitaient du nouveau composant.
Modifier les conditions d'affichage de ce dernier en y faisant appels sur des pages spécifiques.

## 🐝 Remarques

Le bandeau du code candidat est passé aux couleurs de la certification

## 🤧 Pour tester

Se connecter avec certif-success@example.net / pix123
sur la page de certification : 
3 / oui / oui / 10 - 10 - 2000

<img width="1728" alt="Capture d’écran 2025-04-10 à 10 56 51" src="https://github.com/user-attachments/assets/be3daa3a-a558-4321-9bc8-5ef260e9db76" />
<img width="1728" alt="Capture d’écran 2025-04-09 à 16 04 39" src="https://github.com/user-attachments/assets/b28bff3e-843d-4a15-a387-9247614a9aef" />

