### PR TITLE
[FEATURE] Créer une route d'archivage des centres de certification en masse (PIX-17597).

### DIFF
--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -1,6 +1,7 @@
 import { usecases as certificationConfigurationUsecases } from '../../../certification/configuration/domain/usecases/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/monitoring-tools.js';
+import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
 import * as certificationCenterForAdminSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
@@ -9,6 +10,16 @@ const archiveCertificationCenter = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
   const userId = extractUserIdFromRequest(request);
   await usecases.archiveCertificationCenter({ certificationCenterId, userId });
+
+  return h.response().code(204);
+};
+
+const archiveInBatch = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
+  const certificationCenterIds = await csvSerializer.deserializeForCertificationCenterBatchArchive(
+    request.payload.path,
+  );
+  await usecases.archiveCertificationCentersInBatch({ certificationCenterIds, userId });
 
   return h.response().code(204);
 };
@@ -78,6 +89,7 @@ const update = async function (request) {
 
 const certificationCenterAdminController = {
   archiveCertificationCenter,
+  archiveInBatch,
   create,
   findPaginatedFilteredCertificationCenters,
   getCertificationCenterDetails,

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
 import {
+  ArchiveCertificationCentersInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,
@@ -37,6 +38,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: OrganizationBatchUpdateError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: ArchiveCertificationCentersInBatchError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -12,6 +12,14 @@ class UnableToAttachChildOrganizationToParentOrganizationError extends DomainErr
   }
 }
 
+class ArchiveCertificationCentersInBatchError extends DomainError {
+  constructor({ code = 'ARCHIVE_CERTIFICATION_CENTERS_IN_BATCH_ERROR', meta } = {}) {
+    super();
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class DpoEmailInvalid extends DomainError {
   constructor({ code = 'DPO_EMAIL_INVALID', message = 'DPO email invalid', meta } = {}) {
     super(message);
@@ -60,6 +68,7 @@ class FeatureParamsNotProcessable extends DomainError {
 }
 
 export {
+  ArchiveCertificationCentersInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,

--- a/api/src/organizational-entities/domain/usecases/archive-certification-centers-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-certification-centers-in-batch.usecase.js
@@ -1,0 +1,36 @@
+import { ArchiveCertificationCentersInBatchError } from '../errors.js';
+
+/**
+ * @param {Object} params
+ * @param {Array} params.certificationCenterIds
+ * @param {Number} params.userId
+ * @param {Object} params.certificationCenterForAdminRepository
+ * @param {Object} params.certificationCenterApiRepository
+ */
+export const archiveCertificationCentersInBatch = async function ({
+  certificationCenterIds,
+  userId,
+  certificationCenterForAdminRepository,
+  certificationCenterApiRepository,
+}) {
+  // we don't use a transaction here not to rollback lines 0 to N-1 in case of an error on line N
+  const archiveDate = new Date();
+
+  for (const [index, certificationCenterId] of certificationCenterIds.entries()) {
+    try {
+      await certificationCenterApiRepository.archiveCertificationCenterData({
+        certificationCenterId,
+        archivedBy: userId,
+        archiveDate,
+      });
+      await certificationCenterForAdminRepository.archive({ certificationCenterId, archivedBy: userId, archiveDate });
+    } catch {
+      throw new ArchiveCertificationCentersInBatchError({
+        meta: {
+          currentLine: index + 1,
+          totalLines: certificationCenterIds.length,
+        },
+      });
+    }
+  }
+};

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -180,7 +180,7 @@ async function deserializeForCertificationCenterBatchArchive(
   file,
   { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper,
 ) {
-  const requiredFieldNames = ['certificationCenterId'];
+  const requiredFieldNames = ['ID du centre de certification'];
 
   await checkCsvHeader({ filePath: file, requiredFieldNames });
   const cleanedData = await readCsvFile(file);
@@ -194,7 +194,7 @@ async function deserializeForCertificationCenterBatchArchive(
         value = value.trim();
       }
       if (!isEmpty(value)) {
-        if (columnName === 'certificationCenterId') {
+        if (columnName === 'ID du centre de certification') {
           value = Number(value);
         }
       }
@@ -204,7 +204,7 @@ async function deserializeForCertificationCenterBatchArchive(
 
   const parsedData = await parseCsvData(cleanedData, batchCertificationCenterOptionsWithHeader);
 
-  return parsedData.map((data) => data.certificationCenterId);
+  return parsedData.map((data) => data['ID du centre de certification']);
 }
 
 const requiredFieldNamesForCampaignsImport = [

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -176,6 +176,37 @@ async function deserializeForOrganizationsImport(file) {
   return await parseCsvWithHeader(file, batchOrganizationOptionsWithHeader);
 }
 
+async function deserializeForCertificationCenterBatchArchive(
+  file,
+  { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper,
+) {
+  const requiredFieldNames = ['certificationCenterId'];
+
+  await checkCsvHeader({ filePath: file, requiredFieldNames });
+  const cleanedData = await readCsvFile(file);
+
+  const batchCertificationCenterOptionsWithHeader = {
+    skipEmptyLines: true,
+    header: true,
+    transformHeader: (header) => header?.trim(),
+    transform: (value, columnName) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (!isEmpty(value)) {
+        if (columnName === 'certificationCenterId') {
+          value = Number(value);
+        }
+      }
+      return value;
+    },
+  };
+
+  const parsedData = await parseCsvData(cleanedData, batchCertificationCenterOptionsWithHeader);
+
+  return parsedData.map((data) => data.certificationCenterId);
+}
+
 const requiredFieldNamesForCampaignsImport = [
   "Identifiant de l'organisation*",
   'Nom de la campagne*',
@@ -450,6 +481,7 @@ function serializeLine(lineArray) {
 
 export {
   deserializeForCampaignsImport,
+  deserializeForCertificationCenterBatchArchive,
   deserializeForOrganizationsImport,
   deserializeForSessionsImport,
   parseForCampaignsImport,

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -439,7 +439,8 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
         }).id;
 
         await databaseBuilder.commit();
-        const buffer = `certificationCenterId\n` + `${certificationCenterId1}\n` + `${certificationCenterId2}\n`;
+        const buffer =
+          `ID du centre de certification\n` + `${certificationCenterId1}\n` + `${certificationCenterId2}\n`;
 
         // when
         const response = await server.inject({
@@ -465,8 +466,8 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       });
     });
 
-    context('error cases', function () {
-      it('returns an error with meta info', async function () {
+    context('error case', function () {
+      it('returns an archive in batch error with meta info', async function () {
         // given
         const certificationCenterId1 = databaseBuilder.factory.buildCertificationCenter({
           archivedAt: null,
@@ -482,7 +483,7 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
 
         await databaseBuilder.commit();
         const buffer =
-          `certificationCenterId\n` +
+          `ID du centre de certification\n` +
           `${certificationCenterId1}\n` +
           `${certificationCenterId2}\n` +
           `${nonExistingCertifcationCenterId1}\n` +

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -424,4 +424,113 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
       expect(cancelledInvitation.updatedAt).to.deep.equal(archivedCenter.archivedAt);
     });
   });
+
+  describe('POST /api/admin/certification-centers/batch-archive', function () {
+    context('success case', function () {
+      it('returns a 204 http request', async function () {
+        // given
+        const certificationCenterId1 = databaseBuilder.factory.buildCertificationCenter({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const certificationCenterId2 = databaseBuilder.factory.buildCertificationCenter({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        await databaseBuilder.commit();
+        const buffer = `certificationCenterId\n` + `${certificationCenterId1}\n` + `${certificationCenterId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/certification-centers/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedCertificationCenter1 = await knex('certification-centers')
+          .where({ id: certificationCenterId1 })
+          .first();
+        const archivedCertificationCenter2 = await knex('certification-centers')
+          .where({ id: certificationCenterId2 })
+          .first();
+
+        expect(response.statusCode).to.equal(204);
+        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter1.archivedAt).not.to.be.null;
+        expect(archivedCertificationCenter2.archivedAt).not.to.be.null;
+      });
+    });
+
+    context('error cases', function () {
+      it('returns an error with meta info', async function () {
+        // given
+        const certificationCenterId1 = databaseBuilder.factory.buildCertificationCenter({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const certificationCenterId2 = databaseBuilder.factory.buildCertificationCenter({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        const nonExistingCertifcationCenterId1 = 7895;
+        const nonExistingCertifcationCenterId2 = 8513;
+
+        await databaseBuilder.commit();
+        const buffer =
+          `certificationCenterId\n` +
+          `${certificationCenterId1}\n` +
+          `${certificationCenterId2}\n` +
+          `${nonExistingCertifcationCenterId1}\n` +
+          `${nonExistingCertifcationCenterId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/certification-centers/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedCertificationCenter1 = await knex('certification-centers')
+          .where({ id: certificationCenterId1 })
+          .first();
+        const archivedCertificationCenter2 = await knex('certification-centers')
+          .where({ id: certificationCenterId2 })
+          .first();
+
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0].code).to.deep.equal('ARCHIVE_CERTIFICATION_CENTERS_IN_BATCH_ERROR');
+        expect(response.result.errors[0].meta).to.deep.equal({
+          currentLine: 3,
+          totalLines: 4,
+        });
+        expect(archivedCertificationCenter1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedCertificationCenter1.archivedAt).not.to.be.null;
+        expect(archivedCertificationCenter2.archivedAt).not.to.be.null;
+      });
+
+      it('fails when the file payload is too large', async function () {
+        const buffer = Buffer.alloc(1048576 * 22, 'B'); // > 10 Mo buffer
+
+        const options = {
+          method: 'POST',
+          url: '/api/admin/certification-centers/batch-archive',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        };
+
+        const response = await server.inject(options);
+        expect(response.statusCode).to.equal(413);
+        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
+        expect(response.result.errors[0].meta.maxSize).to.equal('20');
+      });
+    });
+  });
 });

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-certification-centers-in-batch.usecase.test.js
@@ -1,0 +1,149 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { ArchiveCertificationCentersInBatchError } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | archive-certification-centers-in-batch', function () {
+  it('archives the certification centers and related data', async function () {
+    // given
+    const creationDate = new Date(2021, 1, 1);
+    const lastUpdateBeforeArchive = new Date(2022, 2, 2);
+    const now = new Date(2023, 3, 3);
+    const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    const pendingStatus = CertificationCenterInvitation.StatusType.PENDING;
+    const superAdminUser = databaseBuilder.factory.buildUser();
+    const user = databaseBuilder.factory.buildUser({});
+
+    const certificationCenter1 = databaseBuilder.factory.buildCertificationCenter({
+      updatedAt: lastUpdateBeforeArchive,
+      createdAt: creationDate,
+    });
+
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      certificationCenterId: certificationCenter1.id,
+      userId: user.id,
+      createdAt: creationDate,
+      updatedAt: lastUpdateBeforeArchive,
+    });
+
+    databaseBuilder.factory.buildCertificationCenterInvitation({
+      certificationCenterId: certificationCenter1.id,
+      email: user.email,
+      status: pendingStatus,
+    });
+
+    const certificationCenter2 = databaseBuilder.factory.buildCertificationCenter({
+      updatedAt: lastUpdateBeforeArchive,
+      createdAt: creationDate,
+    });
+
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      certificationCenterId: certificationCenter2.id,
+      userId: user.id,
+      createdAt: creationDate,
+      updatedAt: lastUpdateBeforeArchive,
+    });
+
+    databaseBuilder.factory.buildCertificationCenterInvitation({
+      certificationCenterId: certificationCenter2.id,
+      email: user.email,
+      status: pendingStatus,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.archiveCertificationCentersInBatch({
+      certificationCenterIds: [certificationCenter1.id, certificationCenter2.id],
+      userId: superAdminUser.id,
+    });
+
+    // then
+    const archivedCertificationCenter1 = await knex('certification-centers')
+      .where({ id: certificationCenter1.id })
+      .first();
+    const disabledCertificationCenter1Membership = await knex('certification-center-memberships')
+      .where({ certificationCenterId: certificationCenter1.id })
+      .first();
+    const cancelledCertificationCenter1Invitation = await knex('certification-center-invitations')
+      .where({ certificationCenterId: certificationCenter1.id })
+      .first();
+
+    const archivedCertificationCenter2 = await knex('certification-centers')
+      .where({ id: certificationCenter2.id })
+      .first();
+    const disabledCertificationCenter2Membership = await knex('certification-center-memberships')
+      .where({ certificationCenterId: certificationCenter2.id })
+      .first();
+    const cancelledCertificationCenter2Invitation = await knex('certification-center-invitations')
+      .where({ certificationCenterId: certificationCenter2.id })
+      .first();
+
+    expect(archivedCertificationCenter1.archivedAt).to.deep.equal(now);
+    expect(archivedCertificationCenter1.archivedBy).to.deep.equal(superAdminUser.id);
+    expect(archivedCertificationCenter1.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
+
+    expect(disabledCertificationCenter1Membership.disabledAt).to.deep.equal(now);
+    expect(disabledCertificationCenter1Membership.updatedByUserId).to.deep.equal(superAdminUser.id);
+    expect(disabledCertificationCenter1Membership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
+
+    expect(cancelledCertificationCenter1Invitation.status).to.deep.equal('cancelled');
+    expect(cancelledCertificationCenter1Invitation.updatedAt).to.deep.equal(now);
+
+    expect(archivedCertificationCenter2.archivedAt).to.deep.equal(now);
+    expect(archivedCertificationCenter2.archivedBy).to.deep.equal(superAdminUser.id);
+    expect(archivedCertificationCenter2.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
+
+    expect(disabledCertificationCenter2Membership.disabledAt).to.deep.equal(now);
+    expect(disabledCertificationCenter2Membership.updatedByUserId).to.deep.equal(superAdminUser.id);
+    expect(disabledCertificationCenter2Membership.updatedAt).to.deep.equal(lastUpdateBeforeArchive);
+
+    expect(cancelledCertificationCenter2Invitation.status).to.deep.equal('cancelled');
+    expect(cancelledCertificationCenter2Invitation.updatedAt).to.deep.equal(now);
+
+    clock.restore();
+  });
+
+  context('when certification center does not exist', function () {
+    it('throws an error archive certification centers in batch error', async function () {
+      // given
+      const creationDate = new Date(2021, 1, 1);
+      const lastUpdateBeforeArchive = new Date(2022, 2, 2);
+      const pendingStatus = CertificationCenterInvitation.StatusType.PENDING;
+      const superAdminUser = databaseBuilder.factory.buildUser();
+      const user = databaseBuilder.factory.buildUser({});
+
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        updatedAt: lastUpdateBeforeArchive,
+        createdAt: creationDate,
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user.id,
+        createdAt: creationDate,
+        updatedAt: lastUpdateBeforeArchive,
+      });
+      databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: certificationCenter.id,
+        email: user.email,
+        status: pendingStatus,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(usecases.archiveCertificationCentersInBatch)({
+        certificationCenterIds: [certificationCenter.id, 1234],
+        userId: superAdminUser.id,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ArchiveCertificationCentersInBatchError);
+      expect(error.meta).to.deep.equal({
+        currentLine: 2,
+        totalLines: 2,
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1462,9 +1462,9 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       const checkCsvHeaderStub = sinon.stub();
       const readCsvFileStub = sinon.stub();
       const parseCsvDataStub = sinon.stub();
-      parseCsvDataStub.resolves([{ certificationCenterId: 1234 }, { certificationCenterId: 5678 }]);
+      parseCsvDataStub.resolves([{ 'ID du centre de certification': 1234 }, { 'ID du centre de certification': 5678 }]);
 
-      const requiredFieldNames = ['certificationCenterId'];
+      const requiredFieldNames = ['ID du centre de certification'];
 
       // when
       const serializedData = await csvSerializer.deserializeForCertificationCenterBatchArchive(filePath, {

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -6,7 +6,6 @@ import { FileValidationError } from '../../../../../../src/shared/domain/errors.
 import * as csvSerializer from '../../../../../../src/shared/infrastructure/serializers/csv/csv-serializer.js';
 import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
-
 describe('Unit | Serializer | CSV | csv-serializer', function () {
   describe('#serializeLine', function () {
     it('should quote strings', async function () {
@@ -1453,6 +1452,30 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
       // then
       expect(checkCsvHeaderStub).to.have.been.calledWithExactly({ filePath, requiredFieldNames });
+    });
+  });
+
+  describe('#deserializeForCertificationCenterBatchArchive', function () {
+    it('should check the required header', async function () {
+      // given
+      const filePath = 'file://certification-centers.csv';
+      const checkCsvHeaderStub = sinon.stub();
+      const readCsvFileStub = sinon.stub();
+      const parseCsvDataStub = sinon.stub();
+      parseCsvDataStub.resolves([{ certificationCenterId: 1234 }, { certificationCenterId: 5678 }]);
+
+      const requiredFieldNames = ['certificationCenterId'];
+
+      // when
+      const serializedData = await csvSerializer.deserializeForCertificationCenterBatchArchive(filePath, {
+        checkCsvHeader: checkCsvHeaderStub,
+        readCsvFile: readCsvFileStub,
+        parseCsvData: parseCsvDataStub,
+      });
+
+      // then
+      expect(checkCsvHeaderStub).to.have.been.calledWithExactly({ filePath, requiredFieldNames });
+      expect(serializedData).to.deep.equal([1234, 5678]);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème & 🌳 Proposition

Créer la route `/api/admin/certification-centers/batch-archive`. Elle prendra en paramètre le fichier csv à importer. Réutiliser le usecase déjà existant en faisant la boucle dans le controller.

## 🤧 Pour tester

- Pas encore d'interface pour appeler la route (ticket suivant)
- Vérifier que les tests passent