### PR TITLE
[TECH] Renommer l'objet du domaine  v3 certification attestation (PIX-17464)

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -4,7 +4,7 @@ import { usecases as certificationSharedUsecases } from '../../../../src/certifi
 import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';
 import { normalizeAndRemoveAccents } from '../../../shared/infrastructure/utils/string-utils.js';
-import { V3CertificationAttestation } from '../domain/models/V3CertificationAttestation.js';
+import { V3Certificate } from '../domain/models/V3Certificate.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as privateCertificateSerializer from '../infrastructure/serializers/private-certificate-serializer.js';
 import * as shareableCertificateSerializer from '../infrastructure/serializers/shareable-certificate-serializer.js';
@@ -59,7 +59,7 @@ const getPDFCertificate = async function (
 
   const certificate = await usecases.getCertificationAttestation({ certificationCourseId });
 
-  if (certificate instanceof V3CertificationAttestation) {
+  if (certificate instanceof V3Certificate) {
     const fileName = i18n.__('certification-confirmation.file-name', {
       deliveredAt: dayjs(certificate.deliveredAt).format('YYYYMMDD'),
     });
@@ -101,7 +101,7 @@ const getSessionCertificates = async function (
     sessionId,
   });
 
-  if (certificates.every((certificate) => certificate instanceof V3CertificationAttestation)) {
+  if (certificates.every((certificate) => certificate instanceof V3Certificate)) {
     const translatedFileName = i18n.__('certification-confirmation.file-name', {
       deliveredAt: dayjs(certificates[0].deliveredAt).format('YYYYMMDD'),
     });
@@ -145,9 +145,8 @@ const downloadDivisionCertificates = async function (
     division,
   });
 
-  if (certificates.some((certificate) => certificate instanceof V3CertificationAttestation)) {
-    const v3Certificates = certificates.filter((certificate) => certificate instanceof V3CertificationAttestation);
-
+  if (certificates.some((certificate) => certificate instanceof V3Certificate)) {
+    const v3Certificates = certificates.filter((certificate) => certificate instanceof V3Certificate);
     const normalizedDivision = normalizeAndRemoveAccents(division);
 
     const translatedFileName = i18n.__('certification-confirmation.file-name', {

--- a/api/src/certification/results/domain/models/V3Certificate.js
+++ b/api/src/certification/results/domain/models/V3Certificate.js
@@ -1,7 +1,7 @@
 import { MAX_REACHABLE_SCORE } from '../../../../shared/domain/constants.js';
 import { GlobalCertificationLevel } from './v3/GlobalCertificationLevel.js';
 
-export class V3CertificationAttestation {
+export class V3Certificate {
   /**
    * @param {Object} props
    * @param {number} props.id - certification course id

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -12,7 +12,7 @@ import {
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { SessionVersion } from '../../../shared/domain/models/SessionVersion.js';
 import { CertificationAttestation } from '../../domain/models/CertificationAttestation.js';
-import { V3CertificationAttestation } from '../../domain/models/V3CertificationAttestation.js';
+import { V3Certificate } from '../../domain/models/V3Certificate.js';
 import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 
@@ -272,7 +272,7 @@ async function _toDomainForCertificationAttestation({ certificationCourseDTO, co
     SessionVersion.isV3(certificationCourseDTO.version) &&
     (await featureToggles.get('isV3CertificationAttestationEnabled'))
   ) {
-    return new V3CertificationAttestation({
+    return new V3Certificate({
       ...certificationCourseDTO,
       resultCompetenceTree: (await featureToggles.get('isV3CertificationPageEnabled')) ? resultCompetenceTree : [],
     });

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../../domain/models/V3CertificationAttestation.js').V3CertificationAttestation} V3CertificationAttestation
+ * @typedef {import ('../../../../domain/models/V3Certificate.js').V3Certificate} V3Certificate
  */
 import path from 'node:path';
 import * as url from 'node:url';
@@ -9,7 +9,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @param {Object} params
- * @param {V3CertificationAttestation} params.data
+ * @param {V3Certificate} params.data
  */
 const generateV3AttestationTemplate = ({ pdf, data, translate }) => {
   // Global

--- a/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../domain/models/V3CertificationAttestation.js').V3CertificationAttestation} V3CertificationAttestation
+ * @typedef {import ('../../../domain/models/V3Certificate.js').V3Certificate} V3Certificate
  */
 import PDFDocument from 'pdfkit';
 
@@ -7,7 +7,7 @@ import generateV3AttestationTemplate from './templates/v3-attestation.js';
 
 /**
  * @param {Object} params
- * @param {Array<V3CertificationAttestation>} params.certificates
+ * @param {Array<V3Certificate>} params.certificates
  */
 const generate = ({ certificates, i18n }) => {
   const doc = new PDFDocument({

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -609,7 +609,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           });
         });
 
-        it('should return a V3CertificationAttestation', async function () {
+        it('should return a V3Certificate', async function () {
           // given
           await featureToggles.set('isV3CertificationAttestationEnabled', true);
           const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -477,8 +477,8 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const userId = 1;
         const i18n = getI18n();
 
-        const v3CertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation();
-        const v2CertificationAttestation = domainBuilder.buildCertificationAttestation({
+        const v3Certificate = domainBuilder.certification.results.buildV3CertificationAttestation();
+        const v2Certificate = domainBuilder.buildCertificationAttestation({
           version: SESSIONS_VERSIONS.V2,
         });
         const generatedPdf = Symbol('Stream');
@@ -499,7 +499,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
             division,
             organizationId,
           })
-          .resolves([v3CertificationAttestation, v3CertificationAttestation, v2CertificationAttestation]);
+          .resolves([v3Certificate, v3Certificate, v2Certificate]);
 
         const generatePdfStub = {
           generate: sinon.stub().returns(generatedPdf),
@@ -512,12 +512,12 @@ describe('Certification | Results | Unit | Application | certificate-controller'
 
         // then
         expect(generatePdfStub.generate).calledOnceWithExactly({
-          certificates: [v3CertificationAttestation, v3CertificationAttestation],
+          certificates: [v3Certificate, v3Certificate],
           i18n,
         });
         expect(response.source).to.deep.equal(generatedPdf);
         expect(response.headers['Content-Disposition']).to.contains(
-          `attachment; filename=3eme-b-certification-pix-${dayjs(v3CertificationAttestation.deliveredAt).format('YYYYMMDD')}.pdf`,
+          `attachment; filename=3eme-b-certification-pix-${dayjs(v3Certificate.deliveredAt).format('YYYYMMDD')}.pdf`,
         );
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3CertificationAttestation } from '../../../../src/certification/results/domain/models/V3CertificationAttestation.js';
+import { V3Certificate } from '../../../../src/certification/results/domain/models/V3Certificate.js';
 
 const buildV3CertificationAttestation = async function ({
   id = 1,
@@ -11,7 +11,7 @@ const buildV3CertificationAttestation = async function ({
   pixScore = 123,
   verificationCode = 'P-SOMECODE',
 } = {}) {
-  return new V3CertificationAttestation({
+  return new V3Certificate({
     id,
     firstName,
     lastName,

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3CertificationAttestation } from '../../../../../../src/certification/results/domain/models/V3CertificationAttestation.js';
+import { V3Certificate } from '../../../../../../src/certification/results/domain/models/V3Certificate.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 
 const buildV3CertificationAttestation = function ({
@@ -14,7 +14,7 @@ const buildV3CertificationAttestation = function ({
   resultCompetenceTree = null,
   algorithmEngineVersion = AlgorithmEngineVersion.V3,
 } = {}) {
-  return new V3CertificationAttestation({
+  return new V3Certificate({
     id,
     firstName,
     lastName,


### PR DESCRIPTION
:warning: fusioner après la PR  #12015 

## 🌸 Problème

L'objet du domaine `V3CertificationAttestation` évoque une attestation plutôt qu'un certificat.

## 🌳 Proposition

Renommer l'objet en `V3Certificate`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
