### PR TITLE
[FEATURE] Ajouter un workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: release
+
+on:
+  repository_dispatch:
+    types: [ 'deploy' ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - uses: 1024pix/pix-actions/release@tech/allow-monorepo-release
+        id: semantic
+        with:
+          changelogTitle: "# Pix Changelog"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}


### PR DESCRIPTION
## 🌸 Problème
Nous souhaitons pouvoir automatiser la création de releases. Pour cela, nous souhaitons utiliser l'action [release dans 1024pix/pix-actions](https://github.com/1024pix/pix-actions/blob/main/release/action.yml) 

## 🌳 Proposition
Ajouter un workflow release déclenchable manuellement ou via un appel HTTP.

## 🤧 Pour tester
Le workflow a été testé depuis le fork https://github.com/1024pix/pix-sementic-version
