### PR TITLE
[TECH] Suppression des tables parcoursup historiques non utilisées (PIX-17324)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@
 /admin/app/services/oidc-identity-providers.js @1024pix/team-acces
 /admin/app/services/session.js @1024pix/team-acces
 
-# Directories maintainted by team Captains
+# Directories maintained by team Captains
 /api/db/migrations/ @1024pix/team-captains
+/api/datamart/migrations/ @1024pix/team-captains
 

--- a/api/datamart/migrations/20250410130742_remove-data-export-parcoursup-certif-result-code-validation-table.js
+++ b/api/datamart/migrations/20250410130742_remove-data-export-parcoursup-certif-result-code-validation-table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'data_export_parcoursup_certif_result_code_validation';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function () {
+  // No use of table recreation as it is not used anymore
+};
+
+export { down, up };

--- a/api/datamart/migrations/20250410130831_remove-data_export_parcoursup_certif_result.js
+++ b/api/datamart/migrations/20250410130831_remove-data_export_parcoursup_certif_result.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'data_export_parcoursup_certif_result';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function () {
+  // No use of table recreation as it is not used anymore
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les tables `data_export_parcoursup_certif_result_code_validation` et `data_export_parcoursup_certif_result` ne sont plus utilisées et plus aucune données n'y est répliquée.

## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Supprimer ces tables.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Migration ok. Les tables n'existent plus dans le datamart.
