### PR TITLE
[BUGFIX] Rajouter les labels sur la nav de Pix admin (PIX-17448)

### DIFF
--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -18,7 +18,11 @@ export default class Sidebar extends Component {
   }
 
   <template>
-    <PixNavigation @menuLabel="Menu">
+    <PixNavigation
+      @navigationAriaLabel={{t "components.layout.sidebar.labels.main"}}
+      @openLabel={{t "components.layout.sidebar.labels.open"}}
+      @closeLabel={{t "components.layout.sidebar.labels.close"}}
+    >
       <:brand>
         <LinkTo @route="authenticated.index">
           <img src="/admin-logo.svg" alt={{t "common.home-page"}} />

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -392,6 +392,11 @@
         "certifications": "Certifications",
         "complementary-certifications": "Compl. certifications",
         "complementary-certifications-label": "Complementary certifications",
+        "labels": {
+          "close": "Close navigation",
+          "main": "Main navigation",
+          "open": "Open navigation"
+        },
         "logout": "Log out",
         "organizations": "Organizations",
         "sessions": "Certif sessions",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -392,6 +392,11 @@
         "certifications": "Certifications",
         "complementary-certifications": "Certifications compl.",
         "complementary-certifications-label": "Certifications complémentaires",
+        "labels": {
+          "close": "Fermer la navigation",
+          "main": "Navigation principale",
+          "open": "Ouvrir la navigation"
+        },
         "logout": "Se déconnecter",
         "organizations": "Organisations",
         "sessions": "Sessions de certif",


### PR DESCRIPTION
## 🌸 Problème

Le composant PixNavigation possède désormais 2 attributs en plus (openLabel et closeLabel) qui sont affichés uniquement pour les lecteurs d'écrans. Ils ne sont pas présent sur Pix admin.

## 🌳 Proposition

Rajouter les labels en les traduisants au passage.

## 🐝 Remarques

On rajoute également l'attributs navigationAriaLabel qui n'était pas présent.

## 🤧 Pour tester
- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Se mettre en mode mobile,
- Si la nouvelle nav n'est pas activée, exécuter cette commande pour l'activer et raffraichir la page:
```shell
scalingo -a pix-api-review-pr12019 run npm run toggles -- --key isPixAdminNewSidebarEnabled --value true
```
- Sur Pix admin se mettre en mode mobile,
- Inspecter le bouton permettant d'ouvrir la nav,
- Constater qu'il est écrit "Ouvrir la navigation",
- Ouvrir la sidebar,
- Réinspecter le bouton,
- Constater que le texte est cette fois "Fermer la navigation".