### PR TITLE
[BUGFIX] Corriger le nombre de contenus formatifs affiché dans la modal de fin de parcours (PIX-17512)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -30,7 +30,8 @@ export default class EvaluationResults extends Component {
   }
 
   get trainingsForModal() {
-    return this.args.model.trainings.slice(0, 2);
+    const MAX_TRAININGS_MODAL_DISPLAYED = 3;
+    return this.args.model.trainings.slice(0, MAX_TRAININGS_MODAL_DISPLAYED);
   }
 
   @action

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -117,6 +117,12 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
           .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 1 youhou' }))
           .exists();
         assert
+          .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 2 youhou' }))
+          .exists();
+        assert
+          .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 3 youhou' }))
+          .exists();
+        assert
           .dom(within(sharedResultsModal).queryByRole('heading', { level: 3, name: 'Mon super training 4 youhou' }))
           .doesNotExist();
       });


### PR DESCRIPTION
## 🌸 Problème

Le nombre de contenus formatifs affiché sur la modale de fin de parcours doit être maximum de 3. Le max est pour le moment de 2.

## 🌳 Proposition
Corriger cela.

## 🐝 Remarques
RAS

## 🤧 Pour tester
- Vérifier que les tests passent 😄 
