### PR TITLE
Ajouter un endpoint pour enregistrer les évènements des passages (PIX-16954)

### DIFF
--- a/api/src/devcomp/application/passage-events/index.js
+++ b/api/src/devcomp/application/passage-events/index.js
@@ -1,0 +1,20 @@
+import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
+import { passageEventsController } from './passage-events-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/passage-events',
+      config: {
+        auth: false,
+        handler: handlerWithDependencies(passageEventsController.create),
+        notes: ['- Permet de créer un évènement utilisateur pour un passage'],
+        tags: ['api', 'passages', 'modules', 'events'],
+      },
+    },
+  ]);
+};
+
+const name = 'passage-events-api';
+export { name, register };

--- a/api/src/devcomp/application/passage-events/passage-events-controller.js
+++ b/api/src/devcomp/application/passage-events/passage-events-controller.js
@@ -1,0 +1,21 @@
+import { BadRequestError } from '../../../shared/application/http-errors.js';
+import { DomainError } from '../../../shared/domain/errors.js';
+
+const create = async function (request, h, { usecases, passageEventSerializer }) {
+  try {
+    const passageEvents = await passageEventSerializer.deserialize(request.payload);
+    await usecases.recordPassageEvents({ events: passageEvents });
+
+    return h.response().created();
+  } catch (error) {
+    if (error instanceof DomainError) {
+      throw new BadRequestError(error);
+    }
+
+    throw error;
+  }
+};
+
+const passageEventsController = { create };
+
+export { passageEventsController };

--- a/api/src/devcomp/domain/usecases/record-passage-events.js
+++ b/api/src/devcomp/domain/usecases/record-passage-events.js
@@ -1,0 +1,34 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
+import {
+  FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
+} from '../models/passage-events/flashcard-events.js';
+
+const recordPassageEvents = async function ({ events, passageEventRepository }) {
+  const passageEvents = events.map(_buildPassageEvent);
+
+  await PromiseUtils.mapSeries(passageEvents, (passageEvent) => passageEventRepository.record(passageEvent));
+};
+
+function _buildPassageEvent(event) {
+  switch (event.type) {
+    case 'FLASHCARDS_STARTED':
+      return new FlashcardsStartedEvent(event);
+    case 'FLASHCARDS_VERSO_SEEN':
+      return new FlashcardsVersoSeenEvent(event);
+    case 'FLASHCARDS_CARD_AUTO_ASSESSED':
+      return new FlashcardsCardAutoAssessedEvent(event);
+    case 'FLASHCARDS_RECTO_REVIEWED':
+      return new FlashcardsRectoReviewedEvent(event);
+    case 'FLASHCARDS_RETRIED':
+      return new FlashcardsRetriedEvent(event);
+    default:
+      throw new DomainError(`Passage event with type ${event.type} does not exist`);
+  }
+}
+
+export { recordPassageEvents };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
@@ -1,0 +1,16 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Deserializer } = jsonapiSerializer;
+
+const deserialize = async function (payload) {
+  const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
+  const passageEventsCollection = await deserializer.deserialize(payload);
+  return passageEventsCollection.passageEvents.map((passageEvent) => {
+    return {
+      ...passageEvent,
+      occurredAt: new Date(passageEvent.occurredAt),
+    };
+  });
+};
+
+export { deserialize };

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -2,12 +2,14 @@ import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/r
 import { usecases } from '../../domain/usecases/index.js';
 import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
 import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
+import * as passageEventSerializer from '../serializers/jsonapi/passage-event-serializer.js';
 import * as passageSerializer from '../serializers/jsonapi/passage-serializer.js';
 
 const dependencies = {
   usecases,
   elementAnswerSerializer,
   moduleSerializer,
+  passageEventSerializer,
   passageSerializer,
   extractUserIdFromRequest,
 };

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -1,9 +1,10 @@
 import * as modulesRoutes from './application/modules/index.js';
+import * as passageEvents from './application/passage-events/index.js';
 import * as passages from './application/passages/index.js';
 import * as trainings from './application/trainings/index.js';
 import * as evaluationTutorials from './application/tutorial-evaluations/index.js';
 import * as userTutorials from './application/user-tutorials/index.js';
 
-const devcompRoutes = [modulesRoutes, passages, trainings, userTutorials, evaluationTutorials];
+const devcompRoutes = [modulesRoutes, passages, passageEvents, trainings, userTutorials, evaluationTutorials];
 
 export { devcompRoutes };

--- a/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
@@ -1,0 +1,44 @@
+import { createServer, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Acceptance | Controller | passage-events-controller', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/passages-events', function () {
+    it('should create a new passage event and response with a 201', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/passage-events',
+        payload: {
+          data: {
+            type: 'passage-event-collection',
+            attributes: {
+              'passage-events': [
+                {
+                  type: 'FLASHCARDS_STARTED',
+                  'occurred-at': 1556419320000,
+                  'passage-id': passage.id,
+                  'element-id': '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+
+      const createdEvent = await knex('passage-events').where({ passageId: passage.id }).first();
+      expect(createdEvent).to.not.be.undefined;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/application/passage-events/passage-events-controller_test.js
+++ b/api/tests/devcomp/unit/application/passage-events/passage-events-controller_test.js
@@ -1,0 +1,62 @@
+import { passageEventsController } from '../../../../../src/devcomp/application/passage-events/passage-events-controller.js';
+import { BadRequestError } from '../../../../../src/shared/application/http-errors.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Application | Passage-Events | Controller', function () {
+  describe('#create', function () {
+    it('should call recordPassageEvents use-case', async function () {
+      // given
+      const serializedPayload = Symbol();
+      const deserializedPayload = Symbol();
+      const passageEventSerializer = {
+        deserialize: sinon.stub().returns(deserializedPayload),
+      };
+      const usecases = {
+        recordPassageEvents: sinon.stub(),
+      };
+      usecases.recordPassageEvents.resolves();
+      const created = sinon.stub();
+      const hStub = {
+        response: () => ({ created }),
+      };
+
+      // when
+      await passageEventsController.create({ payload: serializedPayload }, hStub, {
+        usecases,
+        passageEventSerializer,
+      });
+
+      // then
+      expect(passageEventSerializer.deserialize).to.have.been.calledOnceWithExactly(serializedPayload);
+      expect(usecases.recordPassageEvents).to.have.been.calledWithExactly({ events: deserializedPayload });
+      expect(created).to.have.been.calledOnce;
+    });
+
+    context('when recordPassageEvents usecase throws domain error', function () {
+      it('should throw a "BadRequestError"', async function () {
+        // given
+        const serializedPayload = Symbol();
+        const deserializedPayload = Symbol();
+        const passageEventSerializer = {
+          deserialize: sinon.stub().returns(deserializedPayload),
+        };
+        const hStub = {};
+
+        const usecases = {
+          recordPassageEvents: sinon.stub(),
+        };
+        usecases.recordPassageEvents.rejects(new DomainError('domainError'));
+
+        // when
+        const promise = passageEventsController.create({ payload: serializedPayload }, hStub, {
+          usecases,
+          passageEventSerializer,
+        });
+
+        // then
+        await expect(promise).to.be.rejectedWith(BadRequestError, 'domainError');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -1,0 +1,113 @@
+import {
+  FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import { recordPassageEvents } from '../../../../../src/devcomp/domain/usecases/record-passage-events.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function () {
+  it('should call passage event repository to create the events', async function () {
+    // given
+    const flashcardsVersoSeenEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+      cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+      type: 'FLASHCARDS_VERSO_SEEN',
+    };
+
+    const flashcardsStartedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+      type: 'FLASHCARDS_STARTED',
+    };
+
+    const flashcardsCardAutoAssessedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+      cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+      type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+      autoAssessment: 'yes',
+    };
+
+    const flashcardsRectoReviewedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+      cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+      type: 'FLASHCARDS_RECTO_REVIEWED',
+    };
+
+    const flashcardsRetriedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+      type: 'FLASHCARDS_RETRIED',
+    };
+
+    const events = [
+      flashcardsVersoSeenEvent,
+      flashcardsStartedEvent,
+      flashcardsCardAutoAssessedEvent,
+      flashcardsRectoReviewedEvent,
+      flashcardsRetriedEvent,
+    ];
+
+    const passageEventRepositoryStub = {
+      record: sinon.stub().resolves(),
+    };
+
+    // when
+    await recordPassageEvents({ events, passageEventRepository: passageEventRepositoryStub });
+
+    // then
+    const flashcardsVersoSeenPassageEvent = new FlashcardsVersoSeenEvent(flashcardsVersoSeenEvent);
+    const flashcardsStartedPassageEvent = new FlashcardsStartedEvent(flashcardsStartedEvent);
+    const flashcardsCardAutoAssessedPassageEvent = new FlashcardsCardAutoAssessedEvent(flashcardsCardAutoAssessedEvent);
+    const flashcardsRectoReviewedEventPassageEvent = new FlashcardsRectoReviewedEvent(flashcardsRectoReviewedEvent);
+    const flashcardsRetriedEventPassageEvent = new FlashcardsRetriedEvent(flashcardsRetriedEvent);
+
+    expect(passageEventRepositoryStub.record.getCall(0)).to.have.been.calledWithExactly(
+      flashcardsVersoSeenPassageEvent,
+    );
+    expect(passageEventRepositoryStub.record.getCall(1)).to.have.been.calledWithExactly(flashcardsStartedPassageEvent);
+    expect(passageEventRepositoryStub.record.getCall(2)).to.have.been.calledWithExactly(
+      flashcardsCardAutoAssessedPassageEvent,
+    );
+    expect(passageEventRepositoryStub.record.getCall(3)).to.have.been.calledWithExactly(
+      flashcardsRectoReviewedEventPassageEvent,
+    );
+    expect(passageEventRepositoryStub.record.getCall(4)).to.have.been.calledWithExactly(
+      flashcardsRetriedEventPassageEvent,
+    );
+  });
+  context('when type of passage event does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      const event = {
+        type: 'NON_EXISTING_TYPE',
+      };
+
+      const passageEventRepositoryStub = {
+        record: sinon.stub().resolves(),
+      };
+
+      // when
+      const error = await catchErr(recordPassageEvents)({
+        events: [event],
+        passageEventRepository: passageEventRepositoryStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal(`Passage event with type ${event.type} does not exist`);
+      expect(passageEventRepositoryStub.record).to.not.have.been.called;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
@@ -1,0 +1,43 @@
+import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEventSerializer', function () {
+  describe('#deserialize', function () {
+    it('should convert JSON API data', async function () {
+      // given
+      const type = 'FLASHCARDS_STARTED';
+      const occurredAt = 1556419320000;
+      const passageId = 2;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+
+      const json = {
+        data: {
+          attributes: {
+            'passage-events': [
+              {
+                elementId: elementId,
+                'occurred-at': occurredAt,
+                'passage-id': passageId,
+                type,
+              },
+            ],
+            type: 'passage-event-collection',
+          },
+        },
+      };
+
+      // when
+      const results = await serializer.deserialize(json);
+
+      // then
+      expect(results).to.deep.equal([
+        {
+          elementId,
+          occurredAt: new Date('2019-04-28T02:42:00Z'),
+          passageId,
+          type,
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Solution

On souhaite enregistrer des évènements lors d'action d'utilisateurs qui ne sont pas liés à des appels à l'API. Nous avons donc besoin d'une route dédiée que le front puisse appeler pour demander l'enregistrement de tels évènements.

## 🌳 Proposition

Ajouter ce endpoint.

## 🐝 Remarques

Bien qu'on l'enverra qu'un seul évènement à la fois dans un premier temps, nous souhaitons que le front ait la capacité d'envoyer un lot d'évènements en une seule requête pour des raisons de performance. L'API s'attend donc à recevoir non pas une ressource `PassageEvent` mais une ressource `PassageEventCollection` dont la propriété `passageEvents` contient un tableau de ressources `PassageEvent`.

## 🤧 Pour tester

On testera quand on aura le front…