### PR TITLE
[FEATURE] Afficher la jauge pour le certificat V3 sur Pix App (PIX-17545).

### DIFF
--- a/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
@@ -48,6 +48,7 @@ const attributes = [
   'globalLevelLabel',
   'globalSummaryLabel',
   'globalDescriptionLabel',
+  'level',
   'certificationDate',
   'verificationCode',
 ];
@@ -60,6 +61,7 @@ const serialize = function ({ certificate, translate }) {
       globalLevelLabel: certificate.globalLevel.getLevelLabel(translate),
       globalSummaryLabel: certificate.globalLevel.getSummaryLabel(translate),
       globalDescriptionLabel: certificate.globalLevel.getDescriptionLabel(translate),
+      level: _getLevel(certificate),
     };
   }
   return new Serializer('certifications', {
@@ -74,5 +76,9 @@ const serialize = function ({ certificate, translate }) {
     resultCompetenceTree,
   }).serialize(certificate);
 };
+
+function _getLevel(certificate) {
+  return certificate.globalLevel.meshLevel.split('_').at(-1);
+}
 
 export { serialize };

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
@@ -205,6 +205,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
             'global-level-label': shareableCertificate.globalLevel.getLevelLabel(translate),
             'global-summary-label': shareableCertificate.globalLevel.getSummaryLabel(translate),
             'global-description-label': shareableCertificate.globalLevel.getDescriptionLabel(translate),
+            level: '1',
             'certification-date': new Date('2015-10-03T01:02:03Z'),
           },
           relationships: {

--- a/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
@@ -1,30 +1,59 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixGauge from '@1024pix/pix-ui/components/pix-gauge';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-<template>
-  <div class="certification-score-information">
-    <p>{{t "pages.certificate.certification-value.paragraphs.1"}}</p>
-    <p>{{t "pages.certificate.certification-value.paragraphs.2"}}</p>
-    <p class="certification-score-information--bold">{{t "pages.certificate.certification-value.paragraphs.3"}}</p>
-  </div>
+export default class candidateGlobalLevel extends Component {
+  @service intl;
 
-  <PixBlock class="candidate-global-information">
-    <div class="candidate-global-information__level">
-      <img
-        class="candidate-global-information-level__image"
-        src="/images/certificate/global-level-image.svg"
-        alt=""
-        role="presentation"
+  get stepLabels() {
+    return [
+      this.intl.t('pages.certificate.global.labels.beginner'),
+      this.intl.t('pages.certificate.global.labels.independent'),
+      this.intl.t('pages.certificate.global.labels.advanced'),
+      this.intl.t('pages.certificate.global.labels.expert'),
+    ];
+  }
+
+  <template>
+    <div class="certification-score-information">
+      <p>{{t "pages.certificate.certification-value.paragraphs.1"}}</p>
+      <p>{{t "pages.certificate.certification-value.paragraphs.2"}}</p>
+      <p class="certification-score-information--bold">{{t "pages.certificate.certification-value.paragraphs.3"}}</p>
+    </div>
+
+    <div class="hide-on-mobile global-level-gauge">
+      <PixGauge
+        @label={{t
+          "pages.certificate.global.progressbar-explanation"
+          level=@certificate.level
+          globalLevelLabel=@certificate.globalLevelLabel
+        }}
+        @reachedLevel={{@certificate.level}}
+        @maxLevel="7"
+        @stepLabels={{this.stepLabels}}
       />
-      <div class="candidate-global-information-level__container">
-        <h2>{{t "pages.certificate.global-level"}}</h2>
-        <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+    </div>
+
+    <PixBlock class="candidate-global-information">
+      <div class="candidate-global-information__level">
+        <img
+          class="candidate-global-information-level__image"
+          src="/images/certificate/global-level-image.svg"
+          alt=""
+          role="presentation"
+        />
+        <div class="candidate-global-information-level__container">
+          <h2>{{t "pages.certificate.global.labels.level"}}</h2>
+          <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+        </div>
       </div>
-    </div>
-    <div>
-      <p class="candidate-global-information--bold">{{@certificate.globalSummaryLabel}}</p>
-      <p>{{@certificate.globalDescriptionLabel}}</p>
-    </div>
-  </PixBlock>
-</template>
+      <div>
+        <p class="candidate-global-information--bold">{{@certificate.globalSummaryLabel}}</p>
+        <p>{{@certificate.globalDescriptionLabel}}</p>
+      </div>
+    </PixBlock>
+  </template>
+}

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -32,6 +32,7 @@ export default class Certification extends Model {
   @attr('string') globalSummaryLabel;
   @attr('string') globalDescriptionLabel;
   @attr('date') certificationDate;
+  @attr('string') level;
 
   // includes
   @belongsTo('result-competence-tree', { async: true, inverse: null }) resultCompetenceTree;

--- a/mon-pix/app/styles/components/certifications/certificate-information/_candidate-global-level.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_candidate-global-level.scss
@@ -60,3 +60,7 @@
     }
   }
 }
+
+.global-level-gauge {
+  margin-bottom: var(--pix-spacing-10x);
+}

--- a/mon-pix/app/styles/globals/_a11y.scss
+++ b/mon-pix/app/styles/globals/_a11y.scss
@@ -1,3 +1,5 @@
+@use 'pix-design-tokens/breakpoints';
+
 .sr-only {
   position: absolute;
   display: block;
@@ -19,4 +21,10 @@
   background-repeat: no-repeat;
   background-size: 1rem;
   content: '';
+}
+
+@include breakpoints.device-is('mobile') {
+  .hide-on-mobile {
+    display: none;
+  }
 }

--- a/mon-pix/tests/integration/components/certifications/certificate-information/candidate-global-level-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/candidate-global-level-test.gjs
@@ -19,12 +19,13 @@ module('Integration | Component | Certifications | Certificate information | can
       certificationDate: new Date('2018-02-15T15:15:52Z'),
       deliveredAt: new Date('2018-02-17T15:15:52Z'),
       certificationCenter: 'Université de Lyon',
-      pixScore: 654,
+      pixScore: 840,
       resultCompetenceTree: store.createRecord('result-competence-tree'),
       maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
       globalLevelLabel: 'Expert 1',
       globalDescriptionLabel: 'Vous êtes capable de tout.',
       globalSummaryLabel: 'Expert de tous les domaines, Pix vous dit bravo !',
+      level: '7',
     });
     this.set('certification', certification);
 
@@ -33,9 +34,19 @@ module('Integration | Component | Certifications | Certificate information | can
       <Certifications::CertificateInformation::candidateGlobalLevel @certificate={{this.certification}} />`);
 
     // then
-    assert.dom(screen.getByRole('heading', { name: t('pages.certificate.global-level'), level: 2 })).exists();
+    assert.dom(screen.getByRole('heading', { name: t('pages.certificate.global.labels.level'), level: 2 })).exists();
     assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
     assert.dom(screen.getByText(certification.globalDescriptionLabel)).exists();
     assert.dom(screen.getByText(certification.globalSummaryLabel)).exists();
+    assert
+      .dom(
+        screen.getByRole('progressbar', {
+          name: t('pages.certificate.global.progressbar-explanation', {
+            level: certification.level,
+            globalLevelLabel: certification.globalLevelLabel,
+          }),
+        }),
+      )
+      .exists();
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -645,7 +645,16 @@
         }
       },
       "exam-date": "Completion date:",
-      "global-level": "Your level",
+      "global": {
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        },
+        "progressbar-explanation": "Bar de progression indiquant votre niveau atteint ( {level}, ou niveau {globalLevelLabel} ) sur un niveau maximum atteignable de 7 ( niveau Expert 1 )"
+      },
       "hexagon-score": {
         "certified": "certified"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -612,7 +612,16 @@
       }
     },
     "certificate": {
-      "global-level": "Your level",
+      "global": {
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        }
+      },
       "certification-value": {
         "paragraphs": {
           "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -645,7 +645,16 @@
         }
       },
       "exam-date": "Date de passage :",
-      "global-level": "Votre niveau",
+      "global": {
+        "labels": {
+          "advanced": "Avancé",
+          "beginner": "Novice",
+          "expert": "Expert",
+          "independent": "Indépendant",
+          "level": "Votre niveau"
+        },
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+      },
       "hexagon-score": {
         "certified": "certifiés"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -612,7 +612,16 @@
       }
     },
     "certificate": {
-      "global-level": "Your level",
+      "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
+      "global": {
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        }
+      },
       "certification-value": {
         "paragraphs": {
           "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",


### PR DESCRIPTION
## 🌸 Problème

La nouvelle page V3 pour le certificat n'est toujours pas designé.

## 🌳 Proposition

Ajouter la jauge dans le composant candidateGlobalLevel

## 🐝 Remarques

On profite de faire de l'API pour obtenir le niveau via le meshLevel, nécessaire pour la jauge

## 🤧 Pour tester

1. Tester le responsive, la jauge ne doit pas s'afficher
2. Tester avec le FT en true et false !
3. Me demander pour avoir plusieurs score et voir la jauge bouger

https://app-pr12088.review.pix.fr/verification-certificat


avec le FT à `true` 

V3 :
- Avec le code `P-XCCJKPHF`,
je suis censé voir la nouvelle page, avec la jauge !


<img width="1302" alt="Capture d’écran 2025-04-17 à 12 00 44" src="https://github.com/user-attachments/assets/dce56440-8d12-4261-934e-f6749dd54a50" />

V2 :
- Avec le code `P-V9XRPJYV`,
je suis censé voir l'ancienne page


avec le FT à `false` 

V3 :
- Avec le code `P-XCCJKPHF`,
je suis censé voir l'ancienne page

V2 :
- Avec le code `P-V9XRPJYV`,
je suis censé voir l'ancienne page

