### PR TITLE
[FEATURE] Script de reprise de données d'acceptation de CGU pour les utilisateurs anonymisés (PIX-17272) 

### DIFF
--- a/api/src/legal-documents/scripts/backfill-data-for-anonymized-users-script.js
+++ b/api/src/legal-documents/scripts/backfill-data-for-anonymized-users-script.js
@@ -1,0 +1,43 @@
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
+import { anonymizeGeneralizeDate } from '../../shared/infrastructure/utils/date-utils.js';
+
+export class BackfillDataForAnonymizedUsersScript extends Script {
+  constructor() {
+    super({
+      description: 'Backfills accept date for anonymized users',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run in dry mode ',
+          demandOption: false,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { dryRun } = options;
+    const knexConnection = DomainTransaction.getConnection();
+    const rows = await knexConnection('legal-document-version-user-acceptances as a')
+      .select('a.id', 'a.acceptedAt')
+      .join('users as u', 'a.userId', 'u.id')
+      .where('u.hasBeenAnonymised', true);
+    logger.info(`Found ${rows.length} anonymized rows to ${dryRun ? 'process (dry run)' : 'update'}`);
+    if (!dryRun) {
+      for (const row of rows) {
+        const generalizedDate = anonymizeGeneralizeDate(row.acceptedAt);
+        await knexConnection('legal-document-version-user-acceptances')
+          .where('id', row.id)
+          .update({ acceptedAt: generalizedDate });
+      }
+      logger.info(`✅ Successfully updated ${rows.length} rows.`);
+    } else {
+      logger.info(`Dry run complete. No updates performed.`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, BackfillDataForAnonymizedUsersScript);

--- a/api/tests/legal-documents/integration/scripts/backfill-data-for-anonymized-users-script.test.js
+++ b/api/tests/legal-documents/integration/scripts/backfill-data-for-anonymized-users-script.test.js
@@ -1,0 +1,66 @@
+import { BackfillDataForAnonymizedUsersScript } from '../../../../src/legal-documents/scripts/backfill-data-for-anonymized-users-script.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Integration | LegalDocuments | Scripts | backfill-data-for-anonymized-users', function () {
+  it('backfills acceptedAt in legal document version user acceptances he anonymized users', async function () {
+    // given
+    const acceptanceDate1 = new Date('2023-03-23T23:23:23Z');
+    const acceptanceDate2 = new Date('2022-02-22T22:22:22Z');
+    const admin = databaseBuilder.factory.buildUser.withRole();
+    const legacyAnonymizedUser1 = databaseBuilder.factory.buildUser({
+      firstName: 'Jane',
+      hasBeenAnonymised: true,
+      hasBeenAnonymisedBy: admin.id,
+    });
+    const legacyAnonymizedUser2 = databaseBuilder.factory.buildUser({
+      firstName: 'John',
+      hasBeenAnonymised: true,
+      hasBeenAnonymisedBy: admin.id,
+    });
+    const notAnonymousUser = databaseBuilder.factory.buildUser({
+      firstName: 'Jack',
+      hasBeenAnonymised: false,
+    });
+    const documentVersion = databaseBuilder.factory.buildLegalDocumentVersion({
+      service: 'pix-app',
+      type: 'TOS',
+      versionAt: new Date('2022-01-01'),
+    });
+    databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+      userId: legacyAnonymizedUser1.id,
+      legalDocumentVersionId: documentVersion.id,
+      acceptedAt: acceptanceDate1,
+    });
+    databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+      userId: legacyAnonymizedUser2.id,
+      legalDocumentVersionId: documentVersion.id,
+      acceptedAt: acceptanceDate2,
+    });
+    databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+      userId: notAnonymousUser.id,
+      legalDocumentVersionId: documentVersion.id,
+      acceptedAt: acceptanceDate2,
+    });
+    await databaseBuilder.commit();
+    const script = new BackfillDataForAnonymizedUsersScript();
+
+    // when
+    await script.handle({ logger, options: { dryRun: false } });
+
+    // then
+    const foundUser1Acceptances = await knex('legal-document-version-user-acceptances')
+      .where({ userId: legacyAnonymizedUser1.id })
+      .first();
+    const foundUser2Acceptances = await knex('legal-document-version-user-acceptances')
+      .where({ userId: legacyAnonymizedUser2.id })
+      .first();
+    const foundNonAnonymizedUserAcceptances = await knex('legal-document-version-user-acceptances')
+      .where({ userId: notAnonymousUser.id })
+      .first();
+
+    expect(foundUser1Acceptances.acceptedAt.toISOString()).to.deep.equal('2023-03-01T00:00:00.000Z');
+    expect(foundUser2Acceptances.acceptedAt.toISOString()).to.deep.equal('2022-02-01T00:00:00.000Z');
+    expect(foundNonAnonymizedUserAcceptances.acceptedAt.toISOString()).to.deep.equal('2022-02-22T22:22:22.000Z');
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

les informations à caractère personnel d'acceptation des CGU sont maintenant stockées dans la nouvelle table `legal-document-version-user-acceptances`, et elles n'ont pas été anonymisées par le usecase `api/src/privacy/domain/usecases/anonymize-user.usecase.js` avant correction


## 🌳 Proposition

Faire un script de reprise de données pour anonymiser le champ updatedAt des utilisateurs anonymisés (`hasBeenAnonymised = true` dans la table `users`) ayant une entrée (`userId`) dans la table `legal-document-version-user-acceptances`

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Choisir plusieurs `userId` dans la table `legal-document-version-user-acceptances`
- Sur Pix Admin, anonymiser ces utilisateurs
- Lancer le script en dryRun

   ```shell
   node src/legal-documents/scripts/backfill-data-for-anonymized-users.js --dryRun
  ```

- Vérifier que le nombre de nombre d'acceptances à modifier est correct
- Lancer le script sans dryRun

   ```shell
   node src/legal-documents/scripts/backfill-data-for-anonymized-users.js
  ```

- Vérifier que pour les utilisateurs anonymisés, le champ `acceptedAt` de la table `legal-document-version-user-acceptances` a été ramené au premier du mois à 00:00

