### PR TITLE
[TECH] :truck: Déplace le cas d'utilisation `find competence evaluations by assessment` vers le répertoire `src/shared/`

### DIFF
--- a/api/src/evaluation/domain/usecases/find-competence-evaluations-by-assessment.js
+++ b/api/src/evaluation/domain/usecases/find-competence-evaluations-by-assessment.js
@@ -1,4 +1,4 @@
-import { UserNotAuthorizedToAccessEntityError } from '../../../src/shared/domain/errors.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
 
 const findCompetenceEvaluationsByAssessment = async function ({
   userId,

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -97,7 +97,10 @@ const findCompetenceEvaluations = async function (request) {
   const userId = request.auth.credentials.userId;
   const assessmentId = request.params.id;
 
-  const competenceEvaluations = await usecases.findCompetenceEvaluationsByAssessment({ userId, assessmentId });
+  const competenceEvaluations = await evaluationUsecases.findCompetenceEvaluationsByAssessment({
+    userId,
+    assessmentId,
+  });
 
   return competenceEvaluationSerializer.serialize(competenceEvaluations);
 };

--- a/api/tests/evaluation/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { findCompetenceEvaluationsByAssessment } from '../../../../lib/domain/usecases/find-competence-evaluations-by-assessment.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../test-helper.js';
+import { findCompetenceEvaluationsByAssessment } from '../../../../../src/evaluation/domain/usecases/find-competence-evaluations-by-assessment.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | find-competence-evaluations-by-assessment', function () {
   const userId = 1;

--- a/api/tests/shared/unit/application/assessements/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessements/assessment-controller_test.js
@@ -160,7 +160,7 @@ describe('Unit | Controller | assessment-controller', function () {
       const competenceEvaluation1 = domainBuilder.buildCompetenceEvaluation({ assessmentId, userId });
       const competenceEvaluation2 = domainBuilder.buildCompetenceEvaluation({ assessmentId, userId });
       sinon
-        .stub(usecases, 'findCompetenceEvaluationsByAssessment')
+        .stub(evaluationUsecases, 'findCompetenceEvaluationsByAssessment')
         .withArgs({ assessmentId, userId })
         .resolves([competenceEvaluation1, competenceEvaluation2]);
       const request = {


### PR DESCRIPTION
## 🌸 Problème

Le cas d'utilisation `find competence evaluations by assessment` est dans `lib/`

## 🌳 Proposition

Déplacer le cas d'utilisation `find competence evaluations by assessment` vers le répertoire `src/shared/`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- se connecter à pix app avec `admin-orga@example.net`
- cliquer sur une carte de compétente
- repondre à 1 question
- quitter
- réouvrir la carte de compétence
- Valider qu'on a repris à la précédente question !
