### PR TITLE
[TECH] Ajouter une validation JOI à la route POST /api/assessments

### DIFF
--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -15,6 +15,18 @@ const register = async function (server) {
       path: '/api/assessments',
       config: {
         auth: false,
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                type: Joi.string().required(),
+              }).required(),
+            }).required(),
+          }).required(),
+        },
         handler: assessmentController.save,
         tags: ['api'],
       },

--- a/api/tests/shared/unit/application/assessments/index_test.js
+++ b/api/tests/shared/unit/application/assessments/index_test.js
@@ -3,6 +3,7 @@ import { assessmentController } from '../../../../../src/shared/application/asse
 import * as moduleUnderTest from '../../../../../src/shared/application/assessments/index.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { config as settings } from '../../../../../src/shared/config.js';
+import { Assessment } from '../../../../../src/shared/domain/models/index.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Router | assessment-router', function () {
@@ -12,12 +13,36 @@ describe('Unit | Application | Router | assessment-router', function () {
       sinon.stub(assessmentController, 'save').callsFake((request, h) => h.response('ok').code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
+      const payload = {
+        data: {
+          attributes: {
+            type: Assessment.types.DEMO,
+          },
+        },
+      };
 
       // when
-      const response = await httpTestServer.request('POST', '/api/assessments');
+      const response = await httpTestServer.request('POST', '/api/assessments', payload);
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    describe('When type is not defined', function () {
+      it('should return 400 Bad request', async function () {
+        // given
+        sinon.stub(assessmentController, 'save').callsFake((request, h) => h.response('ok').code(200));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/assessments');
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        expect(response.statusMessage).to.equal('Bad Request');
+        sinon.assert.notCalled(assessmentController.save);
+      });
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème
La route POST /api/assessments renvoie une erreur 500 lorsqu'aucun payload n'est fourni. 

## 🌳 Proposition
Rajouter une validation JOI qui vérifie la présence de l'attribut `type` (ce paramètre est requis, voir le deserializer).

## 🤧 Pour tester
- Vérifier que l'appel suivant renvoie bien une 400 Bad Request: `curl -X POST https://pix-api-review-pr12118.osc-fr1.scalingo.io/api/assessments`
