### PR TITLE
[TECH] Déplacer le check de l'utilisateur téléchargeant le PDF de certificat dans le controller (PIX-17501).

### DIFF
--- a/api/src/certification/results/domain/usecases/get-certification-attestation.js
+++ b/api/src/certification/results/domain/usecases/get-certification-attestation.js
@@ -2,24 +2,12 @@
  * @typedef {import ('../../domain/usecases/index.js').CertificateRepository} CertificateRepository
  * @typedef {import ('../../domain/usecases/index.js').CertificationCourseRepository} CertificationCourseRepository
  */
-import { UnauthorizedError } from '../../../../shared/application/http-errors.js';
 
 /**
  * @param {Object} params
  * @param {CertificateRepository} params.certificateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
-export const getCertificationAttestation = async function ({
-  userId,
-  certificationCourseId,
-  certificateRepository,
-  certificationCourseRepository,
-}) {
-  const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
-
-  if (certificationCourse.getUserId() !== userId) {
-    throw new UnauthorizedError();
-  }
-
+export const getCertificationAttestation = async function ({ certificationCourseId, certificateRepository }) {
   return certificateRepository.getCertificationAttestation({ certificationCourseId });
 };

--- a/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
@@ -1,6 +1,5 @@
 import { getCertificationAttestation } from '../../../../../../src/certification/results/domain/usecases/get-certification-attestation.js';
-import { UnauthorizedError } from '../../../../../../src/shared/application/http-errors.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-certification-attestation', function () {
   let certificateRepository, certificationCourseRepository;
@@ -10,61 +9,31 @@ describe('Unit | UseCase | get-certification-attestation', function () {
     certificationCourseRepository = { get: sinon.stub() };
   });
 
-  context('when the user is not owner of the certification attestation', function () {
-    it('should throw an error', async function () {
-      // given
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 123,
-        userId: 567,
-      });
-      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-
-      // when
-      const error = await catchErr(getCertificationAttestation)({
-        certificationCourseId: 123,
-        userId: 789,
-        certificateRepository,
-        certificationCourseRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(UnauthorizedError);
+  it('should return the certification attestation enhanced with result competence tree', async function () {
+    // given
+    const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({ id: 'myResultTreeId' });
+    const certificationAttestation = domainBuilder.buildCertificationAttestation({
+      id: 123,
+      resultCompetenceTree,
     });
-  });
+    const certificationCourse = domainBuilder.buildCertificationCourse({ id: 123 });
+    certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
+    certificateRepository.getCertificationAttestation
+      .withArgs({ certificationCourseId: 123 })
+      .resolves(certificationAttestation);
 
-  context('when the user is owner of the certification attestation', function () {
-    it('should return the certification attestation enhanced with result competence tree', async function () {
-      // given
-      const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({ id: 'myResultTreeId' });
-      const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        id: 123,
-        userId: 456,
-        resultCompetenceTree,
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 123,
-        userId: 456,
-      });
-      certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      certificateRepository.getCertificationAttestation
-        .withArgs({ certificationCourseId: 123 })
-        .resolves(certificationAttestation);
-
-      // when
-      const actualCertificationAttestation = await getCertificationAttestation({
-        certificationCourseId: 123,
-        userId: 456,
-        certificateRepository,
-        certificationCourseRepository,
-      });
-
-      // then
-      const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
-        id: 123,
-        userId: 456,
-        resultCompetenceTree,
-      });
-      expect(actualCertificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    // when
+    const actualCertificationAttestation = await getCertificationAttestation({
+      certificationCourseId: 123,
+      certificateRepository,
+      certificationCourseRepository,
     });
+
+    // then
+    const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+      id: 123,
+      resultCompetenceTree,
+    });
+    expect(actualCertificationAttestation).to.deep.equal(expectedCertificationAttestation);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Aujourd’hui, c’est le usecase qui vient vérifier que l’utilisateur connecté et demandant le téléchargement est bien le propriétaire de la certif passée.

## 🌳 Proposition

Déplacer ce contrôle d'utilisateur dans le controller.

## 🐝 Remarques

Cela nous avancera pour la récupération des données de certificat partagé. Celle-ci n'ayant pas besoin de vérifier d'utilisateur.

## 🤧 Pour tester

- Télécharger un PDF de certificat en RA
- Tests verts
