### PR TITLE
[FEATURE] Exposer un learnerId unique par clientId (PIX-17513).

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -36,7 +36,7 @@ import { profileRoutes } from './src/profile/routes.js';
 import { questRoutes } from './src/quest/routes.js';
 import { schoolRoutes } from './src/school/routes.js';
 import { config } from './src/shared/config.js';
-import { monitoringTools } from './src/shared/infrastructure/monitoring-tools.js';
+import { installHapiHook } from './src/shared/infrastructure/async-local-storage.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 // bounded context migration
@@ -67,7 +67,7 @@ const prescriptionRoutes = [
   campaignParticipationsRoutes,
 ];
 
-monitoringTools.installHapiHook();
+installHapiHook();
 
 const { logOpsMetrics, port, logging } = config;
 const createServer = async () => {

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -14,13 +14,13 @@ import * as replicationsRoutes from './src/maddo/application/replications-routes
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
 import { config } from './src/shared/config.js';
-import { monitoringTools } from './src/shared/infrastructure/monitoring-tools.js';
+import { installHapiHook } from './src/shared/infrastructure/async-local-storage.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 import { swaggers } from './src/shared/swaggers.js';
 import { handleFailAction } from './src/shared/validate.js';
 
-monitoringTools.installHapiHook();
+installHapiHook();
 
 const { logOpsMetrics, port, logging } = config;
 const createMaddoServer = async () => {

--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -7,6 +7,7 @@ export async function getCampaignParticipations(
 ) {
   const campaignParticipations = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
+    clientId: request.auth.credentials.client_id,
   });
   return h.response(campaignParticipations).code(200);
 }

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -1,23 +1,17 @@
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+
 class CampaignParticipation {
-  constructor({
-    id,
-    createdAt,
-    participantExternalId,
-    status,
-    sharedAt,
-    campaignId,
-    userId,
-    organizationLearnerId,
-  } = {}) {
+  constructor({ id, createdAt, participantExternalId, status, sharedAt, campaignId, userId, clientId } = {}) {
     this.id = id;
     this.createdAt = createdAt;
     this.status = status;
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
     this.campaignId = campaignId;
-    this.userId = userId;
+    assert.ok(clientId, 'Client ID should be defined');
+    this.learnerId = crypto.hash('sha1', `${userId}_${clientId}`);
     this.status = status;
-    this.organizationLearnerId = organizationLearnerId;
   }
 }
 

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -1,3 +1,3 @@
-export async function getCampaignParticipations({ campaignId, campaignParticipationRepository }) {
-  return campaignParticipationRepository.findByCampaignId(campaignId);
+export async function getCampaignParticipations({ campaignId, clientId, campaignParticipationRepository }) {
+  return campaignParticipationRepository.findByCampaignId(campaignId, clientId);
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 
-export async function findByCampaignId(campaignId) {
+export async function findByCampaignId(campaignId, clientId) {
   const rawCampaigns = await knex
     .select(
       'id',
@@ -13,14 +13,13 @@ export async function findByCampaignId(campaignId) {
       'deletedBy',
       'campaignId',
       'userId',
-      'organizationLearnerId',
     )
     .from('campaign-participations')
     .where('campaignId', campaignId)
     .orderBy('id');
-  return rawCampaigns.map(toDomain);
+  return rawCampaigns.map((rawCampaign) => toDomain(rawCampaign, clientId));
 }
 
-function toDomain(rawCampaignParticipation) {
-  return new CampaignParticipation(rawCampaignParticipation);
+function toDomain(rawCampaignParticipation, clientId) {
+  return new CampaignParticipation({ ...rawCampaignParticipation, clientId });
 }

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -1,11 +1,10 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
 import * as sharedProfileForCampaignSerializer from '../infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
 
-const save = async function (request, h, dependencies = { campaignParticipationSerializer, monitoringTools }) {
+const save = async function (request, h, dependencies = { campaignParticipationSerializer }) {
   const userId = request.auth.credentials.userId;
   const campaignParticipation = await dependencies.campaignParticipationSerializer.deserialize(request.payload);
 

--- a/api/src/shared/infrastructure/async-local-storage.js
+++ b/api/src/shared/infrastructure/async-local-storage.js
@@ -1,0 +1,38 @@
+import Request from '@hapi/hapi/lib/request.js';
+import lodash from 'lodash';
+const { get, set } = lodash;
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+function getInContext(path, defaultValue) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  return get(store, path, defaultValue);
+}
+
+function setInContext(path, value) {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return;
+  set(store, path, value);
+}
+
+function getContext() {
+  return asyncLocalStorage.getStore();
+}
+
+function installHapiHook() {
+  const originalMethod = Request.prototype._execute;
+
+  if (!originalMethod) {
+    throw new Error('Hapi method Request.prototype._execute not found while patch');
+  }
+
+  Request.prototype._execute = function (...args) {
+    const request = this;
+    const context = { request };
+    return asyncLocalStorage.run(context, () => originalMethod.call(request, args));
+  };
+}
+
+export { asyncLocalStorage, getContext, getInContext, installHapiHook, setInContext };

--- a/api/tests/integration/infrastructure/plugins/pino_test.js
+++ b/api/tests/integration/infrastructure/plugins/pino_test.js
@@ -91,7 +91,6 @@ describe('Integration | Infrastructure | plugins | pino', function () {
     context('with request monitoring disabled', function () {
       beforeEach(function () {
         sinon.stub(config.hapi, 'enableRequestMonitoring').value(false);
-        monitoringTools.installHapiHook();
       });
 
       it('should log the message and version', async function () {
@@ -122,7 +121,6 @@ describe('Integration | Infrastructure | plugins | pino', function () {
     context('with request monitoring enabled', function () {
       beforeEach(function () {
         sinon.stub(config.hapi, 'enableRequestMonitoring').value(true);
-        monitoringTools.installHapiHook();
       });
 
       it('should log the message, version, user id, route and metrics', async function () {

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -1,8 +1,8 @@
-import { CampaignParticipation } from '../../../../src/maddo/domain/models/CampaignParticipation.js';
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
 import {
   createMaddoServer,
   databaseBuilder,
+  domainBuilder,
   expect,
   generateValidRequestAuthorizationHeaderForApplication,
 } from '../../../test-helper.js';
@@ -56,8 +56,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal([
-        new CampaignParticipation(participation1),
-        new CampaignParticipation(participation2),
+        domainBuilder.maddo.buildCampaignParticipation({ ...participation1, clientId }),
+        domainBuilder.maddo.buildCampaignParticipation({ ...participation2, clientId }),
       ]);
     });
   });

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-participation-repository_test.js
@@ -1,11 +1,11 @@
-import { CampaignParticipation } from '../../../../../src/maddo/domain/models/CampaignParticipation.js';
 import { findByCampaignId } from '../../../../../src/maddo/infrastructure/repositories/campaign-participation-repository.js';
-import { databaseBuilder, expect } from '../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Maddo | Infrastructure | Repositories | Integration | campaign-participation', function () {
   describe('#findByCampaignId', function () {
     it('lists campaign participations belonging to campaign with given id', async function () {
       // given
+      const clientId = 'client-id';
       const campaign1 = databaseBuilder.factory.buildCampaign();
       const campaign2 = databaseBuilder.factory.buildCampaign();
 
@@ -15,12 +15,12 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign-partici
       await databaseBuilder.commit();
 
       const expectedCampaignParticipations = [
-        new CampaignParticipation(campaignParticipation1),
-        new CampaignParticipation(campaignParticipation3),
+        domainBuilder.maddo.buildCampaignParticipation({ ...campaignParticipation1, clientId }),
+        domainBuilder.maddo.buildCampaignParticipation({ ...campaignParticipation3, clientId }),
       ];
 
       // when
-      const campaignParticipations = await findByCampaignId(campaign1.id);
+      const campaignParticipations = await findByCampaignId(campaign1.id, clientId);
 
       // then
       expect(campaignParticipations).to.deep.equal(expectedCampaignParticipations);

--- a/api/tests/shared/unit/infrastructure/async-local-storage_test.js
+++ b/api/tests/shared/unit/infrastructure/async-local-storage_test.js
@@ -1,0 +1,66 @@
+import {
+  asyncLocalStorage,
+  getContext,
+  getInContext,
+  setInContext,
+} from '../../../../src/shared/infrastructure/async-local-storage.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Shared | Unit | Infrastructure | async-local-storage', function () {
+  describe('#getContext', function () {
+    it('should return async local storage', function () {
+      // given
+      const expectedResult = { foo: 'bar' };
+
+      // when
+      const result = asyncLocalStorage.run(expectedResult, () => getContext());
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#getInContext', function () {
+    it('should return value from given path', function () {
+      // given
+      const expectedResult = 'baz';
+      const context = { foo: { bar: expectedResult } };
+
+      // when
+      const result = asyncLocalStorage.run(context, () => getInContext('foo.bar'));
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it('should return defaultValue when given path is undefined', function () {
+      // given
+      const defaultValue = 'foo';
+      const context = {};
+
+      // when
+      const result = asyncLocalStorage.run(context, () => getInContext('foo.bar', defaultValue));
+
+      // then
+      expect(result).to.deep.equal(defaultValue);
+    });
+  });
+
+  describe('#setInContext', function () {
+    it('should set value in given path', function () {
+      // given
+      const givenValue = 'baz';
+      const givenPath = 'foo.bar';
+      const context = {};
+
+      // when
+      const result = asyncLocalStorage.run(context, () => {
+        setInContext(givenPath, givenValue);
+        return asyncLocalStorage.getStore();
+      });
+
+      // then
+      expect(result.foo.bar).to.equal(givenValue);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -210,6 +210,7 @@ import {
   buildLtiPlatformRegistrationWithPlatformConfig,
 } from './identity-access-management/build-lti-platform-registration.js';
 import { buildUserLogin } from './identity-access-management/build-user-login.js';
+import { buildCampaignParticipation as maddoBuildCampaignParticipation } from './maddo/build-campaign-participation.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
 import { buildCampaignResultLevelsPerTubesAndCompetences as boundedContextCampaignBuildCampaignResultLevelsPerTubesAndCompetences } from './prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js';
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
@@ -295,6 +296,10 @@ const identityAccessManagement = {
   buildUserLogin,
   buildLtiPlatformRegistration,
   buildLtiPlatformRegistrationWithPlatformConfig,
+};
+
+const maddo = {
+  buildCampaignParticipation: maddoBuildCampaignParticipation,
 };
 
 export {
@@ -474,5 +479,6 @@ export {
   buildValidator,
   certification,
   identityAccessManagement,
+  maddo,
   prescription,
 };

--- a/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
@@ -1,0 +1,23 @@
+import { CampaignParticipation } from '../../../../../src/maddo/domain/models/CampaignParticipation.js';
+
+export function buildCampaignParticipation({
+  id,
+  createdAt,
+  participantExternalId,
+  status,
+  sharedAt,
+  campaignId,
+  userId,
+  clientId,
+} = {}) {
+  return new CampaignParticipation({
+    id,
+    createdAt,
+    participantExternalId,
+    status,
+    sharedAt,
+    campaignId,
+    userId,
+    clientId,
+  });
+}


### PR DESCRIPTION
## 🌸 Problème

Nous ne souhaitons pas exposer l'userId à l'extérieur de notre SI. 

## 🌳 Proposition

Hasher l'userId avec le clientId de l'application faisant la requête afin de créer des userId spécifique pour son usage et qui ne change pas à chaque requête

## 🐝 Remarques

Au passage un refacto du monitoring-tools s'est glissé dans cette PR. Rien à voir avec la choucroute mais le cout de PR est trop gros.

## 🤧 Pour tester
```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12068.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```

Appeler la route `/api/campaigns/:id/participations` avec le token et en remplaçant l'id de campagne par celui d'une campagne ayant des participations.