### PR TITLE
[TECH] :truck: Déplace la route `user trainings` vers le contexte `/src/devcomp`

### DIFF
--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -2,8 +2,7 @@ import * as healthcheck from '../src/shared/application/healthcheck/index.js';
 import * as campaignParticipations from './application/campaign-participations/index.js';
 import * as frameworks from './application/frameworks/index.js';
 import * as scoOrganizationLearners from './application/sco-organization-learners/index.js';
-import * as users from './application/users/index.js';
 
-const routes = [campaignParticipations, healthcheck, scoOrganizationLearners, frameworks, users];
+const routes = [campaignParticipations, healthcheck, scoOrganizationLearners, frameworks];
 
 export { routes };

--- a/api/src/devcomp/application/user-trainings/index.js
+++ b/api/src/devcomp/application/user-trainings/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
-import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { userController } from './user-controller.js';
 
 const register = async function (server) {

--- a/api/src/devcomp/application/user-trainings/user-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-controller.js
@@ -1,6 +1,6 @@
-import { usecases as devcompUsecases } from '../../../src/devcomp/domain/usecases/index.js';
-import * as trainingSerializer from '../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
-import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
+import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
+import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
 const findPaginatedUserRecommendedTrainings = async function (
   request,

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -3,8 +3,17 @@ import * as passageEvents from './application/passage-events/index.js';
 import * as passages from './application/passages/index.js';
 import * as trainings from './application/trainings/index.js';
 import * as evaluationTutorials from './application/tutorial-evaluations/index.js';
+import * as userTrainings from './application/user-trainings/index.js';
 import * as userTutorials from './application/user-tutorials/index.js';
 
-const devcompRoutes = [modulesRoutes, passages, passageEvents, trainings, userTutorials, evaluationTutorials];
+const devcompRoutes = [
+  modulesRoutes,
+  passages,
+  passageEvents,
+  trainings,
+  userTutorials,
+  evaluationTutorials,
+  userTrainings,
+];
 
 export { devcompRoutes };

--- a/api/tests/devcomp/acceptance/application/user-trainings/users-controller-find-paginated-user-recommended-trainings_test.js
+++ b/api/tests/devcomp/acceptance/application/user-trainings/users-controller-find-paginated-user-recommended-trainings_test.js
@@ -3,7 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | users-controller-find-paginated-user-recommended-trainings', function () {
   let options;

--- a/api/tests/devcomp/unit/application/user-trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/user-trainings/index_test.js
@@ -1,7 +1,7 @@
-import * as moduleUnderTest from '../../../../lib/application/users/index.js';
-import { userController } from '../../../../lib/application/users/user-controller.js';
-import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/user-trainings/index.js';
+import { userController } from '../../../../../src/devcomp/application/user-trainings/user-controller.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | user-router', function () {
   describe('GET /api/users/{id}/trainings', function () {

--- a/api/tests/devcomp/unit/application/user-trainings/user-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-trainings/user-controller_test.js
@@ -1,6 +1,6 @@
-import { userController } from '../../../../lib/application/users/user-controller.js';
-import { usecases as devcompUsecases } from '../../../../src/devcomp/domain/usecases/index.js';
-import { expect, hFake, sinon } from '../../../test-helper.js';
+import { userController } from '../../../../../src/devcomp/application/user-trainings/user-controller.js';
+import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | user-controller', function () {
   describe('#findPaginatedUserRecommendedTrainings', function () {


### PR DESCRIPTION
## 🌸 Problème

La route `user trainings` est dans `lib/`

## 🌳 Proposition

Déplacer la route `user trainings` vers le contexte `/src/devcomp`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
