### PR TITLE
[FEATURE] Empecher un utilisateur ayant participé à une campagne de supprimer son compte en autonomie (PIX-17441).

### DIFF
--- a/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
+++ b/api/src/prescription/campaign-participation/application/api/campaign-participations-api.js
@@ -1,0 +1,12 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+/**
+ * @function
+ * @name hasCampaignParticipations
+ *
+ * @param {number} userId
+ * @returns {Promise<boolean>}
+ */
+export const hasCampaignParticipations = async ({ userId }) => {
+  return usecases.hasCampaignParticipations({ userId });
+};

--- a/api/src/prescription/campaign-participation/domain/usecases/has-campaign-participations.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/has-campaign-participations.js
@@ -1,0 +1,8 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+export const hasCampaignParticipations = withTransaction(async function ({ userId, campaignParticipationRepository }) {
+  const campaignParticipationsCount = await campaignParticipationRepository.getCampaignParticipationsCountByUserId({
+    userId,
+  });
+  return Boolean(campaignParticipationsCount);
+});

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -181,6 +181,15 @@ const findOneByCampaignIdAndUserId = async function ({ campaignId, userId }) {
   });
 };
 
+const getCampaignParticipationsCountByUserId = async function ({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const result = await knexConn('campaign-participations')
+    .count('campaign-participations.id as count')
+    .where({ userId })
+    .first();
+  return result.count;
+};
+
 const hasAssessmentParticipations = async function (userId) {
   const knexConn = DomainTransaction.getConnection();
   const { count } = await knexConn('assessments')
@@ -276,6 +285,7 @@ export {
   get,
   getAllCampaignParticipationsInCampaignForASameLearner,
   getByCampaignIds,
+  getCampaignParticipationsCountByUserId,
   getCampaignParticipationsForOrganizationLearner,
   getCodeOfLastParticipationToProfilesCollectionCampaignForUser,
   getLocked,

--- a/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
+++ b/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
@@ -16,12 +16,16 @@ const canSelfDeleteAccount = async ({
   candidatesApiRepository,
   learnersApiRepository,
   userTeamsApiRepository,
+  campaignParticipationsApi,
 }) => {
   const isSelfAccountDeletionEnabled = await featureToggles.get('isSelfAccountDeletionEnabled');
   if (!isSelfAccountDeletionEnabled) return false;
 
   const hasBeenLearner = await learnersApiRepository.hasBeenLearner({ userId });
   if (hasBeenLearner) return false;
+
+  const hasCampaignParticipations = await campaignParticipationsApi.hasCampaignParticipations({ userId });
+  if (hasCampaignParticipations) return false;
 
   const hasBeenCandidate = await candidatesApiRepository.hasBeenCandidate({ userId });
   if (hasBeenCandidate) return false;

--- a/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
+++ b/api/src/privacy/domain/usecases/can-self-delete-account.usecase.js
@@ -6,6 +6,7 @@ import { featureToggles } from '../../../shared/infrastructure/feature-toggles/i
  * @param {Object} params - The parameters for the use case.
  * @param {number} params.userId - The ID of the user.
  * @param {Object} params.featureToggles - The feature toggles configuration.
+ * @param {Object} params.campaignParticipationsApiRepository - The repository for campaign participations operations.
  * @param {Object} params.candidatesApiRepository - The repository for candidate-related operations.
  * @param {Object} params.learnersApiRepository - The repository for learner-related operations.
  * @param {Object} params.userTeamsApiRepository - The repository for user team access operations.
@@ -16,7 +17,7 @@ const canSelfDeleteAccount = async ({
   candidatesApiRepository,
   learnersApiRepository,
   userTeamsApiRepository,
-  campaignParticipationsApi,
+  campaignParticipationsApiRepository,
 }) => {
   const isSelfAccountDeletionEnabled = await featureToggles.get('isSelfAccountDeletionEnabled');
   if (!isSelfAccountDeletionEnabled) return false;
@@ -24,7 +25,7 @@ const canSelfDeleteAccount = async ({
   const hasBeenLearner = await learnersApiRepository.hasBeenLearner({ userId });
   if (hasBeenLearner) return false;
 
-  const hasCampaignParticipations = await campaignParticipationsApi.hasCampaignParticipations({ userId });
+  const hasCampaignParticipations = await campaignParticipationsApiRepository.hasCampaignParticipations({ userId });
   if (hasCampaignParticipations) return false;
 
   const hasBeenCandidate = await candidatesApiRepository.hasBeenCandidate({ userId });

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -8,6 +8,7 @@ import { refreshTokenRepository } from '../../../identity-access-management/infr
 import { resetPasswordDemandRepository } from '../../../identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as userAcceptanceRepository from '../../../legal-documents/infrastructure/repositories/user-acceptance.repository.js';
+import * as campaignParticipationsApi from '../../../prescription/campaign-participation/application/api/campaign-participations-api.js';
 import * as organizationLearnerRepository from '../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -41,7 +42,7 @@ const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
 };
 
-const dependencies = Object.assign({}, repositories);
+const dependencies = Object.assign({ campaignParticipationsApi }, repositories);
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -8,13 +8,13 @@ import { refreshTokenRepository } from '../../../identity-access-management/infr
 import { resetPasswordDemandRepository } from '../../../identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as userAcceptanceRepository from '../../../legal-documents/infrastructure/repositories/user-acceptance.repository.js';
-import * as campaignParticipationsApi from '../../../prescription/campaign-participation/application/api/campaign-participations-api.js';
 import * as organizationLearnerRepository from '../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../team/infrastructure/repositories/membership.repository.js';
+import * as campaignParticipationsApiRepository from '../../infrastructure/repositories/campaign-participations-api.repository.js';
 import * as candidatesApiRepository from '../../infrastructure/repositories/candidates-api.repository.js';
 import * as learnersApiRepository from '../../infrastructure/repositories/learners-api.repository.js';
 import * as userTeamsApiRepository from '../../infrastructure/repositories/user-teams-api.repository.js';
@@ -23,6 +23,7 @@ const path = dirname(fileURLToPath(import.meta.url));
 
 const repositories = {
   authenticationMethodRepository,
+  campaignParticipationsApiRepository,
   candidatesApiRepository,
   certificationCenterMembershipRepository,
   learnersApiRepository,
@@ -42,7 +43,7 @@ const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
 };
 
-const dependencies = Object.assign({ campaignParticipationsApi }, repositories);
+const dependencies = Object.assign({}, repositories);
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 

--- a/api/src/privacy/infrastructure/repositories/campaign-participations-api.repository.js
+++ b/api/src/privacy/infrastructure/repositories/campaign-participations-api.repository.js
@@ -1,0 +1,16 @@
+import * as campaignParticipationsApi from '../../../prescription/campaign-participation/application/api/campaign-participations-api.js';
+
+/**
+ * Checks if the user has been a candidate.
+ *
+ * @param {Object} params - The parameters.
+ * @param {string} params.userId - The ID of the user.
+ * @param {Object} [params.dependencies] - The dependencies.
+ * @param {Object} [params.dependencies.candidatesApi] - The candidates API.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the user has been a candidate.
+ */
+const hasCampaignParticipations = async ({ userId, dependencies = { campaignParticipationsApi } }) => {
+  return dependencies.campaignParticipationsApi.hasCampaignParticipations({ userId });
+};
+
+export { hasCampaignParticipations };

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/has-campaign-participations_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/has-campaign-participations_test.js
@@ -1,0 +1,46 @@
+import { hasCampaignParticipations } from '../../../../../../src/prescription/campaign-participation/domain/usecases/has-campaign-participations.js';
+import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Campaign participation | Usecase | Has campaign participations', function () {
+  beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((fn) => {
+      return fn({});
+    });
+  });
+
+  context('when user has campaign participations', function () {
+    it('returns true', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await hasCampaignParticipations({ userId, campaignParticipationRepository });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  context('when user has not campaign participations', function () {
+    it('returns false', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const user2Id = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({ userId: user2Id, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await hasCampaignParticipations({ userId, campaignParticipationRepository });
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -427,6 +427,46 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
+  describe('#getCampaignParticipationsCountByUserId', function () {
+    it('should return participations number', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+      });
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: otherUserId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const participations = await campaignParticipationRepository.getCampaignParticipationsCountByUserId({ userId });
+
+      // then
+      expect(participations).to.equal(2);
+    });
+
+    it('returns 0', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: otherUserId,
+      });
+      databaseBuilder.commit();
+
+      // when
+      const result = await campaignParticipationRepository.getCampaignParticipationsCountByUserId({ userId });
+
+      // then
+      expect(result).to.equal(0);
+    });
+  });
+
   describe('#update', function () {
     it('save the changes of the campaignParticipation', async function () {
       const campaignParticipationId = 12;

--- a/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
+++ b/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
@@ -10,7 +10,7 @@ describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function
     dependencies = {
       featureToggles,
       learnersApiRepository: { hasBeenLearner: sinon.stub().resolves(false) },
-      campaignParticipationsApi: {
+      campaignParticipationsApiRepository: {
         hasCampaignParticipations: sinon.stub(),
       },
       candidatesApiRepository: {
@@ -55,7 +55,7 @@ describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function
     context('When user has participated in a campaign', function () {
       it('returns false', async function () {
         // given
-        dependencies.campaignParticipationsApi.hasCampaignParticipations.withArgs({ userId }).resolves(true);
+        dependencies.campaignParticipationsApiRepository.hasCampaignParticipations.withArgs({ userId }).resolves(true);
 
         // when
         const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
@@ -68,7 +68,7 @@ describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function
     context('when user has not participated in a campaign', function () {
       it('returns true', async function () {
         // given
-        dependencies.campaignParticipationsApi.hasCampaignParticipations.withArgs({ userId }).resolves(false);
+        dependencies.campaignParticipationsApiRepository.hasCampaignParticipations.withArgs({ userId }).resolves(false);
 
         // when
         const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });

--- a/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
+++ b/api/tests/privacy/unit/domain/usecases/can-self-delete-account.usecase.test.js
@@ -10,7 +10,12 @@ describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function
     dependencies = {
       featureToggles,
       learnersApiRepository: { hasBeenLearner: sinon.stub().resolves(false) },
-      candidatesApiRepository: { hasBeenCandidate: sinon.stub().resolves(false) },
+      campaignParticipationsApi: {
+        hasCampaignParticipations: sinon.stub(),
+      },
+      candidatesApiRepository: {
+        hasBeenCandidate: sinon.stub().resolves(false),
+      },
       userTeamsApiRepository: {
         getUserTeamsInfo: sinon.stub().resolves({
           isPixAgent: false,
@@ -44,6 +49,32 @@ describe('Unit | Privacy | Domain | UseCase | can-self-delete-account', function
 
         // then
         expect(result).to.be.false;
+      });
+    });
+
+    context('When user has participated in a campaign', function () {
+      it('returns false', async function () {
+        // given
+        dependencies.campaignParticipationsApi.hasCampaignParticipations.withArgs({ userId }).resolves(true);
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    context('when user has not participated in a campaign', function () {
+      it('returns true', async function () {
+        // given
+        dependencies.campaignParticipationsApi.hasCampaignParticipations.withArgs({ userId }).resolves(false);
+
+        // when
+        const result = await usecases.canSelfDeleteAccount({ userId, ...dependencies });
+
+        // then
+        expect(result).to.be.true;
       });
     });
 

--- a/api/tests/privacy/unit/infrastructure/repositories/campaign-participations-api.repository.test.js
+++ b/api/tests/privacy/unit/infrastructure/repositories/campaign-participations-api.repository.test.js
@@ -1,0 +1,21 @@
+import { hasCampaignParticipations } from '../../../../../src/privacy/infrastructure/repositories/campaign-participations-api.repository.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Privacy | Infrastructure | Repositories | campaign-participations-api', function () {
+  describe('#hasCampaignParticipations', function () {
+    it('indicates if user has campaign participations', async function () {
+      // given
+      const dependencies = {
+        campaignParticipationsApi: {
+          hasCampaignParticipations: async () => true,
+        },
+      };
+
+      // when
+      const result = await hasCampaignParticipations({ userId: '123', dependencies });
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème
Un utilisateur ne doit pas pouvoir supprimer son compte en autonomie s’il remplit au moins un des critères suivants :
- Il est lié à au moins une ligne dans la table organization-learner
- Il est lié à au moins une ligne dans la table campaign-participations

## 🌳 Proposition
Rajouter une API interne dans le contexte Campaign Participations pour fournir au contexte Privacy l'information de la participation ou non à une campagne d'un utilisateur.

## 🤧 Pour tester
- Se créer un compte vierge sur Pix App puis s'y connecter.
- Ouvrir la page Mon Compte depuis le menu contextuel 
- Voir s'afficher le bouton "Supprimer mon compte"
- Revenir à l'accueil et lancer une campagne (par exemple EVAL12345)
- Revenir ensuite sur la page Mon Compte et constater que le bouton "Supprimer mon compte" est désormais absent
