### PR TITLE
[BUGFIX] Ne pas ajouter un membre avec le rôle admin à un centre de certif archivé s'il est ajouté à une orga de type sco (PIX-16804)

### DIFF
--- a/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
@@ -3,16 +3,6 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationCenter } from '../../../../shared/domain/models/CertificationCenter.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
 
-const toDomain = (certificationCenter) => {
-  const habilitations = certificationCenter.habilitations.map((dbComplementaryCertification) => {
-    return new ComplementaryCertification(dbComplementaryCertification);
-  });
-  return new CertificationCenter({
-    ...certificationCenter,
-    habilitations,
-  });
-};
-
 const getComplementaryCertifications = async (knexConnection, certificationCenter) =>
   await knexConnection('complementary-certifications')
     .select([
@@ -37,7 +27,7 @@ export const get = async function ({ id }) {
     throw new NotFoundError(`Certification center with id: ${id} not found`);
   }
   const complementaryCertifications = await getComplementaryCertifications(knexConnection, certificationCenter);
-  return toDomain({
+  return _toDomain({
     ...certificationCenter,
     habilitations: complementaryCertifications,
   });
@@ -63,7 +53,7 @@ export const getBySessionId = async ({ sessionId }) => {
     throw new NotFoundError(`Could not find certification center for sessionId ${sessionId}.`);
   }
   const complementaryCertifications = await getComplementaryCertifications(knexConnection, certificationCenter);
-  return toDomain({
+  return _toDomain({
     ...certificationCenter,
     habilitations: complementaryCertifications,
   });
@@ -78,7 +68,7 @@ export const findByExternalId = async ({ externalId }) => {
   }
 
   const complementaryCertifications = await getComplementaryCertifications(knexConnection, certificationCenter);
-  return toDomain({
+  return _toDomain({
     ...certificationCenter,
     habilitations: complementaryCertifications,
   });
@@ -96,4 +86,14 @@ export const getRefererEmails = async ({ id }) => {
     .join('users', 'users.id', 'certification-center-memberships.userId')
     .where('certification-centers.id', id)
     .where('certification-center-memberships.isReferer', true);
+};
+
+const _toDomain = (certificationCenter) => {
+  const habilitations = certificationCenter.habilitations.map((dbComplementaryCertification) => {
+    return new ComplementaryCertification(dbComplementaryCertification);
+  });
+  return new CertificationCenter({
+    ...certificationCenter,
+    habilitations,
+  });
 };

--- a/api/src/shared/domain/models/CertificationCenter.js
+++ b/api/src/shared/domain/models/CertificationCenter.js
@@ -1,13 +1,15 @@
 import { CERTIFICATION_CENTER_TYPES } from '../constants.js';
 
 class CertificationCenter {
-  constructor({ id, name, externalId, type, createdAt, updatedAt, habilitations = [] } = {}) {
+  constructor({ id, name, externalId, type, createdAt, updatedAt, archivedAt, archivedBy, habilitations = [] } = {}) {
     this.id = id;
     this.name = name;
     this.externalId = externalId;
     this.type = type;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.archivedAt = archivedAt;
+    this.archivedBy = archivedBy;
     this.habilitations = habilitations;
   }
 

--- a/api/src/team/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.js
+++ b/api/src/team/domain/usecases/create-certification-center-membership-for-sco-organization-admin-member.usecase.js
@@ -14,7 +14,7 @@ const createCertificationCenterMembershipForScoOrganizationAdminMember = async f
     externalId: existingOrganizationMembership.organization.externalId,
   });
 
-  if (!existingCertificationCenter) return;
+  if (!existingCertificationCenter || existingCertificationCenter.archivedAt) return;
 
   const certificationCenterMembership =
     await certificationCenterMembershipRepository.findByCertificationCenterIdAndUserId({

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -37,6 +37,8 @@ describe('Integration | Repository | Certification Center', function () {
           createdAt: new Date('2018-01-01T05:43:10Z'),
           complementaryCertifications: [],
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
 
         await databaseBuilder.commit();
@@ -95,6 +97,8 @@ describe('Integration | Repository | Certification Center', function () {
           createdAt: new Date('2018-01-01T05:43:10Z'),
           habilitations: [expectedComplementaryCertification2, expectedComplementaryCertification1],
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
 
         await databaseBuilder.commit();
@@ -236,6 +240,8 @@ describe('Integration | Repository | Certification Center', function () {
           externalId: 'EXTERNAL_ID',
           createdAt: new Date('2018-01-01T05:43:10Z'),
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
         await databaseBuilder.commit();
 
@@ -279,6 +285,8 @@ describe('Integration | Repository | Certification Center', function () {
           createdAt: new Date('2018-01-01T05:43:10Z'),
           habilitations: [expectedComplementaryCertification],
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -401,6 +401,8 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         name: certificationCenter.name,
         type: certificationCenter.type,
         updatedAt: certificationCenter.updatedAt,
+        archivedAt: undefined,
+        archivedBy: undefined,
       });
 
       expect(associatedUser).to.be.an.instanceOf(User);

--- a/api/tests/tooling/domain-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center.js
@@ -8,6 +8,8 @@ const buildCertificationCenter = function ({
   createdAt = new Date('2020-01-01'),
   updatedAt,
   habilitations = [],
+  archivedAt = undefined,
+  archivedBy = undefined,
 } = {}) {
   return new CertificationCenter({
     id,
@@ -17,6 +19,8 @@ const buildCertificationCenter = function ({
     updatedAt,
     createdAt,
     habilitations,
+    archivedAt,
+    archivedBy,
   });
 };
 


### PR DESCRIPTION
## 🌸 Problème

Lorsqu'on ajoute un membre avec le rôle admin à une organisation de type sco, le membre est automatiquement ajouté au centre de certification par l'UAI en tant qu'admin. Cela se fait également lorsque le centre de certification est archivé ce qui ne devrait pas être le cas.

## 🌳 Proposition

Ajouter dans le usecase la condition vérifiant si le centre de certification a un archivedAt, au même niveau que son existance.

## 🐝 Remarques

On ajoute dans le modèle également les notions d'archivage avec archivedAt et archivedBy.

## 🤧 Pour tester

- Prendre une grande inspiration: Ça va bien se passer,
- Se rendre sur pix admin,
- Se connecter avec superadmin@example.net,
- Se rendre sur la page des organisations,
- Créer une nouvelle organisation de type SCO,
- La modifier et lui donner un identifiant externe (noter l'identifiant),
- Se rendre sur la page des centres de certifications,
- Créer un centre de certification de type SCO,
- Lui donner le même external id que l'organisation précédemment créée,
- Archiver le centre,
- Retourner sur la page de l'organisation,
- Se rendre dans l'onglet équipe,
- Ajouter un membre,
- En base, constater qu'aucune ligne n'a été créée dans la table certification-center-memberships:
```sql
SELECT * FROM "certification-center-memberships" WHERE "certificationCenterId" = <identifiant du centre>
```