### PR TITLE
[BUGFIX] Retourner les compétences traduites dans les nouveaux certificats v3 (PIX-17592).

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -25,7 +25,10 @@ const getCertificateByVerificationCode = async function (
   const certificationCourse = await usecases.getCertificationCourseByVerificationCode({ verificationCode });
 
   if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
-    certificate = await usecases.getCertificationAttestation({ certificationCourseId: certificationCourse.getId() });
+    certificate = await usecases.getCertificationAttestation({
+      certificationCourseId: certificationCourse.getId(),
+      locale,
+    });
   } else {
     certificate = await usecases.getShareableCertificate({
       certificationCourseId: certificationCourse.getId(),
@@ -49,7 +52,10 @@ const getCertificate = async function (
 
   let certificate;
   if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
-    certificate = await usecases.getCertificationAttestation({ certificationCourseId: certificationCourse.getId() });
+    certificate = await usecases.getCertificationAttestation({
+      certificationCourseId: certificationCourse.getId(),
+      locale,
+    });
     return dependencies.certificateSerializer.serialize({ certificate, translate });
   } else {
     certificate = await usecases.getPrivateCertificate({

--- a/api/src/certification/results/domain/usecases/get-certification-attestation.js
+++ b/api/src/certification/results/domain/usecases/get-certification-attestation.js
@@ -8,6 +8,6 @@
  * @param {CertificateRepository} params.certificateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
-export const getCertificationAttestation = async function ({ certificationCourseId, certificateRepository }) {
-  return certificateRepository.getCertificationAttestation({ certificationCourseId });
+export const getCertificationAttestation = async function ({ certificationCourseId, locale, certificateRepository }) {
+  return certificateRepository.getCertificationAttestation({ certificationCourseId, locale });
 };

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -55,7 +55,7 @@ const findByDivisionForScoIsManagingStudentsOrganization = async function ({ org
   );
 };
 
-const getCertificationAttestation = async function ({ certificationCourseId }) {
+const getCertificationAttestation = async function ({ certificationCourseId, locale }) {
   const certificationCourseDTO = await _selectCertificationAttestations()
     .where('certification-courses.id', '=', certificationCourseId)
     .groupBy('certification-courses.id', 'sessions.id', 'assessment-results.id')
@@ -65,7 +65,7 @@ const getCertificationAttestation = async function ({ certificationCourseId }) {
     throw new NotFoundError(`There is no certification course with id "${certificationCourseId}"`);
   }
 
-  const competenceTree = await competenceTreeRepository.get();
+  const competenceTree = await competenceTreeRepository.get({ locale });
   const certifiedBadges = await _getCertifiedBadges(certificationCourseDTO.id);
 
   return _toDomainForCertificationAttestation({ certificationCourseDTO, competenceTree, certifiedBadges });

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -497,10 +497,12 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     context('when session is V3', function () {
       context('when isV3CertificationAttestationEnabled feature toggle is truthy', function () {
         context('when isV3CertificationPageEnabled feature toggle is truthy', function () {
-          it('should return a V3CertificationAttestation with ResultCompetenceTree', async function () {
+          it('should return a V3CertificationAttestation with translated ResultCompetenceTree', async function () {
             // given
             await featureToggles.set('isV3CertificationAttestationEnabled', true);
             await featureToggles.set('isV3CertificationPageEnabled', true);
+
+            const locale = 'en';
 
             const certificationAttestationData = {
               id: 123,
@@ -552,24 +554,25 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             });
             databaseBuilder.factory.buildCompetenceMark(competenceMarks2);
 
-            await databaseBuilder.commit();
-
-            const competence1 = domainBuilder.buildCompetence({
+            const competence1 = {
               id: 'recComp1',
               index: '1.1',
-              name: 'Traiter des données',
-            });
-            const competence2 = domainBuilder.buildCompetence({
+              name_i18n: { fr: 'competence 1 en français', en: 'english competence 1 name' },
+            };
+            const competence2 = {
               id: 'recComp2',
               index: '1.2',
-              name: 'Traiter des choux',
-            });
+              name_i18n: { fr: 'competence 2 en français', en: 'translated competence 1 name' },
+            };
+
+            await databaseBuilder.commit();
+
             const area1 = domainBuilder.buildArea({
               id: 'recArea1',
               code: '1',
               competences: [
-                { ...competence1, name_i18n: { fr: competence1.name } },
-                { ...competence2, name_i18n: { fr: competence2.name } },
+                { ...competence1, name: competence1.name_i18n[locale] },
+                { ...competence2, name: competence2.name_i18n[locale] },
               ],
               title: 'titre test',
               frameworkId: 'Pix',
@@ -583,6 +586,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             // when
             const certificationAttestation = await certificateRepository.getCertificationAttestation({
               certificationCourseId: 123,
+              locale,
             });
 
             // then

--- a/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certification-attestation_test.js
@@ -11,6 +11,8 @@ describe('Unit | UseCase | get-certification-attestation', function () {
 
   it('should return the certification attestation enhanced with result competence tree', async function () {
     // given
+    const locale = 'fr';
+
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({ id: 'myResultTreeId' });
     const certificationAttestation = domainBuilder.buildCertificationAttestation({
       id: 123,
@@ -19,12 +21,13 @@ describe('Unit | UseCase | get-certification-attestation', function () {
     const certificationCourse = domainBuilder.buildCertificationCourse({ id: 123 });
     certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
     certificateRepository.getCertificationAttestation
-      .withArgs({ certificationCourseId: 123 })
+      .withArgs({ certificationCourseId: 123, locale })
       .resolves(certificationAttestation);
 
     // when
     const actualCertificationAttestation = await getCertificationAttestation({
       certificationCourseId: 123,
+      locale,
       certificateRepository,
       certificationCourseRepository,
     });


### PR DESCRIPTION
## 🌸 Problème

Aujourd’hui, peu importe la locale de l’utilisateur sur PixApp, on affiche le nom des compétences en français.

## 🌳 Proposition

Utiliser la locale dans la méthode de repo `getCertificationAttestation`.

## 🤧 Pour tester

- Sur [PixApp (org)](https://app-pr12116.review.pix.org/)
- Avec `certifiable-sco-user@example.net` (qui a son compte en anglais 🇬🇧)
- Dans la certif en ligne du candidat, vérifier qu'on a bien le tableau de compétences en anglais
- Vérifier aussi dans la [page de vérification de certificat (nouvelle version)](https://app-pr12116.review.pix.org/verification-certificat) avec `P-V7P7QMXX`
