### PR TITLE
[TECH] Suppression des réplications sur les tables historiques de parcoursup (PIX-17451)

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -26,32 +26,6 @@ export const replications = [
     },
   },
   {
-    name: 'data_export_parcoursup_certif_result',
-    before: async ({ datamartKnex }) => {
-      await datamartKnex('data_export_parcoursup_certif_result').delete();
-    },
-    from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result').select(
-        'national_student_id',
-        'organization_uai',
-        'last_name',
-        'first_name',
-        'birthdate',
-        'status',
-        'pix_score',
-        'certification_date',
-        'competence_level',
-        'competence_name',
-        'competence_code',
-        'area_name',
-        'certification_courses_id',
-      );
-    },
-    to: ({ datamartKnex }, chunk) => {
-      return datamartKnex('data_export_parcoursup_certif_result').insert(chunk);
-    },
-  },
-  {
     name: 'certification_results',
     before: async ({ datamartKnex }) => {
       await datamartKnex('certification_results').delete();
@@ -74,31 +48,6 @@ export const replications = [
     },
     to: ({ datamartKnex }, chunk) => {
       return datamartKnex('certification_results').insert(chunk);
-    },
-  },
-  {
-    name: 'data_export_parcoursup_certif_result_code_validation',
-    before: async ({ datamartKnex }) => {
-      await datamartKnex('data_export_parcoursup_certif_result_code_validation').delete();
-    },
-    from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select(
-        'certification_code_verification',
-        'last_name',
-        'first_name',
-        'birthdate',
-        'status',
-        'pix_score',
-        'certification_date',
-        'competence_level',
-        'competence_name',
-        'competence_code',
-        'area_name',
-        'certification_courses_id',
-      );
-    },
-    to: ({ datamartKnex }, chunk) => {
-      return datamartKnex('data_export_parcoursup_certif_result_code_validation').insert(chunk);
     },
   },
 ];


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Des réplications sont réalisées sur des tables parcoursup maintenant inutilisées.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Supprimer ces réplications obsolètes.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
1. Récupérer un token avec le scope réplication : 
```shell
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12020.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

2. Vérifier que les réplications 'data_export_parcoursup_certif_result' et 'data_export_parcoursup_certif_result_code_validation' retournent bien une erreur 404 : 
```
curl -X POST https://pix-api-maddo-review-pr12020.osc-fr1.scalingo.io/api/replications/data_export_parcoursup_certif_result -H "Authorization: Bearer $ACCESS_TOKEN"
```

```
curl -X POST https://pix-api-maddo-review-pr12020.osc-fr1.scalingo.io/api/replications/data_export_parcoursup_certif_result_code_validation -H "Authorization: Bearer $ACCESS_TOKEN"
```

