### PR TITLE
[FEATURE] Support du type de grain "transition" (PIX-17472)

### DIFF
--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -42,6 +42,10 @@ export async function getModulesListAsCsv(modules) {
         label: 'ModuleTotalSummaries',
         value: (row) => row.grains.filter((grain) => grain.type === 'summary').length,
       },
+      {
+        label: 'ModuleTotalTransitions',
+        value: (row) => row.grains.filter((grain) => grain.type === 'transition').length,
+      },
       { label: 'ModuleDuration', value: (row) => `=TEXT(${row.details.duration}/24/60; "mm:ss")` },
       {
         label: 'ModuleTotalElements',

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -11,32 +11,6 @@
     "tabletSupport": "inconvenient",
     "objectives": ["Non régression fonctionnelle"]
   },
-  "transitionTexts": [
-    {
-      "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix&#8239;!</p>",
-      "grainId": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd"
-    },
-    {
-      "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>",
-      "grainId": "73ac3644-7637-4cee-86d4-1a75f53f0b9c"
-    },
-    {
-      "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>",
-      "grainId": "533c69b8-a836-41be-8ffc-8d4636e31224"
-    },
-    {
-      "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>",
-      "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
-    },
-    {
-      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>",
-      "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
-    },
-    {
-      "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>",
-      "grainId": "7cf75e70-8749-4392-8081-f2c02badb0fb"
-    }
-  ],
   "grains": [
     {
       "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
@@ -220,6 +194,21 @@
       ]
     },
     {
+      "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+            "type": "text",
+            "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
       "type": "discovery",
       "title": "Voici un grain de découverte",
@@ -393,6 +382,21 @@
       ]
     },
     {
+      "id": "8147aced-4150-4a5d-afed-54c7a9dff056",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
+            "type": "text",
+            "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
       "type": "lesson",
       "title": "Vidéo de présentation de Pix",
@@ -415,6 +419,21 @@
             "subtitles": "",
             "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
             "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6566cc3a-9d74-4bd9-bda0-3dcb37129a26",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
+            "type": "text",
+            "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
           }
         }
       ]
@@ -516,6 +535,21 @@
       ]
     },
     {
+      "id": "358e6d74-4adf-463a-9bf4-69ddca521d87",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "41186193-1c38-4827-84b7-e70848367d42",
+            "type": "text",
+            "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
       "type": "summary",
       "title": "Les 3 piliers de Pix",
@@ -559,6 +593,21 @@
               }
             },
             "solutions": ["1", "3", "4"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "f589dd19-ac78-425f-8f0d-83246e5e68f4",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "35ae00c5-9d46-4f53-83f1-3724ce39b53d",
+            "type": "text",
+            "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>"
           }
         }
       ]
@@ -647,9 +696,7 @@
                 "ariaLabel": "Année à trouver",
                 "defaultValue": "",
                 "tolerances": [],
-                "solutions": [
-                  "2016"
-                ]
+                "solutions": ["2016"]
               }
             ],
             "feedbacks": {
@@ -714,7 +761,7 @@
               },
               "invalid": {
                 "state": "Incorrect&#8239;!",
-                "diagnosis":  ""
+                "diagnosis": ""
               }
             }
           }
@@ -742,6 +789,21 @@
       ]
     },
     {
+      "id": "5d70a05e-bfac-40b0-9588-e359db862d76",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "72fee40a-7279-4372-acf5-aaf508b1c145",
+            "type": "text",
+            "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "7cf75e70-8749-4392-8081-f2c02badb0fb",
       "type": "activity",
       "title": "Le nom de ce produit",
@@ -762,12 +824,8 @@
                 "placeholder": "",
                 "ariaLabel": "Nom de ce produit",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1"
-                ],
-                "solutions": [
-                  "Modulix"
-                ]
+                "tolerances": ["t1"],
+                "solutions": ["Modulix"]
               }
             ],
             "feedbacks": {

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -52,6 +52,22 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
         ],
         grains: [
           {
+            id: 'd6ed29e2-fb0b-4f03-9e26-61029ecde2e3',
+            type: 'transition',
+            title: '',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: '08a8b1ea-4771-48ef-a5a5-665c664ba673',
+                  type: 'text',
+                  content:
+                    "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>",
+                },
+              },
+            ],
+          },
+          {
             id: '47cd065b-dbf2-4adc-b5c3-02fb69cb9ec2',
             type: 'discovery',
             title: 'Test Stepper',
@@ -409,7 +425,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     // Then
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
-      .equal(`\ufeff"ModuleId"\t"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleDuration"\t"ModuleTotalElements"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Bac à sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t9\t1\t5\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t13`);
+      .equal(`\ufeff"ModuleId"\t"ModuleSlug"\t"ModuleTitle"\t"ModuleLevel"\t"ModuleLink"\t"ModuleIsBeta"\t"ModuleObjectives"\t"ModuleTotalGrains"\t"ModuleTotalLessons"\t"ModuleTotalActivities"\t"ModuleTotalChallenges"\t"ModuleTotalDiscoveries"\t"ModuleTotalSummaries"\t"ModuleTotalTransitions"\t"ModuleDuration"\t"ModuleTotalElements"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Bac à sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t"=TRUE"\t"Naviguer dans Modulix.Découvrir les leçons et les activités"\t10\t1\t5\t1\t1\t1\t1\t"=TEXT(5/24/60; ""mm:ss"")"\t14`);
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -79,8 +79,8 @@ const componentStepperSchema = Joi.object({
 
 const grainSchema = Joi.object({
   id: uuidSchema,
-  type: Joi.string().valid('lesson', 'activity', 'discovery', 'challenge', 'summary').required(),
-  title: htmlNotAllowedSchema.required(),
+  type: Joi.string().valid('lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition').required(),
+  title: htmlNotAllowedSchema.required().allow(''),
   components: Joi.array()
     .items(
       Joi.alternatives().conditional('.type', {

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -24,6 +24,12 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -164,6 +164,10 @@ export default class ModuleGrain extends Component {
     await this.args.onModuleTerminate({ grainId: this.args.grain.id });
   }
 
+  get hasTitle() {
+    return this.args.grain.title && this.args.grain.title.length > 0;
+  }
+
   get elementId() {
     return `grain_${this.args.grain.id}`;
   }
@@ -175,7 +179,9 @@ export default class ModuleGrain extends Component {
       tabindex="-1"
       {{didInsert this.focusAndScroll}}
     >
-      <h2 class="screen-reader-only">{{@grain.title}}</h2>
+      {{#if this.hasTitle}}
+        <h2 class="screen-reader-only">{{@grain.title}}</h2>
+      {{/if}}
 
       {{#if @transition}}
         <header class="grain__header">

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -27,6 +27,23 @@ module('Integration | Component | Module | Grain', function (hooks) {
     assert.dom('.grain').hasAttribute('id', 'grain_12345-abcdef');
   });
 
+  module('when grain has an empty title', function () {
+    test('should not display heading', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const grain = store.createRecord('grain', { id: '12345-abcdef', title: '' });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+      <Module::Grain::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.deepEqual(screen.queryByRole('heading', { name: grain.title, level: 2 }), null);
+      assert.dom('.grain').hasAttribute('id', 'grain_12345-abcdef');
+    });
+  });
+
   module('when grain has transition', function () {
     test('should display transition', async function (assert) {
       // given


### PR DESCRIPTION
## 🌸 Problème
En tant que contributeur de Modulix, je souhaite pouvoir créer un grain de type “transition” afin de dynamiser la lecture des modules.

## 🌳 Proposition
Mise en place et migration dans le bac-a-sable.

On propose que ces transitions n'aient pas avoir de titre obligatoire (contrairement aux autres types de grain). => Petit impact à prévoir, jusqu'à présent on remontait le "titre" du grain au dessus du texte de transition, proposition d'arrêter de faire ça.

Pour éviter de casser les tests e2e, ces titres vides sont cachés côté front en mode "moindre effort".

## 🐝 Remarques
Côté JSON Schema on est limités sur le "titre" obligatoire, j'ai du relacher un peu le schéma. On peut imaginer vérifier ces règles plus fines dans le modèle métier "Grain". Preneur des retours sur ce point.

L'extract CSV est géré.

Matomo est déjà géré puisqu'on enregistre déjà les clics sur "Continuer".

La navbar considère en l'état que les grains transitions sont des grains comme les autres donc on a "trop" d'étapes par rapport à la volonté future, et on se retrouve avec des `Missing translation "pages.modulix.grain.tag.transition" for locale "fr"`. Je pense qu'on peut l'assumer tant que ça ne concerne que le bac-a-sable.

## 🤧 Pour tester
- CI 🍏 
- S'assurer que les modules avec textes de transition classiques fonctionnent bien.
- Vérifier que [le bac-a-sable](https://app-pr12035.review.pix.fr/modules/bac-a-sable) fonctionne en l'état (même si n'a pas l'attendu visuel final).