### PR TITLE
[FEATURE] Coolitude de Modulix v2 

### DIFF
--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -10,6 +10,8 @@
   &__image {
     display: block;
     width: 100%;
+    max-width: 700px;
+    margin: auto;
     object-fit: contain;
     border-radius: var(--modulix-radius-s);
   }

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -109,11 +109,11 @@ export default class ModuleQcm extends ModuleElement {
       {{#if this.shouldDisplayRetryButton}}
         <PixButton
           class="element-qcm__retry-button"
-          @variant="secondary"
+          @variant="tertiary"
           @size="small"
           @type="button"
           @triggerAction={{this.retry}}
-          @iconAfter="refresh"
+          @iconBefore="refresh"
         >
           {{t "pages.modulix.buttons.activity.retry"}}
         </PixButton>

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -113,11 +113,11 @@ export default class ModuleQcu extends ModuleElement {
       {{#if this.shouldDisplayRetryButton}}
         <PixButton
           class="element-qcu__retry-button"
-          @variant="secondary"
+          @variant="tertiary"
           @size="small"
           @type="button"
           @triggerAction={{this.retry}}
-          @iconAfter="refresh"
+          @iconBefore="refresh"
         >
           {{t "pages.modulix.buttons.activity.retry"}}
         </PixButton>

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -170,11 +170,11 @@ export default class ModuleQrocm extends ModuleElement {
       {{#if this.shouldDisplayRetryButton}}
         <PixButton
           class="element-qrocm__retry-button"
-          @variant="secondary"
+          @variant="tertiary"
           @size="small"
           @type="button"
           @triggerAction={{this.retry}}
-          @iconAfter="refresh"
+          @iconBefore="refresh"
         >
           {{t "pages.modulix.buttons.activity.retry"}}
         </PixButton>

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -10,6 +10,8 @@ $grain-card-border-radius: var(--pix-spacing-4x);
 
   width: 100%;
 
+  // margin: var(--pix-spacing-12x) 0;
+
   &--active {
     @extend .auto-scroll;
   }
@@ -25,7 +27,7 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   }
 
   &__card {
-    border-radius: $grain-card-border-radius 0 $grain-card-border-radius $grain-card-border-radius;
+    border-radius: $grain-card-border-radius;
   }
 
   &:focus-visible {
@@ -44,40 +46,77 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   }
 
   &__footer {
-    padding: var(--pix-spacing-6x);
-    border-top: 1px solid var(--pix-neutral-100);
+    padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+    border-top: 0 solid var(--pix-neutral-100);
     border-radius: 0 0 $grain-card-border-radius $grain-card-border-radius;
   }
 
   &__tag {
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
   }
 
-  &--lesson,
-  &--discovery,
+  &--lesson {
+    background: transparent;
+
+    &__tag {
+      background-color: inherit;
+    }
+
+    .grain-card__footer {
+      background: transparent;
+    }
+  }
+
+  &--discovery {
+    background: transparent;
+
+    &__tag {
+      background-color: inherit;
+    }
+
+    .grain-card__footer {
+      background: transparent;
+    }
+  }
+
   &--summary {
-    background: var(--modulix-lesson-card-background);
+    background: var(--pix-secondary-100);
 
     &__tag {
       background-color: inherit;
     }
 
     .grain-card__footer {
-      background: var(--modulix-lesson-card-footer-background);
+      padding: var(--pix-spacing-6x);
+      background: var(--pix-secondary-100);
+      border-top: 1px solid var(--pix-neutral-100);
     }
   }
 
-  &--activity,
-  &--challenge {
-    background: var(--modulix-activity-card-background);
+  &--activity {
+    background: transparent;
 
     &__tag {
       background-color: inherit;
     }
 
     .grain-card__footer {
-      background: var(--modulix-activity-card-footer-background);
+      background: transparent;
+    }
+  }
+
+  &--challenge {
+    background: rgba(var(--pix-primary-100-inline), 0.3);
+
+    &__tag {
+      background-color: inherit;
+    }
+
+    .grain-card__footer {
+      padding: var(--pix-spacing-6x);
+      background: rgba(var(--pix-primary-100-inline), 0.3);
+      border-top: 1px solid var(--pix-neutral-100);
     }
   }
 }

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -26,6 +26,27 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     font-weight: var(--pix-font-medium);
   }
 
+  &__card,
+  &-card__tag {
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.8s fade-in ease-in-out;
+
+      @keyframes fade-in {
+        0% {
+          opacity: 0;
+        }
+
+        33% {
+          opacity: 0;
+        }
+
+        100% {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
   &__card {
     border-radius: $grain-card-border-radius;
   }

--- a/mon-pix/app/components/module/grain/_tag.scss
+++ b/mon-pix/app/components/module/grain/_tag.scss
@@ -13,12 +13,24 @@
   text-transform: uppercase;
   border-radius: var(--modulix-radius) var(--modulix-radius) 0 0;
 
-  &--activity, &--challenge {
+  &--activity {
     background: var(--modulix-activity-card-background);
   }
 
-  &--lesson, &--discovery, &--summary {
+  &--challenge {
+    background: rgba(var(--pix-primary-100-inline), 0.3);
+  }
+
+  &--lesson {
+    background: transparent;
+  }
+
+  &--discovery {
     background: var(--modulix-lesson-card-background);
+  }
+
+  &--summary {
+    background: var(--pix-secondary-100);
   }
 
   &_icon {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -172,10 +172,14 @@ export default class ModuleGrain extends Component {
     return `grain_${this.args.grain.id}`;
   }
 
+  get hasTag() {
+    return false;
+  }
+
   <template>
     <article
       id={{this.elementId}}
-      class="grain {{if @hasJustAppeared 'grain--active'}}"
+      class="grain {{if @hasJustAppeared 'grain--active'}} "
       tabindex="-1"
       {{didInsert this.focusAndScroll}}
     >
@@ -189,9 +193,11 @@ export default class ModuleGrain extends Component {
         </header>
       {{/if}}
 
-      <div class="grain-card__tag">
-        <GrainTag @type={{this.grainType}} />
-      </div>
+      {{#if this.hasTag}}
+        <div class="grain-card__tag">
+          <GrainTag @type={{this.grainType}} />
+        </div>
+      {{/if}}
       <div class="grain__card grain-card--{{this.grainType}}">
         <div class="grain-card__content">
           <!-- eslint-disable-next-line no-unused-vars -->

--- a/mon-pix/app/components/module/layout/_navbar.scss
+++ b/mon-pix/app/components/module/layout/_navbar.scss
@@ -1,11 +1,13 @@
 @use 'pix-design-tokens/typography';
 
 .module-navbar {
+  @extend %pix-body-s;
+
   position: sticky;
   top: 0;
   z-index: var(--modulix-z-index-above-all);
   height: var(--module-navbar-height);
-  padding: var(--pix-spacing-3x);
+  padding: var(--pix-spacing-2x);
   background: var(--pix-neutral-0);
   box-shadow: 0 4px 20px 0 rgb(0 0 0 / 6%);
 

--- a/mon-pix/app/components/module/layout/navbar.gjs
+++ b/mon-pix/app/components/module/layout/navbar.gjs
@@ -55,17 +55,17 @@ export default class ModulixNavbar extends Component {
     <nav
       id="module-navbar"
       class="module-navbar"
-      aria-label={{t "pages.modulix.flashcards.navigation.currentStep" current=@currentStep total=@totalSteps}}
+      aria-label={{t "pages.modulix.flashcards.navigation.longCurrentStep" current=@currentStep total=@totalSteps}}
     >
       <div class="module-navbar__content">
         <PixButton
-          @variant="tertiary"
           @triggerAction={{this.openSidebar}}
+          @iconBefore="book"
+          @variant="secondary"
           aria-label={{t "pages.modulix.sidebar.button"}}
         >
-          {{t "pages.modulix.flashcards.navigation.currentStep" current=@currentStep total=@totalSteps}}
+          {{t "pages.modulix.flashcards.navigation.shortCurrentStep" current=@currentStep total=@totalSteps}}
         </PixButton>
-
         <PixProgressBar @hidePercentage={{true}} @isDecorative={{true}} @value={{this.progressValue}} />
       </div>
     </nav>

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -3,7 +3,7 @@
 .modulix {
   @extend %pix-body-l;
 
-  --modulix-max-content-width: 740px;
+  --modulix-max-content-width: 820px;
   --modulix-radius-xs: 4px;
   --modulix-radius-s: 8px;
   --modulix-radius: 16px;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1656,7 +1656,8 @@
         },
         "direction": "Look for the answer then turn the card",
         "navigation": {
-          "currentStep": "Step {current} of {total}"
+          "longCurrentStep": "Step {current} of {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "Card {currentCardPosition}/{totalCards}"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1645,7 +1645,8 @@
         },
         "direction": "Busca la respuesta y gira la tarjeta",
         "navigation": {
-          "currentStep": "{current} Paso a paso {total}"
+          "shortCurrentStep": "{current}/{total}",
+          "longCurrentStep": "{current} Paso a paso {total}"
         },
         "position": "{currentCardPosition}Tarjeta /{totalCards}"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1656,7 +1656,8 @@
         },
         "direction": "Cherchez la réponse puis tournez la carte",
         "navigation": {
-          "currentStep": "Étape {current} sur {total}"
+          "longCurrentStep": "Étape {current} sur {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "Carte {currentCardPosition}/{totalCards}"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1645,7 +1645,8 @@
         },
         "direction": "Zoek het antwoord en draai de sitemap om",
         "navigation": {
-          "currentStep": "{current} Stap op {total}"
+          "shortCurrentStep": "{current}/{total}",
+          "longCurrentStep": "{current} Stap op {total}"
         },
         "position": "{currentCardPosition}sitemap /{totalCards}"
       },


### PR DESCRIPTION
## 🌸 Problème

Dans le but de rendre les modules plus fun, il y a des ajustements à faire sur la mise en forme avec le Design concernant le fond, la taille max, les tags...

## 🌳 Proposition

Liste des changements effectuées :

- Elargir la largeur max du squelette du module (desktop) et la taille de l'image
- Retirer les tags sur les cartes grains
- Retirer le fond sauf pour les grains de type "défi" et "récap". Les couleurs ont aussi été ajusté pour ceux-là.
- Affinage navbar en ajoutant une icône et enlevant le bouton tertiary
- Mise en retrait du bouton `Réessayer`
- Ajout animation fondu à l'apparition des grains

## 🐝 Remarques

- Certains textes ont une taille de police de 14px sur mobilece qui la rend la lecture plus difficile. On ne ne peut pas ajuster cela facilement car c'est un design tokens et l'override des placeholders en sass n'est pas possible (à moins de revenir sur des mixins 😅)

## 🤧 Pour tester

Aller sur le module suivant et constater les changements : 
- https://app-pr12078.review.pix.fr/modules/protegez-vos-appareils-contre-les-virus
