### PR TITLE
[BUGFIX] Vérifier l'existence du learner avant de créer une mission

### DIFF
--- a/api/src/school/domain/usecases/play-mission.js
+++ b/api/src/school/domain/usecases/play-mission.js
@@ -10,12 +10,16 @@ export async function playMission({
   assessmentRepository,
   missionAssessmentRepository,
   missionRepository,
+  organizationLearnerRepository,
 }) {
   const missionAssessment = await missionAssessmentRepository.getCurrent(missionId, organizationLearnerId);
 
   if (missionAssessment) {
     return getAssessment({ missionAssessment, assessmentRepository });
   }
+
+  await _checkOrganizationLearnerExists({ organizationLearnerRepository, organizationLearnerId });
+
   return _startMission({
     missionId,
     organizationLearnerId,
@@ -77,4 +81,8 @@ async function createMissionAssessment({
   await missionAssessmentRepository.save({ missionAssessment });
 
   return missionAssessment;
+}
+
+async function _checkOrganizationLearnerExists({ organizationLearnerRepository, organizationLearnerId }) {
+  await organizationLearnerRepository.getById({ organizationLearnerId });
 }


### PR DESCRIPTION
## 🌸 Problème
Aujourd'hui, un appel au endpoint `/api/pix1d/assessments` avec un id de learner qui n'existe renvoie une erreur 500 à cause d'une violation de contrainte FK.

## 🌳 Proposition
- Vérifier l'existence du learner avant de créer une mission.

## 🤧 Pour tester
- `curl -X POST https://pix-api-review-pr12132.osc-fr1.scalingo.io/api/pix1d/assessments -d '{"missionId":1,"learnerId":1}' -H "Content-type:application/json"`