### PR TITLE
[TECH] :truck: Déplace le cas d'utilisation `create preview assessment` vers le repertoire `src/shared/`

### DIFF
--- a/api/src/school/application/assessment-controller.js
+++ b/api/src/school/application/assessment-controller.js
@@ -30,7 +30,13 @@ const getCurrentActivity = async function (request, h, dependencies = { activity
   return dependencies.activitySerializer.serialize(activity);
 };
 
+const createAssessmentPreviewForPix1d = async function (request, h, dependencies = { assessmentSerializer }) {
+  const createdAssessment = await usecases.createPreviewAssessment({});
+  return h.response(dependencies.assessmentSerializer.serialize(createdAssessment)).created();
+};
+
 const assessmentController = {
+  createAssessmentPreviewForPix1d,
   getNextChallengeForPix1d,
   create,
   getById,

--- a/api/src/school/application/assessment-route.js
+++ b/api/src/school/application/assessment-route.js
@@ -64,6 +64,15 @@ const register = async function (server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/pix1d/assessments/preview',
+      config: {
+        auth: false,
+        handler: assessmentController.createAssessmentPreviewForPix1d,
+        tags: ['api', 'pix1d', 'assessment'],
+      },
+    },
   ]);
 };
 const name = 'assessment-pix1d-api';

--- a/api/src/school/domain/usecases/create-preview-assessment.js
+++ b/api/src/school/domain/usecases/create-preview-assessment.js
@@ -1,4 +1,4 @@
-import { Assessment } from '../../../src/shared/domain/models/index.js';
+import { Assessment } from '../../../shared/domain/models/index.js';
 
 const createPreviewAssessment = async function ({ assessmentRepository }) {
   const assessment = new Assessment({ type: Assessment.types.PREVIEW });

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -30,11 +30,6 @@ const save = async function (request, h, dependencies = { assessmentRepository }
   return h.response(assessmentSerializer.serialize(createdAssessment)).created();
 };
 
-const createAssessmentPreviewForPix1d = async function (request, h, dependencies = { assessmentSerializer }) {
-  const createdAssessment = await usecases.createPreviewAssessment({});
-  return h.response(dependencies.assessmentSerializer.serialize(createdAssessment)).created();
-};
-
 const get = async function (request, _, dependencies = { assessmentSerializer }) {
   const assessmentId = request.params.id;
   const locale = extractLocaleFromRequest(request);
@@ -166,7 +161,6 @@ const assessmentController = {
   updateLastChallengeState,
   findCompetenceEvaluations,
   autoValidateNextChallenge,
-  createAssessmentPreviewForPix1d,
   createCertificationChallengeLiveAlert,
 };
 

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -32,15 +32,6 @@ const register = async function (server) {
       },
     },
     {
-      method: 'POST',
-      path: '/api/pix1d/assessments/preview',
-      config: {
-        auth: false,
-        handler: assessmentController.createAssessmentPreviewForPix1d,
-        tags: ['api', 'pix1d', 'assessment'],
-      },
-    },
-    {
       method: 'GET',
       path: '/api/assessments/{id}/next',
       config: {

--- a/api/tests/school/integration/domain/usecases/create-preview-assessment_test.js
+++ b/api/tests/school/integration/domain/usecases/create-preview-assessment_test.js
@@ -1,7 +1,7 @@
-import { createPreviewAssessment } from '../../../../lib/domain/usecases/create-preview-assessment.js';
-import { Assessment } from '../../../../src/shared/domain/models/index.js';
-import * as assessmentRepository from '../../../../src/shared/infrastructure/repositories/assessment-repository.js';
-import { expect, knex } from '../../../test-helper.js';
+import { createPreviewAssessment } from '../../../../../src/school/domain/usecases/create-preview-assessment.js';
+import { Assessment } from '../../../../../src/shared/domain/models/index.js';
+import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
+import { expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-preview-assessment', function () {
   let assessmentId;

--- a/api/tests/school/unit/application/assessment-controller_test.js
+++ b/api/tests/school/unit/application/assessment-controller_test.js
@@ -93,4 +93,20 @@ describe('Unit | Controller | assessment-controller', function () {
       });
     });
   });
+
+  describe('#createAssessmentPreviewForPix1d', function () {
+    it('should call the expected usecase', async function () {
+      const assessmentSerializer = { serialize: sinon.stub() };
+      const createdAssessment = Symbol('created-assessment');
+      assessmentSerializer.serialize.withArgs(createdAssessment).resolves(Symbol('serialized-assessment'));
+      sinon.stub(usecases, 'createPreviewAssessment').resolves(createdAssessment);
+
+      const result = await assessmentController.createAssessmentPreviewForPix1d({}, hFake, {
+        assessmentSerializer,
+      });
+
+      expect(result.statusCode).to.be.equal(201);
+      expect(assessmentSerializer.serialize).to.have.been.calledWithExactly(createdAssessment);
+    });
+  });
 });

--- a/api/tests/school/unit/application/assessment-route_test.js
+++ b/api/tests/school/unit/application/assessment-route_test.js
@@ -83,4 +83,21 @@ describe('Unit | Application | Router | assessment-router', function () {
       expect(getCurrentActivityStub).to.have.been.called;
     });
   });
+
+  describe('POST /api/pix1d/assessments/preview', function () {
+    it('should return 200', async function () {
+      // given
+      sinon
+        .stub(assessmentController, 'createAssessmentPreviewForPix1d')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/pix1d/assessments/preview');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/shared/unit/application/assessements/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessements/assessment-controller_test.js
@@ -11,22 +11,6 @@ import { featureToggles } from '../../../../../src/shared/infrastructure/feature
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | assessment-controller', function () {
-  describe('#createAssessmentPreviewForPix1d', function () {
-    it('should call the expected usecase', async function () {
-      const assessmentSerializer = { serialize: sinon.stub() };
-      const createdAssessment = Symbol('created-assessment');
-      assessmentSerializer.serialize.withArgs(createdAssessment).resolves(Symbol('serialized-assessment'));
-      sinon.stub(usecases, 'createPreviewAssessment').resolves(createdAssessment);
-
-      const result = await assessmentController.createAssessmentPreviewForPix1d({}, hFake, {
-        assessmentSerializer,
-      });
-
-      expect(result.statusCode).to.be.equal(201);
-      expect(assessmentSerializer.serialize).to.have.been.calledWithExactly(createdAssessment);
-    });
-  });
-
   describe('#get', function () {
     const authenticatedUserId = '12';
     const locale = 'fr';

--- a/api/tests/shared/unit/application/assessements/index_test.js
+++ b/api/tests/shared/unit/application/assessements/index_test.js
@@ -46,23 +46,6 @@ describe('Unit | Application | Router | assessment-router', function () {
     });
   });
 
-  describe('POST /api/pix1d/assessments/preview', function () {
-    it('should return 200', async function () {
-      // given
-      sinon
-        .stub(assessmentController, 'createAssessmentPreviewForPix1d')
-        .callsFake((request, h) => h.response('ok').code(200));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/pix1d/assessments/preview');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('GET /api/assessments/{id}/next', function () {
     it('should return 200', async function () {
       // given


### PR DESCRIPTION
## 🌸 Problème

Le cas d'utilisation `create preview assessment` est dans `lib/`

## 🌳 Proposition

Déplacer le cas d'utilisation `create preview assessment` vers le répertoire `src/shared/`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Visualiser un challenge de PixJunior en preview.

Exemple : 
https://junior-pr12108.review.pix.fr/challenges/challenge1zjYxfricm0yIF/preview
