### PR TITLE
[FEATURE] Créer un premier composant pour afficher les informations du candidat sur la page de certificat V3 (PIX-17519).

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -18,6 +18,7 @@ const getCertificateByVerificationCode = async function (
   dependencies = { requestResponseUtils, certificateSerializer },
 ) {
   let certificate;
+  const i18n = request.i18n;
   const verificationCode = request.payload.verificationCode;
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
@@ -31,7 +32,7 @@ const getCertificateByVerificationCode = async function (
       locale,
     });
   }
-  return dependencies.certificateSerializer.serialize(certificate);
+  return dependencies.certificateSerializer.serialize({ certificate, translate: i18n.__ });
 };
 
 const getCertificate = async function (request, h, dependencies = { requestResponseUtils }) {

--- a/api/src/certification/results/domain/models/V3Certificate.js
+++ b/api/src/certification/results/domain/models/V3Certificate.js
@@ -15,6 +15,7 @@ export class V3Certificate {
    * @param {string} props.verificationCode
    * @param {Array<ResultCompetenceTree>} props.resultCompetenceTree
    * @param {AlgorithmEngineVersion} props.algorithmEngineVersion
+   * @param {Date} props.certificationDate - date of certification
    */
   constructor({
     id,
@@ -28,6 +29,7 @@ export class V3Certificate {
     verificationCode,
     resultCompetenceTree,
     algorithmEngineVersion,
+    certificationDate,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -42,5 +44,6 @@ export class V3Certificate {
     this.maxReachableScore = MAX_REACHABLE_SCORE;
     this.resultCompetenceTree = resultCompetenceTree;
     this.algorithmEngineVersion = algorithmEngineVersion;
+    this.certificationDate = certificationDate;
   }
 }

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -274,6 +274,7 @@ async function _toDomainForCertificationAttestation({ certificationCourseDTO, co
   ) {
     return new V3Certificate({
       ...certificationCourseDTO,
+      certificationDate: certificationCourseDTO.date,
       resultCompetenceTree: (await featureToggles.get('isV3CertificationPageEnabled')) ? resultCompetenceTree : [],
     });
   }

--- a/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
@@ -45,10 +45,29 @@ const attributes = [
   'maxReachableLevelOnCertificationDate',
   'version',
   'algorithmEngineVersion',
+  'globalLevelLabel',
+  'globalSummaryLabel',
+  'globalDescriptionLabel',
+  'certificationDate',
 ];
 
-const serialize = function (certificate) {
+const serialize = function ({ certificate, translate }) {
+  let globalLevel = {};
+
+  if (certificate?.globalLevel) {
+    globalLevel = {
+      globalLevelLabel: certificate.globalLevel.getLevelLabel(translate),
+      globalSummaryLabel: certificate.globalLevel.getSummaryLabel(translate),
+      globalDescriptionLabel: certificate.globalLevel.getDescriptionLabel(translate),
+    };
+  }
   return new Serializer('certifications', {
+    transform(certificate) {
+      return {
+        ...certificate,
+        ...globalLevel,
+      };
+    },
     typeForAttribute,
     attributes,
     resultCompetenceTree,

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -603,6 +603,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
                 deliveredAt: certificationAttestationData.deliveredAt,
                 pixScore: certificationAttestationData.pixScore,
                 algorithmEngineVersion: AlgorithmEngineVersion.V3,
+                certificationDate: certificationAttestationData.date,
                 resultCompetenceTree,
               });
             expect(certificationAttestation).to.deepEqualInstance(expectedCertificationAttestation);
@@ -646,8 +647,10 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           });
 
           // then
-          const expectedCertificationAttestation =
-            domainBuilder.certification.results.buildV3CertificationAttestation(certificationAttestationData);
+          const expectedCertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation({
+            ...certificationAttestationData,
+            certificationDate: certificationAttestationData.date,
+          });
           expect(certificationAttestation).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
             'resultCompetenceTree',
           ]);

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -19,8 +19,9 @@ describe('Certification | Results | Unit | Application | certificate-controller'
       describe('when isV3CertificationPageEnabled feature toggle is enabled', function () {
         it('should return serialized V3 certificate data', async function () {
           // given
+          const i18n = getI18n();
           await featureToggles.set('isV3CertificationPageEnabled', true);
-          const request = { payload: { verificationCode: 'P-123456BB' } };
+          const request = { i18n, payload: { verificationCode: 'P-123456BB' } };
           const locale = 'fr-fr';
           const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           const certificateSerializerStub = { serialize: sinon.stub() };
@@ -53,8 +54,9 @@ describe('Certification | Results | Unit | Application | certificate-controller'
       describe('when isV3CertificationPageEnabled feature toggle is disabled', function () {
         it('should return serialized V2 certificate data', async function () {
           // given
+          const i18n = getI18n();
           await featureToggles.set('isV3CertificationPageEnabled', false);
-          const request = { payload: { verificationCode: 'P-123456BB' } };
+          const request = { i18n, payload: { verificationCode: 'P-123456BB' } };
           const locale = 'fr-fr';
           const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           const certificateSerializerStub = { serialize: sinon.stub() };
@@ -91,7 +93,8 @@ describe('Certification | Results | Unit | Application | certificate-controller'
     describe('when certification course version is V2', function () {
       it('should return a serialized shareable certificate given by verification code', async function () {
         // given
-        const request = { payload: { verificationCode: 'P-123456BB' } };
+        const i18n = getI18n();
+        const request = { i18n, payload: { verificationCode: 'P-123456BB' } };
         const locale = 'fr-fr';
         const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
         const certificateSerializerStub = { serialize: sinon.stub() };

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
@@ -2,6 +2,7 @@ import { ResultCompetence } from '../../../../../../src/certification/results/do
 import { ResultCompetenceTree } from '../../../../../../src/certification/results/domain/models/ResultCompetenceTree.js';
 import * as serializer from '../../../../../../src/certification/results/infrastructure/serializers/certificate-serializer.js';
 import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
+import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
@@ -51,9 +52,10 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
           maxReachableLevelOnCertificationDate: 6,
           version: SESSIONS_VERSIONS.V3,
         });
+        const translate = getI18n().__;
 
         // when
-        const serializedCertifications = serializer.serialize(shareableCertificate);
+        const serializedCertifications = serializer.serialize({ certificate: shareableCertificate, translate });
 
         // then
         expect(serializedCertifications.data).to.deep.equal({
@@ -181,9 +183,10 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
           id: 123,
           resultCompetenceTree,
         });
+        const translate = getI18n().__;
 
         // when
-        const serializedCertifications = serializer.serialize(shareableCertificate);
+        const serializedCertifications = serializer.serialize({ certificate: shareableCertificate, translate });
 
         // then
         expect(serializedCertifications.data).to.deep.equal({
@@ -198,6 +201,10 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
             'first-name': 'Jean',
             'last-name': 'Bon',
             'pix-score': 123,
+            'global-level-label': shareableCertificate.globalLevel.getLevelLabel(translate),
+            'global-summary-label': shareableCertificate.globalLevel.getSummaryLabel(translate),
+            'global-description-label': shareableCertificate.globalLevel.getDescriptionLabel(translate),
+            'certification-date': new Date('2015-10-03T01:02:03Z'),
           },
           relationships: {
             'result-competence-tree': {

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -13,6 +13,7 @@ const buildV3CertificationAttestation = function ({
   verificationCode = 'P-SOMECODE',
   resultCompetenceTree = null,
   algorithmEngineVersion = AlgorithmEngineVersion.V3,
+  certificationDate = new Date('2015-10-03T01:02:03Z'),
 } = {}) {
   return new V3Certificate({
     id,
@@ -26,6 +27,7 @@ const buildV3CertificationAttestation = function ({
     verificationCode,
     resultCompetenceTree,
     algorithmEngineVersion,
+    certificationDate,
   });
 };
 

--- a/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
@@ -1,0 +1,47 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
+
+<template>
+  <PixBlock class="candidate-information">
+    <div class="candidate-information__score">
+      <div class="candidate-information-score__hexagon">
+        <span class="candidate-information-score-hexagon__pix">{{t "common.pix"}}</span>
+        <span class="candidate-information-score-hexagon__score">{{@certificate.pixScore}}</span>
+        <span class="candidate-information-score-hexagon__certified">{{t
+            "pages.certificate.hexagon-score.certified"
+          }}</span>
+      </div>
+      <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+    </div>
+    <div>
+      <ul class="candidate-information__list">
+        <li class="candidate-information-list--bold candidate-information-list__firstName">
+          {{t "pages.certificate.candidate"}}
+          {{@certificate.firstName}}
+          {{@certificate.lastName}}
+        </li>
+        <li>
+          {{t
+            "pages.certificate.candidate-birth-complete"
+            birthdate=(dayjsFormat @certificate.birthdate "DD/MM/YYYY")
+            birthplace=@certificate.birthplace
+          }}
+        </li>
+        <li class="candidate-information-list--bold">
+          {{t "pages.certificate.certification-center"}}
+          {{@certificate.certificationCenter}}
+        </li>
+        <li>
+          {{t "pages.certificate.certification-date"}}
+          {{dayjsFormat @certificate.certificationDate "DD/MM/YYYY"}}
+        </li>
+        <li>
+          {{t "pages.certificate.delivered-at"}}
+          {{dayjsFormat @certificate.deliveredAt "DD/MM/YYYY"}}
+        </li>
+      </ul>
+    </div>
+  </PixBlock>
+</template>

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
@@ -1,11 +1,17 @@
-<template>
-  <h1>
-    {{! template-lint-disable "no-bare-strings" }}
-    Page Certificat V3
-  </h1>
-  <p>{{@certification.fullName}} {{@certification.birthdate}}</p>
+import { t } from 'ember-intl';
 
-  {{#each @certification.resultCompetenceTree.areas as |area|}}
+import CandidateInformation from '../certificate-information/candidate-information';
+
+<template>
+  <section class="global-page-header">
+    <h1 class="global-page-header__title">
+      {{t "pages.certificate.title"}}
+    </h1>
+  </section>
+
+  <CandidateInformation @certificate={{@certificate}} />
+
+  {{#each @certificate.resultCompetenceTree.areas as |area|}}
     {{#each area.resultCompetences as |resultCompetence|}}
       <p>{{resultCompetence.name}}</p>
     {{/each}}

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -28,6 +28,10 @@ export default class Certification extends Model {
   @attr('number') maxReachableLevelOnCertificationDate;
   @attr('number') version;
   @attr('number') algorithmEngineVersion;
+  @attr('string') globalLevelLabel;
+  @attr('string') globalSummaryLabel;
+  @attr('string') globalDescriptionLabel;
+  @attr('date') certificationDate;
 
   // includes
   @belongsTo('result-competence-tree', { async: true, inverse: null }) resultCompetenceTree;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -45,6 +45,7 @@
 @use 'components/choice-chip' as *;
 @use 'components/reset-campaign-participation-modal' as *;
 @use 'components/tabs' as *;
+@use 'components/certifications/certificate-information/candidate-information' as *;
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/certifications/certificate-information/_candidate-information.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_candidate-information.scss
@@ -1,0 +1,96 @@
+@use 'pix-design-tokens/fonts';
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
+
+
+.candidate-information {
+  @extend %pix-body-s;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-8x);
+
+  @include breakpoints.device-is('tablet') {
+    flex-direction: row;
+    gap: var(--pix-spacing-10x);
+    align-items: center;
+  }
+
+  &__score {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+
+    @include breakpoints.device-is('tablet') {
+      gap: var(--pix-spacing-4x);
+    }
+  }
+
+  &__list {
+    li {
+      &:not(:last-child) {
+        margin-bottom: var(--pix-spacing-1x);
+      }
+
+      &:nth-child(2) {
+        margin-bottom: var(--pix-spacing-3x);
+      }
+    }
+  }
+}
+
+.candidate-information-score {
+  &__hexagon {
+    display:flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-1x);
+    align-items: center;
+    justify-content: center;
+    width: 11rem;
+    height: 12rem;
+    background: url('/images/certificate/pix-score-hexagon.svg') no-repeat center center;
+
+    @include breakpoints.device-is('tablet') {
+      gap: 0;
+    }
+  }
+}
+
+.candidate-information-score-hexagon {
+  &__pix {
+    @extend %pix-body-l;
+
+    text-transform: uppercase;
+
+    @include breakpoints.device-is('tablet') {
+      margin-bottom: var(--pix-spacing-1x);
+    }
+  }
+
+  &__score {
+    @extend %pix-title-l;
+
+    color: var(--pix-neutral-900);
+
+    @include breakpoints.device-is('tablet') {
+      line-height:1;
+    }
+  }
+
+  &__certified {
+    @extend %pix-body-xs;
+
+    text-transform: uppercase;
+  }
+}
+
+.candidate-information-list {
+  &--bold {
+    font-weight: var(--pix-font-bold);
+  }
+
+  &__firstName {
+    text-transform: capitalize;
+  }
+}

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -3,7 +3,7 @@
 <Global::AppLayout>
   <main id="main" class="global-page-container" role="main">
     {{#if this.displayV3CertificationShared}}
-      <Certifications::ShareableCertificate::v3Certificate @certification={{this.model}} />
+      <Certifications::ShareableCertificate::v3Certificate @certificate={{this.model}} />
     {{else}}
       <Certifications::ShareableCertificate::v2Certificate @model={{this.model}} />
     {{/if}}

--- a/mon-pix/mirage/routes/post-shared-certifications.js
+++ b/mon-pix/mirage/routes/post-shared-certifications.js
@@ -32,6 +32,8 @@ function certificationResponse({ version }) {
         'certified-badge-images': [],
         version,
         'algorithm-engine-version': version,
+        'certification-date': '2020-01-31T00:00:00.000Z',
+        'global-level-label': 'Intermédiaire 1',
       },
       relationships: {
         'result-competence-tree': {

--- a/mon-pix/public/images/certificate/pix-score-hexagon.svg
+++ b/mon-pix/public/images/certificate/pix-score-hexagon.svg
@@ -1,0 +1,18 @@
+<svg width="177" height="193" viewBox="0 0 177 193" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_15056_9507)">
+<path d="M77.4563 18.9592L27.0448 48.0647C20.2101 52.0104 16 59.3018 16 67.1931V125.404C16 133.295 20.2101 140.587 27.0449 144.533L77.4563 173.638C84.29 177.584 92.71 177.584 99.5437 173.638L149.956 144.533C156.79 140.587 161 133.295 161 125.404V67.1931C161 59.302 156.79 52.0104 149.956 48.0647L99.5437 18.9592C92.71 15.0136 84.29 15.0136 77.4563 18.9592Z" fill="white"/>
+<path d="M79.4564 22.4233L79.4564 22.4233C85.0524 19.1922 91.9476 19.1922 97.5436 22.4233L97.5437 22.4233L147.956 51.5287C153.553 54.7599 157 60.7311 157 67.1931V125.404C157 131.866 153.553 137.837 147.956 141.068L97.5437 170.174L99.5437 173.638L97.5436 170.174C91.9476 173.405 85.0524 173.405 79.4564 170.174L77.4563 173.638L79.4564 170.174L29.0449 141.068L29.0447 141.068C23.4475 137.837 20 131.866 20 125.404V67.1931C20 60.7311 23.4475 54.7601 29.0446 51.5289L29.0448 51.5288L79.4564 22.4233Z" stroke="#FFDC76" stroke-width="8"/>
+</g>
+<defs>
+<filter id="filter0_d_15056_9507" x="0" y="0" width="177" height="192.597" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="8"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.862745 0 0 0 0 0.462745 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_15056_9507"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_15056_9507" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/mon-pix/tests/acceptance/shared-certification-test.js
+++ b/mon-pix/tests/acceptance/shared-certification-test.js
@@ -24,7 +24,8 @@ module('Acceptance | Certificate verification', function (hooks) {
         await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
 
         // then
-        assert.dom(screen.getByRole('heading', { name: 'Page Certificat V3' })).exists();
+        assert.dom(screen.getByRole('heading', { name: t('pages.certificate.title') })).exists();
+        assert.dom(screen.getByText('Intermédiaire 1')).exists();
       });
     });
 

--- a/mon-pix/tests/integration/components/certifications/certificate-information/candidate-information-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/candidate-information-test.gjs
@@ -1,0 +1,41 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | Certificate information | candidate information', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays certification starter page when extension is enabled', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certification = store.createRecord('certification', {
+      birthdate: '2000-01-22',
+      birthplace: 'Paris',
+      firstName: 'Jean',
+      lastName: 'Bon',
+      certificationDate: new Date('2018-02-15T15:15:52Z'),
+      deliveredAt: new Date('2018-02-17T15:15:52Z'),
+      certificationCenter: 'Université de Lyon',
+      pixScore: 654,
+      resultCompetenceTree: store.createRecord('result-competence-tree'),
+      maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+      globalLevelLabel: 'Expert 1',
+    });
+    this.set('certification', certification);
+
+    // when
+    const screen = await render(hbs`
+      <Certifications::CertificateInformation::candidateInformation @certificate={{this.certification}} />`);
+
+    // then
+    assert.dom(screen.getByText(certification.pixScore)).exists();
+    assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
+    assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Bon`)).exists();
+    assert.dom(screen.getByText(`${t('pages.certificate.certification-center')} Université de Lyon`)).exists();
+    assert.dom(screen.getByText(`${t('pages.certificate.certification-date')} 15/02/2018`)).exists();
+    assert.dom(screen.getByText(`${t('pages.certificate.delivered-at')} 17/02/2018`)).exists();
+  });
+});

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
@@ -1,0 +1,37 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | Shareable certificate | v3-certificate', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays v3 certificate information', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const certification = store.createRecord('certification', {
+      birthdate: '2000-01-22',
+      birthplace: 'Paris',
+      firstName: 'Jean',
+      lastName: 'Bon',
+      certificationDate: new Date('2018-02-15T15:15:52Z'),
+      deliveredAt: new Date('2018-02-17T15:15:52Z'),
+      certificationCenter: 'Université de Lyon',
+      pixScore: 654,
+      resultCompetenceTree: store.createRecord('result-competence-tree'),
+      maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+      globalLevelLabel: 'Expert 1',
+    });
+    this.set('certification', certification);
+
+    // when
+    const screen = await render(hbs`
+      <Certifications::ShareableCertificate::v3Certificate @certificate={{this.certification}} />`);
+
+    // then
+    assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
+    assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -616,9 +616,11 @@
         "download": "Download my certificate"
       },
       "back-link": "Return to my certificates",
+      "candidate": "Candidate:",
       "candidate-birth": "Born on {birthdate}",
       "candidate-birth-complete": "Born on {birthdate} in {birthplace}",
       "certification-center": "Certification centre:",
+      "certification-date": "Exam date:",
       "competences": {
         "information": "Your certified score was calculated based on the answers you gave whilst taking the certification. It may be different from the score shown on your profile. When you took the certification, it was possible to reach a maximum of level {maxReachableLevelOnCertificationDate} in each competence and {maxReachablePixCountOnCertificationDate} pix.",
         "subtitle": "(levels out of {maxReachableLevel})",
@@ -628,6 +630,7 @@
         "alternative": "Additional certification",
         "title": "Other certification awarded"
       },
+      "delivered-at": "Date of issue:",
       "exam-date": "Completion date:",
       "hexagon-score": {
         "certified": "certified"
@@ -2173,7 +2176,7 @@
         },
         "title": "Deactivated courses"
       },
-       "description": "Access your Pix tests, track your progress, and easily pick up where you left off.",
+      "description": "Access your Pix tests, track your progress, and easily pick up where you left off.",
       "title": "My customised tests"
     },
     "user-trainings": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -617,6 +617,9 @@
       "candidate-birth": "Nacido/a el {birthdate}",
       "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
       "certification-center": "Centro de certificación:",
+      "delivered-at": "Date of issue:",
+      "certification-date": "Exam date:",
+      "candidate": "Candidate:",
       "competences": {
         "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo.",
         "subtitle": "(niveles de {maxReachableLevel})",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -616,9 +616,11 @@
         "download": "Télécharger mon certificat"
       },
       "back-link": "Retour à mes certifications",
+      "candidate": "Candidat :",
       "candidate-birth": "Né(e) le {birthdate}",
       "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
       "certification-center": "Centre de certification :",
+      "certification-date": "Date de passage :",
       "competences": {
         "information": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau {maxReachableLevelOnCertificationDate} des compétences et {maxReachablePixCountOnCertificationDate} pix au maximum.",
         "subtitle": "(niveaux sur {maxReachableLevel})",
@@ -628,6 +630,7 @@
         "alternative": "Certification complémentaire",
         "title": "Autre certification obtenue"
       },
+      "delivered-at": "Date de délivrance :",
       "exam-date": "Date de passage :",
       "hexagon-score": {
         "certified": "certifiés"
@@ -1964,7 +1967,7 @@
             "content": "Envoyez vos résultats pour permettre à l’organisateur du parcours de vous accompagner.'<br />'Après avoir partagé, vous bénéficierez d'un accès à ces formations&nbsp;!",
             "share-error": "Il y a eu une erreur lors de l'envoi de vos résultats. Veuillez réessayer."
           },
-          "shared-results-modal" : {
+          "shared-results-modal": {
             "return-results-action": "Fermer et revenir aux résultats",
             "subtitle": "Prêt à développer vos compétences ?  \uD83C\uDF93",
             "title": "Résultats partagés"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -617,6 +617,9 @@
       "candidate-birth": "Geboren op {birthdate}",
       "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}.",
       "certification-center": "Certificeringscentrum :",
+      "delivered-at": "Date of issue:",
+      "certification-date": "Exam date:",
+      "candidate": "Candidate:",
       "competences": {
         "information": "Je gecertificeerde score is berekend op basis van je antwoorden tijdens het certificeringsproces. Deze kan daarom afwijken van het aantal Pix dat wordt weergegeven in je profiel. Op de dag van je certificering was het mogelijk om het {maxReachableLevelOnCertificationDate} vaardigheidsniveau en {maxReachablePixCountOnCertificationDate} pix maximaal te behalen.",
         "subtitle": "(niveaus op {maxReachableLevel})",


### PR DESCRIPTION
## 🌸 Problème

La nouvelle page V3 pour le certificat n'est toujours pas designé.

## 🌳 Proposition

Créer un premier composant "CandidateInformation" pour la page.

## 🐝 Remarques

On profite de faire de l'API pour obtenir les infos de la date de passage de certification et du niveau global pour les besoins de ce premier composant.

## 🤧 Pour tester

1. Tester le responsive de ce composant ! (voir lien Figma dans le ticket JIRA)
2. Tester avec le FT en true et false !

https://app-pr12069.review.pix.fr/verification-certificat


avec le FT à `true` 

V3 :
- Avec le code `P-P7R6HGQT`,
je suis censé voir (de façon moche), une page avec la liste des compétences passées dans la certif

V2 :
- Avec le code `P-YXV9J93Y`,
je suis censé voir l'ancienne page


avec le FT à `false` 

V3 :
- Avec le code `P-P7R6HGQT`,
je suis censé voir l'ancienne page

V2 :
- Avec le code `P-YXV9J93Y`,
je suis censé voir l'ancienne page


<img width="550" alt="Capture d’écran 2025-04-15 à 15 20 39" src="https://github.com/user-attachments/assets/c2be9003-5334-4f1e-9297-5f7a5be9d207" />

