### PR TITLE
[TECH] :truck: Déplace le cas d'utilisation `getCorrectionForAnswer` vers `src/evaluation/`

### DIFF
--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -6,10 +6,8 @@ import * as userRecommendedTrainingRepository from '../../../src/devcomp/infrast
 import { getCorrection } from '../../../src/evaluation/domain/services/solution/solution-service-qrocm-dep.js';
 import { fromDatasourceObject } from '../../../src/shared/infrastructure/adapters/solution-adapter.js';
 import { injectDependencies } from '../../../src/shared/infrastructure/utils/dependency-injection.js';
-import * as correctionRepository from './correction-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
-  correctionRepository,
   trainingRepository,
   trainingTriggerRepository,
   tutorialEvaluationRepository,

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,4 +1,3 @@
-import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
@@ -88,7 +87,7 @@ const getCorrection = async function (request, _h, dependencies = { correctionSe
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const answerId = request.params.id;
 
-  const correction = await usecases.getCorrectionForAnswer({
+  const correction = await evaluationUsecases.getCorrectionForAnswer({
     answerId,
     userId,
     locale,

--- a/api/src/evaluation/domain/usecases/get-correction-for-answer.js
+++ b/api/src/evaluation/domain/usecases/get-correction-for-answer.js
@@ -1,5 +1,8 @@
-import { AssessmentNotCompletedError, NotFoundError } from '../../../src/shared/domain/errors.js';
-import { LearningContentResourceNotFound } from '../../../src/shared/domain/errors.js';
+import {
+  AssessmentNotCompletedError,
+  LearningContentResourceNotFound,
+  NotFoundError,
+} from '../../../shared/domain/errors.js';
 
 const getCorrectionForAnswer = async function ({
   assessmentRepository,

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -2,7 +2,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { certificationCompletedJobRepository } from '../../../../lib/infrastructure/repositories/jobs/certification-completed-job-repository.js';
-import * as courseRepository from '../../../../src/shared/infrastructure/repositories/course-repository.js';
 import * as certificationEvaluationCandidateRepository from '../../../certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
@@ -10,12 +9,14 @@ import * as campaignParticipationRepository from '../../../prescription/campaign
 import { participationCompletedJobRepository } from '../../../prescription/campaign-participation/infrastructure/repositories/jobs/participation-completed-job-repository.js';
 import * as targetProfileAdministrationRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-administration-repository.js';
 import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
+import { fromDatasourceObject } from '../../../shared/infrastructure/adapters/solution-adapter.js';
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as badgeForCalculationRepository from '../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
+import * as courseRepository from '../../../shared/infrastructure/repositories/course-repository.js';
 import { repositories as injectedSharedRepositories } from '../../../shared/infrastructure/repositories/index.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -51,7 +52,9 @@ const dependencies = {
   algorithmDataFetcherService,
   answerJobRepository,
   certificationCompletedJobRepository,
+  fromDatasourceObject,
   answerRepository,
+  correctionRepository: repositories.correctionRepository,
   areaRepository,
   assessmentRepository,
   autonomousCourseRepository: repositories.autonomousCourseRepository,

--- a/api/src/evaluation/infrastructure/repositories/correction-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/correction-repository.js
@@ -1,15 +1,15 @@
 import _ from 'lodash';
 
-import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
-import { Hint } from '../../../src/shared/domain/models/Hint.js';
-import { Challenge } from '../../../src/shared/domain/models/index.js';
-import { Correction } from '../../../src/shared/domain/models/index.js';
-import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
+import { Hint } from '../../../shared/domain/models/Hint.js';
+import { Challenge } from '../../../shared/domain/models/index.js';
+import { Correction } from '../../../shared/domain/models/index.js';
+import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
+import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
+import { Answer } from '../../domain/models/Answer.js';
 
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 
-const getByChallengeId = async function ({
+export async function getByChallengeId({
   challengeId,
   answerValue,
   userId,
@@ -56,8 +56,7 @@ const getByChallengeId = async function ({
     answersEvaluation: correctionDetails?.answersEvaluation || [],
     solutionsWithoutGoodAnswers: correctionDetails?.solutionsWithoutGoodAnswers || [],
   });
-};
-export { getByChallengeId };
+}
 
 async function _getHint(skill) {
   if (_hasValidatedHint(skill) && skill.hint) {

--- a/api/src/evaluation/infrastructure/repositories/index.js
+++ b/api/src/evaluation/infrastructure/repositories/index.js
@@ -1,10 +1,14 @@
+import * as tutorialRepository from '../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userApi from '../../../identity-access-management/application/api/users-api.js';
 import * as campaignApi from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as targetProfileApi from '../../../prescription/target-profile/application/api/target-profile-api.js';
+import { fromDatasourceObject } from '../../../shared/infrastructure/adapters/solution-adapter.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { getCorrection } from '../../domain/services/solution/solution-service-qrocm-dep.js';
 import * as autonomousCourseRepository from './autonomous-course-repository.js';
 import * as autonomousCourseTargetProfileRepository from './autonomous-course-target-profile-repository.js';
 import * as badgeCriteriaRepository from './badge-criteria-repository.js';
+import * as correctionRepository from './correction-repository.js';
 import * as userRepository from './user-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
@@ -12,12 +16,16 @@ const repositoriesWithoutInjectedDependencies = {
   autonomousCourseTargetProfileRepository,
   badgeCriteriaRepository,
   userRepository,
+  correctionRepository,
 };
 
 const dependencies = {
   campaignApi,
   targetProfileApi,
   userApi,
+  tutorialRepository,
+  fromDatasourceObject,
+  getCorrection,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/tests/evaluation/integration/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/correction-repository_test.js
@@ -1,7 +1,7 @@
-import * as correctionRepository from '../../../../lib/infrastructure/repositories/correction-repository.js';
-import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
-import { Correction } from '../../../../src/shared/domain/models/index.js';
-import { databaseBuilder, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
+import * as correctionRepository from '../../../../../src/evaluation/infrastructure/repositories/correction-repository.js';
+import { Correction } from '../../../../../src/shared/domain/models/index.js';
+import { databaseBuilder, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Repository | correction-repository', function () {
   let tutorialRepository;

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -1,4 +1,3 @@
-import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { answerController } from '../../../../../src/evaluation/application/answers/answer-controller.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
@@ -330,7 +329,7 @@ describe('Unit | Controller | answer-controller', function () {
     let correctionSerializerStub;
 
     beforeEach(function () {
-      sinon.stub(usecases, 'getCorrectionForAnswer');
+      sinon.stub(evaluationUsecases, 'getCorrectionForAnswer');
       correctionSerializerStub = { serialize: sinon.stub() };
     });
 
@@ -338,7 +337,7 @@ describe('Unit | Controller | answer-controller', function () {
       // given
       requestResponseUtilsStub.extractUserIdFromRequest.returns(userId);
       requestResponseUtilsStub.extractLocaleFromRequest.returns(locale);
-      usecases.getCorrectionForAnswer.withArgs({ answerId, userId, locale }).resolves({});
+      evaluationUsecases.getCorrectionForAnswer.withArgs({ answerId, userId, locale }).resolves({});
       correctionSerializerStub.serialize.withArgs({}).returns('ok');
 
       // when

--- a/api/tests/evaluation/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-correction-for-answer_test.js
@@ -1,9 +1,9 @@
-import { getCorrectionForAnswer } from '../../../../lib/domain/usecases/get-correction-for-answer.js';
-import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
-import { AssessmentNotCompletedError, NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { LearningContentResourceNotFound } from '../../../../src/shared/domain/errors.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
+import { getCorrectionForAnswer } from '../../../../../src/evaluation/domain/usecases/get-correction-for-answer.js';
+import { AssessmentNotCompletedError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { LearningContentResourceNotFound } from '../../../../../src/shared/domain/errors.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 class OtherError extends Error {}
 


### PR DESCRIPTION
## 🌸 Problème

Le cas d'utilisation `getCorrectionForAnswer` est dans `lib/`

## 🌳 Proposition

Déplacer le cas d'utilisation `getCorrectionForAnswer` vers `src/evaluation/`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Passer au moins deux épreuves et s'assurer que l'on a une réponse bonne et une réponse mauvaise. Rien de spécial ne devrait avoir changé.
