### PR TITLE
[FEATURE] Utiliser la campaignParticipationId pour récupérer les paliers atteint lors d'une campagne (Pix-17331)

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/stage-acquisition-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/stage-acquisition-repository.js
@@ -2,7 +2,6 @@ import {
   CAMPAIGN_PARTICIPATION_ID_COLUMN,
   STAGE_ACQUISITIONS_TABLE_NAME,
   STAGE_ID_COLUMN,
-  USER_ID_COLUMN,
 } from '../../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { StageAcquisition } from '../../domain/models/StageAcquisition.js';
@@ -66,26 +65,6 @@ const getStageIdsByCampaignParticipation = async (campaignParticipationsId) => {
 };
 
 /**
- * @param {number} campaignId
- * @param {number} userId
- *
- * @returns {Promise<StageAcquisition[]>}
- */
-const getByCampaignIdAndUserId = async (campaignId, userId) =>
-  toDomain(
-    await buildSelectAllQuery()
-      .join(
-        'campaign-participations',
-        'campaign-participations.id',
-        `${STAGE_ACQUISITIONS_TABLE_NAME}.${CAMPAIGN_PARTICIPATION_ID_COLUMN}`,
-      )
-      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-      .where('campaigns.id', campaignId)
-      .where(`${STAGE_ACQUISITIONS_TABLE_NAME}.${USER_ID_COLUMN}`, userId)
-      .orderBy(`${STAGE_ACQUISITIONS_TABLE_NAME}.id`),
-  );
-
-/**
  * @param {Stage[]} stages
  * @param {number} userId
  * @param {number} campaignParticipationId
@@ -102,10 +81,4 @@ const saveStages = async (stages, userId, campaignParticipationId) => {
   return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME).insert(acquiredStages);
 };
 
-export {
-  getByCampaignIdAndUserId,
-  getByCampaignParticipation,
-  getByCampaignParticipations,
-  getStageIdsByCampaignParticipation,
-  saveStages,
-};
+export { getByCampaignParticipation, getByCampaignParticipations, getStageIdsByCampaignParticipation, saveStages };

--- a/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-user-campaign-assessment-result.js
@@ -52,7 +52,7 @@ const getUserCampaignAssessmentResult = async function ({
 
     const [stages, acquiredStages] = await Promise.all([
       stageRepository.getByCampaignId(campaignId),
-      stageAcquisitionRepository.getByCampaignIdAndUserId(campaignId, userId),
+      stageAcquisitionRepository.getByCampaignParticipation(campaignParticipation.id),
     ]);
 
     const stagesAndAcquiredStagesComparison = compareStagesAndAcquiredStages.compare(stages, acquiredStages);

--- a/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -1,6 +1,5 @@
 import { StageAcquisition } from '../../../../../src/evaluation/domain/models/StageAcquisition.js';
 import {
-  getByCampaignIdAndUserId,
   getByCampaignParticipation,
   getByCampaignParticipations,
   getStageIdsByCampaignParticipation,
@@ -8,7 +7,7 @@ import {
 } from '../../../../../src/evaluation/infrastructure/repositories/stage-acquisition-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
-describe('Integration | Repository | Stage Acquisition', function () {
+describe('Evaluation | Integration | Repository | Stage Acquisition', function () {
   describe('getByCampaignParticipation', function () {
     let stageAcquisition;
 
@@ -97,47 +96,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
 
       // then
       expect(result.length).to.deep.equal(2);
-    });
-  });
-
-  describe('getByCampaignIdAndUserId', function () {
-    let stage;
-    let user;
-    let campaign;
-    let campaignParticipation;
-    let targetProfile;
-
-    beforeEach(async function () {
-      // given
-      user = databaseBuilder.factory.buildUser();
-      targetProfile = databaseBuilder.factory.buildTargetProfile();
-      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
-      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-      stage = databaseBuilder.factory.buildStage({ campaignId: campaign.id });
-      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
-      databaseBuilder.factory.buildStageAcquisition({
-        campaignParticipationId: campaignParticipation.id,
-        userId: user.id,
-        stageId: stage.id,
-      });
-
-      await databaseBuilder.commit();
-    });
-
-    it('should return StageAcquisition instances', async function () {
-      // when
-      const result = await getByCampaignIdAndUserId(campaign.id, user.id);
-
-      // then
-      expect(result[0]).to.be.instanceof(StageAcquisition);
-    });
-
-    it('should return the expected stages', async function () {
-      // when
-      const result = await getByCampaignIdAndUserId(campaign.id, user.id);
-
-      // then
-      expect(result[0].stageId).to.deep.equal(stage.id);
     });
   });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -9,11 +9,29 @@ import { Assessment, KnowledgeElement } from '../../../../../../src/shared/domai
 import { databaseBuilder, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Prescription Integration | UseCase | get-user-campaign-assessment-result', function () {
+  let skillIds, userId;
+
+  beforeEach(async function () {
+    skillIds = ['acquisA', 'acquisB'];
+    userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.learningContent.buildArea({
+      id: 'monAreaId',
+    });
+    databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'maCompetenceId',
+      areaId: 'monAreaId',
+      name_i18n: {
+        fr: 'nom de la compétence',
+      },
+      skillIds,
+    });
+
+    await databaseBuilder.commit();
+  });
+
   context('when campaign is of type ASSESSMENT', function () {
     it('should return an participant assessment result based on the user profile', async function () {
       // given
-      const skillIds = ['acquisA', 'acquisB'];
-      const userId = databaseBuilder.factory.buildUser().id;
       const campaignId = databaseBuilder.factory.buildCampaign({
         type: CampaignTypes.ASSESSMENT,
       }).id;
@@ -34,17 +52,7 @@ describe('Prescription Integration | UseCase | get-user-campaign-assessment-resu
         campaignParticipationId,
         type: Assessment.types.CAMPAIGN,
       });
-      databaseBuilder.factory.learningContent.buildArea({
-        id: 'monAreaId',
-      });
-      databaseBuilder.factory.learningContent.buildCompetence({
-        id: 'maCompetenceId',
-        areaId: 'monAreaId',
-        name_i18n: {
-          fr: 'nom de la compétence',
-        },
-        skillIds,
-      });
+
       skillIds.map((id, index) => {
         databaseBuilder.factory.learningContent.buildSkill({
           id,
@@ -79,11 +87,10 @@ describe('Prescription Integration | UseCase | get-user-campaign-assessment-resu
       });
     });
   });
+
   context('when campaign is of type EXAM', function () {
-    it('should return an participant assessment result based on the user profile', async function () {
+    it('should return an participant assessment result based on the knowledge element snapshot attach on participation', async function () {
       // given
-      const skillIds = ['acquisA', 'acquisB'];
-      const userId = databaseBuilder.factory.buildUser().id;
       const campaignId = databaseBuilder.factory.buildCampaign({
         type: CampaignTypes.EXAM,
       }).id;
@@ -104,17 +111,7 @@ describe('Prescription Integration | UseCase | get-user-campaign-assessment-resu
         campaignParticipationId,
         type: Assessment.types.CAMPAIGN,
       });
-      databaseBuilder.factory.learningContent.buildArea({
-        id: 'monAreaId',
-      });
-      databaseBuilder.factory.learningContent.buildCompetence({
-        id: 'maCompetenceId',
-        areaId: 'monAreaId',
-        name_i18n: {
-          fr: 'nom de la compétence',
-        },
-        skillIds,
-      });
+
       const domainKEs = skillIds.map((id, index) => {
         databaseBuilder.factory.learningContent.buildSkill({
           id,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -86,6 +86,100 @@ describe('Prescription Integration | UseCase | get-user-campaign-assessment-resu
         id: 'maCompetenceId',
       });
     });
+
+    context('stages', function () {
+      it('return acquired stages on participation', async function () {
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+        }).id;
+        databaseBuilder.factory.buildStage({
+          id: 123,
+          targetProfileId,
+          isFirstSkill: false,
+          level: 0,
+          threshold: null,
+          title: 'Palier niveau 0 titre',
+          message: 'Palier niveau 0 message',
+          prescriberTitle: 'Palier niveau 0 titre prescripteur',
+          prescriberDescription: 'Palier niveau 0 description prescripteur',
+        });
+        databaseBuilder.factory.buildStage({
+          id: 456,
+          targetProfileId,
+          isFirstSkill: false,
+          level: 1,
+          threshold: null,
+        });
+
+        skillIds.map((skillId) =>
+          databaseBuilder.factory.buildCampaignSkill({
+            campaignId,
+            skillId,
+          }),
+        );
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          sharedAt: null,
+          status: CampaignParticipationStatuses.TO_SHARE,
+        }).id;
+
+        databaseBuilder.factory.buildStageAcquisition({
+          stageId: 123,
+          userId,
+          campaignParticipationId,
+        });
+
+        const assessmentDB = databaseBuilder.factory.buildAssessment({
+          userId,
+          campaignParticipationId,
+          type: Assessment.types.CAMPAIGN,
+        });
+
+        skillIds.map((id, index) => {
+          databaseBuilder.factory.learningContent.buildSkill({
+            id,
+            competenceId: 'maCompetenceId',
+            pixValue: PIX_COUNT_BY_LEVEL,
+            status: 'actif',
+            tubeId: 'monTubeId',
+            level: index + 1,
+          });
+          databaseBuilder.factory.buildKnowledgeElement({
+            skillId: id,
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            source: KnowledgeElement.SourceType.DIRECT,
+            userId,
+            assessmentId: assessmentDB.id,
+          });
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const participantAssessmentResult = await usecases.getUserCampaignAssessmentResult({
+          userId,
+          campaignId,
+          locale: 'fr',
+        });
+
+        // then
+        expect(participantAssessmentResult.reachedStage).to.deep.equal({
+          id: 123,
+          isFirstSkill: false,
+          level: 0,
+          title: 'Palier niveau 0 titre',
+          message: 'Palier niveau 0 message',
+          prescriberTitle: 'Palier niveau 0 titre prescripteur',
+          prescriberDescription: 'Palier niveau 0 description prescripteur',
+          reachedStage: 1,
+          targetProfileId,
+          threshold: null,
+          totalStage: 2,
+        });
+      });
+    });
   });
 
   context('when campaign is of type EXAM', function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -30,7 +30,7 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
       get: sinon.stub(),
     };
     stageRepository = { getByCampaignId: sinon.stub() };
-    stageAcquisitionRepository = { getByCampaignIdAndUserId: sinon.stub() };
+    stageAcquisitionRepository = { getByCampaignParticipation: sinon.stub() };
     compareStagesAndAcquiredStages = { compare: sinon.stub() };
     args = {
       userId,
@@ -86,7 +86,9 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
       const stage2 = domainBuilder.buildStage();
       const stageAcquisition = domainBuilder.buildStageAcquisition();
       stageRepository.getByCampaignId.withArgs(campaignId).resolves([stage1, stage2]);
-      stageAcquisitionRepository.getByCampaignIdAndUserId.withArgs(campaignId, userId).resolves([stageAcquisition]);
+      stageAcquisitionRepository.getByCampaignParticipation
+        .withArgs(campaignParticipationId)
+        .resolves([stageAcquisition]);
       compareStagesAndAcquiredStages.compare.withArgs([stage1, stage2], [stageAcquisition]).returns({
         reachedStageNumber: 1,
         totalNumberOfStages: 2,


### PR DESCRIPTION
## 🌸 Problème

Nous souhaitons supprimer la colonne userId de stage acquisition, mais nous en avons encore besoin pour récupérer les paliers atteint sur une participation. 

## 🌳 Proposition

Utiliser la campaignParticipationId qui se trouve déjà dans stage-acquisitions. Ce qui nous permettra de supprimer cette colonne plus tard

## 🐝 Remarques

RAS

## 🤧 Pour tester

* Participer à une campagne ayant des paliers. 
* Essayez d'en obtenir quelque uns s'il vous plaît
* En page de fin de campagne vérifier que l'on vous affiche bien le bon palier atteint.
