### PR TITLE
[BUGFIX] Corriger le code postal de Paris 11 dans la table certification-cpf-cities (PIX-17457).

### DIFF
--- a/api/scripts/certification/fix-paris-11-postal-code.js
+++ b/api/scripts/certification/fix-paris-11-postal-code.js
@@ -1,0 +1,24 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class FixParis11PostalCode extends Script {
+  constructor() {
+    super({
+      description: 'Fix Paris 11th arrondissement postal code in certification-cpf-cities table',
+      permanent: false,
+      options: {},
+    });
+  }
+  async handle({ logger }) {
+    this.logger = logger;
+
+    await knex('certification-cpf-cities').where({ postalCode: '750011' }).update({ postalCode: '75011' });
+
+    this.logger.info('Paris 11 postal code updated');
+
+    return 0;
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixParis11PostalCode);


### PR DESCRIPTION
## 🌸 Problème

Lors de l’inscription d’un candidat à une certification dans Pix Certif, le champ lieu de naissance doit être renseigné, soit par la combinaison code postal + nom de la ville de naissance ou bien par le code INSEE de la ville de naissance du candidat.

Pour les candidats nés dans le 11e arrondissement de Paris, si on rentre “75011+Paris”, on obtient un code erreur alors que si on entre “75011+Paris 11” la ville de naissance est acceptée.

En cause, une ligne en BDD en erreur : 
![image](https://github.com/user-attachments/assets/a3f5d052-8f31-4a8a-8ade-22c2c24c5e35)

## 🌳 Proposition

Il se trouve que le code postal a un "0" en trop ici, le supprimer dans la table `ceritification-cpf-cities` via un script.

## 🤧 Pour tester

- En local, créer une ligne dans la table `ceritification-cpf-cities` qui a `750011` comme `postalCode`.
- Lancer le script
- Vérifier que ce code postal est devenu `75011`.
