### PR TITLE
[BUGFIX] Prendre en compte les legal-document-version-user-acceptances dans le use-case d'anonymisation d'un utilisateur (PIX-17271)

### DIFF
--- a/api/db/database-builder/factory/build-legal-document-version-user-acceptance.js
+++ b/api/db/database-builder/factory/build-legal-document-version-user-acceptance.js
@@ -1,9 +1,14 @@
 import { databaseBuffer } from '../database-buffer.js';
 
-const buildLegalDocumentVersionUserAcceptance = function ({ legalDocumentVersionId, userId, acceptedAt } = {}) {
+const buildLegalDocumentVersionUserAcceptance = function ({
+  id = databaseBuffer.getNextId(),
+  legalDocumentVersionId,
+  userId,
+  acceptedAt,
+} = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'legal-document-version-user-acceptances',
-    values: { legalDocumentVersionId, userId, acceptedAt },
+    values: { id, legalDocumentVersionId, userId, acceptedAt },
   });
 };
 

--- a/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
@@ -62,4 +62,16 @@ const findByLegalDocumentVersionId = async ({ userId, legalDocumentVersionId }) 
   return userAcceptanceDto;
 };
 
-export { create, findByLegalDocumentVersionId, findLastForLegalDocument };
+const findByUserId = async function (userId) {
+  const knexConn = DomainTransaction.getConnection();
+  const userAcceptanceDtos = await knexConn.from(TABLE_NAME).where({ userId });
+  return userAcceptanceDtos;
+};
+
+const update = async function (properties) {
+  const knexConn = DomainTransaction.getConnection();
+  const { id, ...data } = properties;
+  await knexConn(TABLE_NAME).where({ id }).update(data);
+};
+
+export { create, findByLegalDocumentVersionId, findByUserId, findLastForLegalDocument, update };

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -7,6 +7,7 @@ import { lastUserApplicationConnectionsRepository } from '../../../identity-acce
 import { refreshTokenRepository } from '../../../identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import { resetPasswordDemandRepository } from '../../../identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
+import * as userAcceptanceRepository from '../../../legal-documents/infrastructure/repositories/user-acceptance.repository.js';
 import * as organizationLearnerRepository from '../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -29,6 +30,7 @@ const repositories = {
   organizationLearnerRepository,
   refreshTokenRepository,
   resetPasswordDemandRepository,
+  userAcceptanceRepository,
   userAnonymizedEventLoggingJobRepository,
   userLoginRepository,
   userRepository,

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
@@ -177,4 +177,70 @@ describe('Integration | Legal document | Infrastructure | Repository | user-acce
       });
     });
   });
+
+  describe('#findByUserId', function () {
+    it('returns legal document version user acceptances of the given user', async function () {
+      // given
+      const legalDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+        type: TOS,
+        service: PIX_ORGA,
+        versionAt: new Date('2024-02-01'),
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+      const userAcceptanceId = databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: legalDocumentVersion.id,
+        acceptedAt: new Date('2024-03-01'),
+      }).id;
+
+      const user2 = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user2.id,
+        legalDocumentVersionId: legalDocumentVersion.id,
+        acceptedAt: new Date('2024-03-01'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const userAcceptances = await userAcceptanceRepository.findByUserId(user.id);
+
+      // then
+      expect(userAcceptances).to.have.length(1);
+      expect(userAcceptances[0].id).to.equal(userAcceptanceId);
+    });
+  });
+
+  describe('#update', function () {
+    it('updates the legal document version user acceptance corresponding to the given id', async function () {
+      // given
+      const legalDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+        type: TOS,
+        service: PIX_ORGA,
+        versionAt: new Date('2024-03-01'),
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+      const userAcceptanceId = databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+        userId: user.id,
+        legalDocumentVersionId: legalDocumentVersion.id,
+        acceptedAt: new Date('2024-03-01'),
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      await userAcceptanceRepository.update({
+        id: userAcceptanceId,
+        acceptedAt: new Date('2025-03-01'),
+      });
+
+      // then
+      const userAcceptance = await knex('legal-document-version-user-acceptances')
+        .where({ id: userAcceptanceId })
+        .first();
+      expect(userAcceptance.acceptedAt.toISOString()).to.equal('2025-03-01T00:00:00.000Z');
+    });
+  });
 });

--- a/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
+++ b/api/tests/legal-documents/integration/infrastructure/repositories/user-acceptance.repository.test.js
@@ -27,7 +27,7 @@ describe('Integration | Legal document | Infrastructure | Repository | user-acce
   });
 
   describe('#findLastForLegalDocument', function () {
-    it('finds the last user acceptance record for a legal document type and service.', async function () {
+    it('finds the last user acceptance record for a legal document type and service', async function () {
       // given
       const user = databaseBuilder.factory.buildUser();
       const oldDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
@@ -122,7 +122,7 @@ describe('Integration | Legal document | Infrastructure | Repository | user-acce
   });
 
   describe('#findByLegalDocumentVersionId', function () {
-    it('finds the last user acceptance record for a legal document id.', async function () {
+    it('finds the last user acceptance record for a legal document id', async function () {
       // given
       const user = databaseBuilder.factory.buildUser();
       const oldDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({


### PR DESCRIPTION
## 🌸 Problème

L’Epix _« Publication et versionnement des CGU »_ a amené une régression au niveau de anonymisation des utilisateurs. En effet les informations à caractère personnel d'acceptation des CGU sont maintenant stockées dans la nouvelle table `legal-document-version-user-acceptances` et ne sont pas anonymisées par le usecase `api/src/privacy/domain/usecases/anonymize-user.usecase.js`.

## 🌳 Proposition

Modification du code de anonymize-user.usecase.js pour supprimer les données de` legal-document-version-user-acceptances` en généralisant la date `acceptedAt`.

## 🐝 Remarques

RAS

## 🤧 Pour tester

1. Créer un nouvel utilisateur sur Pix App en utilisant l'action « S’inscrire », et noter l'`id` de cet utilisateur.
2. Ajouter cet utilisateur dans une orga, n'importe quelle orga (par exemple à partir de Pix Admin avec l'utilisateur `superadmin@example.net`).
3. Avec ce nouvel utilisateur se connecter à Pix Orga et valider les CGU de Pix Orga.
4. Constater qu'un nouvel enregistrement a été ajouté dans la table `legal-document-version-user-acceptances` à la date et l'heure courante, et noter l`id` de cet enregistrement.
5. Désactiver ce nouvel utilisateur de l'orga dans laquelle il avait été ajouté (en effet on ne pourra pas utiliser la fonctionnalité de suppression de compte en autonomie si l'utilisateur fait encore partie d'une orga).
6. Avec ce nouvel utilisateur aller dans « Mon compte » et réaliser l'action « Supprimer mon compte ».
7. Constater que l'enregistrement de la table `legal-document-version-user-acceptances` dont on a gardé l`id` a eu sa date anonymisée par généralisation (c'est à dire modification au 1er jour du mois et heure mise à 00h00).
