### PR TITLE
[TECH] Enlever les "transitionTexts" des modules et des passages côté app (PIX-17571) (PIX-17453)

### DIFF
--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -7,7 +7,6 @@ import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import Element from 'mon-pix/components/module/component/element';
 import Stepper from 'mon-pix/components/module/component/stepper';
-import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 export default class ModuleGrain extends Component {
@@ -180,12 +179,6 @@ export default class ModuleGrain extends Component {
     >
       {{#if this.hasTitle}}
         <h2 class="screen-reader-only">{{@grain.title}}</h2>
-      {{/if}}
-
-      {{#if @transition}}
-        <header class="grain__header">
-          {{htmlUnsafe @transition.content}}
-        </header>
       {{/if}}
 
       <div class="grain__card grain-card--{{this.grainType}}">

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -265,7 +265,6 @@ export default class ModulePassage extends Component {
             @grain={{grain}}
             @onElementRetry={{this.onElementRetry}}
             @passage={{@passage}}
-            @transition={{this.grainTransition grain.id}}
             @onImageAlternativeTextOpen={{this.onImageAlternativeTextOpen}}
             @onVideoTranscriptionOpen={{this.onVideoTranscriptionOpen}}
             @onElementAnswer={{this.onElementAnswer}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -110,11 +110,6 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  grainTransition(grainId) {
-    return this.args.module.transitionTexts.find((transition) => transition.grainId === grainId);
-  }
-
-  @action
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -32,12 +32,6 @@ export default class ModulixPreview extends Component {
       "Contribuer au contenu d'un Module"
     ]
   },
-  "transitionTexts": [
-    {
-      "content": "<p>Voici un texte de transition</p>",
-      "grainId": "1111111a-1111-1bcd-e111-1f1111gh1111"
-    }
-  ],
   "grains": [
     {
       "id": "1111111a-1111-1bcd-e111-1f1111gh1111",
@@ -99,7 +93,7 @@ export default class ModulixPreview extends Component {
 
   get formattedModule() {
     if (!this.module || this.module === '') {
-      return { grains: [], transitionTexts: [] };
+      return { grains: [] };
     }
 
     const module = JSON.parse(this.module);
@@ -107,7 +101,6 @@ export default class ModulixPreview extends Component {
     return {
       ...module,
       grains: module.grains ?? [],
-      transitionTexts: module.transitionTexts ?? [],
     };
   }
 
@@ -126,11 +119,6 @@ export default class ModulixPreview extends Component {
     } catch (e) {
       this.errorMessage = e.message;
     }
-  }
-
-  @action
-  grainTransition(grainId) {
-    return this.formattedModule.transitionTexts.find((transition) => transition.grainId === grainId);
   }
 
   @action

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -157,7 +157,6 @@ export default class ModulixPreview extends Component {
               @grain={{grain}}
               @onElementRetry={{this.noop}}
               @passage={{this.passage}}
-              @transition={{this.grainTransition grain.id}}
               @onImageAlternativeTextOpen={{this.noop}}
               @onVideoTranscriptionOpen={{this.noop}}
               @onElementAnswer={{this.noop}}

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -3,7 +3,6 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class Module extends Model {
   @attr('string') title;
   @attr('boolean') isBeta;
-  @attr({ defaultValue: () => [] }) transitionTexts;
   @attr() details;
   @hasMany('grain', { async: false, inverse: 'module' }) grains;
 }

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -43,40 +43,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when grain has transition', function () {
-    test('should display transition', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const grain = store.createRecord('grain', { title: 'Grain title' });
-      const transition = { content: 'transition text' };
-      this.set('grain', grain);
-      this.set('transition', transition);
-
-      // when
-      const screen = await render(hbs`
-        <Module::Grain::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
-
-      // then
-      assert.ok(screen.getByText('transition text'));
-    });
-  });
-
-  module('when grain has no transition', function () {
-    test('should not create header', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const grain = store.createRecord('grain', { title: 'Grain title' });
-      this.set('grain', grain);
-
-      // when
-      await render(hbs`
-        <Module::Grain::Grain @grain={{this.grain}} />`);
-
-      // then
-      assert.dom('.grain__header').doesNotExist();
-    });
-  });
-
   module('when component is an element', function () {
     module('when element is a custom element', function () {
       test('should display a "CustomElement" element', async function (assert) {

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -259,6 +259,5 @@ function createModule(owner) {
   return store.createRecord('module', {
     title: 'Didacticiel',
     grains: [grain1, grain2, grain3, grain4],
-    transitionTexts: [],
   });
 }

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -34,9 +34,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         },
       ];
       const grain = store.createRecord('grain', { id: 'grainId1', components });
-      const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
       const passage = store.createRecord('passage');
 
       // when
@@ -44,7 +43,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       // then
       assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-      assert.ok(screen.getByRole('banner').innerText.includes('transition text'));
       assert.strictEqual(findAll('.element-text').length, 1);
       assert.strictEqual(findAll('.element-qcu').length, 1);
 
@@ -71,9 +69,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         },
       ];
       const grain = store.createRecord('grain', { id: 'grainId1', components });
-      const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
       const passage = store.createRecord('passage');
 
       // when
@@ -958,7 +955,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const element = { type: 'text', isAnswerable: false };
       const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
       const passage = store.createRecord('passage');
 
       // when
@@ -983,7 +980,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1008,7 +1005,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1036,7 +1033,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'stepper', steps: [{ elements: [textElement] }, { elements: [qcuElement] }] }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1058,7 +1055,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'stepper', steps: [{ elements: [text1Element] }, { elements: [text2Element] }] }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1268,7 +1265,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
         id: 'module-title',
         title: 'Module title',
         grains: [grain],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       passage.terminate = sinon.stub();
@@ -1308,7 +1304,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         grains: [grain1, grain2],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
@@ -1349,7 +1344,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         grains: [grain1, grain2],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       const modulixAutoScroll = this.owner.lookup('service:modulix-auto-scroll');
@@ -1385,7 +1379,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         grains: [grain1, grain2],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
@@ -1430,7 +1423,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         grains: [grain],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
@@ -1475,7 +1467,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
         const module = store.createRecord('module', {
           title: 'Didacticiel',
           grains: [grain],
-          transitionTexts: [],
         });
         const passage = store.createRecord('passage');
         const metrics = this.owner.lookup('service:metrics');
@@ -1520,7 +1511,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         grains: [grain],
-        transitionTexts: [],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');


### PR DESCRIPTION
## 🌸 Problème

Les transitionTexts ne sont plus utilisés dans les modules et les passages.

## 🌳 Proposition

Les enlever dans le code et les tests.

## 🤧 Pour tester

Passer un module sur la RA : /modules/bien-ecrire-son-adresse-mail par exemple
Vérifier la non-régression sur les transitions.