### PR TITLE
[TECH] Améliorer la page de chargement d'entrée en certification (PIX-17556).

### DIFF
--- a/mon-pix/app/styles/globals/_loading.scss
+++ b/mon-pix/app/styles/globals/_loading.scss
@@ -1,5 +1,4 @@
-.app-loader,
-.app-nested-loader {
+.app-loader {
   position: absolute;
   top: 0;
   left: 0;
@@ -20,9 +19,4 @@
 
 .app-loader__image {
   text-align: center;
-}
-
-.app-nested-loader {
-  position: relative;
-  padding: 40px;
 }

--- a/mon-pix/app/templates/authenticated/certifications/start-loading.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/start-loading.hbs
@@ -1,11 +1,1 @@
-<div class="background-banner-wrapper">
-  <div class="background-banner"></div>
-
-  <div class="app-nested-loader rounded-panel--over-background-banner rounded-panel rounded-panel--strong">
-    <p class="app-loader__image">
-      <img src="/images/interwind.gif" alt="" role="presentation" />
-    </p>
-    <p class="app-loader__text">{{t "common.loading.default"}}</p>
-  </div>
-
-</div>
+<Loader @loaderText={{t "common.loading.default"}} />


### PR DESCRIPTION
## 🌸 Problème

Sur Pix App, lors de l'entrée en certification, si le réseau est mauvais, une page de chargement s'affiche.
Une mise à jour du design à modifié tous les bandeaux en vert, couleur de la certification, mais cette page à été oublié.

<img width="1360" alt="Capture d’écran 2025-04-17 à 15 08 27" src="https://github.com/user-attachments/assets/ccb335b8-7a8e-4376-834f-66c526f941d7" />


## 🌳 Proposition

Utiliser un composant existant, Loader, et le mettre sur cette page.

## 🐝 Remarques

Suppression d'une classe plus utilisé suite à la suppression du code.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
