### PR TITLE
[BUGFIX] Ne pas afficher le bouton envoyé ses résultats lorsque la campagne est desactivé (PIX-17521)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 import AcquiredBadges from './acquired-badges';
@@ -209,7 +210,7 @@ export default class EvaluationResultsHero extends Component {
                 {{t "pages.skill-review.hero.explanations.trainings"}}
               </p>
             {{/if}}
-          {{else}}
+          {{else if (not @campaignParticipationResult.isDisabled)}}
             <p class="evaluation-results-hero-details__explanations">
               {{t "pages.skill-review.hero.explanations.send-results"}}
             </p>
@@ -237,13 +238,19 @@ export default class EvaluationResultsHero extends Component {
                 {{/unless}}
               {{/if}}
             {{else}}
-              <PixButton
-                @triggerAction={{this.handleShareResultsClick}}
-                @size="large"
-                @isLoading={{this.isButtonLoading}}
-              >
-                {{t "pages.skill-review.actions.send"}}
-              </PixButton>
+              {{#if @campaignParticipationResult.isDisabled}}
+                <PixNotificationAlert @type="warning" @withIcon={{true}}>
+                  {{t "pages.skill-review.disabled-share"}}
+                </PixNotificationAlert>
+              {{else}}
+                <PixButton
+                  @triggerAction={{this.handleShareResultsClick}}
+                  @size="large"
+                  @isLoading={{this.isButtonLoading}}
+                >
+                  {{t "pages.skill-review.actions.send"}}
+                </PixButton>
+              {{/if}}
             {{/if}}
             {{#if @campaignParticipationResult.canImprove}}
               <PixButton

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -224,6 +224,37 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         assert.dom(screen.getByRole('button', { name: t('pages.skill-review.actions.send') })).exists();
       });
 
+      test('it should display disabled notation', async function (assert) {
+        // given
+        this.set('campaign', {
+          customResultPageText: 'My custom result page text',
+          organizationId: 1,
+        });
+
+        this.set('campaignParticipationResult', {
+          campaignParticipationBadges: [],
+          isShared: false,
+          isDisabled: true,
+          canImprove: false,
+          masteryRate: 0.75,
+          reachedStage: { acquired: 4, total: 5 },
+        });
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
+/>`,
+        );
+
+        // then
+        assert.ok(screen.getByText(t('pages.skill-review.disabled-share')));
+        assert.notOk(screen.queryByText(t('pages.skill-review.hero.explanations.send-results')));
+        assert.notOk(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') }));
+      });
+
       module('on click on the share button', function (hooks) {
         let campaignParticipationResult, onResultsSharedStub, screen, shareStub;
 
@@ -393,6 +424,35 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
     });
 
     module('when results are shared', function () {
+      test('it should not display disabled notation', async function (assert) {
+        // given
+        this.set('campaign', {
+          customResultPageText: 'My custom result page text',
+          organizationId: 1,
+        });
+
+        this.set('campaignParticipationResult', {
+          campaignParticipationBadges: [],
+          isShared: true,
+          isDisabled: true,
+          canImprove: false,
+          masteryRate: 0.75,
+          reachedStage: { acquired: 4, total: 5 },
+        });
+
+        // when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+  @isSharableCampaign={{true}}
+/>`,
+        );
+
+        // then
+        assert.notOk(screen.queryByText(t('pages.skill-review.disabled-share')));
+      });
+
       module('when there are no trainings and no custom link', function () {
         test('it should display a message and a homepage link', async function (assert) {
           // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1885,7 +1885,7 @@
         "result": "Overall result",
         "title": "Your results by competence"
       },
-      "disabled-share": "This customised test has been deactivated by the organiser.'<br>'It is no longer possible to submit results.",
+      "disabled-share": "This customised test has been deactivated by the organiser. It is no longer possible to submit results.",
       "error": "Oops, an error occurred!",
       "hero": {
         "acquired-badges-title": "Awards received",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1880,7 +1880,7 @@
         "result": "Resultado global",
         "title": "Tus resultados por competencia"
       },
-      "disabled-share": "Este test ha sido desactivado por el organizador.'<br>'Ya no es posible enviar resultados.",
+      "disabled-share": "Este test ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
       "error": "¡Uy, se ha producido un error!",
       "hero": {
         "acquired-badges-title": "Premios obtenidos",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1885,7 +1885,7 @@
         "result": "Résultat global",
         "title": "Vos résultats par compétence"
       },
-      "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>'L'envoi des résultats n'est plus possible.",
+      "disabled-share": "Ce parcours a été désactivé par l'organisateur. L'envoi des résultats n'est plus possible.",
       "error": "Oups, une erreur est survenue !",
       "hero": {
         "acquired-badges-title": "Récompenses obtenues",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1880,7 +1880,7 @@
         "result": "Algemeen resultaat",
         "title": "Je resultaten per vaardigheid"
       },
-      "disabled-share": "Deze route is gedeactiveerd door de organisator.'<br>'Het is niet langer mogelijk om resultaten te versturen.",
+      "disabled-share": "Deze route is gedeactiveerd door de organisator. Het is niet langer mogelijk om resultaten te versturen.",
       "error": "Oeps, er is een fout gemaakt!",
       "hero": {
         "acquired-badges-title": "Gewonnen prijzen",


### PR DESCRIPTION
## 🌸 Problème

Depuis la nouvelle page de fin de parcours, le bouton envoi ses résultats est affiché alors qu'il ne devrait pas l'être

## 🌳 Proposition

Cacher ce bouton lorsque la campagne est désactivé, Afficher le texte qui était présent dans la page skill review avec la fat bee

## 🐝 Remarques

RAS

## 🤧 Pour tester

Participer à une campagne. aller à la fin. 
Sur PixOrga => supprimer cette participation ( ou le learner )
Sur PixApp => vérifier qu'une NotificationAlert apparait en cachant le bouton envoyer