### PR TITLE
[TECH] Correction du script de suppression de réponses superflues (PIX-17257).

### DIFF
--- a/api/scripts/certification/fix-doubled-answers.js
+++ b/api/scripts/certification/fix-doubled-answers.js
@@ -69,7 +69,7 @@ export class FixDoubledAnswers extends Script {
         await transaction('certification-courses').where({ id: certificationCourse.id }).update({
           abortReason: null,
           completedAt: completionDate,
-          endedAt: completionDate,
+          endedAt: null,
           updatedAt: completionDate,
         });
 

--- a/api/tests/integration/scripts/certification/fix-doubled-answers_test.js
+++ b/api/tests/integration/scripts/certification/fix-doubled-answers_test.js
@@ -181,14 +181,14 @@ describe('Integration | Scripts | Certification | fix-doubled-answers', function
         id: certificationCourseId,
         completedAt: new Date('2021-01-02T07:20:45Z'),
         updatedAt: new Date('2021-01-02T07:20:45Z'),
-        endedAt: new Date('2021-01-02T07:20:45Z'),
+        endedAt: null,
         abortReason: null,
       },
       {
         id: secondCertificationCourseId,
         completedAt: new Date('2021-01-02T08:20:45Z'),
         updatedAt: new Date('2021-01-02T08:20:45Z'),
-        endedAt: new Date('2021-01-02T08:20:45Z'),
+        endedAt: null,
         abortReason: null,
       },
     ]);


### PR DESCRIPTION
## 🌸 Problème

Le script de suppression de `certification-challenges` (créé dans la PR #11391 ) et de `answers` associées remplissait la colonne `endedAt` du certification-course en même temps que la date de complétion du test.
Cela n'est pas censé se produire.

## 🌳 Proposition

Passage du `endedAt` à null dans la mise à jour effectuée dans le script (celui-ci corrige des cas terminés par les surveillants alors que leur état final devrait être completed)

## 🤧 Pour tester

NB: Il est également possible (et recommandé) de réaliser ce test avec plusieurs `answerId` et `certificationChallengeId` (donc passer plusieurs tests de certification)

- Créer une nouvelle session avec `sup-center-member@example.net`
- Ajouter un candidat
- Démarrer le test avec `certif-success@example.net` et aller jusqu'à la dernière question sans y répondre
- En BDD, dupliquer le `certification-challenge` en modifiant les colonnes `createdAt` et `updatedAt` de façon à montrer que le doublon a été enregistré un peu après le premier (=réplique d'un enregistrement concurrentiel) et **SURTOUT** en modifiant le `challengeId` en proposant une variante de la question initiale.

⚠️  Noter quelque part la valeur de la colonne `createdAt` de ce doublon nouvellement créé, cela sera utile pour la fin du test fonctionnel

- Répondre à la 32ème question
- Normalement, la 33ème question vous sera proposée, y répondre également finaliser le test afin de générer un `assessment-result` (Qui ne sera pas créé à la complétion du test suite à une erreur lors du scoring)

Une fois cela fait, récupérer l'`id` du `certification-challenge` en trop, ainsi que l'`id` de l'`answer`  qui lui est associé.
Dans un CSV au format qui suit, veuillez utiliser les valeurs correspondantes:

```
certificationChallengeId,answerId,completionDate
123,456,2021-01-02 8:20:45.000000+01:00
```

- Lancer un `assessment` de type évaluation avec le compte Pix que vous souhaitez de façon à créer un nouvel assessment en BDD
- Récupérer l'id de l'`assessment` nouvellement créé
- Lancer le script avec le fichier et assessmentId en paramètres

```
scalingo -a pix-api-review-pr12120 run --file="<csvFilePath>" "node scripts/certification/fix-doubled-answers.js --file /tmp/uploads/<fileName> --assessmentId <assessmentId>"
```

- Vérifier que le certification-challenge en trop a bien été supprimé
- Vérifier que la certification-challenge-capacities en trop a bien été supprimée
- Vérifier que l'answer pointe désormais vers l'assessment de type evaluation
- Vérifier que l'assessment lié aux données supprimées ait les colonnes `state` à `completed` et `updatedAt` correspondant au `createdAt` du certification-challenge n°33 du candidat
- Vérifier que le `certification-course` lié aux données supprimées ait les colonnes `abortReason` à `null` et `completedAt` correspondant au `createdAt` du certification-challenge n°33 du candidat et `endedAt` à `null`
