### PR TITLE
[TECH] Utiliser une 401 plutôt qu'une 403 en cas d'erreur de mot de passe dans la page de connexion à l'espace surveillant (PIX-17461).

### DIFF
--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -47,7 +47,7 @@ const sessionDomainErrorMappingConfiguration = [
   },
   {
     name: InvalidSessionSupervisingLoginError.name,
-    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -107,7 +107,7 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
     const error = httpErrorMapper.httpErrorFn(new InvalidSessionSupervisingLoginError());
 
     // then
-    expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+    expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
     expect(error.message).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.getMessage());
     expect(error.code).to.equal(SESSION_SUPERVISING.INCORRECT_DATA.code);
   });


### PR DESCRIPTION
## 🌸 Problème

Une enseignante voit un drôle de message d'erreur sur Pix Certif, lorsqu'elle veut se connecter à l'espace Surveillant.

<img width="742" alt="Capture d’écran 2025-04-11 à 10 35 56" src="https://github.com/user-attachments/assets/14cd0cf6-cd91-4dec-a64c-9526f43ba42a" />

Ce message provient de Baleen, lorsqu'une 403 (forbidden error) est remontée par notre API.

## 🌳 Proposition

Une erreur de mot de passe ne devrait pas retourner une 403 mais une 401.

## 🤧 Pour tester

Aller sur l'espace surveillant, renseigner un id de session EXISTANT mais un mot de passe bidon.

Voir le message suivant :

<img width="1725" alt="Capture d’écran 2025-04-11 à 10 26 43" src="https://github.com/user-attachments/assets/d02c20b8-b23d-4cf3-b4f8-35c56bd85079" />

