### PR TITLE
[TECH] Utiliser les paliers acquis pour calculer la moyenne obtenue sur une campagne (PIX-17630)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -110,8 +110,8 @@ const dependencies = {
   organizationRepository,
   placementProfileService,
   stageRepository,
-  stageAcquisitionRepository,
   stageCollectionRepository,
+  stageAcquisitionRepository,
   targetProfileRepository: campaignRepositories.targetProfileRepository, // TODO
   tutorialRepository,
   userRepository,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -86,31 +86,16 @@ const get = async function (id) {
   return campaignReport;
 };
 
-const findMasteryRatesAndValidatedSkillsCount = async function (campaignId) {
-  const results = await knex
-    .from('campaign-participations as cp')
-    .select([
-      'organizationLearnerId',
-      getLatestParticipationSharedForOneLearner(knex, 'masteryRate', campaignId),
-      getLatestParticipationSharedForOneLearner(knex, 'validatedSkillsCount', campaignId),
-    ])
-    .groupBy('organizationLearnerId')
-    .where('status', SHARED)
-    .where('deletedAt', null)
-    .where({ campaignId });
-
-  const aggregatedResults = {
-    masteryRates: [],
-    validatedSkillsCounts: [],
-  };
-
-  results.forEach((result) => {
-    aggregatedResults.masteryRates.push(Number(result.masteryRate));
-    aggregatedResults.validatedSkillsCounts.push(Number(result.validatedSkillsCount));
-  });
-
-  return aggregatedResults;
-};
+const findMasteryRates = async (campaignId) =>
+  (
+    await knex
+      .from('campaign-participations as cp')
+      .select(['organizationLearnerId', getLatestParticipationSharedForOneLearner(knex, 'masteryRate', campaignId)])
+      .groupBy('organizationLearnerId')
+      .where('status', SHARED)
+      .where('deletedAt', null)
+      .where({ campaignId })
+  ).map(({ masteryRate }) => Number(masteryRate));
 
 const findPaginatedFilteredByOrganizationId = async function ({ organizationId, filter = {}, page, userId }) {
   const query = knex('campaigns')
@@ -170,4 +155,4 @@ function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName,
   }
 }
 
-export { findMasteryRatesAndValidatedSkillsCount, findPaginatedFilteredByOrganizationId, get };
+export { findMasteryRates, findPaginatedFilteredByOrganizationId, get };

--- a/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
@@ -5,7 +5,7 @@
  * @param {string} columnName
  * @param {number} campaignId
  * @description
- * This function is meant to be use as a subquery on the table campaign-participations aliased as "cp"
+ * This function is meant to be used as a subquery on the table campaign-participations aliased as "cp"
  * to get latest campaign participation of an organization learner for given campaignId
  *
  * @returns {Knex.QueryBuilder}

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -87,10 +87,18 @@ class CampaignReport {
   setStages(stageCollection) {
     this._stageCollection = stageCollection;
     this.stages = stageCollection.stages;
+    this.totalStage = stageCollection.totalStages;
   }
 
   setCoverRate(campaignResultLevelsPerTubesAndCompetences) {
     this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube;
+  }
+
+  /**
+   * @param {number} reachedStage
+   */
+  setReachedStage(reachedStage) {
+    this.reachedStage = reachedStage;
   }
 
   computeAverageResult(masteryRates) {
@@ -98,21 +106,6 @@ class CampaignReport {
     if (totalMasteryRates > 0) {
       this.averageResult = _.sum(masteryRates) / totalMasteryRates;
     } else this.averageResult = null;
-  }
-
-  computeReachedStage(validatedSkillsCounts) {
-    const totalValidatedSkillsCounts = validatedSkillsCounts.length;
-    let averageValidatedSkillsCount = 0;
-
-    if (totalValidatedSkillsCounts > 0) {
-      averageValidatedSkillsCount = _.sum(validatedSkillsCounts) / totalValidatedSkillsCounts;
-    }
-
-    if (this._stageCollection.hasStage) {
-      const reachedStage = this._stageCollection.getReachedStage(averageValidatedSkillsCount, this.averageResult * 100);
-      this.reachedStage = reachedStage.reachedStage;
-      this.totalStage = reachedStage.totalStage;
-    }
   }
 }
 

--- a/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -1,5 +1,6 @@
 import { StageAcquisition } from '../../../../../src/evaluation/domain/models/StageAcquisition.js';
 import {
+  getAverageReachedStageByCampaignId,
   getByCampaignParticipation,
   getByCampaignParticipations,
   getStageIdsByCampaignParticipation,
@@ -132,6 +133,124 @@ describe('Evaluation | Integration | Repository | Stage Acquisition', function (
 
       expect(result).to.have.lengthOf(2);
       expect(result[0]).to.contains({ stageId: stages[0].id });
+    });
+  });
+
+  describe(getAverageReachedStageByCampaignId.name, function () {
+    it('should return the averaged reached stage for a campaign (round under)', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+
+      databaseBuilder.factory.buildStage({ id: 1, targetProfileId });
+      databaseBuilder.factory.buildStage({ id: 2, targetProfileId });
+      databaseBuilder.factory.buildStage({ id: 3, targetProfileId });
+
+      const campaignParticipationId1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      const campaignParticipationId2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      const campaignParticipationId3 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      // first participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 1,
+        campaignParticipationId: campaignParticipationId1,
+      });
+      // first participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 2,
+        campaignParticipationId: campaignParticipationId1,
+      });
+
+      // second participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({ stageId: 1, campaignParticipationId: campaignParticipationId2 });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 2,
+        campaignParticipationId: campaignParticipationId2,
+      });
+
+      // third participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 1,
+        campaignParticipationId: campaignParticipationId3,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 2,
+        campaignParticipationId: campaignParticipationId3,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 3,
+        campaignParticipationId: campaignParticipationId3,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const averageReachedStageNumber = await getAverageReachedStageByCampaignId(campaignId);
+
+      // then
+      expect(averageReachedStageNumber).to.deep.equal(2);
+    });
+
+    it('should return the averaged reached stage for a campaign (round up)', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+
+      databaseBuilder.factory.buildStage({ id: 1, targetProfileId });
+      databaseBuilder.factory.buildStage({ id: 2, targetProfileId });
+      databaseBuilder.factory.buildStage({ id: 3, targetProfileId });
+
+      const campaignParticipationId1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      const campaignParticipationId2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      const campaignParticipationId3 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      }).id;
+
+      // first participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 1,
+        campaignParticipationId: campaignParticipationId1,
+      });
+      // first participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 2,
+        campaignParticipationId: campaignParticipationId1,
+      });
+
+      // second participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({ stageId: 1, campaignParticipationId: campaignParticipationId2 });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 2,
+        campaignParticipationId: campaignParticipationId2,
+      });
+
+      // third participation acquired stages
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 1,
+        campaignParticipationId: campaignParticipationId3,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const averageReachedStageNumber = await getAverageReachedStageByCampaignId(campaignId);
+
+      // then
+      expect(averageReachedStageNumber).to.deep.equal(2);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import * as campaignReportRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
+import { findMasteryRates } from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
 import {
   CampaignExternalIdTypes,
   CampaignParticipationStatuses,
@@ -330,7 +331,7 @@ describe('Integration | Repository | Campaign-Report', function () {
     });
   });
 
-  describe('#findMasteryRatesAndValidatedSkillsCount', function () {
+  describe(findMasteryRates.name, function () {
     let campaignId;
 
     beforeEach(function () {
@@ -338,33 +339,29 @@ describe('Integration | Repository | Campaign-Report', function () {
       return databaseBuilder.commit();
     });
 
-    it('should return array with result', async function () {
+    it('should return an array of mastery rates', async function () {
       // given
       const firstLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       const secondLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         masteryRate: 0.1,
-        validatedSkillsCount: 18,
         organizationLearnerId: firstLearnerId,
         sharedAt: new Date(),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
         masteryRate: 0.3,
-        validatedSkillsCount: 42,
         organizationLearnerId: secondLearnerId,
         sharedAt: new Date(),
       });
       await databaseBuilder.commit();
 
       // when
-      const result = await campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(campaignId);
+      const result = await campaignReportRepository.findMasteryRates(campaignId);
 
       // then
-      expect(result).to.be.instanceOf(Object);
-      expect(result.masteryRates).to.have.members([0.1, 0.3]);
-      expect(result.validatedSkillsCounts).to.have.members([18, 42]);
+      expect(result).to.have.members([0.1, 0.3]);
     });
 
     it('should only take into account participations not deleted', async function () {
@@ -378,10 +375,10 @@ describe('Integration | Repository | Campaign-Report', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(campaignId);
+      const result = await campaignReportRepository.findMasteryRates(campaignId);
 
       // then
-      expect(result).to.deep.equal({ masteryRates: [0.1], validatedSkillsCounts: [0] });
+      expect(result).to.have.members([0.1]);
     });
 
     it('should only take into account shared participations', async function () {
@@ -396,10 +393,10 @@ describe('Integration | Repository | Campaign-Report', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(campaignId);
+      const result = await campaignReportRepository.findMasteryRates(campaignId);
 
       // then
-      expect(result).to.deep.equal({ masteryRates: [0.1], validatedSkillsCounts: [0] });
+      expect(result).to.have.members([0.1]);
     });
 
     it('should only take latest shared participations by learner', async function () {
@@ -425,10 +422,10 @@ describe('Integration | Repository | Campaign-Report', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(campaignId);
+      const result = await campaignReportRepository.findMasteryRates(campaignId);
 
       // then
-      expect(result).to.deep.equal({ masteryRates: [0.3], validatedSkillsCounts: [0] });
+      expect(result).to.have.members([0.3]);
     });
 
     it('should return empty array if campaign can not be found', async function () {
@@ -436,10 +433,10 @@ describe('Integration | Repository | Campaign-Report', function () {
       const nonExistentId = 666;
 
       // when
-      const result = await campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(nonExistentId);
+      const result = await campaignReportRepository.findMasteryRates(nonExistentId);
 
       // then
-      expect(result).to.deep.equal({ masteryRates: [], validatedSkillsCounts: [] });
+      expect(result).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

Actuellement on calcule l'obtention des paliers a la volée pour afficher les statistiques sur la page d'analyse d'une campagne. Or grâce au travail entrepris par la défunte équipe @1024pix/team-evaluation 💞  l'acquisition des paliers est désormais stockée en base. 

## 🌳 Proposition

Utiliser les acquisitions en base pour afficher et calculer le palier moyen atteint par campagne (route /campaign).
![image](https://github.com/user-attachments/assets/09bbd8b4-bfe3-415a-ba8c-a399811f9dd1)

## 🤧 Pour tester

Se rendre sur la page d'analyse d'une campagne.
La répartition par stage doit être cohérente avec le palier moyen affiché au dessus et les paliers atteints dans le tableau en dessous 🕵🏼 .
