### PR TITLE
[FEATURE] Enregistrer les événements `PASSAGE_TERMINATED` sur le usecase `record-passage-events` (PIX-17599)

### DIFF
--- a/api/src/devcomp/domain/usecases/record-passage-events.js
+++ b/api/src/devcomp/domain/usecases/record-passage-events.js
@@ -7,6 +7,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../models/passage-events/flashcard-events.js';
+import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
 const recordPassageEvents = async function ({ events, passageEventRepository }) {
   const passageEvents = events.map(_buildPassageEvent);
@@ -16,6 +17,8 @@ const recordPassageEvents = async function ({ events, passageEventRepository }) 
 
 function _buildPassageEvent(event) {
   switch (event.type) {
+    case 'PASSAGE_TERMINATED':
+      return new PassageTerminatedEvent(event);
     case 'FLASHCARDS_STARTED':
       return new FlashcardsStartedEvent(event);
     case 'FLASHCARDS_VERSO_SEEN':

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -5,6 +5,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import { PassageTerminatedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { recordPassageEvents } from '../../../../../src/devcomp/domain/usecases/record-passage-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
@@ -56,12 +57,20 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       type: 'FLASHCARDS_RETRIED',
     };
 
+    const passageTerminatedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      sequenceNumber: 1,
+      type: 'PASSAGE_TERMINATED',
+    };
+
     const events = [
       flashcardsVersoSeenEvent,
       flashcardsStartedEvent,
       flashcardsCardAutoAssessedEvent,
       flashcardsRectoReviewedEvent,
       flashcardsRetriedEvent,
+      passageTerminatedEvent,
     ];
 
     const passageEventRepositoryStub = {
@@ -77,6 +86,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsCardAutoAssessedPassageEvent = new FlashcardsCardAutoAssessedEvent(flashcardsCardAutoAssessedEvent);
     const flashcardsRectoReviewedEventPassageEvent = new FlashcardsRectoReviewedEvent(flashcardsRectoReviewedEvent);
     const flashcardsRetriedEventPassageEvent = new FlashcardsRetriedEvent(flashcardsRetriedEvent);
+    const passageTerminatedPassageEvent = new PassageTerminatedEvent(passageTerminatedEvent);
 
     expect(passageEventRepositoryStub.record.getCall(0)).to.have.been.calledWithExactly(
       flashcardsVersoSeenPassageEvent,
@@ -91,6 +101,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     expect(passageEventRepositoryStub.record.getCall(4)).to.have.been.calledWithExactly(
       flashcardsRetriedEventPassageEvent,
     );
+    expect(passageEventRepositoryStub.record.getCall(5)).to.have.been.calledWithExactly(passageTerminatedPassageEvent);
   });
   context('when type of passage event does not exist', function () {
     it('should throw an error', async function () {


### PR DESCRIPTION
## 🌸 Problème

Actuellement la route POST /passage-events ne permet pas d’enregistrer les events de type `PASSAGE_TERMINATED`.

## 🌳 Proposition

Gérer cela.

## 🐝 Remarques


## 🤧 Pour tester
- CI au vert
