### PR TITLE
[FEATURE] Ajouter un sequenceNumber dans les `passage-events`(PIX-17490)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,6 +1,7 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const CREATE_PASSAGE_SEQUENCE_NUMBER = 1;
+const TERMINATE_PASSAGE_SEQUENCE_NUMBER = 1000;
 
 const create = async function (request, h, { usecases, passageSerializer }) {
   const { 'module-id': moduleSlug } = request.payload.data.attributes;
@@ -26,12 +27,17 @@ const verifyAndSaveAnswer = async function (request, h, { usecases, elementAnswe
 };
 
 const terminate = async function (request, h, { usecases, passageSerializer }) {
+  const sequenceNumber = TERMINATE_PASSAGE_SEQUENCE_NUMBER;
   const { passageId } = request.params;
   const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
-  const updatedPassage = await usecases.terminatePassage({ passageId, occurredAt: new Date(requestTimestamp) });
+  const updatedPassage = await usecases.terminatePassage({
+    passageId,
+    sequenceNumber,
+    occurredAt: new Date(requestTimestamp),
+  });
   return passageSerializer.serialize(updatedPassage);
 };
 
 const passageController = { create, verifyAndSaveAnswer, terminate };
 
-export { passageController, CREATE_PASSAGE_SEQUENCE_NUMBER };
+export { CREATE_PASSAGE_SEQUENCE_NUMBER, passageController, TERMINATE_PASSAGE_SEQUENCE_NUMBER };

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,11 +1,18 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
+const CREATE_PASSAGE_SEQUENCE_NUMBER = 1;
+
 const create = async function (request, h, { usecases, passageSerializer }) {
   const { 'module-id': moduleSlug } = request.payload.data.attributes;
   const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
   const userId = requestResponseUtils.extractUserIdFromRequest(request);
-  const passage = await usecases.createPassage({ moduleSlug, userId, occurredAt: new Date(requestTimestamp) });
-
+  const sequenceNumber = CREATE_PASSAGE_SEQUENCE_NUMBER;
+  const passage = await usecases.createPassage({
+    moduleSlug,
+    sequenceNumber,
+    userId,
+    occurredAt: new Date(requestTimestamp),
+  });
   const serializedPassage = passageSerializer.serialize(passage);
   return h.response(serializedPassage).created();
 };
@@ -27,4 +34,4 @@ const terminate = async function (request, h, { usecases, passageSerializer }) {
 
 const passageController = { create, verifyAndSaveAnswer, terminate };
 
-export { passageController };
+export { passageController, CREATE_PASSAGE_SEQUENCE_NUMBER };

--- a/api/src/devcomp/domain/models/passage-events/PassageEvent.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEvent.js
@@ -12,7 +12,7 @@ import { PassageEventInstantiationError } from '../../errors.js';
  * This is the base class for all PassageEvents. Subclasses should be named in past tense.
  */
 class PassageEvent {
-  constructor({ id, type, occurredAt, createdAt, passageId, data } = {}) {
+  constructor({ id, type, occurredAt, createdAt, passageId, sequenceNumber, data } = {}) {
     if (this.constructor === PassageEvent) {
       throw new PassageEventInstantiationError();
     }
@@ -20,6 +20,7 @@ class PassageEvent {
     assertNotNullOrUndefined(type, 'The type is required for a PassageEvent');
     assertNotNullOrUndefined(occurredAt, 'The occurredAt is required for a PassageEvent');
     assertNotNullOrUndefined(passageId, 'The passageId is required for a PassageEvent');
+    assertNotNullOrUndefined(sequenceNumber, 'The sequenceNumber is required for a PassageEvent');
 
     this.id = id;
     this.type = type;
@@ -27,6 +28,7 @@ class PassageEvent {
     this.createdAt = createdAt;
     this.setPassageId(passageId);
     this.data = data;
+    this.setSequenceNumber(sequenceNumber);
   }
 
   setPassageId(passageId) {
@@ -43,6 +45,17 @@ class PassageEvent {
     }
 
     this.occurredAt = occurredAt;
+  }
+
+  setSequenceNumber(sequenceNumber) {
+    if (typeof sequenceNumber !== 'number') {
+      throw new DomainError('The sequenceNumber should be a number');
+    }
+    if (sequenceNumber < 1) {
+      throw new DomainError('The sequenceNumber should be a number higher than 0');
+    }
+
+    this.sequenceNumber = sequenceNumber;
   }
 }
 

--- a/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEventWithElement.js
@@ -11,8 +11,8 @@ import { PassageEvent } from './PassageEvent.js';
  * Subclasses should be named in past tense.
  */
 class PassageEventWithElement extends PassageEvent {
-  constructor({ id, type, occurredAt, createdAt, passageId, elementId, data } = {}) {
-    super({ id, type, occurredAt, createdAt, passageId, data: { ...data, elementId } });
+  constructor({ id, type, occurredAt, createdAt, passageId, sequenceNumber, elementId, data } = {}) {
+    super({ id, type, occurredAt, createdAt, passageId, sequenceNumber, data: { ...data, elementId } });
 
     if (this.constructor === PassageEventWithElement) {
       throw new PassageEventWithElementInstantiationError();

--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -17,8 +17,8 @@ const AutoAssessmentEnumValues = Object.freeze({
  * A FlashcardsStartedEvent is generated when a set of Modulix flashcards is started and saved in DB.
  */
 class FlashcardsStartedEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, elementId }) {
-    super({ id, type: 'FLASHCARDS_STARTED', occurredAt, createdAt, passageId, elementId });
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({ id, type: 'FLASHCARDS_STARTED', occurredAt, createdAt, passageId, sequenceNumber, elementId });
 
     this.elementId = elementId;
   }
@@ -30,8 +30,17 @@ class FlashcardsStartedEvent extends PassageEventWithElement {
  * A FlashcardsVersoSeenEvent is generated when a card's answer is seen and saved in DB.
  */
 class FlashcardsVersoSeenEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
-    super({ id, type: 'FLASHCARDS_VERSO_SEEN', occurredAt, createdAt, passageId, elementId, data: { cardId } });
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId }) {
+    super({
+      id,
+      type: 'FLASHCARDS_VERSO_SEEN',
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { cardId },
+    });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a FlashcardsVersoSeenEvent');
     assertHasUuidLength(cardId, 'The cardId property should be exactly 36 characters long');
@@ -47,13 +56,14 @@ class FlashcardsVersoSeenEvent extends PassageEventWithElement {
  * A FlashcardsCardAutoAssessedEvent is generated when an auto-assessment is given and saved in DB.
  */
 class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId, autoAssessment }) {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId, autoAssessment }) {
     super({
       id,
       type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
       occurredAt,
       createdAt,
       passageId,
+      sequenceNumber,
       elementId,
       data: { cardId, autoAssessment },
     });
@@ -79,13 +89,14 @@ class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
  * A FlashcardsRectoReviewedEvent is generated when a card's question is reviewed and saved in DB.
  */
 class FlashcardsRectoReviewedEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, elementId, cardId }) {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId }) {
     super({
       id,
       type: 'FLASHCARDS_RECTO_REVIEWED',
       occurredAt,
       createdAt,
       passageId,
+      sequenceNumber,
       elementId,
       data: { cardId },
     });
@@ -104,8 +115,8 @@ class FlashcardsRectoReviewedEvent extends PassageEventWithElement {
  * A FlashcardsRetriedEvent is generated when a set of Modulix flashcards is retried and saved in DB.
  */
 class FlashcardsRetriedEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, elementId }) {
-    super({ id, type: 'FLASHCARDS_RETRIED', occurredAt, createdAt, passageId, elementId });
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({ id, type: 'FLASHCARDS_RETRIED', occurredAt, createdAt, passageId, sequenceNumber, elementId });
 
     this.elementId = elementId;
   }

--- a/api/src/devcomp/domain/models/passage-events/passage-events.js
+++ b/api/src/devcomp/domain/models/passage-events/passage-events.js
@@ -7,8 +7,8 @@ import { PassageEvent } from './PassageEvent.js';
  * A PassageStartedEvent is generated when a Modulix passage is started and saved in DB.
  */
 class PassageStartedEvent extends PassageEvent {
-  constructor({ id, occurredAt, createdAt, passageId, contentHash }) {
-    super({ id, type: 'PASSAGE_STARTED', occurredAt, createdAt, passageId, data: { contentHash } });
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, contentHash }) {
+    super({ id, type: 'PASSAGE_STARTED', occurredAt, createdAt, passageId, sequenceNumber, data: { contentHash } });
 
     assertNotNullOrUndefined(contentHash, 'The contentHash is required for a PassageStartedEvent');
 
@@ -22,8 +22,8 @@ class PassageStartedEvent extends PassageEvent {
  * A PassageTerminatedEvent is generated when a Modulix passage is terminated and saved in DB.
  */
 class PassageTerminatedEvent extends PassageEvent {
-  constructor({ id, occurredAt, createdAt, passageId }) {
-    super({ id, type: 'PASSAGE_TERMINATED', occurredAt, createdAt, passageId });
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber }) {
+    super({ id, type: 'PASSAGE_TERMINATED', occurredAt, createdAt, passageId, sequenceNumber });
   }
 }
 

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -6,6 +6,7 @@ import { PassageStartedEvent } from '../models/passage-events/passage-events.js'
 const createPassage = withTransaction(async function ({
   moduleSlug,
   occurredAt,
+  sequenceNumber,
   userId,
   moduleRepository,
   passageRepository,
@@ -18,7 +19,7 @@ const createPassage = withTransaction(async function ({
   }
 
   const passage = await passageRepository.save({ moduleId: module.id, userId });
-  await _recordPassageEvent({ module, occurredAt, passage, passageEventRepository });
+  await _recordPassageEvent({ module, occurredAt, passage, sequenceNumber, passageEventRepository });
 
   return passage;
 });
@@ -34,10 +35,10 @@ async function _getModule({ slug, moduleRepository }) {
   }
 }
 
-async function _recordPassageEvent({ module, occurredAt, passage, passageEventRepository }) {
+async function _recordPassageEvent({ module, occurredAt, passage, sequenceNumber, passageEventRepository }) {
   const { id: passageId } = passage;
   const contentHash = module.version;
-  const passageStartedEvent = new PassageStartedEvent({ contentHash, passageId, occurredAt });
+  const passageStartedEvent = new PassageStartedEvent({ contentHash, passageId, occurredAt, sequenceNumber });
 
   await passageEventRepository.record(passageStartedEvent);
 }

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -6,6 +6,7 @@ import { PassageTerminatedEvent } from '../models/passage-events/passage-events.
 const terminatePassage = withTransaction(async function ({
   passageId,
   occurredAt,
+  sequenceNumber,
   passageRepository,
   passageEventRepository,
 }) {
@@ -15,7 +16,7 @@ const terminatePassage = withTransaction(async function ({
   }
   passage.terminate();
   const terminatedPassage = await passageRepository.update({ passage });
-  const event = new PassageTerminatedEvent({ passageId, occurredAt });
+  const event = new PassageTerminatedEvent({ passageId, sequenceNumber, occurredAt });
   await passageEventRepository.record(event);
   return terminatedPassage;
 });

--- a/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
@@ -4,6 +4,7 @@ async function record(event) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('passage-events').insert({
     passageId: event.passageId,
+    sequenceNumber: event.sequenceNumber,
     occurredAt: event.occurredAt,
     type: event.type,
     data: event.data,

--- a/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
@@ -27,6 +27,7 @@ describe('Acceptance | Controller | passage-events-controller', function () {
                   'occurred-at': 1556419320000,
                   'passage-id': passage.id,
                   'element-id': '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+                  'sequence-number': 1,
                 },
               ],
             },
@@ -37,7 +38,7 @@ describe('Acceptance | Controller | passage-events-controller', function () {
       // then
       expect(response.statusCode).to.equal(201);
 
-      const createdEvent = await knex('passage-events').where({ passageId: passage.id }).first();
+      const createdEvent = await knex('passage-events').where({ passageId: passage.id, sequenceNumber: 1 }).first();
       expect(createdEvent).to.not.be.undefined;
     });
   });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -16,10 +16,18 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
+      const sequenceNumber = 3;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
       // when
-      const flashcardsStartedEvent = new FlashcardsStartedEvent({ id, occurredAt, createdAt, passageId, elementId });
+      const flashcardsStartedEvent = new FlashcardsStartedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
 
       // then
       expect(flashcardsStartedEvent.id).to.equal(id);
@@ -27,6 +35,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsStartedEvent.occurredAt).to.equal(occurredAt);
       expect(flashcardsStartedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsStartedEvent.passageId).to.equal(passageId);
+      expect(flashcardsStartedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(flashcardsStartedEvent.elementId).to.equal(elementId);
       expect(flashcardsStartedEvent.data).to.deep.equal({ elementId });
     });
@@ -39,6 +48,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
+      const sequenceNumber = 3;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
 
@@ -48,6 +58,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         occurredAt,
         createdAt,
         passageId,
+        sequenceNumber,
         elementId,
         cardId,
       });
@@ -58,6 +69,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardAnswerSeenEvent.occurredAt).to.equal(occurredAt);
       expect(flashcardsCardAnswerSeenEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardAnswerSeenEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardAnswerSeenEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(flashcardsCardAnswerSeenEvent.elementId).to.equal(elementId);
       expect(flashcardsCardAnswerSeenEvent.data).to.deep.equal({ cardId, elementId });
     });
@@ -69,11 +81,12 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
+        const sequenceNumber = 3;
         const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
-          () => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId, elementId }),
+          () => new FlashcardsVersoSeenEvent({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }),
         )();
 
         // then
@@ -95,6 +108,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
               occurredAt: new Date(),
               createdAt: new Date(),
               passageId: 2,
+              sequenceNumber: 1,
               elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
               cardId,
             }),
@@ -114,6 +128,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
+      const sequenceNumber = 3;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
       const autoAssessment = 'yes';
@@ -124,6 +139,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         occurredAt,
         createdAt,
         passageId,
+        sequenceNumber,
         elementId,
         cardId,
         autoAssessment,
@@ -135,6 +151,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardAutoAssessedEvent.occurredAt).to.equal(occurredAt);
       expect(flashcardsCardAutoAssessedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardAutoAssessedEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardAutoAssessedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(flashcardsCardAutoAssessedEvent.elementId).to.equal(elementId);
       expect(flashcardsCardAutoAssessedEvent.data).to.deep.equal({ cardId, autoAssessment, elementId });
     });
@@ -146,11 +163,13 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
+        const sequenceNumber = 3;
         const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
-          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId, elementId }),
+          () =>
+            new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }),
         )();
 
         // then
@@ -172,6 +191,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
               occurredAt: new Date(),
               createdAt: new Date(),
               passageId: 2,
+              sequenceNumber: 1,
               elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
               cardId,
             }),
@@ -190,12 +210,22 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
+        const sequenceNumber = 3;
         const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
         const cardId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8666';
 
         // when
         const error = catchErrSync(
-          () => new FlashcardsCardAutoAssessedEvent({ id, occurredAt, createdAt, passageId, elementId, cardId }),
+          () =>
+            new FlashcardsCardAutoAssessedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              elementId,
+              cardId,
+            }),
         )();
 
         // then
@@ -211,6 +241,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
+        const sequenceNumber = 3;
         const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
         const cardId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8666';
         const autoAssessment = 'wrong_value';
@@ -223,6 +254,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
               occurredAt,
               createdAt,
               passageId,
+              sequenceNumber,
               elementId,
               cardId,
               autoAssessment,
@@ -243,6 +275,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
+      const sequenceNumber = 3;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
       const cardId = 'c4675f66-97f1-4202-8aeb-0388edf102d5';
 
@@ -252,6 +285,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         occurredAt,
         createdAt,
         passageId,
+        sequenceNumber,
         elementId,
         cardId,
       });
@@ -262,6 +296,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsCardQuestionReviewedEvent.occurredAt).to.equal(occurredAt);
       expect(flashcardsCardQuestionReviewedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsCardQuestionReviewedEvent.passageId).to.equal(passageId);
+      expect(flashcardsCardQuestionReviewedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(flashcardsCardQuestionReviewedEvent.elementId).to.equal(elementId);
       expect(flashcardsCardQuestionReviewedEvent.data).to.deep.equal({ cardId, elementId });
     });
@@ -273,11 +308,12 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         const occurredAt = new Date();
         const createdAt = new Date();
         const passageId = 2;
+        const sequenceNumber = 3;
         const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
         // when
         const error = catchErrSync(
-          () => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId, elementId }),
+          () => new FlashcardsRectoReviewedEvent({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }),
         )();
 
         // then
@@ -299,6 +335,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
               occurredAt: new Date(),
               createdAt: new Date(),
               passageId: 2,
+              sequenceNumber: 1,
               elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
               cardId,
             }),
@@ -318,6 +355,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       const occurredAt = new Date();
       const createdAt = new Date();
       const passageId = 2;
+      const sequenceNumber = 3;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
       // when
@@ -326,6 +364,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
         occurredAt,
         createdAt,
         passageId,
+        sequenceNumber,
         elementId,
       });
 
@@ -335,6 +374,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
       expect(flashcardsRetriedEvent.occurredAt).to.equal(occurredAt);
       expect(flashcardsRetriedEvent.createdAt).to.equal(createdAt);
       expect(flashcardsRetriedEvent.passageId).to.equal(passageId);
+      expect(flashcardsRetriedEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(flashcardsRetriedEvent.elementId).to.equal(elementId);
       expect(flashcardsRetriedEvent.data).to.deep.equal({ elementId });
     });

--- a/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/passage-events_test.js
@@ -13,10 +13,18 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
       const occurredAt = new Date();
       const createdAt = Symbol('date');
       const passageId = 1234;
+      const sequenceNumber = 2;
       const contentHash = Symbol('contentHash');
 
       // when
-      const passageStartedEvent = new PassageStartedEvent({ id, occurredAt, createdAt, passageId, contentHash });
+      const passageStartedEvent = new PassageStartedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        contentHash,
+      });
 
       // then
       expect(passageStartedEvent.id).to.equal(id);
@@ -35,9 +43,12 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
         const occurredAt = new Date();
         const createdAt = Symbol('date');
         const passageId = 1234;
+        const sequenceNumber = 2;
 
         // when
-        const error = catchErrSync(() => new PassageStartedEvent({ id, occurredAt, createdAt, passageId }))();
+        const error = catchErrSync(
+          () => new PassageStartedEvent({ id, occurredAt, createdAt, passageId, sequenceNumber }),
+        )();
 
         // then
         expect(error).to.be.instanceOf(DomainError);
@@ -53,9 +64,16 @@ describe('Integration | Devcomp | Domain | Models | passage-events | passage-eve
       const occurredAt = new Date();
       const createdAt = Symbol('date');
       const passageId = 1234;
+      const sequenceNumber = 2;
 
       // when
-      const passageTerminatedEvent = new PassageTerminatedEvent({ id, occurredAt, createdAt, passageId });
+      const passageTerminatedEvent = new PassageTerminatedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+      });
 
       // then
       expect(passageTerminatedEvent.id).to.equal(id);

--- a/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
@@ -21,6 +21,7 @@ describe('Integration | DevComp | Repositories | PassageEventRepository', functi
       const event = new PassageStartedEvent({
         occurredAt: new Date('2019-04-28'),
         passageId: passage.id,
+        sequenceNumber: 1,
         contentHash: 'abcd1234',
       });
 
@@ -29,7 +30,7 @@ describe('Integration | DevComp | Repositories | PassageEventRepository', functi
 
       // then
       const recordedEvent = await knex('passage-events')
-        .where({ type: 'PASSAGE_STARTED', passageId: passage.id })
+        .where({ type: 'PASSAGE_STARTED', passageId: passage.id, sequenceNumber: 1 })
         .first();
       expect(recordedEvent.data.contentHash).to.equal('abcd1234');
       expect(recordedEvent.occurredAt).to.deep.equal(new Date('2019-04-28'));

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -1,6 +1,7 @@
 import {
   CREATE_PASSAGE_SEQUENCE_NUMBER,
   passageController,
+  TERMINATE_PASSAGE_SEQUENCE_NUMBER,
 } from '../../../../../src/devcomp/application/passages/controller.js';
 import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, sinon } from '../../../../test-helper.js';
@@ -105,6 +106,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const requestTimestamp = new Date('2025-01-01').getTime();
       const serializedPassage = Symbol('serialized modules');
       const passageId = Symbol('passage-id');
+      const sequenceNumber = TERMINATE_PASSAGE_SEQUENCE_NUMBER;
       const passage = Symbol('passage');
       const extractTimestampStub = sinon
         .stub(requestResponseUtils, 'extractTimestampFromRequest')
@@ -112,7 +114,9 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const usecases = {
         terminatePassage: sinon.stub(),
       };
-      usecases.terminatePassage.withArgs({ passageId, occurredAt: new Date(requestTimestamp) }).returns(passage);
+      usecases.terminatePassage
+        .withArgs({ passageId, sequenceNumber, occurredAt: new Date(requestTimestamp) })
+        .returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -1,4 +1,7 @@
-import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
+import {
+  CREATE_PASSAGE_SEQUENCE_NUMBER,
+  passageController,
+} from '../../../../../src/devcomp/application/passages/controller.js';
 import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
@@ -9,6 +12,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const serializedPassage = Symbol('serialized modules');
       const moduleSlug = Symbol('module-slug');
       const passage = Symbol('passage');
+      const sequenceNumber = CREATE_PASSAGE_SEQUENCE_NUMBER;
       const userId = Symbol('user-id');
       const passageSerializer = {
         serialize: sinon.stub(),
@@ -32,7 +36,9 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const usecases = {
         createPassage: sinon.stub(),
       };
-      usecases.createPassage.withArgs({ moduleSlug, userId, occurredAt: new Date(requestTimestamp) }).returns(passage);
+      usecases.createPassage
+        .withArgs({ moduleSlug, sequenceNumber, userId, occurredAt: new Date(requestTimestamp) })
+        .returns(passage);
 
       // when
       await passageController.create({ payload: { data: { attributes: { 'module-id': moduleSlug } } } }, hStub, {

--- a/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEventWithElement_test.js
@@ -11,6 +11,7 @@ describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', 
       const occurredAt = new Date();
       const createdAt = Symbol('date');
       const passageId = 3;
+      const sequenceNumber = 1;
 
       // when
       const error = catchErrSync(
@@ -21,6 +22,7 @@ describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', 
             occurredAt,
             createdAt,
             passageId,
+            sequenceNumber,
           }),
       )();
 
@@ -41,6 +43,7 @@ describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', 
             occurredAt: new Date(),
             createdAt: new Date(),
             passageId: 123,
+            sequenceNumber: 2,
           }),
       )();
 
@@ -63,6 +66,7 @@ describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElement', 
             createdAt: new Date(),
             passageId: 123,
             elementId: 'abcd',
+            sequenceNumber: 2,
           }),
       )();
 

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -54,7 +54,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         // given
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id: 1, type: 'FAKE', passageId: 124, occurredAt: 'abcd' });
+            super({ id: 1, type: 'FAKE', passageId: 124, occurredAt: 'abcd', sequenceNumber: 2 });
           }
         }
 
@@ -85,6 +85,30 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       });
     });
 
+    describe('if a passage event does not have a sequenceNumber', function () {
+      it('should throw an error', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({
+              id: 1,
+              type: 'FAKE',
+              passageId: 124,
+              occurredAt: new Date(),
+              createdAt: Symbol('date'),
+            });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The sequenceNumber is required for a PassageEvent');
+      });
+    });
+
     describe('#setPassageId', function () {
       it('should throw an error when passageId is a string', function () {
         // given
@@ -96,6 +120,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
               occurredAt: new Date(),
               createdAt: Symbol('date'),
               passageId: 'blablabla',
+              sequenceNumber: 2,
             });
           }
         }
@@ -113,7 +138,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const passageId = 2;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id: 1, type: 'FAKE', occurredAt: new Date(), passageId });
+            super({ id: 1, type: 'FAKE', occurredAt: new Date(), passageId, sequenceNumber: 2 });
           }
         }
 
@@ -125,6 +150,70 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
       });
     });
 
+    describe('#setSequenceNumber', function () {
+      it('should throw an error when sequenceNumber is a string', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({
+              id: 1,
+              type: 'FAKE',
+              occurredAt: new Date(),
+              createdAt: Symbol('date'),
+              passageId: 123,
+              sequenceNumber: '9',
+            });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The sequenceNumber should be a number');
+      });
+
+      it('should throw an error when sequenceNumber < 0', function () {
+        // given
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({
+              id: 1,
+              type: 'FAKE',
+              occurredAt: new Date(),
+              createdAt: Symbol('date'),
+              passageId: 123,
+              sequenceNumber: -12,
+            });
+          }
+        }
+
+        // when
+        const error = catchErrSync(() => new FakeEvent())();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The sequenceNumber should be a number higher than 0');
+      });
+
+      it('sets sequenceNumber when it is valid', function () {
+        // given
+        const sequenceNumber = 3;
+        class FakeEvent extends PassageEvent {
+          constructor() {
+            super({ id: 1, type: 'FAKE', occurredAt: new Date(), passageId: 2, sequenceNumber });
+          }
+        }
+
+        // when
+        const fakeEvent = new FakeEvent();
+
+        // then
+        expect(fakeEvent.sequenceNumber).to.deep.equal(sequenceNumber);
+      });
+    });
+
     describe('if a passage event has minimal required attributes', function () {
       it('should create a PassageEvent and set id attribute', function () {
         // given
@@ -132,9 +221,11 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
+
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 
@@ -151,9 +242,10 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 
@@ -170,9 +262,10 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 
@@ -189,9 +282,10 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 
@@ -208,9 +302,10 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 
@@ -227,9 +322,10 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         const occurredAt = new Date('2025-04-27T15:02:00Z');
         const createdAt = Symbol('date');
         const passageId = 3;
+        const sequenceNumber = 3;
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id, type: 'FAKE', occurredAt, createdAt, passageId });
+            super({ id, type: 'FAKE', occurredAt, createdAt, passageId, sequenceNumber });
           }
         }
 

--- a/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEvent_test.js
@@ -72,7 +72,7 @@ describe('Unit | Devcomp | Domain | Models | PassageEvent', function () {
         // given
         class FakeEvent extends PassageEvent {
           constructor() {
-            super({ id: 1, type: 'FAKE', occurredAt: Symbol('date'), createdAt: Symbol('date') });
+            super({ id: 1, type: 'FAKE', occurredAt: new Date(), createdAt: Symbol('date') });
           }
         }
 

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -61,6 +61,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const moduleId = Symbol('moduleId');
     const moduleSlug = 'les-adresses-email';
     const passageId = 1234;
+    const sequenceNumber = 1;
     const userId = Symbol('userId');
 
     const title = 'Les adresses email';
@@ -93,6 +94,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       contentHash: version,
       occurredAt,
       passageId,
+      sequenceNumber,
     });
 
     const userRepositoryStub = {
@@ -116,6 +118,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const result = await createPassage({
       occurredAt,
       moduleSlug,
+      sequenceNumber,
       userId,
       passageRepository: passageRepositoryStub,
       passageEventRepository: passageEventRepositoryStub,

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -15,6 +15,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsVersoSeenEvent = {
       occurredAt: new Date(),
       passageId: 2,
+      sequenceNumber: 1,
       elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
       cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
       type: 'FLASHCARDS_VERSO_SEEN',
@@ -23,6 +24,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsStartedEvent = {
       occurredAt: new Date(),
       passageId: 2,
+      sequenceNumber: 1,
       elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
       type: 'FLASHCARDS_STARTED',
     };
@@ -30,6 +32,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsCardAutoAssessedEvent = {
       occurredAt: new Date(),
       passageId: 2,
+      sequenceNumber: 1,
       elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
       cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
       type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
@@ -39,6 +42,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsRectoReviewedEvent = {
       occurredAt: new Date(),
       passageId: 2,
+      sequenceNumber: 1,
       elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
       cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
       type: 'FLASHCARDS_RECTO_REVIEWED',
@@ -47,6 +51,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsRetriedEvent = {
       occurredAt: new Date(),
       passageId: 2,
+      sequenceNumber: 1,
       elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
       type: 'FLASHCARDS_RETRIED',
     };

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -54,6 +54,7 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
       it('should call terminate method and update passage and return it, then record an event', async function () {
         // given
         const passageId = 1234;
+        const sequenceNumber = 1;
         const occurredAt = new Date('2025-01-01');
 
         const passageRepository = {
@@ -76,12 +77,13 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
         };
         passageRepository.update.withArgs({ passage }).resolves(updatedPassage);
 
-        const event = new PassageTerminatedEvent({ passageId, occurredAt });
+        const event = new PassageTerminatedEvent({ passageId, occurredAt, sequenceNumber });
 
         // when
         const returnedPassage = await terminatePassage({
           passageId,
           occurredAt,
+          sequenceNumber,
           passageRepository,
           passageEventRepository,
         });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
@@ -8,6 +8,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
       const type = 'FLASHCARDS_STARTED';
       const occurredAt = 1556419320000;
       const passageId = 2;
+      const sequenceNumber = 1;
       const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
 
       const json = {
@@ -18,6 +19,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
                 elementId: elementId,
                 'occurred-at': occurredAt,
                 'passage-id': passageId,
+                'sequence-number': sequenceNumber,
                 type,
               },
             ],
@@ -35,6 +37,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
           elementId,
           occurredAt: new Date('2019-04-28T02:42:00Z'),
           passageId,
+          sequenceNumber,
           type,
         },
       ]);


### PR DESCRIPTION
## 🌸 Problème

Aujourd'hui, nous n'avons pas de moyen fiable pour connaître l'ordre dans lequel les PassageEvents se sont produits dans PixApp.

## 🌳 Proposition

Côté API, ajouter un champ "sequenceNumber" aux PassageEvents, qui stockera l'ordre dans lequel l'event a été joué dans un passage donné.

## 🐝 Remarques

- Nous avons dû modifier les fonctionnalités create-passage et terminate-passage pour qu'elles puissent gérer le changement fait. 
**Nous y avons défini des valeurs temporaires pour sequenceNumber :**
	- dans create-passage : sequenceNumber = 1
	- dans terminate-passage : sequenceNumber = 1000

## 🤧 Pour tester

- Ouvrir un module (ex: https://app-pr12066.review.pix.fr/modules/chatgpt-vraiment-neutre/details) et vérifier que l'on peut toujours démarrer et terminer un passage
- La feature pourra être testé lors du branchement au Front
