### PR TITLE
[TECH]  utiliser des modèles intermédiaires pour la calcul du taux de couverture par tube et par comptétence (PIX-17700)

### DIFF
--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -1,4 +1,4 @@
-This doc has been generated on 4/29/2025, 11:49:54 AM with `scripts/generate-api-documentation.js`. See package.json.
+This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-documentation.js`. See package.json.
 
 ---
 ## Modules
@@ -19,6 +19,8 @@ This doc has been generated on 4/29/2025, 11:49:54 AM with `scripts/generate-api
 ## Classes
 
 <dl>
+<dt><a href="#CampaignTubeCoverage">CampaignTubeCoverage</a></dt>
+<dd></dd>
 <dt><a href="#CampaignParticipation">CampaignParticipation</a></dt>
 <dd></dd>
 <dt><a href="#AssessmentCampaignParticipation">AssessmentCampaignParticipation</a></dt>
@@ -50,6 +52,8 @@ This doc has been generated on 4/29/2025, 11:49:54 AM with `scripts/generate-api
 ## Typedefs
 
 <dl>
+<dt><a href="#CampaignListItemArgs">CampaignListItemArgs</a> : <code>object</code></dt>
+<dd></dd>
 <dt><a href="#CampaignParticipationArgs">CampaignParticipationArgs</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#AssessmentCampaignParticipationArgs">AssessmentCampaignParticipationArgs</a> : <code>object</code></dt>
@@ -621,6 +625,23 @@ delete organization learner before adding import feature
 | Param | Type |
 | --- | --- |
 | userId | <code>number</code> | 
+
+<a name="CampaignListItemArgs"></a>
+
+## CampaignListItemArgs : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| name | <code>string</code> | 
+| createdAt | <code>Date</code> | 
+| archivedAt | <code>Date</code> | 
+| type | <code>string</code> | 
+| code | <code>string</code> | 
+| targetProfileName | <code>string</code> | 
+| tubes | [<code>Array.&lt;CampaignTubeCoverage&gt;</code>](#CampaignTubeCoverage) | 
 
 <a name="CampaignParticipationArgs"></a>
 

--- a/api/src/prescription/campaign/application/api/models/CampaignListItem.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignListItem.js
@@ -1,4 +1,19 @@
 export class CampaignListItem {
+  /**
+   * @typedef {object} CampaignListItemArgs
+   * @property {number} id
+   * @property {string} name
+   * @property {Date} createdAt
+   * @property {Date} archivedAt
+   * @property {string} type
+   * @property {string} code
+   * @property {string} targetProfileName
+   * @property {Array<CampaignTubeCoverage>} tubes
+   */
+
+  /**
+   * @param {CampaignListItemArgs} args
+   */
   constructor({ id, name, createdAt, archivedAt, type, code, targetProfileName, tubes }) {
     this.id = id;
     this.name = name;
@@ -8,5 +23,45 @@ export class CampaignListItem {
     this.code = code;
     this.targetProfileName = targetProfileName;
     this.tubes = tubes;
+
+    if (tubes) {
+      this.tubes = tubes.map(({ id, competenceId, title, description, reachedLevel, maxLevel }) => {
+        return new CampaignTubeCoverage({
+          id,
+          competenceId,
+          title,
+          practicalDescription: description,
+          practicalTitle: title,
+          meanLevel: reachedLevel,
+          maxLevel,
+        });
+      });
+    }
+  }
+}
+
+export class CampaignTubeCoverage {
+  /**
+   * @typedef CampaignTubeCoverageArgs
+   * @type {object}
+   * @property {string} id
+   * @property {string} competenceId
+   * @property {string} practicalTitle
+   * @property {string} practicalDescription
+   * @property {number} maxLevel
+   * @property {number} reachedLevel
+   */
+
+  /**
+   * @param {CampaignTubeCoverageArgs} args
+   */
+
+  constructor({ id, competenceId, practicalTitle, practicalDescription, maxLevel, meanLevel }) {
+    this.id = id;
+    this.competenceId = competenceId;
+    this.practicalTitle = practicalTitle;
+    this.practicalDescription = practicalDescription;
+    this.maxLevel = maxLevel;
+    this.meanLevel = meanLevel;
   }
 }

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -82,29 +82,26 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
   }
 }
 
-/**
- * @property {string} id
- * @property {string} competenceId
- * @property {string} practicalTitle
- * @property {string} practicalDescription
- * @property {number} maxLevel
- * @property {number} reachedLevel
- */
 class TubeCoverage {
   /**
-   * @param {object} args
-   * @param {string} args.id
-   * @param {string} args.competenceId
-   * @param {string} args.practicalTitle
-   * @param {string} args.practicalDescription
-   * @param {number} args.maxLevel
-   * @param {number} args.reachedLevel
+   * @typedef {Object} TubeCoverageArgs
+   * @property {string} id
+   * @property {string} competenceId
+   * @property {string} title
+   * @property {string} description
+   * @property {number} maxLevel
+   * @property {number} reachedLevel
    */
-  constructor({ id, competenceId, practicalTitle, practicalDescription, maxLevel, reachedLevel }) {
+
+  /**
+   * @param {TubeCoverageArgs} args
+   */
+
+  constructor({ id, competenceId, title, description, maxLevel, reachedLevel }) {
     this.id = id;
     this.competenceId = competenceId;
-    this.practicalTitle = practicalTitle;
-    this.practicalDescription = practicalDescription;
+    this.practicalTitle = title;
+    this.practicalDescription = description;
     this.maxLevel = maxLevel;
     this.reachedLevel = reachedLevel;
   }

--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -1,35 +1,23 @@
-import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
+import { CompetenceResultForKnowledgeElementSnapshots } from './CompetenceResultForKnowledgeElementSnapshots.js';
+import { TubeResultForKnowledgeElementSnapshots } from './TubeResultForKnowledgeElementSnapshots.js';
 
 class CampaignResultLevelsPerTubesAndCompetences {
-  #difficultyBySkillId;
   #tubesWithLevels;
 
   constructor({ campaignId, learningContent, knowledgeElementsByParticipation } = {}) {
     this.id = campaignId;
     this.learningContent = learningContent;
     this.knowledgeElementSnapshots = Object.values(knowledgeElementsByParticipation);
-    this.#difficultyBySkillId = learningContent.skills.reduce(
-      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
-      {},
-    );
     this.#tubesWithLevels = this.#getTubesWithLevels(learningContent.tubes);
   }
 
   #getTubesWithLevels(tubes) {
     return tubes.map((tube) => {
-      const participationsReachedLevels = this.#computeParticipationsReachedLevelForTube(tube);
-      const meanLevel = average(participationsReachedLevels);
-
-      const maxLevel = tube.getHardestSkill().difficulty;
-
-      return {
-        id: tube.id,
-        competenceId: tube.competenceId,
-        practicalTitle: tube.practicalTitle,
-        practicalDescription: tube.practicalDescription,
-        maxLevel,
-        meanLevel,
-      };
+      return new TubeResultForKnowledgeElementSnapshots({
+        tube,
+        competence: this.learningContent.competences.find((competence) => competence.id === tube.competenceId),
+        knowledgeElementSnapshots: this.knowledgeElementSnapshots,
+      });
     });
   }
 
@@ -39,18 +27,10 @@ class CampaignResultLevelsPerTubesAndCompetences {
 
   get levelsPerCompetence() {
     return this.learningContent.competences.map((competence) => {
-      const tubes = this.#tubesWithLevels.filter((tube) => tube.competenceId === competence.id);
-      const averageTubesMaxReachableLevel = averageBy(tubes, 'maxLevel');
-      const averageTubesMeanReachedLevel = averageBy(tubes, 'meanLevel');
-
-      return {
-        id: competence.id,
-        index: competence.index,
-        name: competence.name,
-        description: competence.description,
-        maxLevel: averageTubesMaxReachableLevel,
-        meanLevel: averageTubesMeanReachedLevel,
-      };
+      return new CompetenceResultForKnowledgeElementSnapshots({
+        competence,
+        knowledgeElementSnapshots: this.knowledgeElementSnapshots,
+      });
     });
   }
 
@@ -61,24 +41,6 @@ class CampaignResultLevelsPerTubesAndCompetences {
   get meanReachedLevel() {
     return averageBy(this.levelsPerTube, 'meanLevel');
   }
-
-  #computeParticipationsReachedLevelForTube(tube) {
-    const skillIdsForTube = tube.skills.map((skill) => skill.id);
-    return this.knowledgeElementSnapshots.map((knowledgeElements) =>
-      this.#computeParticipationReachedLevelForTube(skillIdsForTube, knowledgeElements),
-    );
-  }
-
-  #computeParticipationReachedLevelForTube(skillIds, knowledgeElements) {
-    const validatedKe = knowledgeElements
-      .filter((ke) => skillIds.includes(ke.skillId))
-      .filter((ke) => ke.status === KnowledgeElement.StatusType.VALIDATED);
-
-    if (validatedKe.length === 0) {
-      return 0;
-    }
-    return Math.max(...validatedKe.map((knowledgeElement) => this.#difficultyBySkillId[knowledgeElement.skillId]));
-  }
 }
 
 const averageBy = (collection, propName) => {
@@ -87,6 +49,5 @@ const averageBy = (collection, propName) => {
   }
   return collection.reduce((acc, item) => acc + item[propName], 0) / collection.length;
 };
-const average = (collection) => averageBy(collection);
 
 export { CampaignResultLevelsPerTubesAndCompetences };

--- a/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
@@ -1,0 +1,32 @@
+import { TubeResultForKnowledgeElementSnapshots } from './TubeResultForKnowledgeElementSnapshots.js';
+
+class CompetenceResultForKnowledgeElementSnapshots {
+  id;
+  index;
+  name;
+  description;
+  meanLevel;
+  maxLevel;
+
+  constructor({ competence, knowledgeElementSnapshots } = {}) {
+    const tubeResults = competence.tubes.map(
+      (tube) => new TubeResultForKnowledgeElementSnapshots({ tube, knowledgeElementSnapshots, competence }),
+    );
+
+    this.id = competence.id;
+    this.index = competence.index;
+    this.name = competence.name;
+    this.description = competence.description;
+    this.maxLevel = averageBy(tubeResults, 'maxLevel');
+    this.meanLevel = averageBy(tubeResults, 'meanLevel');
+  }
+}
+
+const averageBy = (collection, propName) => {
+  if (!propName) {
+    return collection.reduce((acc, value) => value + acc, 0) / collection.length;
+  }
+  return collection.reduce((acc, item) => acc + item[propName], 0) / collection.length;
+};
+
+export { CompetenceResultForKnowledgeElementSnapshots };

--- a/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
@@ -1,0 +1,53 @@
+import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
+
+class TubeResultForKnowledgeElementSnapshots {
+  id;
+  competenceId;
+  competenceName;
+  title;
+  description;
+  meanLevel;
+  maxLevel;
+
+  constructor({ tube, knowledgeElementSnapshots, competence } = {}) {
+    const skillIds = tube.skills.map((skill) => skill.id);
+
+    const tubeValidatedKnowledgeElementSnapshots = knowledgeElementSnapshots.map((knowledgeElementSnapshot) =>
+      knowledgeElementSnapshot
+        .filter((ke) => ke.status === KnowledgeElement.StatusType.VALIDATED)
+        .filter((ke) => skillIds.includes(ke.skillId)),
+    );
+
+    const difficultyBySkillId = competence.skills.reduce(
+      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
+      {},
+    );
+
+    this.id = tube.id;
+    this.competenceId = competence.id;
+    this.competenceName = competence.name;
+    this.title = tube.practicalTitle;
+    this.description = tube.practicalDescription;
+    this.maxLevel = tube.getHardestSkill().difficulty;
+    this.meanLevel = this.#computeMeanLevel(difficultyBySkillId, tubeValidatedKnowledgeElementSnapshots);
+  }
+
+  #computeMeanLevel(difficultyBySkillId, knowledgeElementSnapshots) {
+    const knowledgeElementSnapshotReachedLevels = knowledgeElementSnapshots.map((knowledgeElementSnapshot) => {
+      if (knowledgeElementSnapshot.length === 0) {
+        return 0;
+      }
+      return Math.max(
+        ...knowledgeElementSnapshot.map((knowledgeElement) => difficultyBySkillId[knowledgeElement.skillId]),
+      );
+    });
+    if (knowledgeElementSnapshotReachedLevels.length === 0) {
+      return 0;
+    }
+    return average(knowledgeElementSnapshotReachedLevels);
+  }
+}
+
+const average = (collection) => collection.reduce((acc, value) => acc + value, 0) / collection.length;
+
+export { TubeResultForKnowledgeElementSnapshots };

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -85,26 +85,30 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
 /**
  * @property {string} id
  * @property {string} competenceId
- * @property {string} practicalTitle
- * @property {string} practicalDescription
+ * @property {string} competenceName
+ * @property {string} title
+ * @property {string} description
  * @property {number} maxLevel
  * @property {number} reachedLevel
+ *
  */
 class TubeCoverage {
   /**
    * @param {object} args
    * @param {string} args.id
    * @param {string} args.competenceId
-   * @param {string} args.practicalTitle
-   * @param {string} args.practicalDescription
+   * @param {string} args.competenceName
+   * @param {string} args.title
+   * @param {string} args.description
    * @param {number} args.maxLevel
    * @param {number} args.reachedLevel
    */
-  constructor({ id, competenceId, practicalTitle, practicalDescription, maxLevel, reachedLevel }) {
+  constructor({ id, competenceId, competenceName, title, description, maxLevel, reachedLevel }) {
     this.id = id;
     this.competenceId = competenceId;
-    this.practicalTitle = practicalTitle;
-    this.practicalDescription = practicalDescription;
+    this.competenceName = competenceName;
+    this.title = title;
+    this.description = description;
     this.maxLevel = maxLevel;
     this.reachedLevel = reachedLevel;
   }

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -45,12 +45,19 @@ function computeTubes(campaignId, campaignParticipation, learningContent, knowle
     learningContent,
     knowledgeElementsByParticipation,
   });
-  return campaignResultLevelPerTubesAndCompetences.levelsPerTube.map(({ meanLevel, ...tube }) => {
-    return new TubeCoverage({
-      ...tube,
-      reachedLevel: meanLevel,
-    });
-  });
+  return campaignResultLevelPerTubesAndCompetences.levelsPerTube.map(
+    ({ id, competenceId, competenceName, title, description, meanLevel, maxLevel }) => {
+      return new TubeCoverage({
+        id,
+        competenceId,
+        title,
+        description,
+        maxLevel,
+        reachedLevel: meanLevel,
+        competenceName,
+      });
+    },
+  );
 }
 
 export { getCampaignParticipations };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
@@ -13,7 +13,7 @@ const serialize = function (results) {
     levelsPerTube: {
       ref: 'id',
       includes: true,
-      attributes: ['competenceId', 'practicalTitle', 'practicalDescription', 'maxLevel', 'meanLevel'],
+      attributes: ['competenceId', 'competenceName', 'title', 'description', 'maxLevel', 'meanLevel'],
     },
   }).serialize(results);
 };

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { TubeCoverage } from '../../../prescription/campaign/domain/read-models/CampaignParticipation.js';
 import { CampaignTypes } from '../../../prescription/shared/domain/constants.js';
 
 class CampaignReport {
@@ -90,7 +91,19 @@ class CampaignReport {
   }
 
   setCoverRate(campaignResultLevelsPerTubesAndCompetences) {
-    this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube;
+    this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube.map(
+      ({ id, competenceId, competenceName, title, description, meanLevel, maxLevel }) => {
+        return new TubeCoverage({
+          id,
+          competenceId,
+          competenceName,
+          title,
+          description,
+          maxLevel,
+          reachedLevel: meanLevel,
+        });
+      },
+    );
   }
 
   computeAverageResult(masteryRates) {

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -72,15 +72,19 @@ describe('Integration | UseCase | find-paginated-filtered-organization-campaigns
         userId,
         withCoverRate: true,
       });
-
       //then
       expect(result.models[0]).to.be.an.instanceof(CampaignReport);
-      expect(result.models[0].tubes[0].id).to.deep.equal('tubeIdA');
-      expect(result.models[0].tubes[0].competenceId).to.deep.equal('competenceIdA');
-      expect(result.models[0].tubes[0].practicalTitle).to.deep.equal('practicalTitle FR Tube A');
-      expect(result.models[0].tubes[0].practicalDescription).to.deep.equal('practicalDescription FR Tube A');
-      expect(result.models[0].tubes[0].maxLevel).to.deep.equal(2);
-      expect(result.models[0].tubes[0].meanLevel).to.deep.equal(2);
+      expect(result.models[0].tubes).deep.equal([
+        {
+          id: 'tubeIdA',
+          competenceId: 'competenceIdA',
+          competenceName: 'name FR Compétence A',
+          title: 'practicalTitle FR Tube A',
+          description: 'practicalDescription FR Tube A',
+          maxLevel: 2,
+          reachedLevel: 2,
+        },
+      ]);
     });
   });
   context('when campaign is type profiles collect', function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -19,8 +19,8 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       // given
       const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
       const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
-      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+      const competence = databaseBuilder.factory.learningContent.buildCompetence({ areaId });
+      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId: competence.id });
       const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
 
       const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
@@ -85,11 +85,12 @@ describe('Integration | UseCase | get-campaign-participations', function () {
           tubes: [
             {
               id: tube.id,
-              competenceId,
+              competenceId: competence.id,
+              competenceName: competence.name_i18n[FRENCH_SPOKEN],
               maxLevel: 2,
               reachedLevel: 2,
-              practicalDescription: tube.practicalDescription_i18n['fr'],
-              practicalTitle: tube.practicalTitle_i18n['fr'],
+              description: tube.practicalDescription_i18n[FRENCH_SPOKEN],
+              title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
             },
           ],
         }),

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -1,4 +1,6 @@
 import { CampaignResultLevelsPerTubesAndCompetences } from '../../../../../../src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js';
+import { CompetenceResultForKnowledgeElementSnapshots } from '../../../../../../src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js';
+import { TubeResultForKnowledgeElementSnapshots } from '../../../../../../src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
@@ -91,6 +93,8 @@ describe('Integration | UseCase | get-result-levels-per-tubes-and-competences', 
     expect(result).instanceOf(CampaignResultLevelsPerTubesAndCompetences);
     expect(result.maxReachableLevel).to.equal(1);
     expect(result.meanReachedLevel).to.equal(0.5);
+    expect(result.levelsPerCompetence[0]).instanceOf(CompetenceResultForKnowledgeElementSnapshots);
+    expect(result.levelsPerTube[0]).instanceOf(TubeResultForKnowledgeElementSnapshots);
     expect(result.levelsPerCompetence).to.deep.equal([
       {
         description: 'description FR Compétence 1',

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-result-levels-per-tubes-and-competences_test.js
@@ -105,14 +105,15 @@ describe('Integration | UseCase | get-result-levels-per-tubes-and-competences', 
         name: 'name FR Compétence 1',
       },
     ]);
-    expect(result.levelsPerTube).to.deep.equal([
+    expect(result.levelsPerTube).to.equalWithGetter([
       {
         competenceId: 'recCompetence1',
+        competenceName: 'name FR Compétence 1',
         id: 'recTube1',
         maxLevel: 1,
         meanLevel: 0.5,
-        practicalDescription: 'recTube1 fr description',
-        practicalTitle: 'Tube 1 fr title',
+        description: 'recTube1 fr description',
+        title: 'Tube 1 fr title',
       },
     ]);
   });

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -288,7 +288,16 @@ describe('Unit | API | Campaigns', function () {
         expect(firstCampaignListItem.createdAt).to.be.equal(campaignInformation1.createdAt);
         expect(firstCampaignListItem.archivedAt).to.be.equal(campaignInformation1.archivedAt);
         expect(firstCampaignListItem.targetProfileName).to.be.equal(targetProfileName);
-        expect(firstCampaignListItem.tubes).to.be.equal(coverRate.levelsPerTube);
+        expect(firstCampaignListItem.tubes).to.deep.equal([
+          {
+            competenceId: 'competence1',
+            id: 'tube1',
+            maxLevel: 1,
+            meanLevel: 0.5,
+            practicalDescription: 'tube 1 description',
+            practicalTitle: 'tube 1',
+          },
+        ]);
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -114,19 +114,26 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
         knowledgeElementsByParticipation: keData,
       });
 
-      expect(campaignResult.levelsPerTube[0].id).to.deep.equal('tube1');
-      expect(campaignResult.levelsPerTube[0].competenceId).to.deep.equal('competence1');
-      expect(campaignResult.levelsPerTube[0].practicalTitle).to.deep.equal('tube 1');
-      expect(campaignResult.levelsPerTube[0].practicalDescription).to.deep.equal('tube 1 description');
-      expect(campaignResult.levelsPerTube[0].maxLevel).to.deep.equal(2);
-      expect(campaignResult.levelsPerTube[0].meanLevel).to.deep.equal(0.5);
-
-      expect(campaignResult.levelsPerTube[1].id).to.deep.equal('tube2');
-      expect(campaignResult.levelsPerTube[1].competenceId).to.deep.equal('competence2');
-      expect(campaignResult.levelsPerTube[1].practicalTitle).to.deep.equal('tube 2');
-      expect(campaignResult.levelsPerTube[1].practicalDescription).to.deep.equal('tube 2 description');
-      expect(campaignResult.levelsPerTube[1].maxLevel).to.deep.equal(4);
-      expect(campaignResult.levelsPerTube[1].meanLevel).to.deep.equal(2);
+      expect(campaignResult.levelsPerTube).to.deep.equal([
+        {
+          id: 'tube1',
+          competenceId: 'competence1',
+          competenceName: 'compétence 1',
+          title: 'tube 1',
+          description: 'tube 1 description',
+          maxLevel: 2,
+          meanLevel: 0.5,
+        },
+        {
+          id: 'tube2',
+          competenceId: 'competence2',
+          competenceName: 'compétence 2',
+          title: 'tube 2',
+          description: 'tube 2 description',
+          maxLevel: 4,
+          meanLevel: 2,
+        },
+      ]);
     });
 
     it('should get max level per competence', function () {

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -114,24 +114,19 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
         knowledgeElementsByParticipation: keData,
       });
 
-      expect(campaignResult.levelsPerTube).deep.equal([
-        {
-          id: 'tube1',
-          competenceId: 'competence1',
-          practicalTitle: 'tube 1',
-          practicalDescription: 'tube 1 description',
-          maxLevel: 2,
-          meanLevel: 0.5,
-        },
-        {
-          id: 'tube2',
-          competenceId: 'competence2',
-          practicalTitle: 'tube 2',
-          practicalDescription: 'tube 2 description',
-          maxLevel: 4,
-          meanLevel: 2,
-        },
-      ]);
+      expect(campaignResult.levelsPerTube[0].id).to.deep.equal('tube1');
+      expect(campaignResult.levelsPerTube[0].competenceId).to.deep.equal('competence1');
+      expect(campaignResult.levelsPerTube[0].practicalTitle).to.deep.equal('tube 1');
+      expect(campaignResult.levelsPerTube[0].practicalDescription).to.deep.equal('tube 1 description');
+      expect(campaignResult.levelsPerTube[0].maxLevel).to.deep.equal(2);
+      expect(campaignResult.levelsPerTube[0].meanLevel).to.deep.equal(0.5);
+
+      expect(campaignResult.levelsPerTube[1].id).to.deep.equal('tube2');
+      expect(campaignResult.levelsPerTube[1].competenceId).to.deep.equal('competence2');
+      expect(campaignResult.levelsPerTube[1].practicalTitle).to.deep.equal('tube 2');
+      expect(campaignResult.levelsPerTube[1].practicalDescription).to.deep.equal('tube 2 description');
+      expect(campaignResult.levelsPerTube[1].maxLevel).to.deep.equal(4);
+      expect(campaignResult.levelsPerTube[1].meanLevel).to.deep.equal(2);
     });
 
     it('should get max level per competence', function () {
@@ -141,24 +136,19 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
         knowledgeElementsByParticipation: keData,
       });
 
-      expect(campaignResult.levelsPerCompetence).deep.equal([
-        {
-          id: 'competence1',
-          index: '1.1',
-          name: 'compétence 1',
-          description: 'description compétence 1',
-          maxLevel: 2,
-          meanLevel: 0.5,
-        },
-        {
-          id: 'competence2',
-          index: '1.1',
-          name: 'compétence 2',
-          description: 'description compétence 2',
-          maxLevel: 4,
-          meanLevel: 2,
-        },
-      ]);
+      expect(campaignResult.levelsPerCompetence[0].id).to.deep.equal('competence1');
+      expect(campaignResult.levelsPerCompetence[0].index).to.deep.equal('1.1');
+      expect(campaignResult.levelsPerCompetence[0].name).to.deep.equal('compétence 1');
+      expect(campaignResult.levelsPerCompetence[0].description).to.deep.equal('description compétence 1');
+      expect(campaignResult.levelsPerCompetence[0].maxLevel).to.deep.equal(2);
+      expect(campaignResult.levelsPerCompetence[0].meanLevel).to.deep.equal(0.5);
+
+      expect(campaignResult.levelsPerCompetence[1].id).to.deep.equal('competence2');
+      expect(campaignResult.levelsPerCompetence[1].index).to.deep.equal('1.1');
+      expect(campaignResult.levelsPerCompetence[1].name).to.deep.equal('compétence 2');
+      expect(campaignResult.levelsPerCompetence[1].description).to.deep.equal('description compétence 2');
+      expect(campaignResult.levelsPerCompetence[1].maxLevel).to.deep.equal(4);
+      expect(campaignResult.levelsPerCompetence[1].meanLevel).to.deep.equal(2);
     });
 
     it('should compute the maximum reachable level', function () {

--- a/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
@@ -88,12 +88,12 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         //then
         expect(tubeResult.id).equal(tube.id);
         expect(tubeResult.competenceId).equal(tube.competenceId);
-        expect(tubeResult.practicalTitle).equal(tube.practicalTitle);
-        expect(tubeResult.practicalDescription).equal(tube.practicalDescription);
+        expect(tubeResult.title).equal(tube.practicalTitle);
+        expect(tubeResult.description).equal(tube.practicalDescription);
         expect(tubeResult.maxLevel).equal(2);
         // mean level = user1 (level 1: ok, level 2: ko), user2: (level 1: ok)
         expect(tubeResult.meanLevel).equal(1);
-        expect(tubeResult.competenceLabel).equal(competence.name);
+        expect(tubeResult.competenceName).equal(competence.name);
       });
     });
 
@@ -109,11 +109,11 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         //then
         expect(tubeResult.id).equal(tube.id);
         expect(tubeResult.competenceId).equal(tube.competenceId);
-        expect(tubeResult.practicalTitle).equal(tube.practicalTitle);
-        expect(tubeResult.practicalDescription).equal(tube.practicalDescription);
+        expect(tubeResult.title).equal(tube.practicalTitle);
+        expect(tubeResult.description).equal(tube.practicalDescription);
         expect(tubeResult.maxLevel).equal(2);
         expect(tubeResult.meanLevel).equal(0);
-        expect(tubeResult.competenceLabel).equal(competence.name);
+        expect(tubeResult.competenceName).equal(competence.name);
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
@@ -1,0 +1,120 @@
+import { TubeResultForKnowledgeElementSnapshots } from '../../../../../../src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js';
+import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
+import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', function () {
+  let competence, tube, knowledgeElementSnapshots;
+
+  describe('Constructor', function () {
+    beforeEach(function () {
+      const skill1 = domainBuilder.buildSkill({
+        id: 'recSkillWeb1',
+        tubeId: 'tube1',
+        difficulty: 1,
+      });
+      const skill2 = domainBuilder.buildSkill({
+        id: 'recSkillWeb2',
+        tubeId: 'tube1',
+        difficulty: 2,
+      });
+      tube = domainBuilder.buildTube({
+        id: 'tube1',
+        competenceId: 'competence1',
+        skills: [skill1, skill2],
+        practicalTitle: 'tube 1',
+        practicalDescription: 'tube 1 description',
+      });
+
+      const unusedSkill = domainBuilder.buildSkill({
+        id: 'recSkillUrl1',
+        tubeId: 'tube2',
+        difficulty: 3,
+      });
+      const unusedTube = domainBuilder.buildTube({
+        id: 'tube2',
+        competenceId: 'competence1',
+        skills: [unusedSkill],
+        practicalTitle: 'tube 2',
+        practicalDescription: 'tube 2 description',
+      });
+
+      competence = domainBuilder.buildCompetence({
+        id: 'competence1',
+        areaId: 'recArea1',
+        tubes: [tube, unusedTube],
+        name: 'compétence 1',
+        description: 'description compétence 1',
+      });
+
+      const user1ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillWeb1',
+        userId: 1,
+      });
+      const user1ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        skillId: 'recSkillWeb2',
+        userId: 1,
+      });
+
+      const user2ke1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillWeb1',
+        userId: 2,
+      });
+
+      const user2ke2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        skillId: 'recSkillUrl1',
+        userId: 2,
+      });
+
+      knowledgeElementSnapshots = [
+        new KnowledgeElementCollection([user1ke1, user1ke2]).latestUniqNonResetKnowledgeElements,
+        new KnowledgeElementCollection([user2ke1, user2ke2]).latestUniqNonResetKnowledgeElements,
+      ];
+    });
+
+    describe('when there is participations', function () {
+      it('should instanciate a model with correct data', function () {
+        //when
+        const tubeResult = new TubeResultForKnowledgeElementSnapshots({
+          tube,
+          competence,
+          knowledgeElementSnapshots,
+        });
+
+        //then
+        expect(tubeResult.id).equal(tube.id);
+        expect(tubeResult.competenceId).equal(tube.competenceId);
+        expect(tubeResult.practicalTitle).equal(tube.practicalTitle);
+        expect(tubeResult.practicalDescription).equal(tube.practicalDescription);
+        expect(tubeResult.maxLevel).equal(2);
+        // mean level = user1 (level 1: ok, level 2: ko), user2: (level 1: ok)
+        expect(tubeResult.meanLevel).equal(1);
+        expect(tubeResult.competenceLabel).equal(competence.name);
+      });
+    });
+
+    describe('when there is no participation', function () {
+      it('should instanciate a model with correct data', function () {
+        //when
+        const tubeResult = new TubeResultForKnowledgeElementSnapshots({
+          tube,
+          competence,
+          knowledgeElementSnapshots: [],
+        });
+
+        //then
+        expect(tubeResult.id).equal(tube.id);
+        expect(tubeResult.competenceId).equal(tube.competenceId);
+        expect(tubeResult.practicalTitle).equal(tube.practicalTitle);
+        expect(tubeResult.practicalDescription).equal(tube.practicalDescription);
+        expect(tubeResult.maxLevel).equal(2);
+        expect(tubeResult.meanLevel).equal(0);
+        expect(tubeResult.competenceLabel).equal(competence.name);
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -41,10 +41,11 @@ describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-com
           {
             attributes: {
               'competence-id': 'competence1',
+              'competence-name': 'compétence 1',
               'max-level': 1,
               'mean-level': 0.5,
-              'practical-description': 'tube 1 description',
-              'practical-title': 'tube 1',
+              description: 'tube 1 description',
+              title: 'tube 1',
             },
             id: 'tube1',
             type: 'levelsPerTubes',

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -314,6 +314,27 @@ chaiUse(function () {
   });
 });
 
+chaiUse(function () {
+  Assertion.addMethod('equalWithGetter', function (expectedElement) {
+    if (Array.isArray(expectedElement)) {
+      expectedElement.forEach((element, index) => {
+        expect(this._obj[index]).equalWithGetter(element);
+      });
+    } else {
+      Object.keys(expectedElement).forEach((property) => {
+        if (Array.isArray(expectedElement[property])) {
+          expectedElement[property].forEach((subelement, index) => {
+            expect(this._obj[property][index]).equalWithGetter(subelement);
+          });
+        } else {
+          const errorMessage = `expect ${this._obj} with key ${property} to equal ${expectedElement[property]} (found ${this._obj[property]})`;
+          new Assertion(this._obj[property], errorMessage).to.deep.equal(expectedElement[property]);
+        }
+      });
+    }
+  });
+});
+
 async function mockLearningContent(learningContent) {
   const scope = databaseBuilder.factory.learningContent.build(learningContent);
   await databaseBuilder.commit();

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -43,4 +43,44 @@ describe('Test helpers', function () {
       ).to.deep.equal([obj1, obj2]);
     });
   });
+
+  describe('#equalWithGetter', function () {
+    class A {
+      get name() {
+        return "i'm A";
+      }
+    }
+    class B {
+      get name() {
+        return "i'm B";
+      }
+      get A() {
+        return [new A()];
+      }
+    }
+
+    it('should expect on object', function () {
+      expect({ name: 'ho' }).equalWithGetter({ name: 'ho' });
+    });
+
+    it('should expect on array of object', function () {
+      expect([{ name: 'ho' }]).equalWithGetter([{ name: 'ho' }]);
+    });
+
+    it('should expect on class instance with getter', function () {
+      expect(new A()).equalWithGetter({ name: "i'm A" });
+    });
+
+    it('should expect on array of class instance with getter', function () {
+      expect([new A()]).equalWithGetter([{ name: "i'm A" }]);
+    });
+
+    it('should expect on nested class instance with getter', function () {
+      expect(new B()).equalWithGetter({ name: "i'm B", A: [{ name: "i'm A" }] });
+    });
+
+    it('should expect on array nested class instance with getter', function () {
+      expect([new B()]).equalWithGetter([{ name: "i'm B", A: [{ name: "i'm A" }] }]);
+    });
+  });
 });

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -49,7 +49,17 @@ describe('Unit | Domain | Models | CampaignReport', function () {
       // when
       campaignReport.setCoverRate(campaignResultLevelsPerTubesAndCompetences);
       // then
-      expect(campaignReport.tubes).to.deep.equal(campaignResultLevelsPerTubesAndCompetences.levelsPerTube);
+      expect(campaignReport.tubes).to.deep.equal([
+        {
+          competenceId: 'competence1',
+          competenceName: 'compétence 1',
+          description: 'tube 1 description',
+          id: 'tube1',
+          maxLevel: 1,
+          reachedLevel: 0.5,
+          title: 'tube 1',
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

Le modèle qui calcul le taux de couverture pour une campagne et compliqué à comprendre et à maintenir

## 🌳 Proposition

Modifier le modèle CampaignResultLevelsPerTubesAndCompetences pour avoir des modèle intermédiaire  
- TubeResultForKnowledgeElementSnapshots
- CompetenceResultForKnowledgeElementSnapshots

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
- récuperer un token d'auth 
```
ACCESS_TOKEN=$(curl -s 'https://orga-pr12161.review.pix.fr/api/token' --data-raw 'grant_type=password&username=admin-orga@example.net&password=pix123&scope=pix-orga' | jq -r .access_token);
```
- faire la requete vers la route `api/campaign/***/level_by_tubes_and_competences`
```sh
curl -H "Authorization: Bearer $ACCESS_TOKEN" https://orga-pr12161.review.pix.fr/api/campaigns/xxx/level-per-tubes-and-competences
``` 

 
