### PR TITLE
[BUGFIX] Utiliser le variant orga sur les PixBlock (PIX-17283)

### DIFF
--- a/orga/app/components/auth/login-or-register.gjs
+++ b/orga/app/components/auth/login-or-register.gjs
@@ -42,7 +42,7 @@ export default class LoginOrRegister extends Component {
 
   <template>
     <div class="login-or-register">
-      <PixBlock class="login-or-register__panel">
+      <PixBlock class="login-or-register__panel" @variant="orga">
         <div>
           <img src="/pix-orga-color.svg" alt="" role="none" class="login-or-register-panel__logo" />
         </div>

--- a/orga/app/components/campaign/empty-state.gjs
+++ b/orga/app/components/campaign/empty-state.gjs
@@ -17,7 +17,7 @@ export default class EmptyState extends Component {
   }
 
   <template>
-    <PixBlock class="empty-state">
+    <PixBlock class="empty-state" @variant="orga">
       <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
       <div class="empty-state__text">

--- a/orga/app/components/campaign/no-campaign-panel.gjs
+++ b/orga/app/components/campaign/no-campaign-panel.gjs
@@ -2,7 +2,7 @@ import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import { t } from 'ember-intl';
 
 <template>
-  <PixBlock class="no-campaign-panel">
+  <PixBlock class="no-campaign-panel" @variant="orga">
     <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
     <p class="no-campaign-panel__information-text hide-on-mobile">

--- a/orga/app/components/campaign/settings/view.gjs
+++ b/orga/app/components/campaign/settings/view.gjs
@@ -100,7 +100,7 @@ export default class CampaignView extends Component {
   }
 
   <template>
-    <PixBlock class="campaign-settings">
+    <PixBlock class="campaign-settings" @variant="orga">
       <dl>
         <div class="campaign-settings-row">
           <div class="campaign-settings-content">

--- a/orga/app/components/organization-learner/activity/empty-state.gjs
+++ b/orga/app/components/organization-learner/activity/empty-state.gjs
@@ -3,7 +3,7 @@ import { t } from 'ember-intl';
 import capitalize from 'lodash/capitalize';
 
 <template>
-  <PixBlock class="empty-state">
+  <PixBlock class="empty-state" @variant="orga">
     <img src="{{this.rootURL}}/images/empty-state-activity.svg" alt="" role="none" />
 
     <div class="empty-state__text">

--- a/orga/app/components/organization-participant/no-participant-panel.gjs
+++ b/orga/app/components/organization-participant/no-participant-panel.gjs
@@ -12,7 +12,7 @@ export default class List extends Component {
   }
 
   <template>
-    <PixBlock class="no-participant-panel">
+    <PixBlock class="no-participant-panel" @variant="orga">
       <img src="{{this.rootURL}}/images/empty-state-participants.svg" alt="" role="none" />
       <p class="content-text">
         {{t "pages.organization-participants.empty-state.message"}}

--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -113,7 +113,7 @@ export default class Header extends Component {
       </:subtitle>
     </PageTitle>
 
-    <PixBlock class="participant-header">
+    <PixBlock class="participant-header" @variant="orga">
       <header class="panel-header__headline panel-header__headline--with-right-content">
         <h2 class="panel-header-title">{{@campaign.name}}</h2>
         {{#if @campaign.multipleSendings}}

--- a/orga/app/components/participant/profile/header.gjs
+++ b/orga/app/components/participant/profile/header.gjs
@@ -65,7 +65,7 @@ export default class Header extends Component {
       </:subtitle>
     </PageTitle>
 
-    <PixBlock class="participant-header">
+    <PixBlock class="participant-header" @variant="orga">
       <header class="panel-header__headline">
         <h2 class="panel-header-title">{{@campaign.name}}</h2>
       </header>

--- a/orga/app/components/places/place-info.gjs
+++ b/orga/app/components/places/place-info.gjs
@@ -3,7 +3,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { t } from 'ember-intl';
 
 <template>
-  <PixBlock class="place-info">
+  <PixBlock class="place-info" @variant="orga">
     <PixIcon @name="seat" class="place-info__illustration" role="none" />
     <div>
       <section class="place-info__description">

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -171,7 +171,7 @@ export default class Statistics extends Component {
 
       <PixPagination @pagination={{this.pagination}} @locale={{this.currentLocale}} />
     {{else}}
-      <PixBlock class="empty-state">
+      <PixBlock class="empty-state" @variant="orga">
         <div class="empty-state__text">
           <p>{{t "pages.statistics.empty-state"}}</p>
         </div>

--- a/orga/app/components/terms-of-service/acceptation.gjs
+++ b/orga/app/components/terms-of-service/acceptation.gjs
@@ -19,7 +19,7 @@ export default class Acceptation extends Component {
   }
 
   <template>
-    <PixBlock class="terms-of-service-acceptation">
+    <PixBlock class="terms-of-service-acceptation" @variant="orga">
       {{#if this.isUpdateRequested}}
         <h1 class="pix-title-m">{{t "components.terms-of-service.title.update-requested"}}</h1>
         <p class="pix-body-m">{{t "components.terms-of-service.message.update-requested"}}</p>

--- a/orga/app/components/ui/chart-card.gjs
+++ b/orga/app/components/ui/chart-card.gjs
@@ -4,7 +4,7 @@ import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { t } from 'ember-intl';
 
 <template>
-  <PixBlock class="chart-card" ...attributes>
+  <PixBlock class="chart-card" @variant="orga" ...attributes>
     <h3 class="chart-card__title">
       {{@title}}
       {{#if @info}}<PixTooltip @isWide={{true}} @position="left">

--- a/orga/app/components/ui/empty-state.gjs
+++ b/orga/app/components/ui/empty-state.gjs
@@ -1,7 +1,7 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 
 <template>
-  <PixBlock class="empty-state">
+  <PixBlock class="empty-state" @variant="orga">
     <img src="{{this.rootURL}}/images/empty-state-participants.svg" alt="" role="none" />
     <p class="participants-empty-state__text">{{@infoText}}</p>
     <p class="participants-empty-state__text">{{@actionText}}</p>

--- a/orga/app/styles/components/campaign/activity/dashboard.scss
+++ b/orga/app/styles/components/campaign/activity/dashboard.scss
@@ -1,52 +1,29 @@
+@use 'pix-design-tokens/breakpoints';
+
 .activity-dashboard {
   display: flex;
   flex-direction: column;
+  gap: var(--pix-spacing-4x);
+  margin-bottom: var(--pix-spacing-4x);
 
   &__row {
     display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
   }
 
-  &__row:first-child {
-    margin-bottom: 24px;
-  }
-
-  &__total-participants-card {
-    margin-right: 24px;
-  }
-
-  &__participations-by-day {
-    box-sizing: border-box;
-    width: calc(75% - 24px);
-    margin-right: 24px;
-  }
-
-  &__participations-by-status {
-    box-sizing: border-box;
-    width: 25%;
-  }
-
-  @media (max-width: 768px) {
+  @include breakpoints.device-is('desktop') {
     &__row {
-      flex-direction: column;
-      margin: 0;
-    }
-
-    &__row:first-child {
-      margin-bottom: 16px;
-    }
-
-    &__total-participants-card {
-      margin-right: 0;
-      margin-bottom: 16px;
+      flex-direction: row;
+      gap: var(--pix-spacing-8x);
     }
 
     &__participations-by-day {
-      width: 100%;
-      margin-bottom: 16px;
+      width: calc(75% - var(--pix-spacing-8x));
     }
 
     &__participations-by-status {
-      width: 100%;
+      width: calc(25% - 2px);
     }
   }
 }

--- a/orga/app/styles/components/ui/cards.scss
+++ b/orga/app/styles/components/ui/cards.scss
@@ -1,17 +1,14 @@
 @use 'pix-design-tokens/typography';
-@use 'pix-design-tokens/shadows';
 
 .chart-card {
   position: relative;
-  padding: 16px 20px;
 
   &__title {
     @extend %pix-title-xs;
 
     display: flex;
-    gap: 4px;
-    margin-top: 0;
-    margin-bottom: 32px;
+    gap: var(--pix-spacing-1x);
+    margin-bottom: var(--pix-spacing-6x);
     color: var(--pix-neutral-500);
   }
 

--- a/orga/app/templates/join-request.gjs
+++ b/orga/app/templates/join-request.gjs
@@ -7,7 +7,7 @@ import PageTitle from 'pix-orga/components/ui/page-title';
 <template>
   {{pageTitle "Activez ou récupérez votre espace"}}
   <div class="join-request">
-    <PixBlock class="join-request__panel">
+    <PixBlock class="join-request__panel" @variant="orga">
       <div class="panel__image">
         <img src="/pix-orga-color.svg" alt role="none" />
       </div>

--- a/orga/app/templates/login.gjs
+++ b/orga/app/templates/login.gjs
@@ -8,7 +8,7 @@ import PageTitle from 'pix-orga/components/ui/page-title';
   {{pageTitle (t "pages.login.title")}}
   <main class="login-page">
     <div>
-      <PixBlock class="login-page__container">
+      <PixBlock class="login-page__container" @variant="orga">
         <header class="login-page__header">
           <img src="/pix-orga-color.svg" alt="Pix Orga" />
           <PageTitle @centerTitle={{true}}>


### PR DESCRIPTION
## 🌸 Problème

Certains PixBlock sur PixOrga ne sont pas bleu ( comme le bouton :trollface: )

## 🌳 Proposition

Utiliser le bon variant sur les PixBlock

## 🐝 Remarques

Correction au passage des card qui prennent trop de place

## 🤧 Pour tester

Aller sur les page incriminé et vérifier que tout est OK