### PR TITLE
[FEATURE] Réferencer l'id du module plutôt que son slug (PIX-17403)

### DIFF
--- a/api/db/database-builder/factory/build-passage.js
+++ b/api/db/database-builder/factory/build-passage.js
@@ -2,7 +2,7 @@ import { databaseBuffer } from '../database-buffer.js';
 
 const buildPassage = ({
   id = databaseBuffer.getNextId(),
-  moduleId = 'mon-super-module',
+  moduleId = 'c47ffa11-5785-434b-9ea8-8d70c877715b',
   userId = null,
   createdAt = new Date('2024-01-01'),
   updatedAt = new Date('2024-01-01'),

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,10 +1,10 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const create = async function (request, h, { usecases, passageSerializer }) {
-  const { 'module-id': moduleId } = request.payload.data.attributes;
+  const { 'module-id': moduleSlug } = request.payload.data.attributes;
   const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
   const userId = requestResponseUtils.extractUserIdFromRequest(request);
-  const passage = await usecases.createPassage({ moduleId, userId, occurredAt: new Date(requestTimestamp) });
+  const passage = await usecases.createPassage({ moduleSlug, userId, occurredAt: new Date(requestTimestamp) });
 
   const serializedPassage = passageSerializer.serialize(passage);
   return h.response(serializedPassage).created();

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -4,7 +4,7 @@ import { ModuleDoesNotExistError } from '../errors.js';
 import { PassageStartedEvent } from '../models/passage-events/passage-events.js';
 
 const createPassage = withTransaction(async function ({
-  moduleId,
+  moduleSlug,
   occurredAt,
   userId,
   moduleRepository,
@@ -12,20 +12,20 @@ const createPassage = withTransaction(async function ({
   passageEventRepository,
   userRepository,
 }) {
-  const module = await _getModule({ moduleId, moduleRepository });
+  const module = await _getModule({ slug: moduleSlug, moduleRepository });
   if (userId !== null) {
     await userRepository.get(userId);
   }
 
-  const passage = await passageRepository.save({ moduleId, userId });
+  const passage = await passageRepository.save({ moduleId: module.id, userId });
   await _recordPassageEvent({ module, occurredAt, passage, passageEventRepository });
 
   return passage;
 });
 
-async function _getModule({ moduleId, moduleRepository }) {
+async function _getModule({ slug, moduleRepository }) {
   try {
-    return await moduleRepository.getBySlug({ slug: moduleId });
+    return await moduleRepository.getBySlug({ slug });
   } catch (e) {
     if (e instanceof NotFoundError) {
       throw new ModuleDoesNotExistError();

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -7,6 +7,15 @@ import { LearningContentResourceNotFound } from '../../../../shared/domain/error
 const referential = await importModules();
 
 const moduleDatasource = {
+  getById: async (id) => {
+    const foundModule = referential.modules.find((module) => module.id === id);
+
+    if (foundModule === undefined) {
+      throw new LearningContentResourceNotFound();
+    }
+
+    return foundModule;
+  },
   getBySlug: async (slug) => {
     const foundModule = referential.modules.find((module) => module.slug === slug);
 

--- a/api/src/devcomp/infrastructure/repositories/element-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-repository.js
@@ -5,7 +5,7 @@ import { ElementForVerificationFactory } from '../factories/element-for-verifica
 async function getByIdForAnswerVerification({ moduleId, elementId, moduleDatasource }) {
   let moduleData;
   try {
-    moduleData = await moduleDatasource.getBySlug(moduleId);
+    moduleData = await moduleDatasource.getById(moduleId);
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -90,7 +90,7 @@ describe('Acceptance | Controller | passage-controller', function () {
       const cases = [
         {
           case: 'QCU',
-          moduleId: 'bien-ecrire-son-adresse-mail',
+          moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
           elementId: '845fe6d7-7ac5-46bb-a5d6-0419148b3978',
           userResponse: ['2'],
           expectedUserResponseValue: '2',
@@ -103,7 +103,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         },
         {
           case: 'QROCM-ind',
-          moduleId: 'bien-ecrire-son-adresse-mail',
+          moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
           elementId: '8709ad92-093e-447a-a7b6-3223e6171196',
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
@@ -118,7 +118,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         },
         {
           case: 'QCM',
-          moduleId: 'bac-a-sable',
+          moduleId: '6282925d-4775-4bca-b513-4c3009ec5886',
           elementId: '30701e93-1b4d-4da4-b018-fa756c07d53f',
           userResponse: ['1', '3', '4'],
           expectedUserResponseValue: ['1', '3', '4'],

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -20,7 +20,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         const expectedResponse = {
           type: 'passages',
           attributes: {
-            'module-id': 'bien-ecrire-son-adresse-mail',
+            'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
           },
         };
 
@@ -54,7 +54,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         const expectedResponse = {
           type: 'passages',
           attributes: {
-            'module-id': 'bien-ecrire-son-adresse-mail',
+            'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
           },
         };
 

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -41,7 +41,7 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
         const validPayload = {
           data: {
             attributes: {
-              'module-id': 'existing id',
+              'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
             },
           },
         };

--- a/api/tests/devcomp/integration/repositories/element-answer-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-answer-repository_test.js
@@ -18,7 +18,7 @@ describe('Integration | DevComp | Repositories | ElementAnswerRepository', funct
 
     it('should have an element answer', async function () {
       // given
-      const passage = databaseBuilder.factory.buildPassage({ id: 1, moduleId: 'my-module' });
+      const passage = databaseBuilder.factory.buildPassage({ id: 1, moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d' });
       await databaseBuilder.commit();
 
       const passageId = passage.id,

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
   describe('#getByIdForAnswerVerification', function () {
     it('should return an element from a component element', async function () {
       // given
-      const moduleId = 'bac-a-sable';
+      const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
       const element = new QCUForAnswerVerification({
         id: elementId,
@@ -33,9 +33,9 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         solution: '1',
       });
       const moduleDatasourceStub = {
-        getBySlug: sinon.stub(),
+        getById: sinon.stub(),
       };
-      moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
+      moduleDatasourceStub.getById.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
@@ -122,9 +122,9 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         solution: '1',
       });
       const moduleDatasourceStub = {
-        getBySlug: sinon.stub(),
+        getById: sinon.stub(),
       };
-      moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
+      moduleDatasourceStub.getById.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'bac-a-sable',
         title: 'Bac à sable',

--- a/api/tests/devcomp/integration/repositories/passage-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-repository_test.js
@@ -21,7 +21,7 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
       await databaseBuilder.commit();
 
       const passage = {
-        moduleId: 'recModuleId',
+        moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
         userId: userId,
       };
 
@@ -45,7 +45,7 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
     it('should save a passage no userId provided', async function () {
       // given
       const passage = {
-        moduleId: 'recModuleId',
+        moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
         userId: null,
       };
 
@@ -82,7 +82,7 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
       // given
       const passage = databaseBuilder.factory.buildPassage({
         id: 1,
-        moduleId: 'my-module',
+        moduleId: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
         userId: null,
         createdAt: new Date('2023-01-01'),
       });
@@ -114,7 +114,11 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
     describe('when passage exists', function () {
       it('should return the found passage', async function () {
         // given
-        const passage = databaseBuilder.factory.buildPassage({ id: 1, moduleId: 'my-module', userId: null });
+        const passage = databaseBuilder.factory.buildPassage({
+          id: 1,
+          moduleId: '25530e38-fdb9-497a-923e-9e2d1be47918',
+          userId: null,
+        });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -7,7 +7,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
     it('should call createPassage use-case and return serialized passage', async function () {
       // given
       const serializedPassage = Symbol('serialized modules');
-      const moduleId = Symbol('module-id');
+      const moduleSlug = Symbol('module-slug');
       const passage = Symbol('passage');
       const userId = Symbol('user-id');
       const passageSerializer = {
@@ -20,7 +20,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const created = sinon.stub();
       hStub.response.withArgs(serializedPassage).returns({ created });
 
-      const request = { payload: { data: { attributes: { 'module-id': moduleId } } } };
+      const request = { payload: { data: { attributes: { 'module-id': moduleSlug } } } };
 
       const extractUserIdFromRequestStub = sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
       extractUserIdFromRequestStub.withArgs(request).returns(userId);
@@ -32,10 +32,10 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const usecases = {
         createPassage: sinon.stub(),
       };
-      usecases.createPassage.withArgs({ moduleId, userId, occurredAt: new Date(requestTimestamp) }).returns(passage);
+      usecases.createPassage.withArgs({ moduleSlug, userId, occurredAt: new Date(requestTimestamp) }).returns(passage);
 
       // when
-      await passageController.create({ payload: { data: { attributes: { 'module-id': moduleId } } } }, hStub, {
+      await passageController.create({ payload: { data: { attributes: { 'module-id': moduleSlug } } } }, hStub, {
         passageSerializer,
         usecases,
       });

--- a/api/tests/devcomp/unit/domain/models/Passage_test.js
+++ b/api/tests/devcomp/unit/domain/models/Passage_test.js
@@ -6,7 +6,7 @@ describe('Unit | Devcomp | Domain | Models | Passage', function () {
     it('should create a passage and keep attributes', function () {
       // given
       const id = 1;
-      const moduleId = 'les-adresses-email';
+      const moduleId = '25530e38-fdb9-497a-923e-9e2d1be47918';
       const userId = 123;
       const createdAt = new Date('2020-01-01');
       const updatedAt = new Date('2020-01-01');

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -16,15 +16,15 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   describe('when module does not exist', function () {
     it('should throw a ModuleDoesNotExist error', async function () {
       // given
-      const moduleId = Symbol('moduleId');
+      const moduleSlug = 'module-that-does-not-exist';
 
       const moduleRepositoryStub = {
         getBySlug: sinon.stub(),
       };
-      moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).throws(new NotFoundError());
+      moduleRepositoryStub.getBySlug.withArgs({ slug: moduleSlug }).throws(new NotFoundError());
 
       // when
-      const error = await catchErr(createPassage)({ moduleId, moduleRepository: moduleRepositoryStub });
+      const error = await catchErr(createPassage)({ moduleSlug, moduleRepository: moduleRepositoryStub });
 
       // then
       expect(error).to.be.instanceOf(ModuleDoesNotExistError);
@@ -59,17 +59,26 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   it('should save the passage and record passage started event', async function () {
     // given
     const moduleId = Symbol('moduleId');
+    const moduleSlug = 'les-adresses-email';
     const passageId = 1234;
     const userId = Symbol('userId');
 
-    const slug = 'les-adresses-email';
     const title = 'Les adresses email';
     const isBeta = false;
     const grains = [Symbol('text')];
     const transitionTexts = [];
     const details = Symbol('details');
     const version = Symbol('version');
-    const module = new Module({ id: moduleId, slug, title, isBeta, grains, details, transitionTexts, version });
+    const module = new Module({
+      id: moduleId,
+      slug: moduleSlug,
+      title,
+      isBeta,
+      grains,
+      details,
+      transitionTexts,
+      version,
+    });
 
     const occurredAt = new Date('2025-01-01');
     const passageCreatedAt = new Date('2025-03-05');
@@ -93,7 +102,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const moduleRepositoryStub = {
       getBySlug: sinon.stub(),
     };
-    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).resolves(module);
+    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleSlug }).resolves(module);
     const passageRepositoryStub = {
       save: sinon.stub(),
     };
@@ -106,7 +115,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     // when
     const result = await createPassage({
       occurredAt,
-      moduleId,
+      moduleSlug,
       userId,
       passageRepository: passageRepositoryStub,
       passageEventRepository: passageEventRepositoryStub,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -7,6 +7,29 @@ import { moduleSchema } from './validation/module-schema.js';
 const modules = await moduleDatasource.list();
 
 describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasource', function () {
+  describe('#getById', function () {
+    describe('when exists', function () {
+      it('should return something', async function () {
+        // Given
+        const id = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+        const module = await moduleDatasource.getById(id);
+
+        // When & then
+        expect(module).to.exist;
+      });
+    });
+
+    describe("when doesn't exist", function () {
+      it('should throw an LearningContentResourceNotFound', async function () {
+        // given
+        const id = 'fake-uuid';
+
+        // when & then
+        await expect(moduleDatasource.getById(id)).to.have.been.rejectedWith(LearningContentResourceNotFound);
+      });
+    });
+  });
+
   describe('#getBySlug', function () {
     describe('when exists', function () {
       it('should return something', async function () {


### PR DESCRIPTION
## 🌸 Problème
Les slugs de module ont tendance à évoluer. C'est gênant pour nos données car on a un lien passage-module qui casse quand ça arrive.

## 🌳 Proposition
Dans les passages, le moduleId devient le champ `id` du module.

## 🐝 Remarques
Impact imprévu : ça a cassé la vérification de réponses, voir les modifs dans `element-repository.js`.

## 🤧 Pour tester
Non reg passage de module [sur RA](https://app-pr12033.review.pix.fr/modules).

S'assurer qu'il n'y a pas d'erreur en console.