### PR TITLE
[FEATURE] Retirer l'insertion des userId dans stage-acquisitions (Pix-17572)

### DIFF
--- a/api/db/database-builder/factory/build-stage-acquisition.js
+++ b/api/db/database-builder/factory/build-stage-acquisition.js
@@ -2,12 +2,10 @@ import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../migrations/20230721114848_c
 import { databaseBuffer } from '../database-buffer.js';
 import { buildCampaignParticipation } from './build-campaign-participation.js';
 import { buildStage } from './build-stage.js';
-import { buildUser } from './build-user.js';
 
 const buildStageAcquisition = function ({
   id = databaseBuffer.getNextId(),
   stageId = buildStage().id,
-  userId = buildUser().id,
   campaignParticipationId = buildCampaignParticipation().id,
   createdAt = new Date('2000-01-01'),
 } = {}) {
@@ -16,7 +14,6 @@ const buildStageAcquisition = function ({
     values: {
       id,
       stageId,
-      userId,
       campaignParticipationId,
       createdAt,
     },

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -231,7 +231,6 @@ async function createAssessmentCampaign({
 
         databaseBuilder.factory.buildStageAcquisition({
           stageId: stageZero.id,
-          userId,
           campaignParticipationId,
         });
       }

--- a/api/db/seeds/data/team-evaluation/users/eval-campaign-with-stages.js
+++ b/api/db/seeds/data/team-evaluation/users/eval-campaign-with-stages.js
@@ -373,7 +373,6 @@ export default async function initUser(databaseBuilder) {
   ].forEach(({ stages, campaignParticipation }) => {
     stages.stageIds.forEach((stageId) => {
       databaseBuilder.factory.buildStageAcquisition({
-        userId: user.id,
         campaignParticipationId: campaignParticipation.id,
         stageId,
       });

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -187,7 +187,6 @@ const buildCampaignParticipations = (databaseBuilder, users) =>
 
     databaseBuilder.factory.buildStageAcquisition({
       stageId: stageZero.id,
-      userId: user.id,
       campaignParticipationId: participationId,
     });
   });

--- a/api/src/evaluation/domain/models/StageAcquisition.js
+++ b/api/src/evaluation/domain/models/StageAcquisition.js
@@ -2,13 +2,11 @@ class StageAcquisition {
   /**
    *
    * @param {number} id
-   * @param {number} userId
    * @param {number} stageId
    * @param {number} campaignParticipationId
    */
-  constructor({ id, userId, stageId, campaignParticipationId }) {
+  constructor({ id, stageId, campaignParticipationId }) {
     this.id = id;
-    this.userId = userId;
     this.stageId = stageId;
     this.campaignParticipationId = campaignParticipationId;
   }

--- a/api/src/evaluation/domain/usecases/handle-stage-acquisition.js
+++ b/api/src/evaluation/domain/usecases/handle-stage-acquisition.js
@@ -74,7 +74,7 @@ const handleStageAcquisition = async function ({
 
   if (!stagesToStore.length) return;
 
-  await stageAcquisitionRepository.saveStages(stagesToStore, assessment.userId, campaignParticipation.id);
+  await stageAcquisitionRepository.saveStages(stagesToStore, campaignParticipation.id);
 };
 
 /**

--- a/api/src/evaluation/infrastructure/repositories/stage-acquisition-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/stage-acquisition-repository.js
@@ -66,16 +66,14 @@ const getStageIdsByCampaignParticipation = async (campaignParticipationsId) => {
 
 /**
  * @param {Stage[]} stages
- * @param {number} userId
  * @param {number} campaignParticipationId
  *
  * @returns {Promise<[]>}
  */
-const saveStages = async (stages, userId, campaignParticipationId) => {
+const saveStages = async (stages, campaignParticipationId) => {
   const knexConnection = DomainTransaction.getConnection();
   const acquiredStages = stages.map((stage) => ({
     stageId: stage.id,
-    userId,
     campaignParticipationId,
   }));
   return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME).insert(acquiredStages);

--- a/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -128,11 +128,13 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             stages
               .slice(0, 3)
               .map(async (stage) =>
-                databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, userId, campaignParticipationId }),
+                databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, campaignParticipationId }),
               );
 
             await databaseBuilder.commit();
-            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({
+              campaignParticipationId,
+            });
 
             // when
             await evaluationUsecases.handleStageAcquisition({
@@ -141,7 +143,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
             // then
             expect(stageAcquisitionsBefore).to.have.lengthOf(3);
-            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitionsAfter).to.have.lengthOf(4);
           });
         });
@@ -167,29 +169,29 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
               // then
               const transactionStageAcquisitions = await domainTransaction
                 .knexTransaction(STAGE_ACQUISITIONS_TABLE_NAME)
-                .select('userId', 'stageId')
-                .where({ userId });
+                .select('campaignParticipationId', 'stageId')
+                .where({ campaignParticipationId });
 
               expect(transactionStageAcquisitions).to.have.deep.members([
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[0].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[1].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[2].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[3].id,
                 },
               ]);
 
-              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
               expect(stageAcquisitions).to.have.lengthOf(0);
             });
           });
@@ -211,7 +213,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(0);
           });
         });
@@ -235,7 +237,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(4);
           });
         });
@@ -266,7 +268,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           });
 
           // then
-          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
           expect(stageAcquisitionsAfter).to.have.lengthOf(1);
         });
       });
@@ -325,11 +327,13 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             stages
               .slice(0, 3)
               .map(async (stage) =>
-                databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, userId, campaignParticipationId }),
+                databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, campaignParticipationId }),
               );
 
             await databaseBuilder.commit();
-            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({
+              campaignParticipationId,
+            });
 
             // when
             await evaluationUsecases.handleStageAcquisition({
@@ -338,7 +342,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
             // then
             expect(stageAcquisitionsBefore).to.have.lengthOf(3);
-            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitionsAfter).to.have.lengthOf(4);
           });
         });
@@ -364,29 +368,29 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
               // then
               const transactionStageAcquisitions = await domainTransaction
                 .knexTransaction(STAGE_ACQUISITIONS_TABLE_NAME)
-                .select('userId', 'stageId')
-                .where({ userId });
+                .select('campaignParticipationId', 'stageId')
+                .where({ campaignParticipationId });
 
               expect(transactionStageAcquisitions).to.have.deep.members([
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[0].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[1].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[2].id,
                 },
                 {
-                  userId,
+                  campaignParticipationId,
                   stageId: stages[3].id,
                 },
               ]);
 
-              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+              const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
               expect(stageAcquisitions).to.have.lengthOf(0);
             });
           });
@@ -408,7 +412,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(0);
           });
         });
@@ -432,7 +436,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
             });
 
             // then
-            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+            const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
             expect(stageAcquisitions).to.have.lengthOf(4);
           });
         });
@@ -469,7 +473,7 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
           });
 
           // then
-          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+          const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ campaignParticipationId });
           expect(stageAcquisitionsAfter).to.have.lengthOf(1);
         });
       });

--- a/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -103,7 +103,6 @@ describe('Evaluation | Integration | Repository | Stage Acquisition', function (
     let targetProfile;
     let stages;
     let campaign;
-    let user;
     let campaignParticipation;
 
     beforeEach(async function () {
@@ -114,7 +113,6 @@ describe('Evaluation | Integration | Repository | Stage Acquisition', function (
         databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id }),
       ];
       campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-      user = databaseBuilder.factory.buildUser();
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
 
       await databaseBuilder.commit();
@@ -122,7 +120,7 @@ describe('Evaluation | Integration | Repository | Stage Acquisition', function (
 
     it('return the expected stage', async function () {
       // when
-      await saveStages(stages, user.id, campaignParticipation.id);
+      await saveStages(stages, campaignParticipation.id);
 
       // then
       const result = await knex('stage-acquisitions')
@@ -130,7 +128,6 @@ describe('Evaluation | Integration | Repository | Stage Acquisition', function (
           'stageId',
           stages.map(({ id }) => id),
         )
-        .andWhere('userId', user.id)
         .andWhere('campaignParticipationId', campaignParticipation.id);
 
       expect(result).to.have.lengthOf(2);

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -534,7 +534,6 @@ describe('Acceptance | API | Campaign Participations', function () {
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: stage.id,
-        userId: user.id,
         campaignParticipationId: campaignParticipation.id,
       });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -39,13 +39,11 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: targetProfile1Stage1.id,
-        userId: user.id,
         campaignParticipationId: campaign1Participation1.id,
       });
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: targetProfile2Stage2.id,
-        userId: user.id,
         campaignParticipationId: campaign2Participation2.id,
       });
 
@@ -105,19 +103,16 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: stage1.id,
-        userId: user.id,
         campaignParticipationId: campaign1Participation1.id,
       });
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: stage1.id,
-        userId: user.id,
         campaignParticipationId: campaign2Participation2.id,
       });
 
       databaseBuilder.factory.buildStageAcquisition({
         stageId: stage2.id,
-        userId: user.id,
         campaignParticipationId: campaign2Participation2.id,
       });
 

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -128,7 +128,6 @@ describe('Prescription Integration | UseCase | get-user-campaign-assessment-resu
 
         databaseBuilder.factory.buildStageAcquisition({
           stageId: 123,
-          userId,
           campaignParticipationId,
         });
 

--- a/api/tests/tooling/domain-builder/factory/build-stage-acquisition.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage-acquisition.js
@@ -1,14 +1,8 @@
 import { StageAcquisition } from '../../../../src/evaluation/domain/models/StageAcquisition.js';
 
-const buildStageAcquisition = function ({
-  id = 1,
-  userId = 3000,
-  stageId = 4000,
-  campaignParticipationId = 5000,
-} = {}) {
+const buildStageAcquisition = function ({ id = 1, stageId = 4000, campaignParticipationId = 5000 } = {}) {
   return new StageAcquisition({
     id,
-    userId,
     stageId,
     campaignParticipationId,
   });


### PR DESCRIPTION
## 🌸 Problème

On n'utilise plus le userId dans stage-acquisitions

## 🌳 Proposition

Retirer son insertion en base, pour dans un second temps supprimer complètement la colonne

## 🐝 Remarques

Ne pas la merger tant que #12089 n'est pas en prod

## 🤧 Pour tester

Passer une campagne avec paliers. et vérifier que l'on sauvegarde toujours correctement les paliers, sans userId.