### PR TITLE
[BUGFIX] :bug: Révision de la requête SQL pour la récupération de certificat pour le LSU/LSL (PIX-17408)

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -58,19 +58,9 @@ const getCertificatesByOrganizationUAI = async function (uai) {
         .whereRaw('"last-certification-courses"."isCancelled"= false')
         .whereRaw('"certification-courses"."createdAt" < "last-certification-courses"."createdAt"'),
     )
-    .whereNotExists(
-      knex
-        .select(1)
-        .from('certification-courses-last-assessment-results')
-        .innerJoin(
-          'assessment-results',
-          'certification-courses-last-assessment-results.lastAssessmentResultId',
-          'assessment-results.assessmentId',
-        )
-        .whereRaw('"assessment-results"."status" = ?', AssessmentResult.status.CANCELLED),
-    )
     .where({ 'certification-courses.isCancelled': false })
     .where({ 'view-active-organization-learners.isDisabled': false })
+    .whereRaw('"assessment-results"."status" <> ?', AssessmentResult.status.CANCELLED)
     .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
     .groupBy(
       'view-active-organization-learners.id',


### PR DESCRIPTION
## 🌸 Problème

Lors de requête à l'API pour la récupération de certificat pour le LSU/LSL, il en manque certaines (voir email pour le détail).

## 🌳 Proposition

Nous avons détecté un problème dans la requête SQL récupérant les informations de certifications.
L'idée est de ne plus utiliser une sous requête SQL problématique pour ajouter une clause `where` rendu directement possible par la présence d'un `inner join` existant.


## 🐝 Remarques

## 🤧 Pour tester

Faire les requêtes cURL d'appel LSU/LSL

```
TOKEN=$<YOUR_TOKEN> 
UAI=$<YOUR_UAI>
curl https://api.pix.fr/api/organizations/$UAI/certifications \
-H "Authorization: Bearer $TOKEN" \
-H "Content-Type: application/json" \
```