### PR TITLE
[FEATURE] Corriger la phrase sur la date de dernière connexion lorsqu'il n'y en a pas (PIX-17562)

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -573,7 +573,7 @@
       },
       "user-overview": {
         "global-last-login": "Global last login :",
-        "no-last-connection-date-info": "Has not been connected since 03/2025",
+        "no-last-connection-date-info": "Has not been connected since 10/2021",
         "sso": "SSO"
       }
     }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -573,7 +573,7 @@
       },
       "user-overview": {
         "global-last-login": "Date de dernière connexion globale :",
-        "no-last-connection-date-info": "Non connecté depuis 03/2025",
+        "no-last-connection-date-info": "Non connecté depuis 10/2021",
         "sso": "SSO"
       }
     }

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -69,6 +69,15 @@ function _buildUsers(databaseBuilder) {
     emailConfirmedAt: null,
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+
+  // user without lastLoggedAt
+  const userWithoutLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'without',
+    lastName: 'LastLoggedAt',
+    email: 'without-lastlogged@example.net',
+    emailConfirmedAt: null,
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
 }
 
 export function buildUsers(databaseBuilder) {


### PR DESCRIPTION
## 🌸 Problème

Dans Pix admin, on affichait "Non connecté depuis 03/2025" alors qu'il serait plus judicieux de mettre "10/2021".

## 🌳 Proposition

Modifier la chaîne de traduction.

## 🐝 Remarques

On ajoute un nouveau seed pour l'occasion.

## 🤧 Pour tester

- Se rendre sur Pix admin,
- Se connecter avec superadmin@example.net,
- Se rendre sur la page des utilisateurs,
- Rechercher l'utilisateur without-lastlogged@example.net,
- Afficher la page de l'utilisateur,
- Constater qu'il est bien indiqué 10/2021.