### PR TITLE
[FEATURE] Elargir la largeur max du module (desktop) et la taille de l'image (PIX-17564)

### DIFF
--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -10,6 +10,8 @@
   &__image {
     display: block;
     width: 100%;
+    max-width: 700px;
+    margin: auto;
     object-fit: contain;
     border-radius: var(--modulix-radius-s);
   }

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -3,7 +3,7 @@
 .modulix {
   @extend %pix-body-l;
 
-  --modulix-max-content-width: 740px;
+  --modulix-max-content-width: 820px;
   --modulix-radius-xs: 4px;
   --modulix-radius-s: 8px;
   --modulix-radius: 16px;


### PR DESCRIPTION
## 🌳 Proposition
Dans le but de rendre les modules plus fun, il y a des ajustements à faire sur la mise en forme avec le Design.

## 🐝 Remarques
Redécoupage de #12078.

## 🤧 Pour tester
Voir la RA