### PR TITLE
[FEATURE] Enregistrer l'événement STARTED sur le usecase record-passage-events (PIX-17620)

### DIFF
--- a/api/src/devcomp/domain/usecases/record-passage-events.js
+++ b/api/src/devcomp/domain/usecases/record-passage-events.js
@@ -7,7 +7,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../models/passage-events/flashcard-events.js';
-import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
+import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
 const recordPassageEvents = async function ({ events, passageEventRepository }) {
   const passageEvents = events.map(_buildPassageEvent);
@@ -17,6 +17,8 @@ const recordPassageEvents = async function ({ events, passageEventRepository }) 
 
 function _buildPassageEvent(event) {
   switch (event.type) {
+    case 'PASSAGE_STARTED':
+      return new PassageStartedEvent(event);
     case 'PASSAGE_TERMINATED':
       return new PassageTerminatedEvent(event);
     case 'FLASHCARDS_STARTED':

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -5,7 +5,10 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
-import { PassageTerminatedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import {
+  PassageStartedEvent,
+  PassageTerminatedEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { recordPassageEvents } from '../../../../../src/devcomp/domain/usecases/record-passage-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
@@ -64,6 +67,14 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       type: 'PASSAGE_TERMINATED',
     };
 
+    const passageStartedEvent = {
+      occurredAt: new Date(),
+      passageId: 2,
+      sequenceNumber: 1,
+      contentHash: 'module-version',
+      type: 'PASSAGE_STARTED',
+    };
+
     const events = [
       flashcardsVersoSeenEvent,
       flashcardsStartedEvent,
@@ -71,6 +82,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       flashcardsRectoReviewedEvent,
       flashcardsRetriedEvent,
       passageTerminatedEvent,
+      passageStartedEvent,
     ];
 
     const passageEventRepositoryStub = {
@@ -87,6 +99,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const flashcardsRectoReviewedEventPassageEvent = new FlashcardsRectoReviewedEvent(flashcardsRectoReviewedEvent);
     const flashcardsRetriedEventPassageEvent = new FlashcardsRetriedEvent(flashcardsRetriedEvent);
     const passageTerminatedPassageEvent = new PassageTerminatedEvent(passageTerminatedEvent);
+    const passageStartedPassageEvent = new PassageStartedEvent(passageStartedEvent);
 
     expect(passageEventRepositoryStub.record.getCall(0)).to.have.been.calledWithExactly(
       flashcardsVersoSeenPassageEvent,
@@ -102,6 +115,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       flashcardsRetriedEventPassageEvent,
     );
     expect(passageEventRepositoryStub.record.getCall(5)).to.have.been.calledWithExactly(passageTerminatedPassageEvent);
+    expect(passageEventRepositoryStub.record.getCall(6)).to.have.been.calledWithExactly(passageStartedPassageEvent);
   });
   context('when type of passage event does not exist', function () {
     it('should throw an error', async function () {


### PR DESCRIPTION
## 🌸 Problème

Le usecase record-passage-events ne permet pas de gérer l’enregistrement des events PASSAGE_STARTED.

## 🌳 Proposition

Gérer ce cas dans le usecase.

## 🐝 Remarques

RAS

## 🤧 Pour tester

CI OK
