### PR TITLE
[FEATURE] Appeler la route d'archivage des centres de certification en lot depuis Pix Admin (PIX-17628).

### DIFF
--- a/admin/app/adapters/certification-centers-batch-archive.js
+++ b/admin/app/adapters/certification-centers-batch-archive.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCentersBatchArchiveAdapter extends ApplicationAdapter {
+  archiveCertificationCenters(files) {
+    if (!files || files.length === 0) return;
+
+    const url = `${this.host}/${this.namespace}/admin/certification-centers/batch-archive`;
+    return this.ajax(url, 'POST', { data: files[0] });
+  }
+}

--- a/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
@@ -1,0 +1,70 @@
+import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class CertificationCentersBatchArchive extends Component {
+  @service intl;
+  @service pixToast;
+  @service router;
+  @service store;
+
+  @action
+  async archiveCertificationCenters(files) {
+    const adapter = this.store.adapterFor('certification-centers-batch-archive');
+    try {
+      await adapter.archiveCertificationCenters(files);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.administration.certification-centers-batch-archive.notifications.success'),
+      });
+    } catch (errorResponse) {
+      const errors = errorResponse.errors;
+
+      if (!errors) {
+        return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
+      }
+
+      errors.forEach((error) => {
+        switch (error.code) {
+          case 'MISSING_REQUIRED_FIELD_NAMES':
+            this.pixToast.sendErrorNotification({ message: `${error.meta}` });
+            break;
+          case 'ARCHIVE_CERTIFICATION_CENTERS_IN_BATCH_ERROR':
+            this.pixToast.sendErrorNotification({
+              message: this.intl.t(
+                'components.administration.certification-centers-batch-archive.notifications.errors.error-in-batch',
+                {
+                  currentLine: error.meta.currentLine,
+                  totalLines: error.meta.totalLines,
+                },
+              ),
+            });
+            break;
+          default:
+            this.pixToast.sendErrorNotification({ message: error.detail });
+        }
+      });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <AdministrationBlockLayout
+      @title={{t "components.administration.certification-centers-batch-archive.title"}}
+      @description={{t "components.administration.certification-centers-batch-archive.description"}}
+    >
+      <PixButtonUpload
+        @id="archive-certification-centers-file-upload"
+        @onChange={{this.archiveCertificationCenters}}
+        @variant="secondary"
+        accept=".csv"
+      >
+        {{t "components.administration.certification-centers-batch-archive.upload-button"}}
+      </PixButtonUpload>
+    </AdministrationBlockLayout>
+  </template>
+}

--- a/admin/app/components/administration/deployment/index.gjs
+++ b/admin/app/components/administration/deployment/index.gjs
@@ -1,3 +1,4 @@
+import CertificationCentersBatchArchive from './certification-centers-batch-archive';
 import NewTag from './new-tag';
 import OrganizationTagsImport from './organization-tags-import';
 import OrganizationsImport from './organizations-import';
@@ -11,4 +12,6 @@ import UpdateOrganizationsInBatch from './update-organizations-in-batch';
   <OrganizationsImport />
 
   <UpdateOrganizationsInBatch />
+
+  <CertificationCentersBatchArchive />
 </template>

--- a/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
@@ -1,0 +1,106 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import CertificationCentersBatchArchive from 'pix-admin/components/administration/deployment/certification-centers-batch-archive';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | administration/certification-centers-batch-archive', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  setupMirage(hooks);
+
+  let store, adapter, notificationSuccessStub, saveAdapterStub, notificationErrorStub;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    adapter = store.adapterFor('certification-centers-batch-archive');
+    saveAdapterStub = sinon.stub(adapter, 'archiveCertificationCenters');
+    notificationSuccessStub = sinon.stub();
+    notificationErrorStub = sinon.stub().returns();
+  });
+
+  module('when batch archive succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+      class NotificationsStub extends Service {
+        sendSuccessNotification = notificationSuccessStub;
+      }
+      this.owner.register('service:pixToast', NotificationsStub);
+      saveAdapterStub.withArgs(file).resolves();
+
+      // when
+      const screen = await render(<template><CertificationCentersBatchArchive /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.certification-centers-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.true(
+        notificationSuccessStub.calledWith({
+          message: t('components.administration.certification-centers-batch-archive.notifications.success'),
+        }),
+      );
+    });
+  });
+
+  module('when batch archiving of certification center fails', function () {
+    test.only('it displays an error notification', async function (assert) {
+      // given
+      this.server.post(
+        '/admin/certification-centers/batch-archive',
+        () =>
+          new Response(
+            422,
+            {},
+            {
+              errors: [
+                {
+                  status: '422',
+                  title: "Un souci avec l'archivage des centres de certification",
+                  code: 'ARCHIVE_CERTIFICATION_CENTERS_IN_BATCH_ERROR',
+                  detail: `Erreur lors de l'archivage`,
+                  meta: {
+                    currentLine: 2,
+                    totalLines: 4,
+                  },
+                },
+              ],
+            },
+          ),
+        412,
+      );
+      const file = new Blob(['foo'], { type: `valid-file` });
+      class NotificationsStub extends Service {
+        sendErrorNotification = notificationErrorStub;
+      }
+      this.owner.register('service:pixToast', NotificationsStub);
+
+      // when
+      const screen = await render(<template><CertificationCentersBatchArchive /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.certification-centers-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(notificationErrorStub.called);
+      assert.true(
+        notificationSuccessStub.calledWith({
+          message: t(
+            'components.administration.certification-centers-batch-archive.notifications.errors.error-in-batch',
+            {
+              currentLine: 2,
+              totalLines: 4,
+            },
+          ),
+        }),
+      );
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -118,6 +118,17 @@
         "title": "Creation of mass campaigns",
         "upload-button": "Import a CSV file"
       },
+      "certification-centers-batch-archive": {
+        "description": "Archive certification centers in batch. Each line must contain a certification center ID to archive.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "The certification centers archiving has failed. The certification center ID line n°{currentLine} failed, out of {totalLines} lines."
+          },
+          "success": "The certification centers have been archived."
+        },
+        "title": "Archiving of certification centers in batch",
+        "upload-button": "Import a CSV file"
+      },
       "oidc-providers-import": {
         "description": "Note: Trying to import already existing OIDC Providers would produce an error.",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -118,6 +118,17 @@
         "title": "Création de campagnes en masse",
         "upload-button": "Importer un fichier CSV"
       },
+      "certification-centers-batch-archive": {
+        "description": "Permet d'archiver des centres de certification par lot. Chaque ligne doit porter l'identifiant du centre de certification à archiver.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "L'archivage d'un des centres de certification a échoué. Le centre concerné est à la ligne {currentLine} du fichier comportant {totalLines} lignes. Corrigez la ligne concernée et ré-importez le fichier."
+          },
+          "success": "Les centres de certification ont bien été archivés."
+        },
+        "title": "Archivage des centres de certification en masse",
+        "upload-button": "Importer un fichier CSV"
+      },
       "oidc-providers-import": {
         "description": "Note: Chercher à importer à nouveau des OIDC Providers déjà existants renverrait une erreur.",
         "notifications": {


### PR DESCRIPTION
## 🌸 Problème
Après avoir réalisé la route d'archivage des centres de certification, on souhaite mettre en place sur Pix Admin une interface qui propose de téléverser un fichier CSV contenant des identifiants de centre de certification, afin que les centres de certification concernés soient archivés. 

## 🌳 Proposition
Ajouter dans la partie Administration, sous l'onglet Déploiement, une nouvelle rubrique "Archivage des centres de certification en masse". 

## 🤧 Pour tester
- Récupérer ce fichier:
[test-archivage.csv](https://github.com/user-attachments/files/20057816/test-archivage.csv)

- Aller sur Pix Admin en tant que Super Admin
- Se rendre sur la page Administration puis sur l'onglet Déploiement
- Sous le titre "Archivage des centres de certification en masse", cliquer sur Importer un fichier CSV
- Constater qu'une fois le téléversement réalisé, une notification de succès s'affiche. 
