### PR TITLE
[FEATURE] Ajouter plus l'info sur l'import sur la page élèves/étudiants (PIX-16950)

### DIFF
--- a/orga/app/components/import-information-banner.gjs
+++ b/orga/app/components/import-information-banner.gjs
@@ -27,7 +27,15 @@ export default class ImportBanner extends Component {
     if (this.args.importDetail?.hasError) {
       return this.intl.t('components.import-information-banner.error');
     } else if (this.args.importDetail?.isDone) {
-      return this.intl.t('components.import-information-banner.success');
+      const {
+        updatedAt,
+        createdBy: { firstName, lastName },
+      } = this.args.importDetail;
+      return this.intl.t('components.import-information-banner.success', {
+        date: updatedAt.toLocaleDateString(),
+        firstname: firstName,
+        lastname: lastName,
+      });
     }
     if (this.args.importDetail?.inProgress) {
       return this.intl.t('components.import-information-banner.in-progress');

--- a/orga/app/components/import-information-banner.gjs
+++ b/orga/app/components/import-information-banner.gjs
@@ -2,6 +2,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 
 export default class ImportBanner extends Component {
   @service intl;
@@ -32,7 +33,7 @@ export default class ImportBanner extends Component {
         createdBy: { firstName, lastName },
       } = this.args.importDetail;
       return this.intl.t('components.import-information-banner.success', {
-        date: updatedAt.toLocaleDateString(),
+        date: dayjs(updatedAt).format('D MMM YYYY'),
         firstname: firstName,
         lastname: lastName,
       });

--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -2,6 +2,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 
 const statusI18nLabel = {
   STARTED: 'upload-in-progress',
@@ -25,7 +26,7 @@ export default class ImportBanner extends Component {
       createdBy: { firstName, lastName },
     } = this.args.organizationImportDetail;
     return this.intl.t('pages.organization-participants-import.global-success', {
-      date: updatedAt.toLocaleDateString(),
+      date: dayjs(updatedAt).format('D MMM YYYY'),
       firstName,
       lastName,
     });
@@ -81,7 +82,7 @@ export default class ImportBanner extends Component {
     return this.intl.t('pages.organization-participants-import.banner.upload-completed', {
       firstName,
       lastName,
-      date: createdAt.toLocaleDateString(),
+      date: dayjs(createdAt).format('D MMM YYYY'),
     });
   }
 

--- a/orga/tests/integration/components/import-information-banner_test.gjs
+++ b/orga/tests/integration/components/import-information-banner_test.gjs
@@ -3,11 +3,21 @@ import dayjs from 'dayjs';
 import { t } from 'ember-intl/test-support';
 import ImportInformationBanner from 'pix-orga/components/import-information-banner';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | ImportInformationBanner', function (hooks) {
   setupIntlRenderingTest(hooks);
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers({ now: new Date('2024-07-07') });
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
 
   test('it show nothing when there is no import', async function (assert) {
     // when
@@ -67,14 +77,21 @@ module('Integration | Component | ImportInformationBanner', function (hooks) {
     const importDetail = store.createRecord('organization-import-detail', {
       status: 'IMPORTED',
       updatedAt: dayjs().toDate(),
+      createdBy: {
+        firstName: 'Alain',
+        lastName: 'Terieur',
+      },
     });
     // when
     const screen = await render(<template><ImportInformationBanner @importDetail={{importDetail}} /></template>);
-
     assert.ok(
-      screen.getByText(t('components.import-information-banner.success'), {
-        exact: false,
-      }),
+      screen.getByText(
+        t('components.import-information-banner.success', {
+          firstname: importDetail.createdBy.firstName,
+          lastname: importDetail.createdBy.lastName,
+          date: importDetail.updatedAt.toLocaleDateString(),
+        }),
+      ),
     );
   });
 

--- a/orga/tests/integration/components/import-information-banner_test.gjs
+++ b/orga/tests/integration/components/import-information-banner_test.gjs
@@ -89,7 +89,7 @@ module('Integration | Component | ImportInformationBanner', function (hooks) {
         t('components.import-information-banner.success', {
           firstname: importDetail.createdBy.firstName,
           lastname: importDetail.createdBy.lastName,
-          date: importDetail.updatedAt.toLocaleDateString(),
+          date: dayjs(importDetail.updatedAt).format('D MMM YYYY'),
         }),
       ),
     );

--- a/orga/tests/integration/components/import/banner_test.gjs
+++ b/orga/tests/integration/components/import/banner_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import dayjs from 'dayjs';
 import { t } from 'ember-intl/test-support';
 import ImportBanner from 'pix-orga/components/import/banner';
 import { module, test } from 'qunit';
@@ -66,7 +67,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.banner.upload-completed', {
             firstName: 'Obi',
             lastName: 'Wan',
-            date: createdAt.toLocaleDateString(),
+            date: dayjs(createdAt).format('D MMM YYYY'),
           }),
           { exact: false },
         ),
@@ -105,7 +106,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.banner.upload-completed', {
             firstName: 'Obi',
             lastName: 'Wan',
-            date: createdAt.toLocaleDateString(),
+            date: dayjs(createdAt).format('D MMM YYYY'),
           }),
           { exact: false },
         ),
@@ -141,7 +142,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.global-success', {
             firstName: 'Richard',
             lastName: 'Aldana',
-            date: new Date(2020, 10, 2).toLocaleDateString(),
+            date: dayjs(organizationImportDetail.updatedAt).format('D MMM YYYY'),
           }),
         ),
       );
@@ -168,7 +169,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.global-success', {
             firstName: 'Richard',
             lastName: 'Aldana',
-            date: new Date(2020, 10, 2).toLocaleDateString(),
+            date: dayjs(organizationImportDetail.updatedAt).format('D MMM YYYY'),
           }),
         ),
       );
@@ -233,7 +234,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.banner.upload-completed', {
             firstName: 'Dark',
             lastName: 'Vador',
-            date: createdAt.toLocaleDateString(),
+            date: dayjs(createdAt).format('D MMM YYYY'),
           }),
           { exact: false },
         ),
@@ -278,7 +279,7 @@ module('Integration | Component | Import::Banner', function (hooks) {
           t('pages.organization-participants-import.banner.upload-completed', {
             firstName: 'Dark',
             lastName: 'Vador',
-            date: createdAt.toLocaleDateString(),
+            date: dayjs(createdAt).format('D MMM YYYY'),
           }),
           { exact: false },
         ),

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -308,7 +308,7 @@
       "error-link": "(see import page).",
       "in-progress": "An import is in progress",
       "in-progress-link": "(check import status).",
-      "success": "Participants have been imported."
+      "success": "Participants have been imported on {date} by {firstName} {lastName}."
     },
     "organization-participants-header": {
       "default": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -308,7 +308,7 @@
       "error-link": "(voir la page d'import).",
       "in-progress": "Un import est en cours",
       "in-progress-link": "(consulter l'état de l'import).",
-      "success": "Les participants ont bien été importés."
+      "success": "Les participants ont bien été importés le {date} par {firstname} {lastname}."
     },
     "organization-participants-header": {
       "default": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -308,7 +308,7 @@
       "error-link": "(zie de importpagina).",
       "in-progress": "Bezig met importeren",
       "in-progress-link": "(controleer importstatus).",
-      "success": "De deelnemers zijn geïmporteerd."
+      "success": "De deelnemers zijn geïmporteerd op {date} door {firstName} {lastName}."
     },
     "organization-participants-header": {
       "import-button": "Importeren",


### PR DESCRIPTION
## 🌸 Problème
Lors des échanges avec le métier sur la page d’accueil il a été évoqué le besoin d’informer les prescripteurs sur quand a été fait le dernier import. 

## 🌳 Proposition
Reprendre l’info qui est visible sur la page import et la rendre visible à tous sur la page participants (admin et membre) 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Se connecter a PixOrga
- Faire un import SIECLE 
- Vérifier que sur la page élèves, l'info de la date ainsi que l'utilisateur ayant fait l'import apparaît
- Faire la même chose avec un import SUP
- 🐈‍⬛ 
