### PR TITLE
[FEATURE] Retourner le taux de couverture dans le retour du détails des organisations (PIX-17511).

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -28,16 +28,22 @@ const register = async function (server) {
         response: {
           failAction: 'log',
           status: {
-            200: Joi.object({
-              id: Joi.number().description('ID de la participation à la campagne'),
-              createdAt: Joi.date().description('Date de début de participation'),
-              participantExternalId: Joi.string().description('Identifiant Externe rempli en début de participation'),
-              status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
-              sharedAt: Joi.date().description('Date de participation'),
-              campaignId: Joi.number().description('ID de la campagne liée à la participation'),
-              userId: Joi.number().description('ID utilisateur du participant'),
-              organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
-            }).label('CampaignParticipation'),
+            200: Joi.array()
+              .items(
+                Joi.object({
+                  id: Joi.number().description('ID de la participation à la campagne'),
+                  createdAt: Joi.date().description('Date de début de participation'),
+                  participantExternalId: Joi.string().description(
+                    'Identifiant Externe rempli en début de participation',
+                  ),
+                  status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
+                  sharedAt: Joi.date().description('Date de participation'),
+                  campaignId: Joi.number().description('ID de la campagne liée à la participation'),
+                  userId: Joi.number().description('ID utilisateur du participant'),
+                  organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
+                }).label('CampaignParticipation'),
+              )
+              .label('CampaignParticipations'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -23,10 +23,14 @@ const register = async function (server) {
         response: {
           failAction: 'log',
           status: {
-            200: Joi.object({
-              id: Joi.number().description("ID de l'organisation"),
-              name: Joi.string().description("Nom de l'organisation"),
-            }).label('Organization'),
+            200: Joi.array()
+              .items(
+                Joi.object({
+                  id: Joi.number().description("ID de l'organisation"),
+                  name: Joi.string().description("Nom de l'organisation"),
+                }).label('Organization'),
+              )
+              .label('Organizations'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },
@@ -54,21 +58,35 @@ const register = async function (server) {
         response: {
           failAction: 'log',
           status: {
-            200: Joi.object({
-              id: Joi.number().description('ID de la campagne'),
-              name: Joi.string().description('Nom de la campagne'),
-              organizationId: Joi.number().description("ID de l'organisation propriétaire de la campagne"),
-              organizationName: Joi.string().description("Nom de l'organisation propriétaire de la campagne"),
-              type: Joi.string().description('Type de la campagne : ASSESSMENT, EXAM, PROFILES_COLLECTION'),
-              targetProfileId: Joi.number().description(
-                'ID du profil cible lié à la campagne, null si le type est PROFILES_COLLECTION',
-              ),
-              targetProfileName: Joi.string().description(
-                'Nom du profil cible lié à la campagne, null si le type est PROFILES_COLLECTION',
-              ),
-              code: Joi.string().description('Code campagne'),
-              createdAt: Joi.date().description('Date de création de la campagne'),
-            }).label('Organization'),
+            200: Joi.array()
+              .items(
+                Joi.object({
+                  id: Joi.number().description('ID de la campagne'),
+                  name: Joi.string().description('Nom de la campagne'),
+                  type: Joi.string().description('Type de la campagne : ASSESSMENT, EXAM, PROFILES_COLLECTION'),
+                  targetProfileName: Joi.string().description(
+                    'Nom du profil cible lié à la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                  ),
+                  code: Joi.string().description('Code campagne'),
+                  createdAt: Joi.date().description('Date de création de la campagne'),
+                  tubes: Joi.array()
+                    .items(
+                      Joi.object({
+                        competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
+                        id: Joi.string().description('ID du sujet'),
+                        maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
+                        meanLevel: Joi.number().description('Niveau moyen obtenu dans cette campagne'),
+                        practicalDescription: Joi.string().description('Description du sujet'),
+                        practicalTitle: Joi.string().description('Titre du sujet'),
+                      }).label('Tube'),
+                    )
+                    .description(
+                      'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                    )
+                    .label('Tubes'),
+                }).label('Campaign'),
+              )
+              .label('Campaigns'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/domain/models/Campaign.js
+++ b/api/src/maddo/domain/models/Campaign.js
@@ -1,23 +1,11 @@
 export class Campaign {
-  constructor({
-    id,
-    name,
-    organizationId,
-    organizationName,
-    type,
-    targetProfileId,
-    targetProfileName,
-    code,
-    createdAt,
-  }) {
+  constructor({ id, name, type, targetProfileName, code, createdAt, tubes }) {
     this.id = id;
     this.name = name;
-    this.organizationId = organizationId;
-    this.organizationName = organizationName;
     this.type = type;
-    this.targetProfileId = targetProfileId;
     this.targetProfileName = targetProfileName;
     this.code = code;
     this.createdAt = createdAt;
+    this.tubes = tubes;
   }
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -1,25 +1,14 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import * as campaignAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
 export async function findByOrganizationId(organizationId) {
-  const rawCampaigns = await knex
-    .select(
-      'campaigns.id',
-      'campaigns.organizationId',
-      'campaigns.name',
-      'campaigns.type',
-      'campaigns.targetProfileId',
-      'campaigns.code',
-      'campaigns.createdAt',
-      'target-profiles.name as targetProfileName',
-      'organizations.name as organizationName',
-    )
-    .from('campaigns')
-    .join('organizations', 'campaigns.organizationId', 'organizations.id')
-    .join('target-profiles', 'campaigns.targetProfileId', 'target-profiles.id')
-    .where('campaigns.organizationId', organizationId)
-    .orderBy('campaigns.id');
-  return rawCampaigns.map(toDomain);
+  const campaigns = await campaignAPI.findAllForOrganization({
+    organizationId,
+    withCoverRate: true,
+    page: { size: 1000, number: 1 },
+  });
+  return campaigns.models.map(toDomain);
 }
 
 export async function getOrganizationId(campaignId) {

--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -16,7 +16,7 @@ class CampaignResultLevelsPerTubesAndCompetences {
   }
 
   #getTubesWithLevels(tubes) {
-    const maxTubeLevels = tubes.map((tube) => {
+    return tubes.map((tube) => {
       const participationsReachedLevels = this.#computeParticipationsReachedLevelForTube(tube);
       const meanLevel = average(participationsReachedLevels);
 
@@ -31,7 +31,6 @@ class CampaignResultLevelsPerTubesAndCompetences {
         meanLevel,
       };
     });
-    return maxTubeLevels;
   }
 
   get levelsPerTube() {
@@ -39,7 +38,7 @@ class CampaignResultLevelsPerTubesAndCompetences {
   }
 
   get levelsPerCompetence() {
-    const maxCompetenceLevels = this.learningContent.competences.map((competence) => {
+    return this.learningContent.competences.map((competence) => {
       const tubes = this.#tubesWithLevels.filter((tube) => tube.competenceId === competence.id);
       const averageTubesMaxReachableLevel = averageBy(tubes, 'maxLevel');
       const averageTubesMeanReachedLevel = averageBy(tubes, 'meanLevel');
@@ -53,7 +52,6 @@ class CampaignResultLevelsPerTubesAndCompetences {
         meanLevel: averageTubesMeanReachedLevel,
       };
     });
-    return maxCompetenceLevels;
   }
 
   get maxReachableLevel() {

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -1,5 +1,6 @@
 import { Campaign } from '../../../../src/maddo/domain/models/Campaign.js';
 import { Organization } from '../../../../src/maddo/domain/models/Organization.js';
+import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../src/shared/domain/models/KnowledgeElement.js';
 import {
@@ -133,10 +134,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
         new Campaign({
           id: campaign1InJurisdiction.id,
           name: campaign1InJurisdiction.name,
-          organizationId: orgaInJurisdiction.id,
-          organizationName: orgaInJurisdiction.name,
           type: campaign1InJurisdiction.type,
-          targetProfileId: targetProfile.id,
           targetProfileName: targetProfile.name,
           code: campaign1InJurisdiction.code,
           createdAt: campaign1InJurisdiction.createdAt,
@@ -152,6 +150,42 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
           ],
         }),
       ]);
+    });
+
+    context('when organization contains profile collection campaigns', function () {
+      it('returns the list of all campaigns belonging to organization in the client jurisdiction with an HTTP status code 200', async function () {
+        // given
+        const campaign1InJurisdiction = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.PROFILES_COLLECTION,
+          organizationId: orgaInJurisdiction.id,
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${orgaInJurisdiction.id}/campaigns`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal([
+          new Campaign({
+            id: campaign1InJurisdiction.id,
+            name: campaign1InJurisdiction.name,
+            type: campaign1InJurisdiction.type,
+            targetProfileName: null,
+            code: campaign1InJurisdiction.code,
+            createdAt: campaign1InJurisdiction.createdAt,
+            tubes: null,
+          }),
+        ]);
+      });
     });
 
     it('responds with an HTTP Forbidden when organization is not in jurisdiction', async function () {


### PR DESCRIPTION
## 🌸 Problème

Actuellement, nous ne retournons pas le taux de couverture obtenu dans chaque campagne. 

## 🌳 Proposition

Utiliser l'API interne pour récupérer les campagnes d'une organisation avec leur taux de couverture. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12070.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```

```
curl https://pix-api-maddo-review-pr12070.osc-fr1.scalingo.io/api/organizations/1000/campaigns -H "Authorization: Bearer $ACCESS_TOKEN"
```