### PR TITLE
[TECH] Rendre la colonne userId nullable dans la table badge-acquisitions (PIX-16569)

### DIFF
--- a/api/db/migrations/20250416084952_make-userId-nullable-in-badge-acquisitions.js
+++ b/api/db/migrations/20250416084952_make-userId-nullable-in-badge-acquisitions.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'badge-acquisitions';
+const COLUMN_NAME = 'userId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème
Suite de nos travaux sur le chantier de l'anonymisation, on souhaite pouvoir vider le champ userId de la table badge-acquisitions. Ce qui n'est pas possible actuellement car le champ n'est pas nullable

## 🌳 Proposition
Créer une migration afin de rendre ce champ nullable

## 🐝 Remarques
Pas sur après coup que le down serve a quelque chose 🤔 Car dans le cas ou on vide un userId suite au passage de cette migration. La remise de la contrainte sur ce champ ferait crash 

## 🤧 Pour tester

- Se connecter a psql-console, sur la RA via le cli scalingo : `scalingo -a pix-api-review-pr12082 psql-console`
- Aller se faire un café le temps que scalingo réponde :trollface: 
- Lancer la commande `\d "badge-acquisitions";`
- Vérifier que la colonne "userId" est nullable
- 🐈‍⬛ 