### PR TITLE
[FEATURE] Renvoyer le certificat V3 pour un utilisateur connecté (PIX-17478).

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -43,8 +43,12 @@ const getCertificate = async function (request, h, dependencies = { requestRespo
 
   const certificationCourse = await certificationSharedUsecases.getCertificationCourse({ certificationCourseId });
 
-  if (!certificationCourse.isV3()) {
-    const certificate = await usecases.getPrivateCertificate({
+  let certificate;
+  if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
+    certificate = await usecases.getCertificationAttestation({ certificationCourseId: certificationCourse.getId() });
+    return certificateSerializer.serialize({ certificate, translate });
+  } else {
+    certificate = await usecases.getPrivateCertificate({
       userId,
       certificationCourseId: certificationCourse.getId(),
       locale,

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -41,12 +41,16 @@ const getCertificate = async function (request, h, dependencies = { requestRespo
   const translate = request.i18n.__;
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
-  const privateCertificate = await usecases.getPrivateCertificate({
-    userId,
-    certificationCourseId,
-    locale,
-  });
-  return privateCertificateSerializer.serialize(privateCertificate, { translate });
+  const certificationCourse = await certificationSharedUsecases.getCertificationCourse({ certificationCourseId });
+
+  if (!certificationCourse.isV3()) {
+    const certificate = await usecases.getPrivateCertificate({
+      userId,
+      certificationCourseId: certificationCourse.getId(),
+      locale,
+    });
+    return privateCertificateSerializer.serialize(certificate, { translate });
+  }
 };
 
 const findUserCertificates = async function (request) {

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -35,7 +35,11 @@ const getCertificateByVerificationCode = async function (
   return dependencies.certificateSerializer.serialize({ certificate, translate: i18n.__ });
 };
 
-const getCertificate = async function (request, h, dependencies = { requestResponseUtils }) {
+const getCertificate = async function (
+  request,
+  h,
+  dependencies = { requestResponseUtils, certificateSerializer, privateCertificateSerializer },
+) {
   const userId = request.auth.credentials.userId;
   const certificationCourseId = request.params.certificationCourseId;
   const translate = request.i18n.__;
@@ -46,14 +50,14 @@ const getCertificate = async function (request, h, dependencies = { requestRespo
   let certificate;
   if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
     certificate = await usecases.getCertificationAttestation({ certificationCourseId: certificationCourse.getId() });
-    return certificateSerializer.serialize({ certificate, translate });
+    return dependencies.certificateSerializer.serialize({ certificate, translate });
   } else {
     certificate = await usecases.getPrivateCertificate({
       userId,
       certificationCourseId: certificationCourse.getId(),
       locale,
     });
-    return privateCertificateSerializer.serialize(certificate, { translate });
+    return dependencies.privateCertificateSerializer.serialize(certificate, { translate });
   }
 };
 

--- a/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
@@ -49,6 +49,7 @@ const attributes = [
   'globalSummaryLabel',
   'globalDescriptionLabel',
   'certificationDate',
+  'verificationCode',
 ];
 
 const serialize = function ({ certificate, translate }) {

--- a/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/private-certificate-serializer.js
@@ -42,7 +42,6 @@ const attributes = [
   'certificationCenter',
   'pixScore',
   'status',
-  'status',
   'commentForCandidate',
   'resultCompetenceTree',
   'certifiedBadgeImages',

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -128,71 +128,81 @@ describe('Certification | Results | Unit | Application | certificate-controller'
   });
 
   describe('#getCertificate', function () {
-    it('should return a serialized private certificate given by id', async function () {
-      // given
-      const userId = 1;
-      const certificationCourseId = 2;
-      const request = {
-        auth: { credentials: { userId } },
-        params: { certificationCourseId },
-        i18n: getI18n(),
-      };
-      const locale = 'fr-fr';
-      const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
-      const privateCertificate = domainBuilder.buildPrivateCertificate.validated({
-        id: certificationCourseId,
-        firstName: 'Dorothé',
-        lastName: '2Pac',
-        birthdate: '2000-01-01',
-        birthplace: 'Sin City',
-        isPublished: true,
-        date: new Date('2020-01-01T00:00:00Z'),
-        deliveredAt: new Date('2021-01-01T00:00:00Z'),
-        certificationCenter: 'Centre des choux de Bruxelles',
-        pixScore: 456,
-        commentForCandidate: 'Cette personne est impolie !',
-        certifiedBadgeImages: [],
-        verificationCode: 'P-SUPERCODE',
-        maxReachableLevelOnCertificationDate: 6,
-        version: SESSIONS_VERSIONS.V3,
-      });
-      sinon.stub(usecases, 'getPrivateCertificate');
-      usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(privateCertificate);
-      requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
+    describe('when certification course version is V2', function () {
+      it('should return a serialized private certificate given by id', async function () {
+        // given
+        const userId = 1;
+        const certificationCourseId = 2;
+        const request = {
+          auth: { credentials: { userId } },
+          params: { certificationCourseId },
+          i18n: getI18n(),
+        };
+        const locale = 'fr-fr';
+        const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          id: certificationCourseId,
+          version: AlgorithmEngineVersion.V2,
+        });
+        const certificate = domainBuilder.buildPrivateCertificate.validated({
+          id: certificationCourseId,
+          firstName: 'Dorothé',
+          lastName: '2Pac',
+          birthdate: '2000-01-01',
+          birthplace: 'Sin City',
+          isPublished: true,
+          date: new Date('2020-01-01T00:00:00Z'),
+          deliveredAt: new Date('2021-01-01T00:00:00Z'),
+          certificationCenter: 'Centre des choux de Bruxelles',
+          pixScore: 456,
+          commentForCandidate: 'Cette personne est impolie !',
+          certifiedBadgeImages: [],
+          verificationCode: 'P-SUPERCODE',
+          maxReachableLevelOnCertificationDate: 6,
+          version: SESSIONS_VERSIONS.V3,
+        });
+        sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
+        certificationSharedUsecases.getCertificationCourse
+          .withArgs({ certificationCourseId })
+          .resolves(certificationCourse);
+        sinon.stub(usecases, 'getPrivateCertificate');
+        usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(certificate);
+        requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
-      // when
-      const response = await certificateController.getCertificate(request, hFake, {
-        requestResponseUtils: requestResponseUtilsStub,
-      });
+        // when
+        const response = await certificateController.getCertificate(request, hFake, {
+          requestResponseUtils: requestResponseUtilsStub,
+        });
 
-      // then
-      expect(response).to.deep.equal({
-        data: {
-          id: '2',
-          type: 'certifications',
-          attributes: {
-            'first-name': 'Dorothé',
-            'last-name': '2Pac',
-            birthdate: '2000-01-01',
-            birthplace: 'Sin City',
-            'certification-center': 'Centre des choux de Bruxelles',
-            date: new Date('2020-01-01T00:00:00Z'),
-            'delivered-at': new Date('2021-01-01T00:00:00Z'),
-            'is-published': true,
-            'pix-score': 456,
-            status: 'validated',
-            'comment-for-candidate': 'Cette personne est impolie !',
-            'certified-badge-images': [],
-            'verification-code': 'P-SUPERCODE',
-            'max-reachable-level-on-certification-date': 6,
-            version: SESSIONS_VERSIONS.V3,
-          },
-          relationships: {
-            'result-competence-tree': {
-              data: null,
+        // then
+        expect(response).to.deep.equal({
+          data: {
+            id: '2',
+            type: 'certifications',
+            attributes: {
+              'first-name': 'Dorothé',
+              'last-name': '2Pac',
+              birthdate: '2000-01-01',
+              birthplace: 'Sin City',
+              'certification-center': 'Centre des choux de Bruxelles',
+              date: new Date('2020-01-01T00:00:00Z'),
+              'delivered-at': new Date('2021-01-01T00:00:00Z'),
+              'is-published': true,
+              'pix-score': 456,
+              status: 'validated',
+              'comment-for-candidate': 'Cette personne est impolie !',
+              'certified-badge-images': [],
+              'verification-code': 'P-SUPERCODE',
+              'max-reachable-level-on-certification-date': 6,
+              version: SESSIONS_VERSIONS.V3,
+            },
+            relationships: {
+              'result-competence-tree': {
+                data: null,
+              },
             },
           },
-        },
+        });
       });
     });
   });

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -205,6 +205,162 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         });
       });
     });
+
+    describe('when certification course version is V3', function () {
+      describe('when isV3CertificationPageEnabled feature toggle is enabled', function () {
+        it('should return a serialized certificate given by id', async function () {
+          // given
+          const userId = 1;
+          const certificationCourseId = 2;
+          const request = {
+            auth: { credentials: { userId } },
+            params: { certificationCourseId },
+            i18n: getI18n(),
+          };
+          const locale = 'fr-fr';
+          await featureToggles.set('isV3CertificationPageEnabled', true);
+          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
+          const certificationCourse = domainBuilder.buildCertificationCourse({
+            id: certificationCourseId,
+            version: AlgorithmEngineVersion.V3,
+          });
+          const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+            id: certificationCourseId,
+            firstName: 'Dorothé',
+            lastName: '2Pac',
+            birthdate: '2000-01-01',
+            birthplace: 'Sin City',
+            deliveredAt: new Date('2021-01-01T00:00:00Z'),
+            certificationCenter: 'Centre des choux de Bruxelles',
+            pixScore: 456,
+            verificationCode: 'P-SUPERCODE',
+            resultCompetenceTree: null,
+            algorithmEngineVersion: AlgorithmEngineVersion.V3,
+            certificationDate: new Date('2020-01-01T00:00:00Z'),
+          });
+          sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
+          certificationSharedUsecases.getCertificationCourse
+            .withArgs({ certificationCourseId })
+            .resolves(certificationCourse);
+          sinon.stub(usecases, 'getCertificationAttestation');
+          usecases.getCertificationAttestation.withArgs({ certificationCourseId }).resolves(certificate);
+          requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
+
+          // when
+          const response = await certificateController.getCertificate(request, hFake, {
+            requestResponseUtils: requestResponseUtilsStub,
+          });
+
+          // then
+          const translate = getI18n().__;
+          expect(response).to.deep.equal({
+            data: {
+              id: '2',
+              type: 'certifications',
+              attributes: {
+                'first-name': 'Dorothé',
+                'last-name': '2Pac',
+                birthdate: '2000-01-01',
+                birthplace: 'Sin City',
+                'certification-center': 'Centre des choux de Bruxelles',
+                'certification-date': new Date('2020-01-01T00:00:00Z'),
+                'delivered-at': new Date('2021-01-01T00:00:00Z'),
+                'pix-score': 456,
+                'algorithm-engine-version': AlgorithmEngineVersion.V3,
+                'verification-code': 'P-SUPERCODE',
+                'global-level-label': certificate.globalLevel.getLevelLabel(translate),
+                'global-summary-label': certificate.globalLevel.getSummaryLabel(translate),
+                'global-description-label': certificate.globalLevel.getDescriptionLabel(translate),
+              },
+              relationships: {
+                'result-competence-tree': {
+                  data: null,
+                },
+              },
+            },
+          });
+        });
+      });
+
+      describe('when isV3CertificationPageEnabled feature toggle is disabled', function () {
+        it('should return a serialized private certificate given by id', async function () {
+          // given
+          const userId = 1;
+          const certificationCourseId = 2;
+          const request = {
+            auth: { credentials: { userId } },
+            params: { certificationCourseId },
+            i18n: getI18n(),
+          };
+          const locale = 'fr-fr';
+          await featureToggles.set('isV3CertificationPageEnabled', false);
+          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
+          const certificationCourse = domainBuilder.buildCertificationCourse({
+            id: certificationCourseId,
+            version: AlgorithmEngineVersion.V3,
+          });
+          const certificate = domainBuilder.buildPrivateCertificate.validated({
+            id: certificationCourseId,
+            firstName: 'Dorothé',
+            lastName: '2Pac',
+            birthdate: '2000-01-01',
+            birthplace: 'Sin City',
+            isPublished: true,
+            date: new Date('2020-01-01T00:00:00Z'),
+            deliveredAt: new Date('2021-01-01T00:00:00Z'),
+            certificationCenter: 'Centre des choux de Bruxelles',
+            pixScore: 456,
+            commentForCandidate: 'Cette personne est impolie !',
+            certifiedBadgeImages: [],
+            verificationCode: 'P-SUPERCODE',
+            maxReachableLevelOnCertificationDate: 6,
+            version: SESSIONS_VERSIONS.V3,
+          });
+          sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
+          certificationSharedUsecases.getCertificationCourse
+            .withArgs({ certificationCourseId })
+            .resolves(certificationCourse);
+          sinon.stub(usecases, 'getPrivateCertificate');
+          usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(certificate);
+          requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
+
+          // when
+          const response = await certificateController.getCertificate(request, hFake, {
+            requestResponseUtils: requestResponseUtilsStub,
+          });
+
+          // then
+          expect(response).to.deep.equal({
+            data: {
+              id: '2',
+              type: 'certifications',
+              attributes: {
+                'first-name': 'Dorothé',
+                'last-name': '2Pac',
+                birthdate: '2000-01-01',
+                birthplace: 'Sin City',
+                'certification-center': 'Centre des choux de Bruxelles',
+                date: new Date('2020-01-01T00:00:00Z'),
+                'delivered-at': new Date('2021-01-01T00:00:00Z'),
+                'is-published': true,
+                'pix-score': 456,
+                status: 'validated',
+                'comment-for-candidate': 'Cette personne est impolie !',
+                'certified-badge-images': [],
+                'verification-code': 'P-SUPERCODE',
+                'max-reachable-level-on-certification-date': 6,
+                version: SESSIONS_VERSIONS.V3,
+              },
+              relationships: {
+                'result-competence-tree': {
+                  data: null,
+                },
+              },
+            },
+          });
+        });
+      });
+    });
   });
 
   describe('#findUserCertificates', function () {

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -129,7 +129,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
 
   describe('#getCertificate', function () {
     describe('when certification course version is V2', function () {
-      it('should return a serialized private certificate given by id', async function () {
+      it('should return a serialized private certificate', async function () {
         // given
         const userId = 1;
         const certificationCourseId = 2;
@@ -139,76 +139,44 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           i18n: getI18n(),
         };
         const locale = 'fr-fr';
-        const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
         const certificationCourse = domainBuilder.buildCertificationCourse({
           id: certificationCourseId,
           version: AlgorithmEngineVersion.V2,
         });
-        const certificate = domainBuilder.buildPrivateCertificate.validated({
-          id: certificationCourseId,
-          firstName: 'Dorothé',
-          lastName: '2Pac',
-          birthdate: '2000-01-01',
-          birthplace: 'Sin City',
-          isPublished: true,
-          date: new Date('2020-01-01T00:00:00Z'),
-          deliveredAt: new Date('2021-01-01T00:00:00Z'),
-          certificationCenter: 'Centre des choux de Bruxelles',
-          pixScore: 456,
-          commentForCandidate: 'Cette personne est impolie !',
-          certifiedBadgeImages: [],
-          verificationCode: 'P-SUPERCODE',
-          maxReachableLevelOnCertificationDate: 6,
-          version: SESSIONS_VERSIONS.V3,
-        });
+        const certificate = Symbol('V2 private certificate');
         sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
         certificationSharedUsecases.getCertificationCourse
           .withArgs({ certificationCourseId })
           .resolves(certificationCourse);
         sinon.stub(usecases, 'getPrivateCertificate');
         usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(certificate);
+
+        const privateCertificateSerializerStub = {
+          serialize: sinon.stub(),
+        };
+
+        const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
         requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
-        // when
-        const response = await certificateController.getCertificate(request, hFake, {
+        const dependencies = {
           requestResponseUtils: requestResponseUtilsStub,
-        });
+          privateCertificateSerializer: privateCertificateSerializerStub,
+        };
+
+        // when
+        await certificateController.getCertificate(request, hFake, dependencies);
 
         // then
-        expect(response).to.deep.equal({
-          data: {
-            id: '2',
-            type: 'certifications',
-            attributes: {
-              'first-name': 'Dorothé',
-              'last-name': '2Pac',
-              birthdate: '2000-01-01',
-              birthplace: 'Sin City',
-              'certification-center': 'Centre des choux de Bruxelles',
-              date: new Date('2020-01-01T00:00:00Z'),
-              'delivered-at': new Date('2021-01-01T00:00:00Z'),
-              'is-published': true,
-              'pix-score': 456,
-              status: 'validated',
-              'comment-for-candidate': 'Cette personne est impolie !',
-              'certified-badge-images': [],
-              'verification-code': 'P-SUPERCODE',
-              'max-reachable-level-on-certification-date': 6,
-              version: SESSIONS_VERSIONS.V3,
-            },
-            relationships: {
-              'result-competence-tree': {
-                data: null,
-              },
-            },
-          },
+        const translate = getI18n().__;
+        expect(dependencies.privateCertificateSerializer.serialize).to.have.been.calledWithExactly(certificate, {
+          translate,
         });
       });
     });
 
     describe('when certification course version is V3', function () {
       describe('when isV3CertificationPageEnabled feature toggle is enabled', function () {
-        it('should return a serialized certificate given by id', async function () {
+        it('should return a serialized certificate', async function () {
           // given
           const userId = 1;
           const certificationCourseId = 2;
@@ -217,67 +185,40 @@ describe('Certification | Results | Unit | Application | certificate-controller'
             params: { certificationCourseId },
             i18n: getI18n(),
           };
-          const locale = 'fr-fr';
           await featureToggles.set('isV3CertificationPageEnabled', true);
-          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           const certificationCourse = domainBuilder.buildCertificationCourse({
             id: certificationCourseId,
             version: AlgorithmEngineVersion.V3,
           });
-          const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
-            id: certificationCourseId,
-            firstName: 'Dorothé',
-            lastName: '2Pac',
-            birthdate: '2000-01-01',
-            birthplace: 'Sin City',
-            deliveredAt: new Date('2021-01-01T00:00:00Z'),
-            certificationCenter: 'Centre des choux de Bruxelles',
-            pixScore: 456,
-            verificationCode: 'P-SUPERCODE',
-            resultCompetenceTree: null,
-            algorithmEngineVersion: AlgorithmEngineVersion.V3,
-            certificationDate: new Date('2020-01-01T00:00:00Z'),
-          });
+          const certificate = Symbol('V3 certificate');
           sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
           certificationSharedUsecases.getCertificationCourse
             .withArgs({ certificationCourseId })
             .resolves(certificationCourse);
           sinon.stub(usecases, 'getCertificationAttestation');
           usecases.getCertificationAttestation.withArgs({ certificationCourseId }).resolves(certificate);
+
+          const certificateSerializerStub = {
+            serialize: sinon.stub(),
+          };
+
+          const locale = 'fr-fr';
+          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
-          // when
-          const response = await certificateController.getCertificate(request, hFake, {
+          const dependencies = {
             requestResponseUtils: requestResponseUtilsStub,
-          });
+            certificateSerializer: certificateSerializerStub,
+          };
+
+          // when
+          await certificateController.getCertificate(request, hFake, dependencies);
 
           // then
           const translate = getI18n().__;
-          expect(response).to.deep.equal({
-            data: {
-              id: '2',
-              type: 'certifications',
-              attributes: {
-                'first-name': 'Dorothé',
-                'last-name': '2Pac',
-                birthdate: '2000-01-01',
-                birthplace: 'Sin City',
-                'certification-center': 'Centre des choux de Bruxelles',
-                'certification-date': new Date('2020-01-01T00:00:00Z'),
-                'delivered-at': new Date('2021-01-01T00:00:00Z'),
-                'pix-score': 456,
-                'algorithm-engine-version': AlgorithmEngineVersion.V3,
-                'verification-code': 'P-SUPERCODE',
-                'global-level-label': certificate.globalLevel.getLevelLabel(translate),
-                'global-summary-label': certificate.globalLevel.getSummaryLabel(translate),
-                'global-description-label': certificate.globalLevel.getDescriptionLabel(translate),
-              },
-              relationships: {
-                'result-competence-tree': {
-                  data: null,
-                },
-              },
-            },
+          expect(dependencies.certificateSerializer.serialize).to.have.been.calledWithExactly({
+            translate,
+            certificate,
           });
         });
       });
@@ -287,76 +228,44 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           // given
           const userId = 1;
           const certificationCourseId = 2;
+          const locale = 'fr-fr';
           const request = {
             auth: { credentials: { userId } },
             params: { certificationCourseId },
             i18n: getI18n(),
           };
-          const locale = 'fr-fr';
           await featureToggles.set('isV3CertificationPageEnabled', false);
-          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           const certificationCourse = domainBuilder.buildCertificationCourse({
             id: certificationCourseId,
             version: AlgorithmEngineVersion.V3,
           });
-          const certificate = domainBuilder.buildPrivateCertificate.validated({
-            id: certificationCourseId,
-            firstName: 'Dorothé',
-            lastName: '2Pac',
-            birthdate: '2000-01-01',
-            birthplace: 'Sin City',
-            isPublished: true,
-            date: new Date('2020-01-01T00:00:00Z'),
-            deliveredAt: new Date('2021-01-01T00:00:00Z'),
-            certificationCenter: 'Centre des choux de Bruxelles',
-            pixScore: 456,
-            commentForCandidate: 'Cette personne est impolie !',
-            certifiedBadgeImages: [],
-            verificationCode: 'P-SUPERCODE',
-            maxReachableLevelOnCertificationDate: 6,
-            version: SESSIONS_VERSIONS.V3,
-          });
+          const certificate = Symbol('V2 private certificate');
           sinon.stub(certificationSharedUsecases, 'getCertificationCourse');
           certificationSharedUsecases.getCertificationCourse
             .withArgs({ certificationCourseId })
             .resolves(certificationCourse);
           sinon.stub(usecases, 'getPrivateCertificate');
           usecases.getPrivateCertificate.withArgs({ userId, certificationCourseId, locale }).resolves(certificate);
+
+          const privateCertificateSerializerStub = {
+            serialize: sinon.stub(),
+          };
+
+          const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
           requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
-          // when
-          const response = await certificateController.getCertificate(request, hFake, {
+          const dependencies = {
             requestResponseUtils: requestResponseUtilsStub,
-          });
+            privateCertificateSerializer: privateCertificateSerializerStub,
+          };
+
+          // when
+          await certificateController.getCertificate(request, hFake, dependencies);
 
           // then
-          expect(response).to.deep.equal({
-            data: {
-              id: '2',
-              type: 'certifications',
-              attributes: {
-                'first-name': 'Dorothé',
-                'last-name': '2Pac',
-                birthdate: '2000-01-01',
-                birthplace: 'Sin City',
-                'certification-center': 'Centre des choux de Bruxelles',
-                date: new Date('2020-01-01T00:00:00Z'),
-                'delivered-at': new Date('2021-01-01T00:00:00Z'),
-                'is-published': true,
-                'pix-score': 456,
-                status: 'validated',
-                'comment-for-candidate': 'Cette personne est impolie !',
-                'certified-badge-images': [],
-                'verification-code': 'P-SUPERCODE',
-                'max-reachable-level-on-certification-date': 6,
-                version: SESSIONS_VERSIONS.V3,
-              },
-              relationships: {
-                'result-competence-tree': {
-                  data: null,
-                },
-              },
-            },
+          const translate = getI18n().__;
+          expect(dependencies.privateCertificateSerializer.serialize).to.have.been.calledWithExactly(certificate, {
+            translate,
           });
         });
       });

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
@@ -201,6 +201,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
             'first-name': 'Jean',
             'last-name': 'Bon',
             'pix-score': 123,
+            'verification-code': 'P-SOMECODE',
             'global-level-label': shareableCertificate.globalLevel.getLevelLabel(translate),
             'global-summary-label': shareableCertificate.globalLevel.getSummaryLabel(translate),
             'global-description-label': shareableCertificate.globalLevel.getDescriptionLabel(translate),


### PR DESCRIPTION
## 🌸 Problème

Le nouveau visuel du certificat en ligne viendra en remplacement de la version actuelle pour toutes les certifications Pix v3 (rétroactivité).
Cette nouvelle version du certificat en ligne doit pouvoir être consultée par un vérificateur (utilisateur non authentifié - cf tickets précédents) mais aussi par le candidat ayant obtenu cette certification (utilisateur authentifié), cas de cette PR.

## 🌳 Proposition

Utilisation de la route existante et ajout d'une condition pour vérifier la version de l'algo utilisé dans le cadre de la certif (en plus du FT)

## 🐝 Remarques

Après discussion et étude de la complexité induite par le fait de créer une nouvelle route unique comme prévu initialement, nous avons décidé de conserver les deux routes initiales et n’introduire qu’une seule condition par route au lieu d’une imbrication de conditions dans une route unique.

## 🤧 Pour tester

avec le FT  `isV3CertificationPageEnabled` à `true` ou `false`

Voir l'intégralité des certificat/attestation (une certification V3 et une V2) dans l'ancien format.
Se connecter avec le candidat : `certif-success@example.net`

