### PR TITLE
[TECH] migrer les tests e2e d'orga vers Playwright (PIX-17586)

### DIFF
--- a/high-level-tests/e2e-playwright/pix-orga/migration.md
+++ b/high-level-tests/e2e-playwright/pix-orga/migration.md
@@ -20,7 +20,7 @@
 
 **student-sup**
 
-- [ ] J'affiche la liste des élèves
+- [x] J'affiche la liste des élèves
 
 **campaign-evaluation**
 

--- a/high-level-tests/e2e-playwright/pix-orga/students.test.ts
+++ b/high-level-tests/e2e-playwright/pix-orga/students.test.ts
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+
+import { useLoggedUser } from '../helpers/auth.js';
+import { databaseBuilder } from '../helpers/db.js';
+import { test } from '../helpers/fixtures.js';
+
+const loggedUserId = useLoggedUser('pix-orga');
+
+test('Students management for a sco organization', async ({ page }) => {
+  await _buildTestData();
+
+  await page.goto('/');
+
+  await page.getByRole('link', { name: 'Étudiants' }).click();
+  await expect(page.getByRole('heading', { name: 'Étudiant (1)' })).toBeVisible();
+  await expect(page.getByRole('table', { name: 'Tableau des étudiants trié' })).toBeVisible();
+});
+
+async function _buildTestData() {
+  // SCO organization
+  const organization = databaseBuilder.factory.buildOrganization({
+    type: 'SUP',
+    isManagingStudents: true,
+  });
+
+  // Member of the organization
+  const member = databaseBuilder.factory.buildUser.withMembership({
+    id: loggedUserId,
+    organizationId: organization.id,
+    role: 'MEMBER',
+  });
+  const legalDocument = databaseBuilder.factory.buildLegalDocumentVersion({ type: 'TOS', service: 'pix-orga' });
+  databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+    legalDocumentVersionId: legalDocument.id,
+    userId: member.id,
+  });
+
+  // Learner linked to user with PIX authentication method
+  const learnerPixAuth = databaseBuilder.factory.buildUser.withRawPassword();
+  databaseBuilder.factory.buildOrganizationLearner({
+    organizationId: organization.id,
+    firstName: learnerPixAuth.firstName,
+    lastName: learnerPixAuth.lastName,
+    userId: learnerPixAuth.id,
+  });
+
+  await databaseBuilder.commit();
+}


### PR DESCRIPTION
## 🌸 Problème

On souhaiterai ne plus utiliser cypress pour les tests e2e mais plutot Playwrigth afin d'améliorer l'expérience développeur et faciliter leur maintenance.

## 🌳 Proposition

on migre les tests existants vers Playwright

## 🐝 Remarques

Pour lancer les tests en local, faire un `npm ci` sur `orga`, `mon-pix` et api
Dans le cas où l'on souhaite lancer les tests `pix-orga` seulement, s'assurer qu'on a aussi cocher le `pix-orga-setup` correspondant dans la liste des suites de tests.
<img width="255" alt="image" src="https://github.com/user-attachments/assets/b6f2a927-7c22-4136-a5d6-ff504815c790" />

## 🤧 Pour tester
ras