### PR TITLE
[TECH] add index on tables

### DIFF
--- a/api/db/migrations/20250425084124_add_index_on_tables.js
+++ b/api/db/migrations/20250425084124_add_index_on_tables.js
@@ -1,0 +1,25 @@
+const indexesToAdd = [
+  { tableName: 'organizations', index: ['name'] },
+  { tableName: 'mission-assessments', index: ['missionId'] },
+  { tableName: 'activity-answers', index: ['activityId'] },
+  { tableName: 'certification-cpf-cities', index: ['INSEECode'] },
+  { tableName: 'certification-cpf-cities', index: ['postalCode'] },
+  { tableName: 'certification-center-memberships', index: ['certificationCenterId'] },
+];
+
+const up = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.index(index);
+    });
+  }
+};
+
+const down = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.dropIndex(index);
+    });
+  }
+};
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème
Il manque des index pour que certaines requêtes soient performantes.

## 🌳 Proposition

Cette PR ajoute des index sur : 
- table organizations colonne 'name'
- table 'mission-assessments' colonne 'missionId'
- table 'activity-answers' colonne 'activityId'
- table 'certification-cpf-cities' colonne 'INSEECode'
- table 'certification-cpf-cities' colonne 'postalCode'
- table 'certification-center-memberships' colonne 'certificationCenterId'