### PR TITLE
[TECH] Ajouter un script pour archiver en masse des centres de certification (PIX-16851)

### DIFF
--- a/api/src/organizational-entities/scripts/archive-certification-centers-script.js
+++ b/api/src/organizational-entities/scripts/archive-certification-centers-script.js
@@ -1,0 +1,65 @@
+import Joi from 'joi';
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { usecases } from '../domain/usecases/index.js';
+
+const columnsSchemas = [
+  { name: 'certificationCenterId', schema: Joi.number().required() },
+  { name: 'archivedBy', schema: Joi.number().required() },
+];
+
+export class ArchiveCertificationCentersScript extends Script {
+  constructor() {
+    super({
+      description: 'Archive certification centers from a csv file',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'The file path',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchemas),
+        },
+        dryRun: {
+          type: 'boolean',
+          description: 'If true, the script will not update the database',
+          default: false,
+        },
+      },
+    });
+    this.totalLines = 0;
+    this.successLines = 0;
+    this.failedLines = 0;
+    this.errorOccured = false;
+  }
+
+  async handle({ options, logger, archiveCertificationCenter = usecases.archiveCertificationCenter }) {
+    const { file, dryRun } = options;
+    if (!dryRun) {
+      for (const [index, certificationCenter] of file.entries()) {
+        this.totalLines++;
+        try {
+          await archiveCertificationCenter({
+            certificationCenterId: certificationCenter.certificationCenterId,
+            userId: certificationCenter.archivedBy,
+          });
+          this.successLines++;
+        } catch (error) {
+          this.failedLines++;
+          this.errorOccured = true;
+          logger.error(`Error on line ${index}. ${error}`);
+        }
+      }
+      logger.info(`${this.successLines} of ${this.totalLines} certification centers archived`);
+      if (this.errorOccured) {
+        throw new Error(`There were ${this.failedLines} errors while archiving certification centers`);
+      }
+    } else {
+      logger.info(`This is a dry run. No certification centers were archived but ${file.length} lines were processed`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, ArchiveCertificationCentersScript);

--- a/api/tests/organizational-entities/unit/scripts/archive-certification-centers-script.test.js
+++ b/api/tests/organizational-entities/unit/scripts/archive-certification-centers-script.test.js
@@ -1,0 +1,98 @@
+import { ArchiveCertificationCentersScript } from '../../../../src/organizational-entities/scripts/archive-certification-centers-script.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Scripts | Archive certification centers', function () {
+  let logger;
+  let script;
+  let archiveCertificationCenter;
+
+  beforeEach(function () {
+    script = new ArchiveCertificationCentersScript();
+    logger = { info: sinon.spy(), error: sinon.spy() };
+    archiveCertificationCenter = sinon.stub();
+  });
+
+  describe('#handle', function () {
+    context('when dryRun mode', function () {
+      it('should return the lines that will be processed', async function () {
+        // given
+        const file = [
+          { certificationCenterId: 1, archivedBy: 500 },
+          { certificationCenterId: 2, archivedBy: 600 },
+          { certificationCenterId: 3, archivedBy: 700 },
+        ];
+
+        // when
+        await script.handle({
+          options: {
+            file,
+            dryRun: true,
+          },
+          logger,
+          archiveCertificationCenter,
+        });
+
+        // then
+        expect(logger.info).to.have.been.calledWith(
+          `This is a dry run. No certification centers were archived but 3 lines were processed`,
+        );
+      });
+    });
+
+    context('when not dryRun mode', function () {
+      it('should archive successfull certification centers', async function () {
+        // given
+        const file = [
+          { certificationCenterId: 1, archivedBy: 500 },
+          { certificationCenterId: 2, archivedBy: 600 },
+          { certificationCenterId: 3, archivedBy: 700 },
+        ];
+
+        // when
+        await script.handle({
+          options: {
+            file,
+            dryRun: false,
+          },
+          logger,
+          archiveCertificationCenter,
+        });
+
+        // then
+        expect(archiveCertificationCenter).to.have.been.callCount(3);
+        expect(logger.info).to.have.been.calledWith('3 of 3 certification centers archived');
+      });
+
+      it('should display errors when error occurred', async function () {
+        // given
+        const file = [
+          { certificationCenterId: 1, archivedBy: 500 },
+          { certificationCenterId: 2, archivedBy: 600 },
+          { certificationCenterId: 3, archivedBy: 700 },
+        ];
+        archiveCertificationCenter
+          .withArgs({
+            certificationCenterId: file[1].certificationCenterId,
+            userId: file[1].archivedBy,
+          })
+          .rejects('No archivable');
+
+        // when/then
+        await expect(
+          script.handle({
+            options: {
+              file,
+              dryRun: false,
+            },
+            logger,
+            archiveCertificationCenter,
+          }),
+        ).to.be.rejectedWith('There were 1 errors while archiving certification centers');
+
+        // then
+        expect(archiveCertificationCenter).to.have.been.callCount(3);
+        expect(logger.error).to.have.been.calledWith('Error on line 1. No archivable');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

On souhaite archiver en masse des centres de certification maintenant que la fonctionnalité est disponible.

## 🌳 Proposition

Créer un script qui permet de réaliser cette action à partir d'un fichier .csv.

## 🐝 Remarques

Ce script est temporaire, il sera supprimé après utilisation.

## 🤧 Pour tester

- Prendre une grande inspiration,
- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Dans la section utilisateur noter son identifiant,
- Se rendre sur la page des centres de certification,
- Choisir quelques identifiants de centres,
- Créer un fichier .csv avec le schéma suivant:
```
certificationCenterId,archivedBy
```
- Remplir les colones avec l'identifiant des centres de certification et son userId,
- Exécuter le script avec le dryRun:
```shell
node src/organizational-entities/scripts/archive-certification-centers-script.js --file <votre_fichier.csv> --dryRun
```
- Constater que le nombre de centre traîté est le même que le nombre de lignes du fichier,
- Réexécuter la commande sans le dryRun,
- Constater que le script indique que les centres ont étét archivés,
- Dans Pix admin, constater que les centres de certification sont archivés.