### PR TITLE
[FEATURE] Gestion des compétences et du niveau global du Certificat v3 en cas de score en dessous de 64 pix (PIX-17541)

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -5,7 +5,7 @@ import * as requestResponseUtils from '../../../../src/shared/infrastructure/uti
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { normalizeAndRemoveAccents } from '../../../shared/infrastructure/utils/string-utils.js';
-import { V3Certificate } from '../domain/models/v3/Certificate.js';
+import { Certificate } from '../domain/models/v3/Certificate.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certificateSerializer from '../infrastructure/serializers/certificate-serializer.js';
 import * as privateCertificateSerializer from '../infrastructure/serializers/private-certificate-serializer.js';
@@ -87,7 +87,7 @@ const getPDFCertificate = async function (
 
   const certificate = await usecases.getCertificationAttestation({ certificationCourseId });
 
-  if (certificate instanceof V3Certificate) {
+  if (certificate instanceof Certificate) {
     const fileName = i18n.__('certification-confirmation.file-name', {
       deliveredAt: dayjs(certificate.deliveredAt).format('YYYYMMDD'),
     });
@@ -129,7 +129,7 @@ const getSessionCertificates = async function (
     sessionId,
   });
 
-  if (certificates.every((certificate) => certificate instanceof V3Certificate)) {
+  if (certificates.every((certificate) => certificate instanceof Certificate)) {
     const translatedFileName = i18n.__('certification-confirmation.file-name', {
       deliveredAt: dayjs(certificates[0].deliveredAt).format('YYYYMMDD'),
     });
@@ -173,8 +173,8 @@ const downloadDivisionCertificates = async function (
     division,
   });
 
-  if (certificates.some((certificate) => certificate instanceof V3Certificate)) {
-    const v3Certificates = certificates.filter((certificate) => certificate instanceof V3Certificate);
+  if (certificates.some((certificate) => certificate instanceof Certificate)) {
+    const v3Certificates = certificates.filter((certificate) => certificate instanceof Certificate);
     const normalizedDivision = normalizeAndRemoveAccents(division);
 
     const translatedFileName = i18n.__('certification-confirmation.file-name', {

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -5,7 +5,7 @@ import * as requestResponseUtils from '../../../../src/shared/infrastructure/uti
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { normalizeAndRemoveAccents } from '../../../shared/infrastructure/utils/string-utils.js';
-import { V3Certificate } from '../domain/models/V3Certificate.js';
+import { V3Certificate } from '../domain/models/v3/Certificate.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certificateSerializer from '../infrastructure/serializers/certificate-serializer.js';
 import * as privateCertificateSerializer from '../infrastructure/serializers/private-certificate-serializer.js';

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -40,15 +40,16 @@ export class Certificate {
     this.deliveredAt = deliveredAt;
     this.certificationCenter = certificationCenter;
     this.pixScore = pixScore;
-    this.globalLevel = this.isPreBeginnerLevel ? null : new GlobalCertificationLevel({ score: pixScore });
+    this.globalLevel = this.#findLevel();
     this.verificationCode = verificationCode;
     this.maxReachableScore = MAX_REACHABLE_SCORE;
-    this.resultCompetenceTree = this.isPreBeginnerLevel ? null : resultCompetenceTree;
+    this.resultCompetenceTree = this.globalLevel ? resultCompetenceTree : null;
     this.algorithmEngineVersion = algorithmEngineVersion;
     this.certificationDate = certificationDate;
   }
 
-  get isPreBeginnerLevel() {
-    return new GlobalCertificationLevel({ score: this.pixScore }).meshLevel === CERTIFICATE_LEVELS.preBeginner;
+  #findLevel() {
+    const globalCertificationLevel = new GlobalCertificationLevel({ score: this.pixScore });
+    return globalCertificationLevel.meshLevel === CERTIFICATE_LEVELS.preBeginner ? null : globalCertificationLevel;
   }
 }

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -2,7 +2,7 @@ import { MAX_REACHABLE_SCORE } from '../../../../../shared/domain/constants.js';
 import { CERTIFICATE_LEVELS } from './CertificateLevels.js';
 import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
 
-export class V3Certificate {
+export class Certificate {
   /**
    * @param {Object} props
    * @param {number} props.id - certification course id

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -1,5 +1,5 @@
-import { MAX_REACHABLE_SCORE } from '../../../../shared/domain/constants.js';
-import { GlobalCertificationLevel } from './v3/GlobalCertificationLevel.js';
+import { MAX_REACHABLE_SCORE } from '../../../../../shared/domain/constants.js';
+import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
 
 export class V3Certificate {
   /**
@@ -39,11 +39,15 @@ export class V3Certificate {
     this.deliveredAt = deliveredAt;
     this.certificationCenter = certificationCenter;
     this.pixScore = pixScore;
-    this.globalLevel = new GlobalCertificationLevel({ score: pixScore });
+    this.globalLevel = this.isPreBeginnerLevel ? null : new GlobalCertificationLevel({ score: pixScore });
     this.verificationCode = verificationCode;
     this.maxReachableScore = MAX_REACHABLE_SCORE;
-    this.resultCompetenceTree = resultCompetenceTree;
+    this.resultCompetenceTree = this.isPreBeginnerLevel ? null : resultCompetenceTree;
     this.algorithmEngineVersion = algorithmEngineVersion;
     this.certificationDate = certificationDate;
+  }
+
+  get isPreBeginnerLevel() {
+    return new GlobalCertificationLevel({ score: this.pixScore }).meshLevel === 'LEVEL_PRE_BEGINNER';
   }
 }

--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -1,4 +1,5 @@
 import { MAX_REACHABLE_SCORE } from '../../../../../shared/domain/constants.js';
+import { CERTIFICATE_LEVELS } from './CertificateLevels.js';
 import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
 
 export class V3Certificate {
@@ -48,6 +49,6 @@ export class V3Certificate {
   }
 
   get isPreBeginnerLevel() {
-    return new GlobalCertificationLevel({ score: this.pixScore }).meshLevel === 'LEVEL_PRE_BEGINNER';
+    return new GlobalCertificationLevel({ score: this.pixScore }).meshLevel === CERTIFICATE_LEVELS.preBeginner;
   }
 }

--- a/api/src/certification/results/domain/models/v3/CertificateLevels.js
+++ b/api/src/certification/results/domain/models/v3/CertificateLevels.js
@@ -1,0 +1,11 @@
+export const CERTIFICATE_LEVELS = {
+  preBeginner: 'LEVEL_PRE_BEGINNER',
+  beginner1: 'LEVEL_BEGINNER_1',
+  beginner2: 'LEVEL_BEGINNER_2',
+  independent3: 'LEVEL_INDEPENDENT_3',
+  independent4: 'LEVEL_INDEPENDENT_4',
+  advanced5: 'LEVEL_ADVANCED_5',
+  advanced6: 'LEVEL_ADVANCED_6',
+  expert7: 'LEVEL_EXPERT_7',
+  expert8: 'LEVEL_EXPERT_8',
+};

--- a/api/src/certification/results/domain/models/v3/MeshConfiguration.js
+++ b/api/src/certification/results/domain/models/v3/MeshConfiguration.js
@@ -1,4 +1,5 @@
 import { config } from '../../../../../shared/config.js';
+import { CERTIFICATE_LEVELS } from './CertificateLevels.js';
 
 export class MeshConfiguration {
   /**
@@ -13,15 +14,15 @@ export class MeshConfiguration {
    * @enum {Map<String, Mesh>}
    */
   MESH_CONFIGURATION = new Map([
-    ['LEVEL_PRE_BEGINNER', { weight: 64, coefficient: 0 }],
-    ['LEVEL_BEGINNER_1', { weight: 64, coefficient: 1 }],
-    ['LEVEL_BEGINNER_2', { weight: 128, coefficient: 1 }],
-    ['LEVEL_INDEPENDENT_3', { weight: 128, coefficient: 2 }],
-    ['LEVEL_INDEPENDENT_4', { weight: 128, coefficient: 3 }],
-    ['LEVEL_ADVANCED_5', { weight: 128, coefficient: 4 }],
-    ['LEVEL_ADVANCED_6', { weight: 128, coefficient: 5 }],
-    ['LEVEL_EXPERT_7', { weight: 128, coefficient: 6 }],
-    ['LEVEL_EXPERT_8', { weight: 128, coefficient: 7 }],
+    [CERTIFICATE_LEVELS.preBeginner, { weight: 64, coefficient: 0 }],
+    [CERTIFICATE_LEVELS.beginner1, { weight: 64, coefficient: 1 }],
+    [CERTIFICATE_LEVELS.beginner2, { weight: 128, coefficient: 1 }],
+    [CERTIFICATE_LEVELS.independent3, { weight: 128, coefficient: 2 }],
+    [CERTIFICATE_LEVELS.independent4, { weight: 128, coefficient: 3 }],
+    [CERTIFICATE_LEVELS.advanced5, { weight: 128, coefficient: 4 }],
+    [CERTIFICATE_LEVELS.advanced6, { weight: 128, coefficient: 5 }],
+    [CERTIFICATE_LEVELS.expert7, { weight: 128, coefficient: 6 }],
+    [CERTIFICATE_LEVELS.expert8, { weight: 128, coefficient: 7 }],
   ]);
 
   #MAX_REACHABLE_LEVEL = config.v3Certification.maxReachableLevel;

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -12,7 +12,7 @@ import {
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { SessionVersion } from '../../../shared/domain/models/SessionVersion.js';
 import { CertificationAttestation } from '../../domain/models/CertificationAttestation.js';
-import { V3Certificate } from '../../domain/models/V3Certificate.js';
+import { V3Certificate } from '../../domain/models/v3/Certificate.js';
 import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -12,7 +12,7 @@ import {
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { SessionVersion } from '../../../shared/domain/models/SessionVersion.js';
 import { CertificationAttestation } from '../../domain/models/CertificationAttestation.js';
-import { V3Certificate } from '../../domain/models/v3/Certificate.js';
+import { Certificate } from '../../domain/models/v3/Certificate.js';
 import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 
@@ -272,7 +272,7 @@ async function _toDomainForCertificationAttestation({ certificationCourseDTO, co
     SessionVersion.isV3(certificationCourseDTO.version) &&
     (await featureToggles.get('isV3CertificationAttestationEnabled'))
   ) {
-    return new V3Certificate({
+    return new Certificate({
       ...certificationCourseDTO,
       certificationDate: certificationCourseDTO.date,
       resultCompetenceTree: (await featureToggles.get('isV3CertificationPageEnabled')) ? resultCompetenceTree : [],

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../../domain/models/V3Certificate.js').V3Certificate} V3Certificate
+ * @typedef {import ('../../../../domain/models/v3/Certificate.js').V3Certificate} V3Certificate
  */
 import path from 'node:path';
 import * as url from 'node:url';
@@ -125,7 +125,7 @@ const generateV3AttestationTemplate = ({ pdf, data, translate }) => {
 
   const globalLevel = data.globalLevel;
 
-  if (globalLevel.meshLevel !== 'LEVEL_PRE_BEGINNER') {
+  if (!data.isPreBeginnerLevel) {
     pdf
       .font('Roboto-Regular')
       .fontSize(11)

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -125,7 +125,7 @@ const generateV3AttestationTemplate = ({ pdf, data, translate }) => {
 
   const globalLevel = data.globalLevel;
 
-  if (!data.isPreBeginnerLevel) {
+  if (data.globalLevel) {
     pdf
       .font('Roboto-Regular')
       .fontSize(11)

--- a/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/templates/v3-attestation.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../../domain/models/v3/Certificate.js').V3Certificate} V3Certificate
+ * @typedef {import ('../../../../domain/models/v3/Certificate.js').Certificate} Certificate
  */
 import path from 'node:path';
 import * as url from 'node:url';
@@ -9,7 +9,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @param {Object} params
- * @param {V3Certificate} params.data
+ * @param {Certificate} params.data
  */
 const generateV3AttestationTemplate = ({ pdf, data, translate }) => {
   // Global

--- a/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../domain/models/v3/Certificate.js').V3Certificate} V3Certificate
+ * @typedef {import ('../../../domain/models/v3/Certificate.js').Certificate} Certificate
  */
 import PDFDocument from 'pdfkit';
 
@@ -7,7 +7,7 @@ import generateV3AttestationTemplate from './templates/v3-attestation.js';
 
 /**
  * @param {Object} params
- * @param {Array<V3Certificate>} params.certificates
+ * @param {Array<Certificate>} params.certificates
  */
 const generate = ({ certificates, i18n }) => {
   const doc = new PDFDocument({

--- a/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
+++ b/api/src/certification/results/infrastructure/utils/pdf/v3-certification-attestation-pdf.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import ('../../../domain/models/V3Certificate.js').V3Certificate} V3Certificate
+ * @typedef {import ('../../../domain/models/v3/Certificate.js').V3Certificate} V3Certificate
  */
 import PDFDocument from 'pdfkit';
 

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -591,21 +591,20 @@ describe('Integration | Infrastructure | Repository | Certification', function (
               competenceMarks: [competenceMarks1, competenceMarks2],
               competenceTree: domainBuilder.buildCompetenceTree({ areas: [area1] }),
             });
-            const expectedCertificationAttestation =
-              domainBuilder.certification.results.buildV3CertificationAttestation({
-                ...certificationAttestationData,
-                id: certificationAttestationData.id,
-                firstName: certificationAttestationData.firstName,
-                lastName: certificationAttestationData.lastName,
-                birthdate: certificationAttestationData.birthdate,
-                birthplace: certificationAttestationData.birthplace,
-                certificationCenter: certificationAttestationData.certificationCenter,
-                deliveredAt: certificationAttestationData.deliveredAt,
-                pixScore: certificationAttestationData.pixScore,
-                algorithmEngineVersion: AlgorithmEngineVersion.V3,
-                certificationDate: certificationAttestationData.date,
-                resultCompetenceTree,
-              });
+            const expectedCertificationAttestation = domainBuilder.certification.results.buildCertificate({
+              ...certificationAttestationData,
+              id: certificationAttestationData.id,
+              firstName: certificationAttestationData.firstName,
+              lastName: certificationAttestationData.lastName,
+              birthdate: certificationAttestationData.birthdate,
+              birthplace: certificationAttestationData.birthplace,
+              certificationCenter: certificationAttestationData.certificationCenter,
+              deliveredAt: certificationAttestationData.deliveredAt,
+              pixScore: certificationAttestationData.pixScore,
+              algorithmEngineVersion: AlgorithmEngineVersion.V3,
+              certificationDate: certificationAttestationData.date,
+              resultCompetenceTree,
+            });
             expect(certificationAttestation).to.deepEqualInstance(expectedCertificationAttestation);
           });
         });
@@ -647,7 +646,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           });
 
           // then
-          const expectedCertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation({
+          const expectedCertificationAttestation = domainBuilder.certification.results.buildCertificate({
             ...certificationAttestationData,
             certificationDate: certificationAttestationData.date,
           });

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -610,7 +610,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           });
         });
 
-        it('should return a V3Certificate', async function () {
+        it('should return a Certificate', async function () {
           // given
           await featureToggles.set('isV3CertificationAttestationEnabled', true);
           const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);

--- a/api/tests/certification/results/integration/infrastructure/utils/pdf/v3-certification-attestation-pdf_test.js
+++ b/api/tests/certification/results/integration/infrastructure/utils/pdf/v3-certification-attestation-pdf_test.js
@@ -19,7 +19,7 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
 
   it('should generate a PDF buffer', async function () {
     // given
-    const certificates = [domainBuilder.certification.results.buildV3CertificationAttestation()];
+    const certificates = [domainBuilder.certification.results.buildCertificate()];
 
     // when
     const pdfStream = await generate({ certificates, i18n });
@@ -34,9 +34,9 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
   it('should generate a page for each certificate', async function () {
     // given
     const certificates = [
-      domainBuilder.certification.results.buildV3CertificationAttestation(),
-      domainBuilder.certification.results.buildV3CertificationAttestation(),
-      domainBuilder.certification.results.buildV3CertificationAttestation(),
+      domainBuilder.certification.results.buildCertificate(),
+      domainBuilder.certification.results.buildCertificate(),
+      domainBuilder.certification.results.buildCertificate(),
     ];
 
     // when
@@ -54,7 +54,7 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
   it('should display data content', async function () {
     // given
     const certificates = [
-      domainBuilder.certification.results.buildV3CertificationAttestation({
+      domainBuilder.certification.results.buildCertificate({
         id: 123,
         firstName: 'Alain',
         lastName: 'Cendy',
@@ -70,7 +70,7 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
         pixScore: 256,
         sessionId: 789,
       }),
-      domainBuilder.certification.results.buildV3CertificationAttestation({
+      domainBuilder.certification.results.buildCertificate({
         id: 128,
         firstName: 'Alain',
         lastName: 'Terieur',
@@ -124,7 +124,7 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
   it('snapshot', async function () {
     // given
     const certificates = [
-      domainBuilder.certification.results.buildV3CertificationAttestation({
+      domainBuilder.certification.results.buildCertificate({
         id: 123,
         firstName: 'Alain',
         lastName: 'Cendy',
@@ -176,7 +176,7 @@ describe('Integration | Infrastructure | Utils | Pdf | V3 Certification Attestat
     it('should display data content without global level information', async function () {
       // given
       const certificates = [
-        domainBuilder.certification.results.buildV3CertificationAttestation({
+        domainBuilder.certification.results.buildCertificate({
           id: 123,
           firstName: 'Alain',
           lastName: 'Cendy',

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -393,7 +393,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           .withArgs({ certificationCourseId: request.params.certificationCourseId })
           .resolves(certificationCourse);
 
-        const v3CertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation();
+        const v3CertificationAttestation = domainBuilder.certification.results.buildCertificate();
         sinon
           .stub(usecases, 'getCertificationAttestation')
           .withArgs({ certificationCourseId: request.params.certificationCourseId })
@@ -480,7 +480,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const userId = 1;
         const i18n = getI18n();
 
-        const v3CertificationAttestation = domainBuilder.certification.results.buildV3CertificationAttestation();
+        const v3CertificationAttestation = domainBuilder.certification.results.buildCertificate();
         const session = domainBuilder.certification.sessionManagement.buildSession.finalized({ id: 12 });
         const generatedPdf = Symbol('Stream');
 
@@ -605,7 +605,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const userId = 1;
         const i18n = getI18n();
 
-        const v3Certificate = domainBuilder.certification.results.buildV3CertificationAttestation();
+        const v3Certificate = domainBuilder.certification.results.buildCertificate();
         const v2Certificate = domainBuilder.buildCertificationAttestation({
           version: SESSIONS_VERSIONS.V2,
         });

--- a/api/tests/certification/results/unit/domain/models/v3/Certificate_test.js
+++ b/api/tests/certification/results/unit/domain/models/v3/Certificate_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Models | Certification | Results | Certificate v3', fu
   describe('when the level is pre-beginner', function () {
     it('should return the model with an empty competence tree array and a null global level', function () {
       // given & when
-      const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+      const certificate = domainBuilder.certification.results.buildCertificate({
         pixScore: 63,
         resultCompetenceTree: [Symbol('competence')],
       });
@@ -19,7 +19,7 @@ describe('Unit | Domain | Models | Certification | Results | Certificate v3', fu
   describe('when the level is not pre-beginner', function () {
     it('should return the model with filled competence tree array and a global level object', function () {
       // given & when
-      const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+      const certificate = domainBuilder.certification.results.buildCertificate({
         pixScore: 65,
         resultCompetenceTree: [Symbol('competence')],
       });

--- a/api/tests/certification/results/unit/domain/models/v3/Certificate_test.js
+++ b/api/tests/certification/results/unit/domain/models/v3/Certificate_test.js
@@ -1,0 +1,32 @@
+import { GlobalCertificationLevel } from '../../../../../../../src/certification/results/domain/models/v3/GlobalCertificationLevel.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | Certification | Results | Certificate v3', function () {
+  describe('when the level is pre-beginner', function () {
+    it('should return the model with an empty competence tree array and a null global level', function () {
+      // given & when
+      const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+        pixScore: 63,
+        resultCompetenceTree: [Symbol('competence')],
+      });
+
+      // then
+      expect(certificate.resultCompetenceTree).to.be.null;
+      expect(certificate.globalLevel).to.be.null;
+    });
+  });
+
+  describe('when the level is not pre-beginner', function () {
+    it('should return the model with filled competence tree array and a global level object', function () {
+      // given & when
+      const certificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+        pixScore: 65,
+        resultCompetenceTree: [Symbol('competence')],
+      });
+
+      // then
+      expect(certificate.resultCompetenceTree).to.be.instanceOf(Array).and.to.not.be.empty;
+      expect(certificate.globalLevel).to.be.instanceOf(GlobalCertificationLevel);
+    });
+  });
+});

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
@@ -179,7 +179,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
           id: '123-456',
           areas: [area1],
         });
-        const shareableCertificate = domainBuilder.certification.results.buildV3CertificationAttestation({
+        const shareableCertificate = domainBuilder.certification.results.buildCertificate({
           id: 123,
           resultCompetenceTree,
         });

--- a/api/tests/tooling/domain-builder/factory/build-certificate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certificate.js
@@ -1,6 +1,6 @@
 import { Certificate } from '../../../../src/certification/results/domain/models/v3/Certificate.js';
 
-const buildV3CertificationAttestation = async function ({
+const buildCertificate = async function ({
   id = 1,
   firstName = 'Jean',
   lastName = 'Bon',
@@ -24,4 +24,4 @@ const buildV3CertificationAttestation = async function ({
   });
 };
 
-export { buildV3CertificationAttestation };
+export { buildCertificate };

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3Certificate } from '../../../../src/certification/results/domain/models/v3/Certificate.js';
+import { Certificate } from '../../../../src/certification/results/domain/models/v3/Certificate.js';
 
 const buildV3CertificationAttestation = async function ({
   id = 1,
@@ -11,7 +11,7 @@ const buildV3CertificationAttestation = async function ({
   pixScore = 123,
   verificationCode = 'P-SOMECODE',
 } = {}) {
-  return new V3Certificate({
+  return new Certificate({
     id,
     firstName,
     lastName,

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3Certificate } from '../../../../src/certification/results/domain/models/V3Certificate.js';
+import { V3Certificate } from '../../../../src/certification/results/domain/models/v3/Certificate.js';
 
 const buildV3CertificationAttestation = async function ({
   id = 1,

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3Certificate } from '../../../../../../src/certification/results/domain/models/V3Certificate.js';
+import { V3Certificate } from '../../../../../../src/certification/results/domain/models/v3/Certificate.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 
 const buildV3CertificationAttestation = function ({

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,7 +1,7 @@
 import { Certificate } from '../../../../../../src/certification/results/domain/models/v3/Certificate.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 
-const buildV3CertificationAttestation = function ({
+const buildCertificate = function ({
   id = 1,
   firstName = 'Jean',
   lastName = 'Bon',
@@ -31,4 +31,4 @@ const buildV3CertificationAttestation = function ({
   });
 };
 
-export { buildV3CertificationAttestation };
+export { buildCertificate };

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -1,4 +1,4 @@
-import { V3Certificate } from '../../../../../../src/certification/results/domain/models/v3/Certificate.js';
+import { Certificate } from '../../../../../../src/certification/results/domain/models/v3/Certificate.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 
 const buildV3CertificationAttestation = function ({
@@ -15,7 +15,7 @@ const buildV3CertificationAttestation = function ({
   algorithmEngineVersion = AlgorithmEngineVersion.V3,
   certificationDate = new Date('2015-10-03T01:02:03Z'),
 } = {}) {
-  return new V3Certificate({
+  return new Certificate({
     id,
     firstName,
     lastName,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,4 +1,4 @@
-import { buildV3CertificationAttestation } from '../factory/certification/results/build-v3-certification-attestation.js';
+import { buildCertificate } from '../factory/certification/results/build-v3-certification-attestation.js';
 import { buildEmptyInformationBanner, buildInformationBanner } from './banner/build-banner-information.js';
 import { buildAccountRecoveryDemand } from './build-account-recovery-demand.js';
 import { buildActivity } from './build-activity.js';
@@ -273,7 +273,7 @@ const certification = {
   },
   results: {
     buildGlobalCertificationLevel,
-    buildV3CertificationAttestation,
+    buildCertificate,
     parcoursup: {
       buildCertificationResult: parcoursupCertificationResult,
       buildCompetence: parcoursupCompetence,

--- a/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
@@ -17,6 +17,17 @@ export default class candidateGlobalLevel extends Component {
     ];
   }
 
+  get gaugeLabel() {
+    if (!this.args.certificate.level) {
+      return this.intl.t('pages.certificate.global.progress-bar-explanation.pre-beginner-level');
+    }
+
+    return this.intl.t('pages.certificate.global.progress-bar-explanation.default', {
+      level: this.args.certificate.level,
+      globalLevelLabel: this.args.certificate.globalLevelLabel,
+    });
+  }
+
   <template>
     <div class="certification-score-information">
       <p>{{t "pages.certificate.certification-value.paragraphs.1"}}</p>
@@ -26,34 +37,32 @@ export default class candidateGlobalLevel extends Component {
 
     <div class="hide-on-mobile">
       <PixGauge
-        @label={{t
-          "pages.certificate.global.progressbar-explanation"
-          level=@certificate.level
-          globalLevelLabel=@certificate.globalLevelLabel
-        }}
+        @label={{this.gaugeLabel}}
         @reachedLevel={{@certificate.level}}
         @maxLevel="7"
         @stepLabels={{this.stepLabels}}
       />
     </div>
 
-    <PixBlock class="candidate-global-information">
-      <div class="candidate-global-information__level">
-        <img
-          class="candidate-global-information-level__image"
-          src="/images/certificate/global-level-image.svg"
-          alt=""
-          role="presentation"
-        />
-        <div class="candidate-global-information-level__container">
-          <h2>{{t "pages.certificate.global.labels.level"}}</h2>
-          <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+    {{#if @certificate.globalLevelLabel}}
+      <PixBlock class="candidate-global-information">
+        <div class="candidate-global-information__level">
+          <img
+            class="candidate-global-information-level__image"
+            src="/images/certificate/global-level-image.svg"
+            alt=""
+            role="presentation"
+          />
+          <div class="candidate-global-information-level__container">
+            <h2>{{t "pages.certificate.global.labels.level"}}</h2>
+            <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+          </div>
         </div>
-      </div>
-      <div>
-        <p class="candidate-global-information--bold">{{@certificate.globalSummaryLabel}}</p>
-        <p>{{@certificate.globalDescriptionLabel}}</p>
-      </div>
-    </PixBlock>
+        <div>
+          <p class="candidate-global-information--bold">{{@certificate.globalSummaryLabel}}</p>
+          <p>{{@certificate.globalDescriptionLabel}}</p>
+        </div>
+      </PixBlock>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
@@ -13,7 +13,9 @@ import { t } from 'ember-intl';
             "pages.certificate.hexagon-score.certified"
           }}</span>
       </div>
-      <PixTag>{{@certificate.globalLevelLabel}}</PixTag>
+      {{#if @certificate.globalLevelLabel}}
+        <PixTag data-testid="global-level-label-tag">{{@certificate.globalLevelLabel}}</PixTag>
+      {{/if}}
     </div>
     <div>
       <ul class="candidate-information__list">

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
@@ -36,7 +36,9 @@ export default class v3Certificate extends Component {
 
       <CandidateGlobalLevel @certificate={{@certificate}} />
 
-      <CompetencesDetails @resultCompetenceTree={{@certificate.resultCompetenceTree}} />
+      {{#if @certificate.resultCompetenceTree}}
+        <CompetencesDetails @resultCompetenceTree={{@certificate.resultCompetenceTree}} />
+      {{/if}}
     </section>
   </template>
 }

--- a/mon-pix/tests/integration/components/certifications/certificate-information/candidate-global-level-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/candidate-global-level-test.gjs
@@ -8,45 +8,82 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Certifications | Certificate information | candidate global level', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays the component', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certification = store.createRecord('certification', {
-      birthdate: '2000-01-22',
-      birthplace: 'Paris',
-      firstName: 'Jean',
-      lastName: 'Bon',
-      certificationDate: new Date('2018-02-15T15:15:52Z'),
-      deliveredAt: new Date('2018-02-17T15:15:52Z'),
-      certificationCenter: 'Université de Lyon',
-      pixScore: 840,
-      resultCompetenceTree: store.createRecord('result-competence-tree'),
-      maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
-      globalLevelLabel: 'Expert 1',
-      globalDescriptionLabel: 'Vous êtes capable de tout.',
-      globalSummaryLabel: 'Expert de tous les domaines, Pix vous dit bravo !',
-      level: '7',
-    });
-    this.set('certification', certification);
+  module('when the global level label is pre-beginner', function () {
+    test('it does not display global level information', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 12,
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+      });
+      this.set('certification', certification);
 
-    // when
-    const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
       <Certifications::CertificateInformation::candidateGlobalLevel @certificate={{this.certification}} />`);
 
-    // then
-    assert.dom(screen.getByRole('heading', { name: t('pages.certificate.global.labels.level'), level: 2 })).exists();
-    assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
-    assert.dom(screen.getByText(certification.globalDescriptionLabel)).exists();
-    assert.dom(screen.getByText(certification.globalSummaryLabel)).exists();
-    assert
-      .dom(
-        screen.getByRole('progressbar', {
-          name: t('pages.certificate.global.progressbar-explanation', {
-            level: certification.level,
-            globalLevelLabel: certification.globalLevelLabel,
+      // then
+      assert
+        .dom(screen.queryByRole('heading', { name: t('pages.certificate.global.labels.level'), level: 2 }))
+        .doesNotExist();
+      assert
+        .dom(
+          screen.getByRole('progressbar', {
+            name: t('pages.certificate.global.progress-bar-explanation.pre-beginner-level'),
           }),
-        }),
-      )
-      .exists();
+        )
+        .exists();
+    });
+  });
+
+  module('when the global level label is not pre-beginner', function () {
+    test('it displays global level information', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 840,
+        resultCompetenceTree: store.createRecord('result-competence-tree'),
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+        globalLevelLabel: 'Expert 1',
+        globalDescriptionLabel: 'Vous êtes capable de tout.',
+        globalSummaryLabel: 'Expert de tous les domaines, Pix vous dit bravo !',
+        level: '7',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+        <Certifications::CertificateInformation::candidateGlobalLevel @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: t('pages.certificate.global.labels.level'), level: 2 })).exists();
+      assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
+      assert.dom(screen.getByText(certification.globalDescriptionLabel)).exists();
+      assert.dom(screen.getByText(certification.globalSummaryLabel)).exists();
+      assert
+        .dom(
+          screen.getByRole('progressbar', {
+            name: t('pages.certificate.global.progress-bar-explanation.default', {
+              level: certification.level,
+              globalLevelLabel: certification.globalLevelLabel,
+            }),
+          }),
+        )
+        .exists();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/certifications/certificate-information/candidate-information-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/candidate-information-test.gjs
@@ -8,34 +8,67 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Certifications | Certificate information | candidate information', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays certification starter page when extension is enabled', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certification = store.createRecord('certification', {
-      birthdate: '2000-01-22',
-      birthplace: 'Paris',
-      firstName: 'Jean',
-      lastName: 'Bon',
-      certificationDate: new Date('2018-02-15T15:15:52Z'),
-      deliveredAt: new Date('2018-02-17T15:15:52Z'),
-      certificationCenter: 'Université de Lyon',
-      pixScore: 654,
-      resultCompetenceTree: store.createRecord('result-competence-tree'),
-      maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
-      globalLevelLabel: 'Expert 1',
+  module('when the global level label is pre-beginner', function () {
+    test('it displays candidate information without global level label', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 22,
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+        <Certifications::CertificateInformation::candidateInformation @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByText(certification.pixScore)).exists();
+      assert.dom(screen.queryByTestId('global-level-label-tag')).doesNotExist();
+      assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Bon`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.certification-center')} Université de Lyon`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.certification-date')} 15/02/2018`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.delivered-at')} 17/02/2018`)).exists();
     });
-    this.set('certification', certification);
+  });
 
-    // when
-    const screen = await render(hbs`
-      <Certifications::CertificateInformation::candidateInformation @certificate={{this.certification}} />`);
+  module('when the global level label is not pre-beginner', function () {
+    test('it displays candidate information with global level label', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 654,
+        resultCompetenceTree: store.createRecord('result-competence-tree'),
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+        globalLevelLabel: 'Expert 1',
+      });
+      this.set('certification', certification);
 
-    // then
-    assert.dom(screen.getByText(certification.pixScore)).exists();
-    assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
-    assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Bon`)).exists();
-    assert.dom(screen.getByText(`${t('pages.certificate.certification-center')} Université de Lyon`)).exists();
-    assert.dom(screen.getByText(`${t('pages.certificate.certification-date')} 15/02/2018`)).exists();
-    assert.dom(screen.getByText(`${t('pages.certificate.delivered-at')} 17/02/2018`)).exists();
+      // when
+      const screen = await render(hbs`
+        <Certifications::CertificateInformation::candidateInformation @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByText(certification.pixScore)).exists();
+      assert.dom(screen.getByText(certification.globalLevelLabel)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.candidate')} Jean Bon`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.certification-center')} Université de Lyon`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.certification-date')} 15/02/2018`)).exists();
+      assert.dom(screen.getByText(`${t('pages.certificate.delivered-at')} 17/02/2018`)).exists();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
@@ -8,38 +8,79 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Certifications | Shareable certificate | v3-certificate', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays v3 certificate information', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const certification = store.createRecord('certification', {
-      birthdate: '2000-01-22',
-      birthplace: 'Paris',
-      firstName: 'Jean',
-      lastName: 'Bon',
-      certificationDate: new Date('2018-02-15T15:15:52Z'),
-      deliveredAt: new Date('2018-02-17T15:15:52Z'),
-      certificationCenter: 'Université de Lyon',
-      pixScore: 654,
-      resultCompetenceTree: store.createRecord('result-competence-tree'),
-      maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
-      globalLevelLabel: 'Expert 1',
+  module('when the global level label is pre-beginner', function () {
+    test('it displays certificate information without resultCompetenceTree', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 31,
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+        <Certifications::ShareableCertificate::v3Certificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
+      assert
+        .dom(
+          within(screen.getByRole('navigation')).getByRole('link', {
+            name: t('pages.fill-in-certificate-verification-code.title'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(screen.queryByRole('heading', { name: t('pages.certificate.details.competences.title') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('tablist', { name: t('pages.certificate.details.competences.title') }))
+        .doesNotExist();
     });
-    this.set('certification', certification);
+  });
 
-    // when
-    const screen = await render(hbs`
-      <Certifications::ShareableCertificate::v3Certificate @certificate={{this.certification}} />`);
+  module('when the global level label is not pre-beginner', function () {
+    test('it displays certificate information with resultCompetenceTree', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 654,
+        resultCompetenceTree: store.createRecord('result-competence-tree'),
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+        globalLevelLabel: 'Expert 1',
+      });
+      this.set('certification', certification);
 
-    // then
-    assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
-    assert
-      .dom(
-        within(screen.getByRole('navigation')).getByRole('link', {
-          name: t('pages.fill-in-certificate-verification-code.title'),
-        }),
-      )
-      .exists();
-    const globalLevelLabels = screen.getAllByText(certification.globalLevelLabel);
-    assert.strictEqual(globalLevelLabels.length, 2);
+      // when
+      const screen = await render(hbs`
+        <Certifications::ShareableCertificate::v3Certificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
+      assert
+        .dom(
+          within(screen.getByRole('navigation')).getByRole('link', {
+            name: t('pages.fill-in-certificate-verification-code.title'),
+          }),
+        )
+        .exists();
+      const globalLevelLabels = screen.getAllByText(certification.globalLevelLabel);
+      assert.strictEqual(globalLevelLabels.length, 2);
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -623,9 +623,9 @@
       "certification-date": "Exam date:",
       "certification-value": {
         "paragraphs": {
-          "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
+          "1": "Officially recognised, the Pix Certification attests to your mastery of digital skills. You are joining a community of several millions of certified users. Congratulations on this important step in your journey!",
           "2": "Your certified score has been calculated on the basis of your answers during the certification process. It may therefore differ from the number of pix shown in your profile.",
-          "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
+          "3": " On the day of your certification, it was possible to reach level 7 for each competence and a maximum of 895 pix (Expert 1 level)"
         }
       },
       "competences": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -653,7 +653,10 @@
           "independent": "Independent",
           "level": "Your level"
         },
-        "progressbar-explanation": "Bar de progression indiquant votre niveau atteint ( {level}, ou niveau {globalLevelLabel} ) sur un niveau maximum atteignable de 7 ( niveau Expert 1 )"
+        "progress-bar-explanation" : {
+          "default" : "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
+          "pre-beginner-level" : "Progress bar indicating the maximum level that can be reached in certification (i.e. 7 or Expert 1 level)"
+        }
       },
       "hexagon-score": {
         "certified": "certified"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -653,7 +653,10 @@
           "independent": "Indépendant",
           "level": "Votre niveau"
         },
-        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+        "progress-bar-explanation" : {
+          "default" : "Barre de progression indiquant votre niveau atteint ( {level}, ou niveau {globalLevelLabel} ) sur un niveau maximum atteignable de 7 ( niveau Expert 1 )",
+          "pre-beginner-level" : "Barre de progression indiquant le niveau maximum que l'on peut atteindre en certification (soit, 7 ou niveau Expert 1 )"
+        }
       },
       "hexagon-score": {
         "certified": "certifiés"


### PR DESCRIPTION
## 🌸 Problème

La nouvelle page du certificat V3 est implémenté coté certificat partagé sur Pix App.

Seulement, un candidat ayant moins de 64 pix n'a pas de niveau global et le métier a aussi décidé qu'il n'est pas pertinent qu'il ait accès aux tableaux des compétences. La page ne gère pas encore ce cas de figure.

## 🌳 Proposition

- Ne pas remonter d'infos liées au niveau global et aux compétences en cas de score inférieur à 64pix coté BACK

- Conditionner l'affichage coté FRONT.

## 🐝 Remarques

Cette PR comprend une modification du PDF V3, il est nécessaire de faire une non reg dessus également !

## 🤧 Pour tester

- Non reg du PDF V3
- Non reg du certificat V2
- Check du nouveau certificatV3


avec le FT à `true` 

V3 :
- Avec le code `P-6JPHP2TV`
- Voir le certificat complet si plus de 64 pix
- Voir le certificat incomplet (pas de tableau, pas de niveau global) si moins de 64 pix

Puis télécharger le PDF, doit être complet

V2 :
- Avec le code `P-H2YH3HBP`,
je suis censé voir l'ancienne page

Puis télécharger le PDF, doit être complet

avec le FT à `false` 

V3 :
- Avec le code `P-6JPHP2TV`,
je suis censé voir l'ancienne page

V2 :
- Avec le code `P-H2YH3HBP`,
je suis censé voir l'ancienne page

