### PR TITLE
[FEATURE] Cacher le grain transition de la navbar (PIX-17473)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -13,6 +13,21 @@
   },
   "grains": [
     {
+      "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+      "type": "transition",
+      "title": "",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+            "type": "text",
+            "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
       "type": "lesson",
       "title": "test iframe",
@@ -189,21 +204,6 @@
             "url": "https://epreuves.pix.fr/fr/qcu_image/1d_iconewriter.html",
             "instruction": "<p>Instruction</p>",
             "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-            "type": "text",
-            "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
           }
         }
       ]

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -18,6 +18,13 @@ export default class ModulePassage extends Component {
   displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
 
+  displayableGrainsInNavbar = this.displayableGrains.filter((grain) => grain.type !== 'transition');
+  @tracked grainsToDisplayInNavbar = this.grainsToDisplay.filter((grain) => grain.type !== 'transition');
+
+  get navbarCurrentPassageStep() {
+    return this.grainsToDisplayInNavbar.length;
+  }
+
   @action
   hasGrainJustAppeared(index) {
     if (this.grainsToDisplay.length === 1) {
@@ -86,6 +93,10 @@ export default class ModulePassage extends Component {
 
     const nextGrain = this.displayableGrains[this.currentGrainIndex + 1];
     this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
+
+    if (nextGrain.type !== 'transition') {
+      this.grainsToDisplayInNavbar = [...this.grainsToDisplayInNavbar, nextGrain];
+    }
   }
 
   @action
@@ -202,7 +213,7 @@ export default class ModulePassage extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
-      'pix-event-name': `Click sur le bouton Étape ${this.currentPassageStep} sur ${this.displayableGrains.length} de la barre de navigation`,
+      'pix-event-name': `Click sur le bouton Étape ${this.navbarCurrentPassageStep} sur ${this.displayableGrainsInNavbar.length} de la barre de navigation`,
     });
   }
 
@@ -236,10 +247,10 @@ export default class ModulePassage extends Component {
       <BetaBanner />
     {{/if}}
     <ModuleNavbar
-      @currentStep={{this.currentPassageStep}}
-      @totalSteps={{this.displayableGrains.length}}
+      @currentStep={{this.navbarCurrentPassageStep}}
+      @totalSteps={{this.displayableGrainsInNavbar.length}}
       @module={{@module}}
-      @grainsToDisplay={{this.grainsToDisplay}}
+      @grainsToDisplay={{this.grainsToDisplayInNavbar}}
       @goToGrain={{this.goToGrain}}
       @onSidebarOpen={{this.onSidebarOpen}}
     />

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -13,42 +13,75 @@ import { waitForDialog } from '../../../helpers/wait-for';
 module('Integration | Component | Module | Passage', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display given module with one grain', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const textElement = { content: 'content', type: 'text' };
-    const qcuElement = {
-      instruction: 'instruction',
-      proposals: ['radio1', 'radio2'],
-      type: 'qcu',
-    };
-    const components = [
-      {
-        type: 'element',
-        element: textElement,
-      },
-      {
-        type: 'element',
-        element: qcuElement,
-      },
-    ];
-    const grain = store.createRecord('grain', { id: 'grainId1', components });
-    const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
+  module('when module has one grain', function () {
+    test('should display given module', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const components = [
+        {
+          type: 'element',
+          element: textElement,
+        },
+        {
+          type: 'element',
+          element: qcuElement,
+        },
+      ];
+      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
-    const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
-    const passage = store.createRecord('passage');
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
+      const passage = store.createRecord('passage');
 
-    // when
-    const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
-    // then
-    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-    assert.ok(screen.getByRole('banner').innerText.includes('transition text'));
-    assert.strictEqual(findAll('.element-text').length, 1);
-    assert.strictEqual(findAll('.element-qcu').length, 1);
+      // then
+      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+      assert.ok(screen.getByRole('banner').innerText.includes('transition text'));
+      assert.strictEqual(findAll('.element-text').length, 1);
+      assert.strictEqual(findAll('.element-qcu').length, 1);
 
-    assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 1' }));
-    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+    });
+
+    test('should display navigation', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const components = [
+        {
+          type: 'element',
+          element: textElement,
+        },
+        {
+          type: 'element',
+          element: qcuElement,
+        },
+      ];
+      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
+      const passage = store.createRecord('passage');
+
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 1' })).exists();
+    });
   });
 
   module('when a grain contains non existing elements', function () {
@@ -159,31 +192,54 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  test('should display given module with more than one grain', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const textElement = { content: 'content', type: 'text' };
-    const qcuElement = {
-      instruction: 'instruction',
-      proposals: ['radio1', 'radio2'],
-      type: 'qcu',
-    };
-    const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
-    const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+  module('when module has more than on grain', function () {
+    test('should display given module', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
 
-    const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-    const passage = store.createRecord('passage');
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const passage = store.createRecord('passage');
 
-    // when
-    const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
-    // then
-    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-    assert.strictEqual(findAll('.element-text').length, 1);
-    assert.strictEqual(findAll('.element-qcu').length, 0);
+      // then
+      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+      assert.strictEqual(findAll('.element-text').length, 1);
+      assert.strictEqual(findAll('.element-qcu').length, 0);
 
-    assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 2' }));
-    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+    });
+
+    test('should display navigation', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const passage = store.createRecord('passage');
+
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 2' })).exists();
+    });
   });
 
   module('when user clicks on skip button', function () {
@@ -277,7 +333,26 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       const grainsAfteronGrainContinue = screen.getAllByRole('article');
       assert.strictEqual(grainsAfteronGrainContinue.length, 2);
-      assert.dom(screen.getByRole('navigation', { name: 'Étape 2 sur 2' }));
+    });
+
+    test('should update navigation', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = { content: 'content', type: 'text' };
+      const text2Element = { content: 'content 2', type: 'text' };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const passage = store.createRecord('passage');
+
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      assert.dom(screen.getByRole('navigation', { name: 'Étape 2 sur 2' })).exists();
     });
 
     test('should give focus on the last grain when appearing', async function (assert) {


### PR DESCRIPTION
## 🌸 Problème
Le nouveau type de grain transition est trop présent, notamment dans la navbar.

## 🌳 Proposition
Ne pas considérer ce type de grain.

En approche tech naïve, j'ai l'impression que ça pousse des cas func un peu bizarres si un grain de transition est au début ou la fin du module, j'ai posé des tests pour l'expliciter mais ça pourra être discuté.

Petit impact sur le tracking également.

## 🐝 Remarques
RAS

## 🤧 Pour tester
[Voir la RA.](https://app-pr12091.review.pix.fr/modules/bac-a-sable/passage)