### PR TITLE
[FEATURE] Afficher le détail des compétences d'un certificat en ligne (PIX-17477).

### DIFF
--- a/mon-pix/app/components/certifications/certificate-information/competences-details.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/competences-details.gjs
@@ -1,0 +1,113 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { eq } from 'ember-truth-helpers';
+
+export default class CertificateCompetencesDetails extends Component {
+  @service url;
+
+  @tracked activeTab = 0;
+
+  @action
+  handleTabChange(tabIndex) {
+    this.activeTab = tabIndex;
+  }
+
+  @action
+  handleTabNavigation(event) {
+    const focusedTab = document.activeElement;
+    const focusedTabIndex = Array.from(focusedTab.parentNode.children).indexOf(focusedTab);
+    const tabsCount = this.args.resultCompetenceTree.get('areas').length;
+
+    if (
+      event.key === 'ArrowDown' ||
+      event.key === 'ArrowUp' ||
+      event.key === 'ArrowLeft' ||
+      event.key === 'ArrowRight'
+    ) {
+      event.preventDefault();
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      if (focusedTabIndex + 1 < tabsCount) {
+        focusedTab.parentNode.children[focusedTabIndex + 1].focus();
+      } else {
+        focusedTab.parentNode.children[0].focus();
+      }
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      if (focusedTabIndex < 1) {
+        focusedTab.parentNode.children[tabsCount - 1].focus();
+      } else {
+        focusedTab.parentNode.children[focusedTabIndex - 1].focus();
+      }
+    }
+  }
+
+  <template>
+    <section class="certificate-competences-details">
+      <h2 id="competences-list-title" class="certificate-competences-details__title">
+        {{t "pages.certificate.details.competences.title"}}
+      </h2>
+      <p class="certificate-competences-details__description">
+        {{t "pages.certificate.details.competences.description"}}
+        <PixButtonLink
+          @href={{this.url.certificationResultsExplanationUrl}}
+          target="_blank"
+          rel="noopener noreferrer"
+          @variant="tertiary"
+          @iconAfter="openNew"
+        > {{t "pages.certificate.learn-about-certification-results"}}</PixButtonLink>
+      </p>
+
+      <PixBlock class="certificate-competences-details__tabs" @variant="admin">
+        <div class="certificate-competences-details__tablist" role="tablist" aria-labelledby="competences-list-title">
+          {{#each @resultCompetenceTree.areas as |area index|}}
+            <button
+              id="area-tab-{{index}}"
+              class="certificate-competences-details-tablist__tab"
+              data-area-code={{area.code}}
+              type="button"
+              role="tab"
+              aria-controls="area-{{index}}"
+              aria-selected={{if (eq index this.activeTab) "true" ""}}
+              tabindex={{if (eq index this.activeTab) 0 -1}}
+              {{on "click" (fn this.handleTabChange index)}}
+              {{on "keydown" this.handleTabNavigation}}
+            >
+              <span class="focus">{{area.title}}</span>
+            </button>
+          {{/each}}
+        </div>
+        <div>
+          {{#each @resultCompetenceTree.areas as |area index|}}
+            <div
+              id="area-{{index}}"
+              role="tabpanel"
+              aria-labelledby="area-tab-{{index}}"
+              hidden={{if (eq index this.activeTab) "" "true"}}
+            >
+              <div class="certificate-competences-details-tablist__area-header" data-area-code={{area.code}}>
+                <h3>{{area.title}}</h3>
+                <div role="presentation">{{t "common.level"}}</div>
+              </div>
+              <ol class="certificate-competences-details-tablist__competences-list">
+                {{#each area.resultCompetences as |resultCompetence|}}
+                  <li data-competence-index={{resultCompetence.index}}>
+                    <span>{{resultCompetence.name}}</span>
+                    <span><small class="sr-only">{{t "common.level"}}</small>{{resultCompetence.level}}</span>
+                  </li>
+                {{/each}}
+              </ol>
+            </div>
+          {{/each}}
+        </div>
+      </PixBlock>
+    </section>
+  </template>
+}

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
@@ -1,6 +1,7 @@
 import { t } from 'ember-intl';
 
 import CandidateInformation from '../certificate-information/candidate-information';
+import CompetencesDetails from '../certificate-information/competences-details';
 
 <template>
   <section class="global-page-header">
@@ -10,10 +11,5 @@ import CandidateInformation from '../certificate-information/candidate-informati
   </section>
 
   <CandidateInformation @certificate={{@certificate}} />
-
-  {{#each @certificate.resultCompetenceTree.areas as |area|}}
-    {{#each area.resultCompetences as |resultCompetence|}}
-      <p>{{resultCompetence.name}}</p>
-    {{/each}}
-  {{/each}}
+  <CompetencesDetails @resultCompetenceTree={{@certificate.resultCompetenceTree}} />
 </template>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -30,6 +30,8 @@
 @use 'components/certification-not-certifiable' as *;
 @use 'components/certifications-list' as *;
 @use 'components/certifications-list-item' as *;
+@use 'components/certifications/certificate-information/candidate-information' as *;
+@use 'components/certifications/certificate-information/competences-details' as *;
 @use 'components/certifications/certification-ender' as *;
 @use 'components/communication-banner' as *;
 @use 'components/companion/blocker' as *;
@@ -45,7 +47,6 @@
 @use 'components/choice-chip' as *;
 @use 'components/reset-campaign-participation-modal' as *;
 @use 'components/tabs' as *;
-@use 'components/certifications/certificate-information/candidate-information' as *;
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/certifications/certificate-information/_competences-details.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_competences-details.scss
@@ -1,0 +1,250 @@
+@use 'pix-design-tokens/typography';
+
+.certificate-competences-details__title {
+  @extend %pix-title-xs;
+}
+
+.certificate-competences-details__description {
+  @extend %pix-body-m;
+
+  color: var(--pix-neutral-900);
+
+  a {
+    display: inline-flex;
+  }
+}
+
+.certificate-competences-details__tabs {
+  display: grid;
+  grid-template-columns: 9rem auto;
+  gap: 0 var(--pix-spacing-10x);
+  margin-top: var(--pix-spacing-4x);
+  text-wrap: pretty;
+}
+
+.certificate-competences-details__tablist {
+  display: grid;
+  gap: var(--pix-spacing-2x);
+
+  button {
+    --area-color: var(--pix-primary-10);
+
+    @extend %pix-body-s;
+
+    position: relative;
+    z-index: 0;
+    min-height: 4.4375rem;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-2x);
+    overflow: hidden;
+    text-align: left;
+    border-radius: 0.5rem;
+
+    &::before {
+      position: absolute;
+      z-index: -1;
+      background-color: var(--area-color);
+      visibility: hidden;
+      opacity: 0.1;
+      content: '';
+      inset: 0;
+    }
+
+    &[aria-selected='true'],
+    &:hover,
+    &:focus-visible {
+      font-weight: var(--pix-font-bold);
+
+      &::before {
+        visibility: visible;
+      }
+    }
+  }
+}
+
+.certificate-competences-details-tablist__area-header {
+  --area-color: var(--pix-primary-10);
+
+  position: relative;
+  z-index: 0;
+  display: flex;
+  gap: var(--pix-spacing-4x);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  overflow: hidden;
+  border-radius: 0.5rem;
+
+  &::before {
+    position: absolute;
+    z-index: -1;
+    background-color: var(--area-color);
+    opacity: 0.1;
+    content: '';
+    inset: 0;
+  }
+
+  & > :first-child {
+    @extend %pix-title-xxs;
+
+    color: var(--area-color-dark);
+    font-weight: var(--pix-font-bold);
+  }
+
+  & > :last-child {
+    @extend %pix-body-s;
+
+    color: var(--pix-neutral-500);
+    font-weight: var(--pix-font-bold);
+    text-transform: capitalize;
+  }
+}
+
+.certificate-competences-details-tablist__competences-list {
+  li {
+    @extend %pix-body-m;
+
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+
+    & + li {
+      border-top: 1px solid var(--pix-neutral-100);
+    }
+
+    &::before {
+      display: block;
+      flex-shrink: 0;
+      width: 3rem;
+      height: 3rem;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: contain;
+      content: '';
+    }
+
+    span:first-of-type {
+      flex-grow: 1;
+      font-weight: var(--pix-font-bold);
+    }
+
+    span:last-of-type {
+      font-weight: var(--pix-font-bold);
+      font-size: 125%;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .certificate-competences-details__tabs {
+    display: block;
+
+    [role="tabpanel"][hidden] {
+      display: block;
+    }
+
+    [role="tabpanel"]:not(:first-child) {
+      margin-top: var(--pix-spacing-10x);
+    }
+  }
+
+  .certificate-competences-details__tablist {
+    display: none;
+  }
+}
+
+/**
+ * Areas colors and competences icons
+ */
+.certificate-competences-details {
+  // Areas colors
+  [data-area-code='1'] {
+    --area-color: var(--pix-information-light);
+    --area-color-dark: var(--pix-information-dark);
+  }
+
+  [data-area-code='2'] {
+    --area-color: var(--pix-content-light);
+     --area-color-dark: var(--pix-content-dark);
+  }
+
+  [data-area-code='3'] {
+    --area-color: var(--pix-communication-light);
+     --area-color-dark: var(--pix-communication-dark);
+  }
+
+  [data-area-code='4'] {
+    --area-color: var(--pix-security-light);
+     --area-color-dark: var(--pix-security-dark);
+  }
+
+  [data-area-code='5'] {
+    --area-color: var(--pix-environment-light);
+     --area-color-dark: var(--pix-environment-dark);
+  }
+
+  // Competences icons
+  [data-competence-index='1.1']::before {
+    background-image: url('/images/icons/competences/mener-une-recherche.svg');
+  }
+
+  [data-competence-index='1.2']::before {
+    background-image: url('/images/icons/competences/gerer-des-donnees.svg');
+  }
+
+  [data-competence-index='1.3']::before {
+    background-image: url('/images/icons/competences/traiter-des-donnees.svg');
+  }
+
+  [data-competence-index='2.1']::before {
+    background-image: url('/images/icons/competences/interagir.svg');
+  }
+
+  [data-competence-index='2.2']::before {
+    background-image: url('/images/icons/competences/partager-et-publier.svg');
+  }
+
+  [data-competence-index='2.3']::before {
+    background-image: url('/images/icons/competences/collaborer.svg');
+  }
+
+  [data-competence-index='2.4']::before {
+    background-image: url('/images/icons/competences/inserer-dans-le-monde-numerique.svg');
+  }
+
+  [data-competence-index='3.1']::before {
+    background-image: url('/images/icons/competences/developper-des-docs-textuels.svg');
+  }
+
+  [data-competence-index='3.2']::before {
+    background-image: url('/images/icons/competences/developper-des-docs-multimedia.svg');
+  }
+
+  [data-competence-index='3.3']::before {
+    background-image: url('/images/icons/competences/adapter-les-documents.svg');
+  }
+
+  [data-competence-index='3.4']::before {
+    background-image: url('/images/icons/competences/programmer.svg');
+  }
+
+  [data-competence-index='4.1']::before {
+    background-image: url('/images/icons/competences/securiser-environnement.svg');
+  }
+
+  [data-competence-index='4.2']::before {
+    background-image: url('/images/icons/competences/proteger-les-donnees.svg');
+  }
+
+  [data-competence-index='4.3']::before {
+    background-image: url('/images/icons/competences/proteger-la-sante.svg');
+  }
+
+  [data-competence-index='5.1']::before {
+    background-image: url('/images/icons/competences/problemes-techniques.svg');
+  }
+
+  [data-competence-index='5.2']::before {
+    background-image: url('/images/icons/competences/environnement-numerique.svg');
+  }
+}

--- a/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
@@ -1,0 +1,130 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+import { click, tab } from '@ember/test-helpers';
+import userEvent from '@testing-library/user-event';
+import { t } from 'ember-intl/test-support';
+import CompetencesDetails from 'mon-pix/components/certifications/certificate-information/competences-details';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | Certificate | Competences details', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let screen;
+
+  hooks.beforeEach(async () => {
+    // given
+    const resultCompetenceTree = _getCompetenceTree();
+
+    // when
+    screen = await render(<template><CompetencesDetails @resultCompetenceTree={{resultCompetenceTree}} /></template>);
+  });
+
+  test('should display component', function (assert) {
+    // then
+    assert.dom(screen.getByRole('heading', { name: t('pages.certificate.details.competences.title') })).exists();
+    assert.dom(screen.getByText(t('pages.certificate.details.competences.description'))).exists();
+    assert.dom(screen.getByRole('link', { name: t('pages.certificate.learn-about-certification-results') })).exists();
+
+    const tablist = screen.getByRole('tablist', { name: t('pages.certificate.details.competences.title') });
+    assert.dom(tablist).exists();
+    assert.strictEqual(within(tablist).getAllByRole('tab').length, 2);
+    assert.strictEqual(within(tablist).getAllByRole('tab')[0].textContent.trim(), 'Domaine numéro 1');
+    assert.strictEqual(within(tablist).getAllByRole('tab')[1].textContent.trim(), 'Domaine 2');
+
+    const tabpanel = screen.getByRole('tabpanel', { name: 'Domaine numéro 1' });
+    assert.dom(within(tabpanel).getByRole('heading', { name: /Domaine numéro 1/ })).exists();
+    assert.strictEqual(within(tabpanel).getByRole('presentation').textContent.trim(), t('common.level'));
+
+    const displayedCompetences = within(tabpanel).getAllByRole('listitem');
+    assert.strictEqual(displayedCompetences.length, 3);
+    // Competence 1
+    assert.dom(within(displayedCompetences[0]).getByText('Competence 1 du domaine 1')).exists();
+    assert.dom(within(displayedCompetences[0]).getByText('niveau')).exists();
+    assert.dom(within(displayedCompetences[0]).getByText('3')).exists();
+    // Competence 2
+    assert.dom(within(displayedCompetences[1]).getByText('Competence 2 du domaine 1')).exists();
+    assert.dom(within(displayedCompetences[1]).getByText('niveau')).exists();
+    assert.dom(within(displayedCompetences[1]).getByText('6')).exists();
+    // Competence 3
+    assert.dom(within(displayedCompetences[2]).getByText('Competence 3 du domaine 1')).exists();
+    assert.dom(within(displayedCompetences[2]).getByText('niveau')).exists();
+    assert.dom(within(displayedCompetences[2]).getByText('1')).exists();
+  });
+
+  test('should update tabpanel on tab click', async function (assert) {
+    const tablist = screen.getByRole('tablist', { name: t('pages.certificate.details.competences.title') });
+    click(within(tablist).getAllByRole('tab')[1]);
+
+    const tabpanel = await screen.findByRole('tabpanel', { name: /Domaine 2/ });
+    assert.dom(within(tabpanel).getByRole('heading', { name: /Domaine 2/ })).exists();
+    assert.strictEqual(within(tabpanel).getAllByRole('listitem').length, 1);
+    assert.dom(within(within(tabpanel).getAllByRole('listitem')[0]).getByText('Competence 1 du domaine 2')).exists();
+    assert.dom(within(within(tabpanel).getAllByRole('listitem')[0]).getByText('niveau')).exists();
+    assert.dom(within(within(tabpanel).getAllByRole('listitem')[0]).getByText('4')).exists();
+  });
+
+  test('should update tabpanel on keyboard navigation', async function (assert) {
+    const tablist = screen.getByRole('tablist', { name: t('pages.certificate.details.competences.title') });
+
+    await tab();
+    await tab();
+
+    await userEvent.keyboard('[ArrowDown]');
+    assert.strictEqual(document.activeElement, within(tablist).getAllByRole('tab')[1]);
+    await userEvent.keyboard('[ArrowRight]');
+    assert.strictEqual(document.activeElement, within(tablist).getAllByRole('tab')[0]);
+    await userEvent.keyboard('[ArrowUp]');
+    assert.strictEqual(document.activeElement, within(tablist).getAllByRole('tab')[1]);
+    await userEvent.keyboard('[ArrowLeft]');
+    assert.strictEqual(document.activeElement, within(tablist).getAllByRole('tab')[0]);
+    await userEvent.keyboard('[ArrowUp]');
+
+    await userEvent.keyboard('[Enter]');
+    assert.dom(screen.getByRole('tabpanel', { name: /Domaine 2/ })).exists();
+  });
+});
+
+function _getCompetenceTree() {
+  return EmberObject.create({
+    areas: [
+      EmberObject.create({
+        code: 1,
+        id: 'recvoGdo7z2z7pXWa',
+        name: '1. Premier domaine',
+        title: 'Domaine numéro 1',
+        resultCompetences: [
+          EmberObject.create({
+            index: '2.1',
+            name: 'Competence 1 du domaine 1',
+            level: 3,
+          }),
+          EmberObject.create({
+            index: '2.2',
+            name: 'Competence 2 du domaine 1',
+            level: 6,
+          }),
+          EmberObject.create({
+            index: '2.3',
+            name: 'Competence 3 du domaine 1',
+            level: 1,
+          }),
+        ],
+      }),
+      EmberObject.create({
+        code: 2,
+        id: 'recs7Gpf90ln8NCv7',
+        name: '2. Deuxième domaine',
+        title: 'Domaine 2',
+        resultCompetences: [
+          EmberObject.create({
+            index: '1.1',
+            name: 'Competence 1 du domaine 2',
+            level: 4,
+          }),
+        ],
+      }),
+    ],
+  });
+}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -631,6 +631,12 @@
         "title": "Other certification awarded"
       },
       "delivered-at": "Date of issue:",
+      "details": {
+        "competences": {
+          "description": "Your Pix score gives an estimate of your level in the 16 digital skills.",
+          "title": "Your digital skills profile"
+        }
+      },
       "exam-date": "Completion date:",
       "hexagon-score": {
         "certified": "certified"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -631,6 +631,12 @@
         "title": "Autre certification obtenue"
       },
       "delivered-at": "Date de délivrance :",
+      "details": {
+        "competences": {
+          "description": "Votre score Pix donne une estimation de votre niveau dans les 16 compétences numériques.",
+          "title": "Votre profil de compétences numériques"
+        }
+      },
       "exam-date": "Date de passage :",
       "hexagon-score": {
         "certified": "certifiés"
@@ -1969,7 +1975,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Fermer et revenir aux résultats",
-            "subtitle": "Prêt à développer vos compétences ?  \uD83C\uDF93",
+            "subtitle": "Prêt à développer vos compétences ?  🎓",
             "title": "Résultats partagés"
           },
           "tab-label": "Formations",


### PR DESCRIPTION
## 🌸 Problème

La page de vérification v3 actuelle redirige le vérificateur vers une version améliorée du certificat en ligne v3 mais qui ne détaille pas les résultats par compétence obtenus par le candidat.

## 🌳 Proposition

Ajouter le composant de détail des résultats par compétence dans le nouveau certificat en ligne.

## 🤧 Pour tester

- Aller sur https://app-pr12071.review.pix.fr/verification-certificat
- Entrer ce code
```
P-QDR4HD7H
``` 
- Visualiser le détail des compétences :
	* ☑️ Vérifier les versions `desktop 🖥️` + `mobile 📱`
	* ☑️ En version desktop, tester la **navigation au clavier**
	       (avec les flèches directionnelles une fois que le focus est sur un onglet et `↩️ Entrée` pour afficher le bon panel)
