### PR TITLE
[TECH] Créer un script permanent pour anonymiser des utilisateurs en masse (PIX-17552)

### DIFF
--- a/api/src/identity-access-management/scripts/anonymize-users-in-batch.script.js
+++ b/api/src/identity-access-management/scripts/anonymize-users-in-batch.script.js
@@ -1,0 +1,71 @@
+import joi from 'joi';
+
+import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { usecases } from '../domain/usecases/index.js';
+
+const columnsSchema = [{ name: 'userId', schema: joi.number().required() }];
+
+export class AnonymizeUsersInBatchScript extends Script {
+  constructor() {
+    super({
+      description: 'Anonymizes the given user accounts.',
+      permanent: true,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'The file path',
+          demandOption: true,
+          coerce: csvFileParser(columnsSchema),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'If present, the script will not make any changes to the database',
+          default: false,
+        },
+        anonymizerId: {
+          type: 'number',
+          describe: 'The user id of the anonymizer',
+          demandOption: true,
+        },
+      },
+    });
+
+    this.successLines = 0;
+    this.failedLines = 0;
+    this.totalLines = 0;
+    this.errorOccured = false;
+  }
+
+  async handle({ options, logger, anonymizeUser = usecases.anonymizeUser }) {
+    const { file, dryRun, anonymizerId } = options;
+    if (dryRun) {
+      logger.info(`DryRun mode, ${file.length} user accounts to be processed.`);
+      return;
+    }
+
+    this.totalLines = file.length;
+    for (const [index, { userId }] of file.entries()) {
+      try {
+        await anonymizeUser({
+          userId,
+          updatedByUserId: anonymizerId,
+        });
+        this.successLines++;
+      } catch (error) {
+        this.errorOccured = true;
+        this.failedLines++;
+        logger.error(`Error on line ${index + 1}. ${error}`);
+      }
+    }
+
+    logger.info(`${this.successLines} user accounts processed successfully.`);
+
+    if (this.errorOccured) {
+      throw new Error('There was some errors during the process.');
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, AnonymizeUsersInBatchScript);

--- a/api/tests/identity-access-management/unit/scripts/anonymize-users-in-batch.script.test.js
+++ b/api/tests/identity-access-management/unit/scripts/anonymize-users-in-batch.script.test.js
@@ -1,0 +1,90 @@
+import { AnonymizeUsersInBatchScript } from '../../../../src/identity-access-management/scripts/anonymize-users-in-batch.script.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | Identities Access Management | Scripts | Anonymize users in batch', function () {
+  let script;
+  let logger;
+  let anonymizeUser;
+
+  beforeEach(function () {
+    script = new AnonymizeUsersInBatchScript();
+    logger = {
+      info: sinon.spy(),
+      error: sinon.spy(),
+    };
+    anonymizeUser = sinon.stub();
+  });
+
+  describe('#handle', function () {
+    context('dryRun mode', function () {
+      it('displays the dryRun message', async function () {
+        // given
+        const file = [{ userId: 1 }, { userId: 2 }, { userId: 3 }];
+
+        // when
+        await script.handle({
+          options: {
+            file,
+            dryRun: true,
+            anonymizerId: 1234,
+          },
+          logger,
+          anonymizeUser,
+        });
+
+        // then
+        expect(logger.info).to.have.been.calledWith(`DryRun mode, 3 user accounts to be processed.`);
+      });
+    });
+
+    context('without dryRun mode', function () {
+      it('returns anonymizes successfully', async function () {
+        // given
+        const file = [{ userId: 1 }, { userId: 2 }, { userId: 3 }];
+
+        // when
+        await script.handle({
+          options: {
+            file,
+            dryRun: false,
+            anonymizerId: 1234,
+          },
+          logger,
+          anonymizeUser,
+        });
+
+        // then
+        expect(anonymizeUser.callCount).to.equal(3);
+        expect(logger.info).to.have.been.calledWith('3 user accounts processed successfully.');
+      });
+
+      context('when there are errors', function () {
+        it('continues the process and reports the errors', async function () {
+          // given
+          const file = [{ userId: 1 }, { userId: 2 }, { userId: 3 }];
+          const error = new Error('An error occurred');
+          anonymizeUser.onCall(1).rejects(error);
+
+          // when // then
+          await expect(
+            script.handle({
+              options: {
+                file,
+                dryRun: false,
+                anonymizerId: 1234,
+              },
+              logger,
+              anonymizeUser,
+            }),
+          ).to.be.rejectedWith('There was some errors during the process.');
+
+          // then
+          expect(anonymizeUser.callCount).to.equal(file.length);
+          expect(logger.info).to.have.been.calledWith(`2 user accounts processed successfully.`);
+          expect(logger.error).to.have.been.calledWith(`Error on line 2. ${error}`);
+          expect(script.successLines).to.equal(2);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

On a besoin d'anonymiser plusieurs utilisateurs de manière massive. On ne veut pas faire plusieurs appels api.

## 🌳 Proposition

Créer un script qui va appeler le usecase, sans appels réseaux, directement depuis l'api.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

- Se rendre sur PIx admin,
- Se connecter avec le compte superadmin@example.net,
- Se rendre dans la liste des utilisateurs,
- Choisir plusieurs identifiants d'utilisateurs,
- Noter l'identifiant du compte superadmin,
- Créer un fichier .csv avec une unique colone userId dans la quelle on met tous les identifiants sauf l'identifiant superadmin en voici un exemple: 
[test_anonymisation.csv](https://github.com/user-attachments/files/19955855/test_anonymisation.csv)
,
- Exécuter le script avec le dryRun d'abord:
```shell
scalingo -a pix-api-review-pr12157 --file votre_fichier.csv run src/identity-access-management/scripts/anonymize-users-in-batch.script.js --file /tmp/uploads/votre_fichier.csv --anonymizerId <identifiant_super_admin> --dryRun
```
- Constater que le script est indiqué comme exécuté en dryRun et traîtera le nombre de ligne contenu dans le fichier,
- Retirer l'option dryRun et réexécuter le script,
- Constater un message indiquant que les lignes du fichier ont été traîté,
- Sur Pix admin, constater que les utilisateurs ont disparu.

Ajout Mathias : vérifier que l'anonymisation est bien loggée dans Audit Logger 