### PR TITLE
[FEATURE] Ajouter l’action d’archivage d’un CDC dans Pix Admin (PIX-16750)

### DIFF
--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -2,4 +2,8 @@ import ApplicationAdapter from './application';
 
 export default class CertificationCenterAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
+
+  archiveCertificationCenter(certificationCenterId) {
+    return this.ajax(`${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/archive`, 'POST');
+  }
 }

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -1,6 +1,8 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -12,6 +14,7 @@ import HabilitationTag from './habilitation-tag';
 export default class InformationView extends Component {
   @service intl;
   @tracked habilitations = [];
+  @tracked isArchiveModalOpen = false;
 
   constructor() {
     super(...arguments);
@@ -58,6 +61,16 @@ export default class InformationView extends Component {
   get externalURL() {
     const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
     return urlDashboardPrefix && urlDashboardPrefix + this.args.certificationCenter.id;
+  }
+
+  @action
+  toggleShowArchiveModal() {
+    this.isArchiveModalOpen = !this.isArchiveModalOpen;
+  }
+
+  @action
+  async archiveCertificationCenter() {
+    alert('coucou');
   }
 
   <template>
@@ -121,6 +134,13 @@ export default class InformationView extends Component {
           {{t "common.actions.edit"}}
         </PixButton>
       </li>
+      {{#unless @certificationCenter.isArchived}}
+        <li>
+          <PixButton @variant="error" @size="small" @triggerAction={{this.toggleShowArchiveModal}}>
+            {{t "common.actions.archive"}}
+          </PixButton>
+        </li>
+      {{/unless}}
       <li>
         <PixButtonLink
           @variant="secondary"
@@ -133,5 +153,37 @@ export default class InformationView extends Component {
         </PixButtonLink>
       </li>
     </ul>
+
+    {{#if this.isArchiveModalOpen}}
+      <PixModal
+        @title={{t
+          "pages.certification-centers.archive-confirmation-modal.title"
+          certificationCenterName=@certificationCenter.name
+        }}
+        @showModal={{this.isArchiveModalOpen}}
+        @onCloseButtonClick={{this.toggleShowArchiveModal}}
+      >
+        <:content>
+          <p>{{t "pages.certification-centers.archive-confirmation-modal.question"}}</p>
+          <ul class="certification-center-confirmation-modal__list">
+            <li>{{t "pages.certification-centers.archive-confirmation-modal.members"}}</li>
+            <li>{{t "pages.certification-centers.archive-confirmation-modal.invitations"}}</li>
+            <li>{{t "pages.certification-centers.archive-confirmation-modal.campaigns"}}</li>
+            <li>{{t "pages.certification-centers.archive-confirmation-modal.attachment"}}</li>
+          </ul>
+          <p class="certification-center-confirmation-modal__warning">{{t
+              "pages.certification-centers.archive-confirmation-modal.warning"
+            }}</p>
+        </:content>
+        <:footer>
+          <PixButton @triggerAction={{this.toggleShowArchiveModal}} @size="small" @variant="secondary">
+            {{t "common.actions.cancel"}}
+          </PixButton>
+          <PixButton @triggerAction={{this.archiveCertificationCenter}} @size="small">
+            {{t "common.actions.confirm"}}
+          </PixButton>
+        </:footer>
+      </PixModal>
+    {{/if}}
   </template>
 }

--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -15,6 +15,7 @@ export default class InformationView extends Component {
   @service intl;
   @tracked habilitations = [];
   @tracked isArchiveModalOpen = false;
+  @service store;
 
   constructor() {
     super(...arguments);
@@ -70,7 +71,13 @@ export default class InformationView extends Component {
 
   @action
   async archiveCertificationCenter() {
-    alert('coucou');
+    const adapter = this.store.adapterFor('certification-center');
+    await adapter.archiveCertificationCenter(this.args.certificationCenter.id);
+
+    this.toggleShowArchiveModal();
+    await this.args.certificationCenter.reload();
+
+    return this.args.refreshModel();
   }
 
   <template>

--- a/admin/app/components/certification-centers/information.gjs
+++ b/admin/app/components/certification-centers/information.gjs
@@ -28,6 +28,7 @@ export default class Information extends Component {
             @certificationCenter={{@certificationCenter}}
             @availableHabilitations={{@availableHabilitations}}
             @toggleEditMode={{this.toggleEditMode}}
+            @refreshModel={{@refreshModel}}
           />
         {{/if}}
       </div>

--- a/admin/app/components/certification-centers/information.scss
+++ b/admin/app/components/certification-centers/information.scss
@@ -124,3 +124,15 @@
     }
   }
 }
+
+.certification-center-confirmation-modal {
+  &__list {
+    margin:var(--pix-spacing-4x) var(--pix-spacing-4x) 0;
+    list-style-type: disc;
+  }
+
+  &__warning {
+    padding-top: var(--pix-spacing-3x);
+    font-weight: 900;
+  }
+}

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -31,4 +31,9 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
       });
     }
   }
+
+  @action
+  refresh() {
+    this.send('refreshModel');
+  }
 }

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import RSVP from 'rsvp';
@@ -13,5 +14,10 @@ export default class CertificationCentersGetRoute extends Route {
       certificationCenter,
       habilitations,
     });
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -8,6 +8,7 @@
     @availableHabilitations={{this.model.habilitations}}
     @certificationCenter={{this.model.certificationCenter}}
     @updateCertificationCenter={{this.updateCertificationCenter}}
+    @refreshModel={{this.refresh}}
   />
 
   {{#unless this.model.certificationCenter.isArchived}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -189,6 +189,13 @@ function routes() {
       failureCount: 0,
     });
   });
+
+  this.post('/admin/certification-centers/:id/archive', (schema, request) => {
+    const certificationCenterId = request.params.id;
+    const certificationCenter = schema.certificationCenters.findBy({ id: certificationCenterId });
+    return certificationCenter.update({ archivedAt: new Date('2025-01-01'), archivistFullName: 'John Doe' });
+  });
+
   this.post('/admin/users/:id/anonymize', (schema, request) => {
     const userId = request.params.id;
     const user = schema.users.findBy({ id: userId });

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -239,6 +239,28 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
     });
 
+    module('when the archive confirmation button is clicked', function () {
+      test('displays archived certification center banner', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const certificationCenter = server.create('certification-center', {
+          name: 'Pokemon Center',
+          externalId: 'ABCDEF',
+          type: 'PRO',
+          archivedAt: null,
+          archivistFullName: null,
+        });
+
+        // when
+        const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+        await click(screen.getByRole('button', { name: 'Archiver' }));
+        await click(screen.getByRole('button', { name: 'Confirmer' }));
+
+        // then
+        assert.dom(await screen.findByText('Archivé le 01/01/2025 par John Doe.')).exists();
+      });
+    });
+
     module('tab navigation', function () {
       test('should show Équipe and Invitations tab', async function (assert) {
         // given

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -200,6 +200,45 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   });
 
   module('when certification center is not archived', function () {
+    test('displays the "Archive" button', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const certificationCenter = server.create('certification-center', {
+        name: 'Pokemon Center',
+        externalId: 'ABCDEF',
+        type: 'PRO',
+        archivedAt: null,
+        archivistFullName: null,
+      });
+
+      // when
+      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Archiver' })).exists();
+    });
+
+    module('when the "Archive" button is clicked', function () {
+      test('displays the confirmation modal', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const certificationCenter = server.create('certification-center', {
+          name: 'Pokemon Center',
+          externalId: 'ABCDEF',
+          type: 'PRO',
+          archivedAt: null,
+          archivistFullName: null,
+        });
+
+        // when
+        const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+        await click(screen.getByRole('button', { name: 'Archiver' }));
+
+        // then
+        assert.dom(screen.getByText('Archiver le centre de certification Pokemon Center')).exists();
+      });
+    });
+
     module('tab navigation', function () {
       test('should show Équipe and Invitations tab', async function (assert) {
         // given
@@ -248,6 +287,24 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   });
 
   module('when certification center is archived', function () {
+    test('does not display "Archive" button', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const certificationCenter = server.create('certification-center', {
+        name: 'Pokemon Center',
+        externalId: 'ABCDEF',
+        type: 'PRO',
+        archivedAt: new Date(),
+        archivistFullName: null,
+      });
+
+      // when
+      const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Archiver' })).doesNotExist();
+    });
+
     test('displays archived at date and archivist full name', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile-test.js
@@ -160,7 +160,6 @@ module(
               await targetProfileSelectable.click();
 
               // then
-              //await new Promise((a) => setTimeout(() => a(), 2000));
               assert
                 .dom(
                   await screen.findByRole('checkbox', {

--- a/admin/tests/unit/adapters/certification-centers-test.js
+++ b/admin/tests/unit/adapters/certification-centers-test.js
@@ -1,0 +1,22 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | certification centers', function (hooks) {
+  setupTest(hooks);
+
+  module('#archiveCertificationCenter', function () {
+    test('should build get url from certification details id', function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:certification-center');
+
+      sinon.stub(adapter, 'ajax');
+
+      // when
+      adapter.archiveCertificationCenter(123);
+
+      // then
+      assert.ok(adapter.ajax.calledWith('http://localhost:3000/api/admin/certification-centers/123/archive', 'POST'));
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -2,8 +2,10 @@
   "common": {
     "actions": {
       "add": "Add",
+      "archive": "Archive",
       "cancel": "Cancel",
       "close": "Close",
+      "confirm": "Confirm",
       "deactivate": "Deactivate",
       "download-template": "Download template",
       "edit": "Edit",
@@ -667,6 +669,15 @@
       }
     },
     "certification-centers": {
+      "archive-confirmation-modal": {
+        "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
+        "campaigns": "Les campagnes actives vont être archivées",
+        "invitations": "Les invitations en attente vont être annulées",
+        "members": "Les membres actifs vont être désactivés",
+        "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",
+        "title": "Archiver le centre de certification {certificationCenterName}",
+        "warning": "Cette action est irréversible."
+      },
       "information-view": {
         "habilitations": {
           "aria-label": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -2,8 +2,10 @@
   "common": {
     "actions": {
       "add": "Ajouter",
+      "archive": "Archiver",
       "cancel": "Annuler",
       "close": "Fermer",
+      "confirm": "Confirmer",
       "deactivate": "Désactiver",
       "download-template": "Télécharger le template",
       "edit": "Modifier",
@@ -667,6 +669,15 @@
       }
     },
     "certification-centers": {
+      "archive-confirmation-modal": {
+        "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
+        "campaigns": "Les campagnes actives vont être archivées",
+        "invitations": "Les invitations en attente vont être annulées",
+        "members": "Les membres actifs vont être désactivés",
+        "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",
+        "title": "Archiver le centre de certification {certificationCenterName}",
+        "warning": "Cette action est irréversible."
+      },
       "information-view": {
         "habilitations": {
           "aria-label": {


### PR DESCRIPTION
## 🌸 Problème

ETQ agent Pix, je veux archiver un CDC depuis la page de détail.

## 🌳 Proposition

Ajouter l’action d’archivage d’une CDC dans Pix Admin:

- Si le CDC n’est pas archivé, ajouter le bouton “Archiver le centre” dans la section détail de page du CDC (en “rouge”, entre le bouton “Modifier” & “Tableau de bord”)

- Afficher une modale de confirmation quand l’utilisateur clique sur le bouton “Archiver le centre”. Exemple pour une organisation

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Sur pix-admin, se rendre sur la page de détai d'un centre de certif non archivé
- Archiver le centre
- Constater que le centre à été archivé avec succès