### PR TITLE
[FEATURE] Proposer une api interne pour récupérer les campagnes participations (PIX-17350)

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -20,7 +20,7 @@ const buildCampaign = function ({
   archivedBy = null,
   deletedAt = null,
   deletedBy = null,
-  type = 'ASSESSMENT',
+  type = CampaignTypes.ASSESSMENT,
   createdAt = new Date('2020-01-01'),
   organizationId,
   creatorId,

--- a/api/scripts/generate-api-documentation.js
+++ b/api/scripts/generate-api-documentation.js
@@ -4,11 +4,13 @@ import * as url from 'node:url';
 
 import jsdocToMarkdown from 'jsdoc-to-markdown';
 
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
-
 async function main(baseFolder) {
   const docs = await jsdocToMarkdown.render({ files: `${baseFolder}/**/application/api/**/*.js` });
 
+  console.log(
+    `This doc has been generated on ${new Date().toLocaleString()} with \`scripts/generate-api-documentation.js\`. See package.json.`,
+  );
+  console.log('\n---');
   console.log(docs);
 }
 
@@ -20,7 +22,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main(process.argv[2]);
     } catch (error) {
-      logger.error(error);
+      console.error(error);
       process.exitCode = 1;
     }
   }

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -1,4 +1,4 @@
-This doc has been generated on 4/23/2025, 11:18:17 AM with `scripts/generate-api-documentation.js`. See package.json.
+This doc has been generated on 4/23/2025, 5:31:41 PM with `scripts/generate-api-documentation.js`. See package.json.
 
 ---
 ## Modules
@@ -27,6 +27,13 @@ This doc has been generated on 4/23/2025, 11:18:17 AM with `scripts/generate-api
 </dd>
 </dl>
 
+## Functions
+
+<dl>
+<dt><a href="#hasCampaignParticipations">hasCampaignParticipations(userId)</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd></dd>
+</dl>
+
 <a name="module_CampaignApi"></a>
 
 ## CampaignApi
@@ -38,7 +45,7 @@ This doc has been generated on 4/23/2025, 11:18:17 AM with `scripts/generate-api
     * [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
     * [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
     * [~findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds)](#module_CampaignApi..findCampaignSkillIdsForCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
-    * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationDTO&gt;&gt;</code>
+    * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationModels.AssessmentCampaignParticipation&gt;&gt;</code>
     * [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
     * [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
     * [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
@@ -108,7 +115,7 @@ This doc has been generated on 4/23/2025, 11:18:17 AM with `scripts/generate-api
 
 <a name="module_CampaignApi..getCampaignParticipations"></a>
 
-### CampaignApi~getCampaignParticipations(payload) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationDTO&gt;&gt;</code>
+### CampaignApi~getCampaignParticipations(payload) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationModels.AssessmentCampaignParticipation&gt;&gt;</code>
 **Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
 | Param | Type |
@@ -516,5 +523,14 @@ delete organization learner before adding import feature
 | params | <code>object</code> |  |
 | params.userId | <code>number</code> | The ID of the user wich request the action |
 | params.organizationId | <code>number</code> | The ID of the organizationId to find learner to delete |
+
+<a name="hasCampaignParticipations"></a>
+
+## hasCampaignParticipations(userId) ⇒ <code>Promise.&lt;boolean&gt;</code>
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| userId | <code>number</code> | 
 
 

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -1,7 +1,12 @@
+This doc has been generated on 4/23/2025, 11:18:17 AM with `scripts/generate-api-documentation.js`. See package.json.
+
+---
 ## Modules
 
 <dl>
 <dt><a href="#module_CampaignApi">CampaignApi</a></dt>
+<dd></dd>
+<dt><a href="#module_KnowledgeElementSnapshotAPI">KnowledgeElementSnapshotAPI</a></dt>
 <dd></dd>
 <dt><a href="#module_OrganizationLearnerApi">OrganizationLearnerApi</a></dt>
 <dd></dd>
@@ -11,382 +16,505 @@
 <dd></dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#hasBeenLearner">hasBeenLearner</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if user has been a learner of an organization</p>
+</dd>
+<dt><a href="#deleteOrganizationLearnerBeforeImportFeature">deleteOrganizationLearnerBeforeImportFeature</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
+<dd><p>delete organization learner before adding import feature</p>
+</dd>
+</dl>
+
 <a name="module_CampaignApi"></a>
 
 ## CampaignApi
 
-- [CampaignApi](#module_CampaignApi)
-  - [~save(campaign)](#module_CampaignApi..save) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
-  - [~get(campaignId)](#module_CampaignApi..get) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-  - [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
-  - [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
-  - [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
-  - [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
-  - [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
-  - [~PageDefinition](#module_CampaignApi..PageDefinition) : <code>object</code>
-  - [~CampaignListPayload](#module_CampaignApi..CampaignListPayload) : <code>object</code>
-  - [~Pagination](#module_CampaignApi..Pagination) : <code>object</code>
-  - [~CampaignListResponse](#module_CampaignApi..CampaignListResponse) : <code>object</code>
+* [CampaignApi](#module_CampaignApi)
+    * [~save(campaign)](#module_CampaignApi..save) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
+    * [~get(campaignId)](#module_CampaignApi..get) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+    * [~getByCampaignParticipationId(campaignParticipationId)](#module_CampaignApi..getByCampaignParticipationId) ⇒ <code>Promise.&lt;(Campaign\|null)&gt;</code>
+    * [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+    * [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
+    * [~findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds)](#module_CampaignApi..findCampaignSkillIdsForCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
+    * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationDTO&gt;&gt;</code>
+    * [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
+    * [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
+    * [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
+    * [~PageDefinition](#module_CampaignApi..PageDefinition) : <code>object</code>
+    * [~CampaignListPayload](#module_CampaignApi..CampaignListPayload) : <code>object</code>
+    * [~Pagination](#module_CampaignApi..Pagination) : <code>object</code>
+    * [~CampaignListResponse](#module_CampaignApi..CampaignListResponse) : <code>object</code>
+    * [~CampaignParticipationsPayload](#module_CampaignApi..CampaignParticipationsPayload) : <code>object</code>
 
 <a name="module_CampaignApi..save"></a>
 
 ### CampaignApi~save(campaign) ⇒ <code>Promise.&lt;SavedCampaign&gt;</code>
-
 **Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Throws**:
 
 - <code>UserNotAuthorizedToCreateCampaignError</code> to be improved to handle different error types
 
-| Param    | Type                         |
-| -------- | ---------------------------- |
-| campaign | <code>CampaignPayload</code> |
+
+| Param | Type |
+| --- | --- |
+| campaign | <code>CampaignPayload</code> | 
 
 <a name="module_CampaignApi..get"></a>
 
 ### CampaignApi~get(campaignId) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
+| Param | Type |
+| --- | --- |
+| campaignId | <code>number</code> | 
 
-| Param      | Type                |
-| ---------- | ------------------- |
-| campaignId | <code>number</code> |
+<a name="module_CampaignApi..getByCampaignParticipationId"></a>
+
+### CampaignApi~getByCampaignParticipationId(campaignParticipationId) ⇒ <code>Promise.&lt;(Campaign\|null)&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
+
+| Param | Type |
+| --- | --- |
+| campaignParticipationId | <code>number</code> | 
 
 <a name="module_CampaignApi..update"></a>
 
 ### CampaignApi~update(payload) ⇒ <code>Promise.&lt;Campaign&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
-
-| Param   | Type                               |
-| ------- | ---------------------------------- |
-| payload | <code>UpdateCampaignPayload</code> |
+| Param | Type |
+| --- | --- |
+| payload | <code>UpdateCampaignPayload</code> | 
 
 <a name="module_CampaignApi..findAllForOrganization"></a>
 
 ### CampaignApi~findAllForOrganization(payload) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
-**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)
+| Param | Type |
+| --- | --- |
+| payload | <code>CampaignListPayload</code> | 
 
-| Param   | Type                             |
-| ------- | -------------------------------- |
-| payload | <code>CampaignListPayload</code> |
+<a name="module_CampaignApi..findCampaignSkillIdsForCampaignParticipations"></a>
+
+### CampaignApi~findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
+
+| Param | Type |
+| --- | --- |
+| campaignParticipationIds | <code>Array.&lt;Number&gt;</code> | 
+
+<a name="module_CampaignApi..getCampaignParticipations"></a>
+
+### CampaignApi~getCampaignParticipations(payload) ⇒ <code>Promise.&lt;Array.&lt;CampaignParticipationDTO&gt;&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
+
+| Param | Type |
+| --- | --- |
+| payload | <code>CampaignParticipationsPayload</code> | 
 
 <a name="module_CampaignApi..CampaignPayload"></a>
 
 ### CampaignApi~CampaignPayload : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name                  | Type                |
-| --------------------- | ------------------- |
-| name                  | <code>string</code> |
-| title                 | <code>string</code> |
-| targetProfileId       | <code>number</code> |
-| organizationId        | <code>number</code> |
-| creatorId             | <code>number</code> |
-| customLandingPageText | <code>string</code> |
+| Name | Type |
+| --- | --- |
+| name | <code>string</code> | 
+| title | <code>string</code> | 
+| targetProfileId | <code>number</code> | 
+| organizationId | <code>number</code> | 
+| creatorId | <code>number</code> | 
+| customLandingPageText | <code>string</code> | 
 
 <a name="module_CampaignApi..UserNotAuthorizedToCreateCampaignError"></a>
 
 ### CampaignApi~UserNotAuthorizedToCreateCampaignError : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| message | <code>string</code> |
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
 
 <a name="module_CampaignApi..UpdateCampaignPayload"></a>
 
 ### CampaignApi~UpdateCampaignPayload : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name                  | Type                |
-| --------------------- | ------------------- |
-| campaignId            | <code>number</code> |
-| name                  | <code>string</code> |
-| title                 | <code>string</code> |
-| customLandingPageText | <code>string</code> |
+| Name | Type |
+| --- | --- |
+| campaignId | <code>number</code> | 
+| name | <code>string</code> | 
+| title | <code>string</code> | 
+| customLandingPageText | <code>string</code> | 
 
 <a name="module_CampaignApi..PageDefinition"></a>
 
 ### CampaignApi~PageDefinition : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name   | Type                |
-| ------ | ------------------- |
-| size   | <code>number</code> |
-| number | <code>Page</code>   |
+| Name | Type |
+| --- | --- |
+| size | <code>number</code> | 
+| number | <code>Page</code> | 
 
 <a name="module_CampaignApi..CampaignListPayload"></a>
 
 ### CampaignApi~CampaignListPayload : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name           | Type                        |
-| -------------- | --------------------------- |
-| organizationId | <code>number</code>         |
-| page           | <code>PageDefinition</code> |
-| withCoverRate  | <code>boolean</code>        |
+| Name | Type |
+| --- | --- |
+| organizationId | <code>number</code> | 
+| page | <code>PageDefinition</code> | 
+| withCoverRate | <code>boolean</code> | 
 
 <a name="module_CampaignApi..Pagination"></a>
 
 ### CampaignApi~Pagination : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name      | Type                |
-| --------- | ------------------- |
-| page      | <code>number</code> |
-| pageSize  | <code>number</code> |
-| rowCount  | <code>number</code> |
-| pageCount | <code>number</code> |
+| Name | Type |
+| --- | --- |
+| page | <code>number</code> | 
+| pageSize | <code>number</code> | 
+| rowCount | <code>number</code> | 
+| pageCount | <code>number</code> | 
 
 <a name="module_CampaignApi..CampaignListResponse"></a>
 
 ### CampaignApi~CampaignListResponse : <code>object</code>
-
 **Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
 **Properties**
 
-| Name   | Type                                        |
-| ------ | ------------------------------------------- |
-| models | <code>Array.&lt;CampaignListItem&gt;</code> |
-| meta   | <code>Pagination</code>                     |
+| Name | Type |
+| --- | --- |
+| models | <code>Array.&lt;CampaignListItem&gt;</code> | 
+| meta | <code>Pagination</code> | 
+
+<a name="module_CampaignApi..CampaignParticipationsPayload"></a>
+
+### CampaignApi~CampaignParticipationsPayload : <code>object</code>
+**Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| campaignId | <code>number</code> | 
+
+<a name="module_KnowledgeElementSnapshotAPI"></a>
+
+## KnowledgeElementSnapshotAPI
+
+* [KnowledgeElementSnapshotAPI](#module_KnowledgeElementSnapshotAPI)
+    * [~save(knowledgeElementSnapshotPayload)](#module_KnowledgeElementSnapshotAPI..save) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+    * [~getByParticipation(campaignParticipationId)](#module_KnowledgeElementSnapshotAPI..getByParticipation) ⇒ <code>Promise.&lt;(KnowledgeElementSnapshot\|null)&gt;</code>
+    * [~KnowledgeElementSnapshotPayload](#module_KnowledgeElementSnapshotAPI..KnowledgeElementSnapshotPayload) : <code>object</code>
+
+<a name="module_KnowledgeElementSnapshotAPI..save"></a>
+
+### KnowledgeElementSnapshotAPI~save(knowledgeElementSnapshotPayload) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+**Kind**: inner method of [<code>KnowledgeElementSnapshotAPI</code>](#module_KnowledgeElementSnapshotAPI)  
+
+| Param | Type |
+| --- | --- |
+| knowledgeElementSnapshotPayload | <code>KnowledgeElementSnapshotPayload</code> | 
+
+<a name="module_KnowledgeElementSnapshotAPI..getByParticipation"></a>
+
+### KnowledgeElementSnapshotAPI~getByParticipation(campaignParticipationId) ⇒ <code>Promise.&lt;(KnowledgeElementSnapshot\|null)&gt;</code>
+**Kind**: inner method of [<code>KnowledgeElementSnapshotAPI</code>](#module_KnowledgeElementSnapshotAPI)  
+
+| Param | Type |
+| --- | --- |
+| campaignParticipationId | <code>number</code> | 
+
+<a name="module_KnowledgeElementSnapshotAPI..KnowledgeElementSnapshotPayload"></a>
+
+### KnowledgeElementSnapshotAPI~KnowledgeElementSnapshotPayload : <code>object</code>
+**Kind**: inner typedef of [<code>KnowledgeElementSnapshotAPI</code>](#module_KnowledgeElementSnapshotAPI)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| userId | <code>number</code> | 
+| campaignParticipationId | <code>number</code> | 
+| knowledgeElements | <code>Array.&lt;KnowledgeElement&gt;</code> | 
 
 <a name="module_OrganizationLearnerApi"></a>
 
 ## OrganizationLearnerApi
 
-- [OrganizationLearnerApi](#module_OrganizationLearnerApi)
-  - [~find(payload)](#module_OrganizationLearnerApi..find) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
-  - [~get(organizationLearnerId)](#module_OrganizationLearnerApi..get) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
-  - [~PageDefinition](#module_OrganizationLearnerApi..PageDefinition) : <code>object</code>
-  - [~FilterDefinition](#module_OrganizationLearnerApi..FilterDefinition) : <code>object</code>
-  - [~OrganizationLearnerListPayload](#module_OrganizationLearnerApi..OrganizationLearnerListPayload) : <code>object</code>
-  - [~Pagination](#module_OrganizationLearnerApi..Pagination) : <code>object</code>
-  - [~OrganizationLearner](#module_OrganizationLearnerApi..OrganizationLearner) : <code>object</code>
-  - [~OrganizationLearnerListResponse](#module_OrganizationLearnerApi..OrganizationLearnerListResponse) : <code>object</code>
+* [OrganizationLearnerApi](#module_OrganizationLearnerApi)
+    * [~find(payload)](#module_OrganizationLearnerApi..find) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
+    * [~get(organizationLearnerId)](#module_OrganizationLearnerApi..get) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
+    * [~PageDefinition](#module_OrganizationLearnerApi..PageDefinition) : <code>object</code>
+    * [~FilterDefinition](#module_OrganizationLearnerApi..FilterDefinition) : <code>object</code>
+    * [~OrganizationLearnerListPayload](#module_OrganizationLearnerApi..OrganizationLearnerListPayload) : <code>object</code>
+    * [~Pagination](#module_OrganizationLearnerApi..Pagination) : <code>object</code>
+    * [~OrganizationLearner](#module_OrganizationLearnerApi..OrganizationLearner) : <code>object</code>
+    * [~OrganizationLearnerListResponse](#module_OrganizationLearnerApi..OrganizationLearnerListResponse) : <code>object</code>
 
 <a name="module_OrganizationLearnerApi..find"></a>
 
 ### OrganizationLearnerApi~find(payload) ⇒ <code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>
-
 Récupère les organization-learners pour une organization. Par défaut, ces organizations-learners sont triés par prénom puis par nom.
 Si le params 'page' est présent, les organization-learners seront paginés
 Si le params 'filter' est présent, les organization-learners seront filtrés
 
-**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)
+**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 
-| Param   | Type                                        |
-| ------- | ------------------------------------------- |
-| payload | <code>OrganizationLearnerListPayload</code> |
+| Param | Type |
+| --- | --- |
+| payload | <code>OrganizationLearnerListPayload</code> | 
 
 <a name="module_OrganizationLearnerApi..get"></a>
 
 ### OrganizationLearnerApi~get(organizationLearnerId) ⇒ <code>Promise.&lt;OrganizationLearner&gt;</code>
+**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 
-**Kind**: inner method of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)
-
-| Param                 | Type                |
-| --------------------- | ------------------- |
-| organizationLearnerId | <code>number</code> |
+| Param | Type |
+| --- | --- |
+| organizationLearnerId | <code>number</code> | 
 
 <a name="module_OrganizationLearnerApi..PageDefinition"></a>
 
 ### OrganizationLearnerApi~PageDefinition : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name   | Type                |
-| ------ | ------------------- |
-| size   | <code>number</code> |
-| number | <code>Page</code>   |
+| Name | Type |
+| --- | --- |
+| size | <code>number</code> | 
+| number | <code>Page</code> | 
 
 <a name="module_OrganizationLearnerApi..FilterDefinition"></a>
 
 ### OrganizationLearnerApi~FilterDefinition : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name      | Type                              |
-| --------- | --------------------------------- |
-| divisions | <code>Array.&lt;string&gt;</code> |
-| name      | <code>string</code>               |
+| Name | Type |
+| --- | --- |
+| divisions | <code>Array.&lt;string&gt;</code> | 
+| name | <code>string</code> | 
 
 <a name="module_OrganizationLearnerApi..OrganizationLearnerListPayload"></a>
 
 ### OrganizationLearnerApi~OrganizationLearnerListPayload : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Propery**: <code>(FilterDefinition\|undefined)</code> filter  
 **Properties**
 
-| Name           | Type                                                  |
-| -------------- | ----------------------------------------------------- |
-| organizationId | <code>number</code>                                   |
-| page           | <code>PageDefinition</code> \| <code>undefined</code> |
+| Name | Type |
+| --- | --- |
+| organizationId | <code>number</code> | 
+| page | <code>PageDefinition</code> \| <code>undefined</code> | 
 
 <a name="module_OrganizationLearnerApi..Pagination"></a>
 
 ### OrganizationLearnerApi~Pagination : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name      | Type                |
-| --------- | ------------------- |
-| page      | <code>number</code> |
-| pageSize  | <code>number</code> |
-| rowCount  | <code>number</code> |
-| pageCount | <code>number</code> |
+| Name | Type |
+| --- | --- |
+| page | <code>number</code> | 
+| pageSize | <code>number</code> | 
+| rowCount | <code>number</code> | 
+| pageCount | <code>number</code> | 
 
 <a name="module_OrganizationLearnerApi..OrganizationLearner"></a>
 
 ### OrganizationLearnerApi~OrganizationLearner : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name           | Type                |
-| -------------- | ------------------- |
-| id             | <code>number</code> |
-| firstName      | <code>string</code> |
-| lastName       | <code>string</code> |
-| division       | <code>string</code> |
-| organizationId | <code>number</code> |
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| firstName | <code>string</code> | 
+| lastName | <code>string</code> | 
+| division | <code>string</code> | 
+| organizationId | <code>number</code> | 
 
 <a name="module_OrganizationLearnerApi..OrganizationLearnerListResponse"></a>
 
 ### OrganizationLearnerApi~OrganizationLearnerListResponse : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerApi</code>](#module_OrganizationLearnerApi)  
 **Properties**
 
-| Name                 | Type                                              |
-| -------------------- | ------------------------------------------------- |
-| organizationLearners | <code>Array.&lt;OrganizationLearner&gt;</code>    |
-| pagination           | <code>Pagination</code> \| <code>undefined</code> |
+| Name | Type |
+| --- | --- |
+| organizationLearners | <code>Array.&lt;OrganizationLearner&gt;</code> | 
+| pagination | <code>Pagination</code> \| <code>undefined</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi"></a>
 
 ## OrganizationLearnerWithParticipationsApi
 
-- [OrganizationLearnerWithParticipationsApi](#module_OrganizationLearnerWithParticipationsApi)
-  - [~find(payload)](#module_OrganizationLearnerWithParticipationsApi..find) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
-  - [~FindPayload](#module_OrganizationLearnerWithParticipationsApi..FindPayload) : <code>object</code>
-  - [~OrganizationLearner](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearner) : <code>object</code>
-  - [~Organization](#module_OrganizationLearnerWithParticipationsApi..Organization) : <code>object</code>
-  - [~CampaignParticipation](#module_OrganizationLearnerWithParticipationsApi..CampaignParticipation) : <code>object</code>
-  - [~OrganizationLearnerWithParticipations](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations) : <code>object</code>
+* [OrganizationLearnerWithParticipationsApi](#module_OrganizationLearnerWithParticipationsApi)
+    * [~find(payload)](#module_OrganizationLearnerWithParticipationsApi..find) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
+    * [~FindPayload](#module_OrganizationLearnerWithParticipationsApi..FindPayload) : <code>object</code>
+    * [~OrganizationLearner](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearner) : <code>object</code>
+    * [~Organization](#module_OrganizationLearnerWithParticipationsApi..Organization) : <code>object</code>
+    * [~CampaignParticipation](#module_OrganizationLearnerWithParticipationsApi..CampaignParticipation) : <code>object</code>
+    * [~OrganizationLearnerWithParticipations](#module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations) : <code>object</code>
 
 <a name="module_OrganizationLearnerWithParticipationsApi..find"></a>
 
 ### OrganizationLearnerWithParticipationsApi~find(payload) ⇒ <code>Promise.&lt;Array.&lt;OrganizationLearnerWithParticipations&gt;&gt;</code>
-
 Récupère les organizations-learners avec leurs participations à partir d'une liste d'ids d'utilisateurs
 
-**Kind**: inner method of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)
+**Kind**: inner method of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 
-| Param   | Type                     |
-| ------- | ------------------------ |
-| payload | <code>FindPayload</code> |
+| Param | Type |
+| --- | --- |
+| payload | <code>FindPayload</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi..FindPayload"></a>
 
 ### OrganizationLearnerWithParticipationsApi~FindPayload : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name    | Type                              |
-| ------- | --------------------------------- |
-| userIds | <code>Array.&lt;number&gt;</code> |
+| Name | Type |
+| --- | --- |
+| userIds | <code>Array.&lt;number&gt;</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearner"></a>
 
 ### OrganizationLearnerWithParticipationsApi~OrganizationLearner : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| id      | <code>number</code> |
-| MEFCode | <code>string</code> |
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| MEFCode | <code>string</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi..Organization"></a>
 
 ### OrganizationLearnerWithParticipationsApi~Organization : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name               | Type                              |
-| ------------------ | --------------------------------- |
-| isManagingStudents | <code>boolean</code>              |
-| tags               | <code>Array.&lt;string&gt;</code> |
-| type               | <code>string</code>               |
+| Name | Type |
+| --- | --- |
+| isManagingStudents | <code>boolean</code> | 
+| tags | <code>Array.&lt;string&gt;</code> | 
+| type | <code>string</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi..CampaignParticipation"></a>
 
 ### OrganizationLearnerWithParticipationsApi~CampaignParticipation : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name            | Type                |
-| --------------- | ------------------- |
-| targetProfileId | <code>number</code> |
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| targetProfileId | <code>number</code> | 
+| status | <code>string</code> | 
+| campaignName | <code>string</code> | 
 
 <a name="module_OrganizationLearnerWithParticipationsApi..OrganizationLearnerWithParticipations"></a>
 
 ### OrganizationLearnerWithParticipationsApi~OrganizationLearnerWithParticipations : <code>object</code>
-
 **Kind**: inner typedef of [<code>OrganizationLearnerWithParticipationsApi</code>](#module_OrganizationLearnerWithParticipationsApi)  
 **Properties**
 
-| Name                   | Type                                             |
-| ---------------------- | ------------------------------------------------ |
-| organizationLearner    | <code>OrganizationLearner</code>                 |
-| organization           | <code>Organization</code>                        |
-| campaignParticipations | <code>Array.&lt;CampaignParticipation&gt;</code> |
+| Name | Type |
+| --- | --- |
+| organizationLearner | <code>OrganizationLearner</code> | 
+| organization | <code>Organization</code> | 
+| campaignParticipations | <code>Array.&lt;CampaignParticipation&gt;</code> | 
 
 <a name="module_TargetProfileApi"></a>
 
 ## TargetProfileApi
 
-- [TargetProfileApi](#module_TargetProfileApi)
-  - [~getByOrganizationId(organizationId)](#module_TargetProfileApi..getByOrganizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
-  - [~getById(id)](#module_TargetProfileApi..getById) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+* [TargetProfileApi](#module_TargetProfileApi)
+    * [~getByOrganizationId(organizationId)](#module_TargetProfileApi..getByOrganizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
+    * [~getByIdForAdmin(id)](#module_TargetProfileApi..getByIdForAdmin) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+    * [~getById(id)](#module_TargetProfileApi..getById) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+    * [~findSkillByTargetProfileIds(targetProfilsIds)](#module_TargetProfileApi..findSkillByTargetProfileIds) ⇒ <code>Promise.&lt;Array.&lt;TargetProfileSkill&gt;&gt;</code>
 
 <a name="module_TargetProfileApi..getByOrganizationId"></a>
 
 ### TargetProfileApi~getByOrganizationId(organizationId) ⇒ <code>Promise.&lt;Array.&lt;TargetProfile&gt;&gt;</code>
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
 
-**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)
+| Param | Type |
+| --- | --- |
+| organizationId | <code>number</code> | 
 
-| Param          | Type                |
-| -------------- | ------------------- |
-| organizationId | <code>number</code> |
+<a name="module_TargetProfileApi..getByIdForAdmin"></a>
+
+### TargetProfileApi~getByIdForAdmin(id) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
+
+| Param | Type |
+| --- | --- |
+| id | <code>number</code> | 
 
 <a name="module_TargetProfileApi..getById"></a>
 
 ### TargetProfileApi~getById(id) ⇒ <code>Promise.&lt;TargetProfile&gt;</code>
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
 
-**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)
+| Param | Type |
+| --- | --- |
+| id | <code>number</code> | 
 
-| Param | Type                |
-| ----- | ------------------- |
-| id    | <code>number</code> |
+<a name="module_TargetProfileApi..findSkillByTargetProfileIds"></a>
+
+### TargetProfileApi~findSkillByTargetProfileIds(targetProfilsIds) ⇒ <code>Promise.&lt;Array.&lt;TargetProfileSkill&gt;&gt;</code>
+**Kind**: inner method of [<code>TargetProfileApi</code>](#module_TargetProfileApi)  
+
+| Param | Type |
+| --- | --- |
+| targetProfilsIds | <code>Array.&lt;number&gt;</code> | 
+
+<a name="hasBeenLearner"></a>
+
+## hasBeenLearner ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if user has been a learner of an organization
+
+**Kind**: global constant  
+**Throws**:
+
+- TypeError - Throw when params.userId is not defined
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | <code>object</code> |  |
+| params.userId | <code>number</code> | The ID of the user to check |
+
+<a name="deleteOrganizationLearnerBeforeImportFeature"></a>
+
+## deleteOrganizationLearnerBeforeImportFeature ⇒ <code>Promise.&lt;void&gt;</code>
+delete organization learner before adding import feature
+
+**Kind**: global constant  
+**Throws**:
+
+- TypeError - Throw when params.userId or params.organizationId is not defined
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | <code>object</code> |  |
+| params.userId | <code>number</code> | The ID of the user wich request the action |
+| params.organizationId | <code>number</code> | The ID of the organizationId to find learner to delete |
+
+

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -1,6 +1,11 @@
+import { AssessmentCampaignParticipation } from '../../domain/read-models/CampaignParticipation.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { Campaign } from './models/Campaign.js';
 import { CampaignListItem } from './models/CampaignListItem.js';
+import {
+  AssessmentCampaignParticipation as AssessmentCampaignParticipationAPI,
+  ProfilesCollectionCampaignParticipation as ProfilesCollectionCampaignParticipationAPI,
+} from './models/CampaignParticipation.js';
 import { SavedCampaign } from './models/SavedCampaign.js';
 /**
  * @module CampaignApi
@@ -151,4 +156,26 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
   return usecases.findCampaignSkillIdsForCampaignParticipations({
     campaignParticipationIds,
   });
+};
+
+/**
+ * @typedef CampaignParticipationsPayload
+ * @type {object}
+ * @property {number} campaignId
+ */
+
+/**
+ * @function
+ * @name getCampaignParticipations
+ *
+ * @param {CampaignParticipationsPayload} payload
+ * @returns {Promise<Array<AssessmentCampaignParticipationAPI>|Array<ProfilesCollectionCampaignParticipationAPI>>}
+ */
+export const getCampaignParticipations = async function ({ campaignId }) {
+  const campaignParticipations = await usecases.getCampaignParticipations({ campaignId });
+  return campaignParticipations.map((campaignParticipation) =>
+    campaignParticipation instanceof AssessmentCampaignParticipation
+      ? new AssessmentCampaignParticipationAPI(campaignParticipation)
+      : new ProfilesCollectionCampaignParticipationAPI(campaignParticipation),
+  );
 };

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -1,0 +1,106 @@
+import _ from 'lodash';
+
+/**
+ * @typedef {
+    participantFirstName,
+    participantLastName,
+    participantExternalId,
+    studentNumber = null,
+    userId,
+    additionalInfos,
+    campaignParticipationId,
+    isCompleted,
+    createdAt,
+    sharedAt,
+    division,
+    group,
+    masteryRate,
+    validatedSkillsCount,
+    status,
+    pixScore,
+  } CampaignParticipationArgs
+*/
+
+class CampaignParticipation {
+  /**
+   * @typedef {Object} CampaignParticipationArgs
+   * @property {string} participantFirstName
+   * @property {string} participantLastName
+   * @property {string | null} participantExternalId
+   * @property {number} userId
+   * @property {number} campaignParticipationId
+   * @property {Date} createdAt
+   * @property {Date | null} sharedAt
+   * @property {string} status
+   */
+
+  /**
+   * @param {CampaignParticipationArgs} args
+   */
+  constructor({
+    participantFirstName,
+    participantLastName,
+    participantExternalId = null,
+    userId,
+    campaignParticipationId,
+    createdAt,
+    sharedAt,
+    status,
+  } = {}) {
+    this.participantFirstName = participantFirstName;
+    this.participantLastName = participantLastName;
+    this.participantExternalId = participantExternalId;
+    this.userId = userId;
+    this.campaignParticipationId = campaignParticipationId;
+    this.createdAt = createdAt;
+    this.sharedAt = sharedAt;
+    this.status = status;
+  }
+
+  get id() {
+    return this.campaignParticipationId;
+  }
+
+  get isShared() {
+    return Boolean(this.sharedAt);
+  }
+}
+
+/**
+ * @typedef {object} AssessmentCampaignParticipationArgs
+ * @extends CampaignParticipationArgs
+ * @property {number} masteryRate
+ * @property {Object} tubes
+ */
+
+/**
+ * @class
+ */
+class AssessmentCampaignParticipation extends CampaignParticipation {
+  /**
+   * @param {AssessmentCampaignParticipationArgs} args
+   */
+  constructor(args) {
+    super(args);
+    this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
+    this.tubes = args.tubes;
+  }
+}
+
+/**
+ * @typedef {object} ProfilesCollectionCampaignParticipationArgs
+ * @extends CampaignParticipationArgs
+ * @property {number} pixScore
+ */
+
+class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
+  /**
+   * @param {ProfilesCollectionCampaignParticipationArgs} args
+   */
+  constructor(args) {
+    super(args);
+    this.pixScore = args.pixScore;
+  }
+}
+
+export { AssessmentCampaignParticipation, CampaignParticipation, ProfilesCollectionCampaignParticipation };

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -1,0 +1,106 @@
+import _ from 'lodash';
+
+/**
+ * @typedef {
+    participantFirstName,
+    participantLastName,
+    participantExternalId,
+    studentNumber = null,
+    userId,
+    additionalInfos,
+    campaignParticipationId,
+    isCompleted,
+    createdAt,
+    sharedAt,
+    division,
+    group,
+    masteryRate,
+    validatedSkillsCount,
+    status,
+    pixScore,
+  } CampaignParticipationArgs
+*/
+
+class CampaignParticipation {
+  /**
+   * @typedef {Object} CampaignParticipationArgs
+   * @property {string} participantFirstName
+   * @property {string} participantLastName
+   * @property {string | null} participantExternalId
+   * @property {number} userId
+   * @property {number} campaignParticipationId
+   * @property {Date} createdAt
+   * @property {Date | null} sharedAt
+   * @property {string} status
+   */
+
+  /**
+   * @param {CampaignParticipationArgs} args
+   */
+  constructor({
+    participantFirstName,
+    participantLastName,
+    participantExternalId = null,
+    userId,
+    campaignParticipationId,
+    createdAt,
+    sharedAt,
+    status,
+  } = {}) {
+    this.participantFirstName = participantFirstName;
+    this.participantLastName = participantLastName;
+    this.participantExternalId = participantExternalId;
+    this.userId = userId;
+    this.campaignParticipationId = campaignParticipationId;
+    this.createdAt = createdAt;
+    this.sharedAt = sharedAt;
+    this.status = status;
+  }
+
+  get id() {
+    return this.campaignParticipationId;
+  }
+
+  get isShared() {
+    return Boolean(this.sharedAt);
+  }
+}
+
+/**
+ * @typedef {object} AssessmentCampaignParticipationArgs
+ * @extends CampaignParticipationArgs
+ * @property {number} masteryRate
+ * @property {Object} tubes
+ */
+
+/**
+ * @class
+ */
+class AssessmentCampaignParticipation extends CampaignParticipation {
+  /**
+   * @param {AssessmentCampaignParticipationArgs} args
+   */
+  constructor(args) {
+    super(args);
+    this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
+    this.tubes = args.tubes;
+  }
+}
+
+/**
+ * @typedef {object} ProfilesCollectionCampaignParticipationArgs
+ * @extends CampaignParticipationArgs
+ * @property {number} pixScore
+ */
+
+class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
+  /**
+   * @param {ProfilesCollectionCampaignParticipationArgs} args
+   */
+  constructor(args) {
+    super(args);
+    this.pixScore = args.pixScore;
+  }
+}
+
+export { AssessmentCampaignParticipation, CampaignParticipation, ProfilesCollectionCampaignParticipation };

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js
@@ -4,6 +4,7 @@ const Joi = BaseJoi.extend(JoiDate);
 import _ from 'lodash';
 
 import { validateEntity } from '../../../../shared/domain/validators/entity-validator.js';
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 
 const validationSchema = Joi.object({
   participantFirstName: Joi.string().required().allow(''),
@@ -20,6 +21,10 @@ const validationSchema = Joi.object({
   group: Joi.string().allow(null).optional(),
   masteryRate: Joi.number().required().allow(null),
   validatedSkillsCount: Joi.number().required().allow(null),
+  status: Joi.string()
+    .valid(...Object.values(CampaignParticipationStatuses))
+    .required(),
+  pixScore: Joi.number().default(null).allow(null),
 });
 
 class CampaignParticipationInfo {
@@ -38,6 +43,8 @@ class CampaignParticipationInfo {
     group,
     masteryRate,
     validatedSkillsCount,
+    status,
+    pixScore,
   } = {}) {
     this.participantFirstName = participantFirstName;
     this.participantLastName = participantLastName;
@@ -53,7 +60,13 @@ class CampaignParticipationInfo {
     this.group = group;
     this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
     this.validatedSkillsCount = !_.isNil(validatedSkillsCount) ? Number(validatedSkillsCount) : null;
+    this.status = status;
+    this.pixScore = pixScore;
     validateEntity(validationSchema, this);
+  }
+
+  get id() {
+    return this.campaignParticipationId;
   }
 
   get isShared() {

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -1,0 +1,50 @@
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+import { CampaignResultLevelsPerTubesAndCompetences } from '../models/CampaignResultLevelsPerTubesAndCompetences.js';
+import {
+  AssessmentCampaignParticipation,
+  ProfilesCollectionCampaignParticipation,
+} from '../read-models/CampaignParticipation.js';
+
+const getCampaignParticipations = async function ({
+  campaignId,
+  locale,
+  campaignRepository,
+  campaignParticipationRepository,
+  knowledgeElementSnapshotRepository,
+  learningContentRepository,
+}) {
+  const campaign = await campaignRepository.get(campaignId);
+  const participations = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+
+  if (campaign.isProfilesCollection) {
+    return participations.map((participation) => {
+      return new ProfilesCollectionCampaignParticipation(participation);
+    });
+  }
+
+  const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
+  const knowledgeElementsByParticipations = await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(
+    participations.map((participation) => participation.id),
+  );
+  return participations.map((participation) => {
+    const tubes = computeTubes(campaignId, participation, learningContent, {
+      [participation.id]: knowledgeElementsByParticipations[participation.id],
+    });
+    return new AssessmentCampaignParticipation({ ...participation, tubes });
+  });
+};
+
+function computeTubes(campaignId, campaignParticipation, learningContent, knowledgeElementsByParticipation) {
+  if (campaignParticipation.status !== CampaignParticipationStatuses.SHARED) {
+    return undefined;
+  }
+
+  const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
+    campaignId,
+    learningContent,
+    knowledgeElementsByParticipation,
+  });
+  return campaignResultLevelPerTubesAndCompetences.levelsPerTube;
+}
+
+export { getCampaignParticipations };

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -36,7 +36,7 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
   const [allPixCompetences, organization, campaignParticipationResultDatas] = await Promise.all([
     competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),
     organizationRepository.get(campaign.organizationId),
-    campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id),
+    campaignParticipationRepository.findInfoByCampaignId(campaign.id),
   ]);
 
   const campaignProfilesCollectionExport = new CampaignProfilesCollectionExport({

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
@@ -59,5 +59,7 @@ function _rowToCampaignParticipationInfo(row) {
     group: row.group,
     masteryRate: row.masteryRate,
     validatedSkillsCount: row.validatedSkillsCount,
+    status: row.status,
+    pixScore: row.pixScore,
   });
 }

--- a/api/src/prescription/target-profile/application/api/target-profile-api.js
+++ b/api/src/prescription/target-profile/application/api/target-profile-api.js
@@ -50,7 +50,7 @@ export const getById = async (id) => {
  * @name findSkillByTargetProfileIds
  *
  * @param {Array<number>} targetProfilsIds
- * @returns {Promise<<Array<TargetProfileSkill>>}
+ * @returns {Promise<Array<TargetProfileSkill>>}
  */
 export const findSkillsByTargetProfileIds = async (targetProfileIds) => {
   const skillsData = await usecases.findSkillsByTargetProfileIds({ targetProfileIds });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import * as knowledgeElementSnapshotAPI from '../../../../../../src/prescription/campaign/application/api/knowledge-element-snapshots-api.js';
+import { CampaignParticipationInfo } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js';
 import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
@@ -799,7 +800,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         createdAt: new Date('2024-05-01'),
         isImproved: false,
       });
-      // add a particpation from another user
+      // add a participation from another user
       databaseBuilder.factory.buildCampaignParticipation({ campaignId });
 
       await databaseBuilder.commit();
@@ -840,7 +841,7 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
-  describe('#findProfilesCollectionResultDataByCampaignId', function () {
+  describe('#findInfoByCampaignId', function () {
     let campaign1;
     let campaign2;
     let campaignParticipation1;
@@ -858,12 +859,17 @@ describe('Integration | Repository | Campaign Participation', function () {
         division: '6emeD',
         group: null,
         attributes: { hobby: 'Genky' },
+        studentNumber: '1002',
       };
       campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
         organizationLearner1,
         {
           campaignId: campaign1.id,
           createdAt: new Date('2017-03-15T14:59:35Z'),
+          sharedAt: new Date('2017-03-16T14:59:35Z'),
+          validatedSkillsCount: 10,
+          pixScore: 10,
+          masteryRate: null,
         },
       );
       databaseBuilder.factory.buildCampaignParticipation({
@@ -877,14 +883,13 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const participationResultDatas =
-        await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       expect(participationResultDatas).lengthOf(1);
-      expect(participationResultDatas[0]).to.deep.include({
-        id: campaignParticipation1.id,
-        isShared: true,
+      expect(participationResultDatas[0]).to.be.instanceOf(CampaignParticipationInfo);
+      expect(participationResultDatas[0]).to.deep.equal({
+        isCompleted: false,
         sharedAt: campaignParticipation1.sharedAt,
         participantExternalId: campaignParticipation1.participantExternalId,
         userId: campaignParticipation1.userId,
@@ -892,6 +897,14 @@ describe('Integration | Repository | Campaign Participation', function () {
         participantLastName: organizationLearner1.lastName,
         division: organizationLearner1.division,
         additionalInfos: organizationLearner1.attributes,
+        status: campaignParticipation1.status,
+        pixScore: campaignParticipation1.pixScore,
+        validatedSkillsCount: campaignParticipation1.validatedSkillsCount,
+        createdAt: campaignParticipation1.createdAt,
+        studentNumber: organizationLearner1.studentNumber,
+        campaignParticipationId: campaignParticipation1.id,
+        masteryRate: campaignParticipation1.masteryRate,
+        group: organizationLearner1.group,
       });
     });
 
@@ -909,8 +922,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       await databaseBuilder.commit();
 
       // when
-      const participationResultDatas =
-        await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -932,8 +944,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const participationResultDatas =
-        await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -979,8 +990,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       it('should return the division of the school registration linked to the campaign', async function () {
-        const campaignParticipationInfos =
-          await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id);
+        const campaignParticipationInfos = await campaignParticipationRepository.findInfoByCampaignId(campaign.id);
 
         expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].division).to.equal('3eme');
@@ -1008,8 +1018,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const participationResultDatas =
-          await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+        const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
         // then
         expect(participationResultDatas).to.lengthOf(2);
@@ -1031,8 +1040,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const participationResultDatas =
-          await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id);
+        const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaign.id);
 
         // then
         expect(participationResultDatas[0].sharedAt).to.equal(null);

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -1,4 +1,11 @@
 import * as campaignApi from '../../../../../../src/prescription/campaign/application/api/campaigns-api.js';
+import { CampaignParticipation } from '../../../../../../src/prescription/campaign/application/api/models/CampaignParticipation.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Application | campaign-api', function () {
@@ -31,6 +38,108 @@ describe('Integration | Application | campaign-api', function () {
       expect(result.models.length).to.be.equal(1);
       expect(result.models[0].id).to.deep.equal(campaignId2);
       expect(result.meta.pageCount).to.equal(2);
+    });
+  });
+
+  describe('#getCampaignParticipations', function () {
+    it('should return an array of campaign participations', async function () {
+      // given
+      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+      const { id: userId } = databaseBuilder.factory.buildUser({
+        firstName: 'user firstname 1',
+        lastName: 'user lastname 1',
+      });
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+        userId,
+        firstName: 'firstname 1',
+        lastName: 'lastname 1',
+      });
+      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner1.id,
+        masteryRate: 0.1,
+        pixScore: 42,
+        validatedSkillsCount: 10,
+        userId,
+        participantExternalId: 'external id 1',
+        createdAt: new Date('2025-01-02'),
+        sharedAt: new Date('2025-01-03'),
+      });
+      const ke = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId,
+        userId: participation1.userId,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation1.id,
+        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+      });
+
+      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organizationLearner1.organizationId,
+      });
+      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId: organizationLearner2.id,
+        userId: organizationLearner2.userId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignApi.getCampaignParticipations({
+        campaignId: campaign.id,
+        locale: 'fr',
+      });
+
+      // then
+      expect(result[0]).instanceOf(CampaignParticipation);
+      expect(result[1]).instanceOf(CampaignParticipation);
+      expect(result).to.deep.equal([
+        {
+          campaignParticipationId: participation2.id,
+          participantFirstName: organizationLearner2.firstName,
+          participantLastName: organizationLearner2.lastName,
+          participantExternalId: participation2.participantExternalId,
+          userId: organizationLearner2.userId,
+          createdAt: participation2.createdAt,
+          sharedAt: null,
+          masteryRate: null,
+          status: CampaignParticipationStatuses.STARTED,
+          tubes: undefined,
+        },
+        {
+          campaignParticipationId: participation1.id,
+          participantFirstName: 'firstname 1',
+          participantLastName: 'lastname 1',
+          participantExternalId: 'external id 1',
+          userId,
+          createdAt: new Date('2025-01-02'),
+          sharedAt: new Date('2025-01-03'),
+          masteryRate: 0.1,
+          status: CampaignParticipationStatuses.SHARED,
+          tubes: [
+            {
+              competenceId: 'competenceIdA',
+              id: 'tubeIdA',
+              maxLevel: 2,
+              meanLevel: 2,
+              practicalDescription: 'practicalDescription FR Tube A',
+              practicalTitle: 'practicalTitle FR Tube A',
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -1,0 +1,178 @@
+import {
+  AssessmentCampaignParticipation,
+  ProfilesCollectionCampaignParticipation,
+} from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipation.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+  KnowledgeElement,
+} from '../../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+const { FRENCH_SPOKEN } = LOCALE;
+
+describe('Integration | UseCase | get-campaign-participations', function () {
+  context('when campaign type is assessment', function () {
+    it('should return all participations for given campaign', async function () {
+      // given
+      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
+      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner1.id,
+        masteryRate: 0.1,
+        pixScore: 42,
+        validatedSkillsCount: 10,
+      });
+      const ke = databaseBuilder.factory.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId,
+        userId: participation1.userId,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        campaignParticipationId: participation1.id,
+        snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+      });
+
+      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organizationLearner1.organizationId,
+      });
+      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId: organizationLearner2.id,
+        masteryRate: null,
+        pixScore: null,
+        validatedSkillsCount: null,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        status: CampaignParticipationStatuses.STARTED,
+        masteryRate: 0.5,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const participations = await usecases.getCampaignParticipations({
+        campaignId: campaign.id,
+        locale: FRENCH_SPOKEN,
+      });
+
+      // then
+      expect(participations).to.have.lengthOf(2);
+      expect(participations).to.deep.members([
+        new AssessmentCampaignParticipation({
+          campaignParticipationId: participation1.id,
+          userId: participation1.userId,
+          participantExternalId: participation1.participantExternalId,
+          status: participation1.status,
+          masteryRate: participation1.masteryRate,
+          createdAt: participation1.createdAt,
+          sharedAt: participation1.sharedAt,
+          participantFirstName: organizationLearner1.firstName,
+          participantLastName: organizationLearner1.lastName,
+          tubes: [
+            {
+              id: tube.id,
+              competenceId,
+              maxLevel: 2,
+              meanLevel: 2,
+              practicalDescription: tube.practicalDescription_i18n['fr'],
+              practicalTitle: tube.practicalTitle_i18n['fr'],
+            },
+          ],
+        }),
+        new AssessmentCampaignParticipation({
+          campaignParticipationId: participation2.id,
+          userId: participation2.userId,
+          participantExternalId: participation2.participantExternalId,
+          status: participation2.status,
+          masteryRate: participation2.masteryRate,
+          createdAt: participation2.createdAt,
+          sharedAt: participation2.sharedAt,
+          participantFirstName: organizationLearner2.firstName,
+          participantLastName: organizationLearner2.lastName,
+          tubes: undefined,
+        }),
+      ]);
+    });
+  });
+  context('when campaign type is profile collection', function () {
+    it('should return all participations for given campaign', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
+      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.SHARED,
+        organizationLearnerId: organizationLearner1.id,
+        masteryRate: 0.1,
+        pixScore: 42,
+        validatedSkillsCount: 10,
+      });
+      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organizationLearner1.organizationId,
+      });
+      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId: organizationLearner2.id,
+        masteryRate: 0.3,
+        pixScore: 21,
+        validatedSkillsCount: 10,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        status: CampaignParticipationStatuses.STARTED,
+        masteryRate: 0.5,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const participations = await usecases.getCampaignParticipations({
+        campaignId: campaign.id,
+        locale: FRENCH_SPOKEN,
+      });
+
+      //then
+      expect(participations).to.have.lengthOf(2);
+      expect(participations[0]).instanceOf(ProfilesCollectionCampaignParticipation);
+      expect(participations[1]).instanceOf(ProfilesCollectionCampaignParticipation);
+      expect(participations).to.deep.members([
+        {
+          campaignParticipationId: participation1.id,
+          userId: participation1.userId,
+          participantExternalId: participation1.participantExternalId,
+          status: participation1.status,
+          createdAt: participation1.createdAt,
+          sharedAt: participation1.sharedAt,
+          pixScore: participation1.pixScore,
+          participantFirstName: organizationLearner1.firstName,
+          participantLastName: organizationLearner1.lastName,
+        },
+        {
+          campaignParticipationId: participation2.id,
+          userId: participation2.userId,
+          participantExternalId: participation2.participantExternalId,
+          status: participation2.status,
+          createdAt: participation2.createdAt,
+          sharedAt: participation2.sharedAt,
+          pixScore: participation2.pixScore,
+          participantFirstName: organizationLearner2.firstName,
+          participantLastName: organizationLearner2.lastName,
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -29,6 +29,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           {
             campaignId: campaign1.id,
             userId,
+            pixScore: 42,
           },
           false,
         );
@@ -42,7 +43,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
 
         const campaign2 = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
 
-        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation(
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           {
             firstName: 'First',
             lastName: 'Last',
@@ -51,6 +52,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           {
             campaignId: campaign2.id,
             userId,
+            pixScore: 120,
           },
         );
 
@@ -78,6 +80,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
             campaignParticipationId: campaignParticipation1.id,
             isCompleted: false,
             masteryRate: null,
+            pixScore: 42,
             participantFirstName: 'First',
             participantLastName: 'Last',
             additionalInfos: { hobby: 'Wan' },
@@ -85,6 +88,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
             division: null,
             group: null,
             validatedSkillsCount: null,
+            status: campaignParticipation1.status,
           },
         ]);
         expect(campaignParticipationInfos[0].isShared).to.be.true;
@@ -167,6 +171,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           campaignParticipationId: campaignParticipation2.id,
           isCompleted: true,
           masteryRate: null,
+          pixScore: null,
           additionalInfos: null,
           participantFirstName: 'Tyler',
           participantLastName: 'Durden',
@@ -174,6 +179,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           division: null,
           group: null,
           validatedSkillsCount: null,
+          status: campaignParticipation2.status,
         });
         expect(campaignParticipationInfos[0].isShared).to.be.false;
 
@@ -185,6 +191,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           campaignParticipationId: campaignParticipation1.id,
           isCompleted: false,
           masteryRate: null,
+          pixScore: null,
           additionalInfos: null,
           participantFirstName: 'The',
           participantLastName: 'Narrator',
@@ -192,6 +199,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           division: null,
           group: null,
           validatedSkillsCount: null,
+          status: campaignParticipation1.status,
         });
         expect(campaignParticipationInfos[1].isShared).to.be.true;
       });
@@ -246,12 +254,14 @@ describe('Integration | Repository | Campaign Participation Info', function () {
             isCompleted: true,
             additionalInfos: null,
             masteryRate: null,
+            pixScore: null,
             participantFirstName: 'The',
             participantLastName: 'Narrator',
             studentNumber: null,
             division: null,
             group: null,
             validatedSkillsCount: null,
+            status: campaignParticipation.status,
           },
         ]);
       });
@@ -323,12 +333,14 @@ describe('Integration | Repository | Campaign Participation Info', function () {
             isCompleted: false,
             additionalInfos: null,
             masteryRate: null,
+            pixScore: null,
             participantFirstName: 'The',
             participantLastName: 'Narrator',
             studentNumber: null,
             division: null,
             group: null,
             validatedSkillsCount: null,
+            status: secondCampaignParticipation.status,
           },
           {
             sharedAt: firstCampaignParticipation.sharedAt,
@@ -339,12 +351,14 @@ describe('Integration | Repository | Campaign Participation Info', function () {
             isCompleted: true,
             additionalInfos: null,
             masteryRate: null,
+            pixScore: null,
             participantFirstName: 'The',
             participantLastName: 'Narrator',
             studentNumber: null,
             division: null,
             group: null,
             validatedSkillsCount: null,
+            status: firstCampaignParticipation.status,
           },
         ]);
       });

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipationInfo_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipationInfo_test.js
@@ -1,4 +1,5 @@
 import { CampaignParticipationInfo } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js';
+import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { ObjectValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 
@@ -19,6 +20,8 @@ describe('Unit | Domain | Read-models | CampaignParticipationInfo', function () 
         sharedAt: new Date('2019-05-01'),
         masteryPercentage: 1,
         additionalInfos: null,
+        status: CampaignParticipationStatuses.SHARED,
+        pixScore: 120,
       };
     });
 
@@ -211,6 +214,7 @@ describe('Unit | Domain | Read-models | CampaignParticipationInfo', function () 
         isCompleted: true,
         createdAt: new Date('2019-04-01'),
         masteryPercentage: 1,
+        status: CampaignParticipationStatuses.SHARED,
       };
     });
 

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -13,7 +13,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
   const userRepository = { getWithMemberships: () => undefined };
   const competenceRepository = { listPixCompetencesOnly: () => undefined };
   const organizationRepository = { get: () => undefined };
-  const campaignParticipationRepository = { findProfilesCollectionResultDataByCampaignId: () => undefined };
+  const campaignParticipationRepository = { findInfoByCampaignId: () => undefined };
   let organizationFeatureApi;
   let writableStream;
   let csvPromise;
@@ -30,8 +30,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
       .rejects('error for competenceRepository.listPixCompetencesOnly');
     sinon.stub(organizationRepository, 'get').rejects('error for organizationRepository.get');
     sinon
-      .stub(campaignParticipationRepository, 'findProfilesCollectionResultDataByCampaignId')
-      .rejects('error for campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId');
+      .stub(campaignParticipationRepository, 'findInfoByCampaignId')
+      .rejects('error for campaignParticipationRepository.findInfoByCampaignId');
     sinon
       .stub(CampaignProfilesCollectionExport.prototype, 'export')
       .rejects('CampaignProfilesCollectionExport.prototype.export');
@@ -82,7 +82,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
     userRepository.getWithMemberships.withArgs(user.id).resolves(user);
     organizationRepository.get.withArgs(organization.id).resolves(organization);
     competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
-    campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId
+    campaignParticipationRepository.findInfoByCampaignId
       .withArgs(campaign.id)
       .resolves(campaignParticipationResultDatas);
     CampaignProfilesCollectionExport.prototype.export

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
@@ -1,4 +1,5 @@
 import { CampaignParticipationInfo } from '../../../../src/prescription/campaign/domain/read-models/CampaignParticipationInfo.js';
+import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
 
 function buildCampaignParticipationInfo({
   participantFirstName = 'participantFirstName',
@@ -14,6 +15,8 @@ function buildCampaignParticipationInfo({
   group,
   masteryRate = 1,
   additionalInfos = null,
+  status = CampaignParticipationStatuses.SHARED,
+  pixScore = 120,
 } = {}) {
   return new CampaignParticipationInfo({
     participantFirstName,
@@ -29,6 +32,8 @@ function buildCampaignParticipationInfo({
     group,
     masteryRate,
     additionalInfos,
+    status,
+    pixScore,
   });
 }
 


### PR DESCRIPTION
## 🌸 Problème

Des partenaires ont besoin d'avoir à disposition des données concernant les participations, tout statut confondu, en donnant en entrée un campaign id.

## 🌳 Proposition
On a créé une méthode dans campaigns-api pour renvoyer ces données, ainsi qu'un usecase spécifique (get-campaign-participations) et un DTO (CampaignParticipationDTO) qui vient filtrer les données renvoyées par le usecase au niveau de la méthode getCampaignParticipations de campaigns-api.js.

- [x] Première itération : pour tous les types de campagne, renvoyer via un model CampaignParticipationDTO : 
participantFirstName,
participantLastName,
participantExternalId,
userId,
campaignParticipationId,
createdAt,
sharedAt,
masteryRate,
status,

- [x] Deuxième itération : dans le cas des campagnes `EXAM` / `ASSESSMENT` renvoyer le taux de couverture atteint par participation et dans le cas des campagnes ` PROFILE_COLLECTION`,  renvoyer le pixScore

- [ ] Troisième itération (autre PR) : dans le cas des campagnes `EXAM` / `ASSESSMENT`, renvoyer les badges / paliers atteints par participation et dans le cas des campagnes ` PROFILE_COLLECTION`,  renvoyer les  champs
( Nb de compétences certifiables, certificabilité,  niveau par compétence,  nb de pix par compétence)


## 🤧 Pour tester
A rédiger