### PR TITLE
[TECH] Ne pas lancer la CI lorsque une PR est encore au stade de développement

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -2,14 +2,14 @@ name: Trigger CircleCI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
   push:
     branches: dev
 
 jobs:
   trigger-ci:
     runs-on: ubuntu-latest
-    if: (!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev'
+    if: (!contains(github.event.pull_request.labels.*.name, 'Development in progress')) && ((!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev')
 
     steps:
       - name: Extract branch name


### PR DESCRIPTION
## 🌸 Problème

On se rend compte que la CI tourne même lorsque le label Development in progress est présent, ce qui n'est pas utile, sauf dans certains cas particuliers.

## 🌳 Proposition

Rajouter une condition au workflow de lancement de la CI pour que seul les pull request n'ayant pas ce label soient prises.

## 🐝 Remarques

On pourrait se poser la question dans l'autre sens, et ne lancer la CI que lorsque le label contient les termes "Review needed".

## 🤧 Pour tester

Changer les labels et constater, lorsqu'on retire puis qu'on remet le development in progress que la CI ne tourne pas et n'est pas relancée.