### PR TITLE
[FEATURE] Ajout animation fondu à l'apparition des grains (PIX-17567)

### DIFF
--- a/high-level-tests/e2e/cypress/support/disable-animation.js
+++ b/high-level-tests/e2e/cypress/support/disable-animation.js
@@ -1,0 +1,15 @@
+export function disableAnimation(win) {
+  const injectedStyleEl = win.document.getElementById('__cy_disable_motion__');
+  if (injectedStyleEl) {
+    return;
+  }
+  win.document.head.insertAdjacentHTML(
+    'beforeend',
+    `
+    <style id="__cy_disable_motion__">
+      /* Disable CSS animations. */
+      *, *::before, *::after { -webkit-animation: none !important; -moz-animation: none !important; -o-animation: none !important; -ms-animation: none !important; animation: none !important; }
+    </style>
+  `.trim()
+  );
+}

--- a/high-level-tests/e2e/cypress/support/index.js
+++ b/high-level-tests/e2e/cypress/support/index.js
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import 'cypress-axe';
+import { disableAnimation } from "./disable-animation";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -25,6 +26,13 @@ beforeEach(() => {
 
   cy.window().then((win) => {
     win.sessionStorage.clear();
+  });
+
+  // disable CSS animations due to possible flakiness with tests
+  // see https://gist.github.com/cvan/576eb41ab5d382660c14e3831c33c6ea
+  // for source code inspiration
+  cy.on('window:before:load', (cyWindow) => {
+    disableAnimation(cyWindow);
   });
 
   cy.on('uncaught:exception', (err) => {

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -22,6 +22,27 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     font-weight: var(--pix-font-medium);
   }
 
+  &__card,
+  &-card__tag {
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.8s fade-in ease-in-out;
+
+      @keyframes fade-in {
+        0% {
+          opacity: 0;
+        }
+
+        33% {
+          opacity: 0;
+        }
+
+        100% {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
   &__card {
     border-radius: $grain-card-border-radius;
   }


### PR DESCRIPTION
## 🌳 Proposition
Dans le but de rendre les modules plus fun, il y a des ajustements à faire sur la mise en forme avec le Design.

Côté tests e2e ça cause des soucis de stabilité, on a désactivé les animations CSS dans Cypress en s'inspirant de https://gist.github.com/cvan/576eb41ab5d382660c14e3831c33c6ea

## 🐝 Remarques
Redécoupage de #12078.

## 🤧 Pour tester
Voir la RA