### PR TITLE
[FEATURE] Améliorer la vitesse des réplications (PIX-17456).

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -2,7 +2,7 @@ export const replications = [
   {
     name: 'sco_certification_results',
     before: async ({ datamartKnex }) => {
-      await datamartKnex('sco_certification_results').delete();
+      await datamartKnex('sco_certification_results').truncate();
     },
     from: ({ datawarehouseKnex }) => {
       return datawarehouseKnex('data_export_parcoursup_certif_result').select(
@@ -28,7 +28,7 @@ export const replications = [
   {
     name: 'certification_results',
     before: async ({ datamartKnex }) => {
-      await datamartKnex('certification_results').delete();
+      await datamartKnex('certification_results').truncate();
     },
     from: ({ datawarehouseKnex }) => {
       return datawarehouseKnex('data_export_parcoursup_certif_result_code_validation').select(


### PR DESCRIPTION
## 🌸 Problème

L'usage de delete sur des tables volumineuses est long et peut-être fourbe car il déclenchera un vacuum à postériori ce qui peut en plus provoquer des problèmes de ralentissement.

## 🌳 Proposition

Nous préférons utiliser TRUNCATE qui comme [la doc le mentionne](https://www.postgresql.org/docs/current/sql-truncate.html) est adapté pour les tables volumineuses et a l'avantage de réclamer l'espace disque directement sans passer par un vacuum ensuite.  

> TRUNCATE quickly removes all rows from a set of tables. It has the same effect as an unqualified DELETE on each table, but since it does not actually scan the tables it is faster. Furthermore, it reclaims disk space immediately, rather than requiring a subsequent VACUUM operation. This is most useful on large tables.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
