### PR TITLE
[BUGFIX] Passer les tubes à null pour récupérer les collectes de profil via Campaign-Api.js (PIX-17531)

### DIFF
--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -47,6 +47,7 @@ class CampaignReport {
     this.badges = badges;
     this.stages = stages;
     this.multipleSendings = multipleSendings;
+    this.tubes = this.canComputeCoverRate ? undefined : null;
   }
 
   get isAssessment() {
@@ -59,6 +60,10 @@ class CampaignReport {
 
   get isProfilesCollection() {
     return this.type === CampaignTypes.PROFILES_COLLECTION;
+  }
+
+  get canComputeCoverRate() {
+    return !this.isProfilesCollection;
   }
 
   get isArchived() {

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
@@ -74,14 +75,35 @@ describe('Integration | UseCase | find-paginated-filtered-organization-campaigns
 
       //then
       expect(result.models[0]).to.be.an.instanceof(CampaignReport);
-      expect(result.models[0].tubes[0]).to.deep.equal({
-        id: 'tubeIdA',
-        competenceId: 'competenceIdA',
-        practicalTitle: 'practicalTitle FR Tube A',
-        practicalDescription: 'practicalDescription FR Tube A',
-        maxLevel: 2,
-        meanLevel: 2,
+      expect(result.models[0].tubes[0].id).to.deep.equal('tubeIdA');
+      expect(result.models[0].tubes[0].competenceId).to.deep.equal('competenceIdA');
+      expect(result.models[0].tubes[0].practicalTitle).to.deep.equal('practicalTitle FR Tube A');
+      expect(result.models[0].tubes[0].practicalDescription).to.deep.equal('practicalDescription FR Tube A');
+      expect(result.models[0].tubes[0].maxLevel).to.deep.equal(2);
+      expect(result.models[0].tubes[0].meanLevel).to.deep.equal(2);
+    });
+  });
+  context('when campaign is type profiles collect', function () {
+    it('should return model Campaign Report without cover rate', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildCampaign({
+        organizationId,
+        type: CampaignTypes.PROFILES_COLLECTION,
+      }).id;
+      await databaseBuilder.commit();
+
+      const result = await usecases.findPaginatedFilteredOrganizationCampaigns({
+        locale: 'fr',
+        organizationId,
+        page: { number: 1, size: 4 },
+        userId,
+        withCoverRate: true,
       });
+
+      //then
+      expect(result.models[0]).to.be.an.instanceof(CampaignReport);
+      expect(result.models[0].tubes).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

L'API de récupération des détails d'une campagne ne doit pas remonter de tubes si la campagne est de type collecte de profils.

## 🌳 Proposition
Si la campagne est une campagne de type collecte de profils, campaignReports.tubes est set à null.