### PR TITLE
[TECH] Utiliser une transaction pour la fonction d'acceptation des termes d'utilisations de certif (PIX-15374)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/accept-pix-certif-terms-of-service.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/accept-pix-certif-terms-of-service.usecase.js
@@ -1,3 +1,5 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
 /**
  * @param {{
  *   userId: string,
@@ -5,6 +7,6 @@
  * }} params
  * @return {Promise<User>}
  */
-export const acceptPixCertifTermsOfService = function ({ userId, userRepository }) {
+export const acceptPixCertifTermsOfService = withTransaction(function ({ userId, userRepository }) {
   return userRepository.updatePixCertifTermsOfServiceAcceptedToTrue(userId);
-};
+});

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -354,9 +354,10 @@ const acceptPixLastTermsOfService = async function (id) {
 };
 
 const updatePixCertifTermsOfServiceAcceptedToTrue = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
   const now = new Date();
 
-  const [user] = await knex('users')
+  const [user] = await knexConn('users')
     .where({ id })
     .update({ pixCertifTermsOfServiceAccepted: true, lastPixCertifTermsOfServiceValidatedAt: now, updatedAt: now })
     .returning('*');

--- a/api/tests/identity-access-management/unit/domain/usecases/accept-pix-certif-terms-of-service.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/accept-pix-certif-terms-of-service.usecase.test.js
@@ -1,10 +1,15 @@
 import { acceptPixCertifTermsOfService } from '../../../../../src/identity-access-management/domain/usecases/accept-pix-certif-terms-of-service.usecase.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | accept-pix-certif-terms-of-service', function () {
   let userRepository;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((fn) => {
+      return fn({});
+    });
     userRepository = { updatePixCertifTermsOfServiceAcceptedToTrue: sinon.stub() };
   });
 


### PR DESCRIPTION
## 🌸 Problème

La fonction updatePixCertifTermsOfServiceAcceptedToTrue n'est pas transactionnelle alors qu'elle devrait l’être puisqu'elle effectue des modifications.

## 🌳 Proposition

- Mettre le usecase dans une transaction,
- Rendre la méthode du repository transactionnelle également.

## 🐝 Remarques

RAS

## 🤧 Pour tester
- Se rendre sur Pix certif,
- Se connecter avec certif-pro@example.net,
- Accepter les conditions.