### PR TITLE
[TECH] Suppression de la table Maddo inutilisée campaign_participation_tube_reached_levels

### DIFF
--- a/api/datamart/migrations/20250425095526_delete-table-campaign_participation_tube_reached_levels.js
+++ b/api/datamart/migrations/20250425095526_delete-table-campaign_participation_tube_reached_levels.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'campaign_participation_tube_reached_levels';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function () {
+  // not needed as the table is not used
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Les niveaux atteints par tube devaient être stockés dans le datamart. Ils seront finalement recalculés à la volée par l'API Campaigns de Prescription.

## 🌳 Proposition

Supprimer la table `campaign_participation_tube_reached_levels` qui devait accueillir ces informations.

## 🤧 Pour tester

La table `campaign_participation_tube_reached_levels` n'existe plus dans le datamart et tout va bien.