### PR TITLE
[TECH] Ajouter une colonne "id" à la table legal-document-version-user-acceptances (PIX-17466)

### DIFF
--- a/api/db/migrations/20250411101356_add-id-to-legal-document-version-user-acceptances.js
+++ b/api/db/migrations/20250411101356_add-id-to-legal-document-version-user-acceptances.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'legal-document-version-user-acceptances';
+const COLUMN_NAME = 'id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.increments(COLUMN_NAME).primary();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/high-level-tests/e2e/cypress/fixtures/legal-document-version-user-acceptances.json
+++ b/high-level-tests/e2e/cypress/fixtures/legal-document-version-user-acceptances.json
@@ -1,21 +1,26 @@
 [
   {
+    "id": 1,
     "legalDocumentVersionId": 1,
     "userId": 1
   },
   {
+    "id": 2,
     "legalDocumentVersionId": 1,
     "userId": 3
   },
   {
+    "id": 3,
     "legalDocumentVersionId": 1,
     "userId": 10
   },
   {
+    "id": 4,
     "legalDocumentVersionId": 1,
     "userId": 13
   },
   {
+    "id": 5,
     "legalDocumentVersionId": 1,
     "userId": 14
   }


### PR DESCRIPTION
## 🌸 Problème

La table `legal-document-version-user-acceptances` n'a pas de colonne `id`, ce qui empêche de réaliser des requêtes ciblées sur des enregistrements spécifiques.

## 🌳 Proposition

Ajouter une colonne `id` classique (clé primaire auto-incrémentée).

## 🐝 Remarques

Il est étonnant que nous n'ayons pas pensé à mettre cette colonne `id` lors de la création initiale de la table `legal-document-version-user-acceptances`. Effectivement pour le fonctionnalité d'acceptation des documents légaux cette colonne `id` n'était pas immédiatement nécessaire, mais le besoin de pouvoir manipuler unitairement des enregistrements est commun à tous les contexte et permanent.

## 🤧 Pour tester

1. Exécuter la commande de mise à jour du schéma de la BDD : 
   ```shell
   npm run db:migrate
   ```
2. Constater qu'une colonne `id` a été ajoutée à la table  `legal-document-version-user-acceptances` et que cette colonne est remplie pour tous les enregistrements.
3. Effectuer une action qui ajoute un enregistrement à la table `legal-document-version-user-acceptances` pour vérifier que l'incrémentation automatique de la colonne `id` fonctionne bien.

   Cela peut être effectué en utilisant les applications Pix, mais on peut le faire aussi très simplement en SQL : 
   ```sql
   insert into "legal-document-versions" (type, service, "versionAt") values ('TOS', 'pix-orga', now());
   insert into "legal-document-version-user-acceptances" ("legalDocumentVersionId", "userId", "acceptedAt") values (1002, 90000, now());
   ```

4. Exécuter la commande de rollback du schéma de la BDD : 
   ```shell
   npm run db:rollback:latest
   ```
5. Constater que la colonne `id` a été supprimée de la table  `legal-document-version-user-acceptances`.
