### PR TITLE
[FEATURE] Finaliser la conception de la page de certificat candidat sur Pix App (PIX-17481).

### DIFF
--- a/mon-pix/app/components/certifications/candidate-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/candidate-certificate/v3-certificate.gjs
@@ -34,7 +34,20 @@ export default class v3Certificate extends Component {
 
     <section class="v3-candidate-certificate">
       <div class="v3-candidate-certificate__information">
-        <CandidateInformation @certificate={{@certificate}} />
+        <CandidateInformation @certificate={{@certificate}}>
+          {{#if @certificate.globalLevelLabel}}
+            <h2 class="v3-candidate-certificate-information__congratulations">
+              {{t "pages.certificate.congratulations"}}
+            </h2>
+            <p class="v3-candidate-certificate-information__global-level-information">
+              {{t "pages.certificate.global.explanation.default" globalLevelLabel=@certificate.globalLevelLabel}}
+            </p>
+          {{else}}
+            <h2 class="v3-candidate-certificate-information__global-level-information">
+              {{t "pages.certificate.global.explanation.pre-beginner-level"}}
+            </h2>
+          {{/if}}
+        </CandidateInformation>
 
         <DownloadPdf @certificate={{@certificate}} />
       </div>

--- a/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-information.gjs
@@ -17,8 +17,9 @@ import { t } from 'ember-intl';
         <PixTag data-testid="global-level-label-tag">{{@certificate.globalLevelLabel}}</PixTag>
       {{/if}}
     </div>
-    <div>
-      <ul class="candidate-information__list">
+    <div class="candidate-information__list">
+      {{yield}}
+      <ul>
         <li class="candidate-information-list--bold candidate-information-list__firstName">
           {{t "pages.certificate.candidate"}}
           {{@certificate.firstName}}

--- a/mon-pix/app/styles/components/certifications/candidate-certificate/_v3-certificate.scss
+++ b/mon-pix/app/styles/components/certifications/candidate-certificate/_v3-certificate.scss
@@ -19,3 +19,15 @@
     }
   }
 }
+
+.v3-candidate-certificate-information {
+  &__congratulations {
+    @extend %pix-title-s;
+  }
+
+  &__global-level-information {
+    @extend %pix-title-xs;
+
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}

--- a/mon-pix/app/styles/components/certifications/certificate-information/_candidate-information.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_candidate-information.scss
@@ -28,6 +28,9 @@
   }
 
   &__list {
+    display:flex;
+    flex-direction: column;
+
     li {
       &:not(:last-child) {
         margin-bottom: var(--pix-spacing-1x);

--- a/mon-pix/app/styles/components/certifications/certificate-information/_competences-details.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_competences-details.scss
@@ -160,17 +160,17 @@
   // Areas colors
   [data-area-code='1'] {
     --area-color: var(--pix-information-light);
-    --area-color-dark: var(--pix-information-dark);
+    --area-color-dark: var(--pix-error-700);
   }
 
   [data-area-code='2'] {
     --area-color: var(--pix-content-light);
-     --area-color-dark: var(--pix-content-dark);
+     --area-color-dark: var(--pix-certif-500);
   }
 
   [data-area-code='3'] {
     --area-color: var(--pix-communication-light);
-     --area-color-dark: var(--pix-communication-dark);
+     --area-color-dark: var(--pix-tertiary-900);
   }
 
   [data-area-code='4'] {

--- a/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-certificate-test.gjs
@@ -33,6 +33,11 @@ module('Integration | Component | Certifications | Candidate certificate | v3-ce
       assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
       assert
         .dom(
+          screen.getByRole('heading', { level: 2, name: t('pages.certificate.global.explanation.pre-beginner-level') }),
+        )
+        .exists();
+      assert
+        .dom(
           within(screen.getByRole('navigation')).getByRole('link', {
             name: t('pages.certifications-list.title'),
           }),
@@ -72,6 +77,14 @@ module('Integration | Component | Certifications | Candidate certificate | v3-ce
 
       // then
       assert.dom(screen.getByRole('heading', { level: 1, name: t('pages.certificate.title') })).exists();
+      assert.dom(screen.getByRole('heading', { level: 2, name: t('pages.certificate.congratulations') })).exists();
+      assert
+        .dom(
+          screen.getByText(
+            t('pages.certificate.global.explanation.default', { globalLevelLabel: certification.globalLevelLabel }),
+          ),
+        )
+        .exists();
       assert
         .dom(
           within(screen.getByRole('navigation')).getByRole('link', {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -637,6 +637,7 @@
         "alternative": "Additional certification",
         "title": "Other certification awarded"
       },
+      "congratulations": "Congratulations!",
       "delivered-at": "Date of issue:",
       "details": {
         "competences": {
@@ -646,6 +647,10 @@
       },
       "exam-date": "Completion date:",
       "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
         "labels": {
           "advanced": "Advanced",
           "beginner": "Beginner",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -612,7 +612,12 @@
       }
     },
     "certificate": {
+      "congratulations": "Congratulations!",
       "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
         "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
         "labels": {
           "advanced": "Advanced",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -637,6 +637,7 @@
         "alternative": "Certification complémentaire",
         "title": "Autre certification obtenue"
       },
+      "congratulations": "Félicitations !",
       "delivered-at": "Date de délivrance :",
       "details": {
         "competences": {
@@ -646,6 +647,10 @@
       },
       "exam-date": "Date de passage :",
       "global": {
+        "explanation": {
+          "default": "Vous avez atteint le niveau {globalLevelLabel} de la Certification Pix !",
+          "pre-beginner-level": "Vous avez terminé votre test de Certification Pix, mais vos résultats ne permettent pas l’obtention du premier niveau."
+        },
         "labels": {
           "advanced": "Avancé",
           "beginner": "Novice",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -612,6 +612,7 @@
       }
     },
     "certificate": {
+      "congratulations": "Congratulations!",
       "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
       "global": {
         "labels": {
@@ -620,6 +621,10 @@
           "expert": "Expert",
           "independent": "Independent",
           "level": "Your level"
+        },
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
         }
       },
       "certification-value": {


### PR DESCRIPTION
## 🌸 Problème

La nouvelle page coté candidat est créé mais elle reste encore incomplète.

## 🌳 Proposition

Ajouter le message de félicitations sur le certificat

## 🤧 Pour tester

- se connecter avec certif-success@example.net
https://app-pr12138.review.pix.fr/mes-certifications/1  (V3)

- Voir la page candidat avec le nouveau format et le message de félicitation avec le sous teste indiquant son niveau.

<img width="1283" alt="Capture d’écran 2025-04-25 à 16 01 07" src="https://github.com/user-attachments/assets/d4698707-2bbd-4b7e-b28a-ccd8679a3679" />


- Baisser son score en dessous de 64 pix et constater qu'un autre message est affiché.

<img width="1283" alt="Capture d’écran 2025-04-25 à 16 02 50" src="https://github.com/user-attachments/assets/08dbde2e-0ace-4f2e-9b22-481c98bb84d9" />
