### PR TITLE
[BUGFIX] Appeler la traduction du formulaire correctement (PIX-17614)

### DIFF
--- a/mon-pix/app/components/campaign-code-form.gjs
+++ b/mon-pix/app/components/campaign-code-form.gjs
@@ -96,7 +96,7 @@ export default class CampaignCodeForm extends Component {
         <PixCode
           @id="campaign-code"
           @length="9"
-          @requiredLabel={{t "common.forms.mandatory"}}
+          @requiredLabel={{t "common.form.mandatory"}}
           @screenReaderOnly={{true}}
           @value={{this.certificateVerificationCode}}
           @validationStatus={{this.validationStatus}}

--- a/mon-pix/app/components/certification-verification-code-form.gjs
+++ b/mon-pix/app/components/certification-verification-code-form.gjs
@@ -67,7 +67,7 @@ export default class CertificationVerificationCodeForm extends Component {
     <form class="fill-in-certificate-verification-code__form" autocomplete="off">
       <PixCode
         @length="10"
-        @requiredLabel={{t "common.forms.mandatory"}}
+        @requiredLabel={{t "common.form.mandatory"}}
         @subLabel={{t "pages.fill-in-certificate-verification-code.sub-label"}}
         @value={{this.certificateVerificationCode}}
         @validationStatus={{this.status}}


### PR DESCRIPTION
## 🌸 Problème

Dans les pages d'entrée en session de certification et de parcours, on appelle la traduction common.forms.mandatory. Or, la traduction est située dans common.form.mandatory. Cela pose un problème surtout pour les lecteurs d'écran.

## 🌳 Proposition

Corriger l'appel à la traduction.

## 🐝 Remarques

Il y a peut-être d'autres erreurs de ce type.

## 🤧 Pour tester

Se rendre sur les pages d'entrée en session de certif et de parcours et constater que le terme « obligatoire » est bien présent.