### PR TITLE
[FEATURE] Empêcher l'accès à l'espace surveillant d'un centre de certification archivé (PIX-16805)

### DIFF
--- a/api/src/certification/session-management/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session-management/application/http-error-mapper-configuration.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 import {
+  CertificationCenterIsArchivedError,
   ChallengeToBeDeneutralizedNotFoundError,
   ChallengeToBeNeutralizedNotFoundError,
   InvalidSessionSupervisingLoginError,
@@ -47,6 +48,10 @@ const sessionDomainErrorMappingConfiguration = [
   },
   {
     name: InvalidSessionSupervisingLoginError.name,
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+  },
+  {
+    name: CertificationCenterIsArchivedError.name,
     httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -100,7 +100,15 @@ class SendingEmailToResultRecipientError extends DomainError {
   }
 }
 
+class CertificationCenterIsArchivedError extends DomainError {
+  constructor(message = 'Ce centre de certification est archivé.') {
+    super(message);
+    this.code = 'CERTIFICATION_CENTER_IS_ARCHIVED';
+  }
+}
+
 export {
+  CertificationCenterIsArchivedError,
   CertificationCourseNotPublishableError,
   CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually,
   ChallengeToBeDeneutralizedNotFoundError,

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -1,4 +1,8 @@
-import { InvalidSessionSupervisingLoginError, SessionNotAccessible } from '../../domain/errors.js';
+import {
+  CertificationCenterIsArchivedError,
+  InvalidSessionSupervisingLoginError,
+  SessionNotAccessible,
+} from '../../domain/errors.js';
 
 const superviseSession = async function ({
   sessionId,
@@ -6,14 +10,20 @@ const superviseSession = async function ({
   userId,
   sessionRepository,
   supervisorAccessRepository,
+  certificationCenterRepository,
 }) {
   // should use a specific get from sessionRepository instead
   const session = await sessionRepository.get({ id: sessionId });
+
   if (!session.isSupervisable(invigilatorPassword)) {
     throw new InvalidSessionSupervisingLoginError();
   }
   if (!session.isAccessible()) {
     throw new SessionNotAccessible();
+  }
+  const certificationCenter = await certificationCenterRepository.getBySessionId({ sessionId });
+  if (certificationCenter.archivedAt || certificationCenter.archivedBy) {
+    throw new CertificationCenterIsArchivedError();
   }
   await supervisorAccessRepository.create({ sessionId, userId });
 };

--- a/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-center-repository.js
@@ -44,6 +44,8 @@ export const getBySessionId = async ({ sessionId }) => {
       'certification-centers.type',
       'certification-centers.createdAt',
       'certification-centers.updatedAt',
+      'certification-centers.archivedAt',
+      'certification-centers.archivedBy',
     )
     .where({ 'sessions.id': sessionId })
     .innerJoin('sessions', 'sessions.certificationCenterId', 'certification-centers.id')

--- a/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session-management/unit/application/http-error-mapper-configuration_test.js
@@ -1,6 +1,7 @@
 import { sessionDomainErrorMappingConfiguration } from '../../../../../src/certification/session-management/application/http-error-mapper-configuration.js';
 import { SESSION_SUPERVISING } from '../../../../../src/certification/session-management/domain/constants.js';
 import {
+  CertificationCenterIsArchivedError,
   InvalidSessionSupervisingLoginError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
@@ -94,6 +95,25 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       //then
       expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
       expect(error.message).to.equal(message);
+    });
+  });
+
+  context('when mapping "CertificationCenterIsArchivedError"', function () {
+    it('returns an UnauthorizedError Http Error', function () {
+      // given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CertificationCenterIsArchivedError.name,
+      );
+      const message = 'Test message error';
+      const code = 'CERTIFICATION_CENTER_IS_ARCHIVED';
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new CertificationCenterIsArchivedError(message, code));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+      expect(error.message).to.equal(message);
+      expect(error.code).to.equal(code);
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/errors_test.js
+++ b/api/tests/certification/session-management/unit/domain/errors_test.js
@@ -33,4 +33,8 @@ describe('Certification | session-management | Unit | Domain | Errors', function
   it('should export a SessionNotAccessible error', function () {
     expect(errors.SessionNotAccessible).to.exist;
   });
+
+  it('should export a certificationCenterIsArchived error', function () {
+    expect(errors.CertificationCenterIsArchivedError).to.exist;
+  });
 });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -143,6 +143,8 @@ describe('Integration | Repository | Certification Center', function () {
           createdAt: new Date('2018-01-01T05:43:10Z'),
           habilitations: [],
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
 
         await databaseBuilder.commit();
@@ -187,6 +189,8 @@ describe('Integration | Repository | Certification Center', function () {
           createdAt: new Date('2018-01-01T05:43:10Z'),
           habilitations: [expectedComplementaryCertification],
           updatedAt: now,
+          archivedAt: null,
+          archivedBy: null,
         });
         const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
 

--- a/certif/app/components/login-session-supervisor/index.gjs
+++ b/certif/app/components/login-session-supervisor/index.gjs
@@ -44,6 +44,8 @@ export default class LoginSessionSupervisor extends Component {
       const errorCode = get(error, 'errors[0].code');
       if (errorCode === 'INCORRECT_DATA') {
         errorMessage = this.intl.t('pages.session-supervising.login.form.errors.incorrect-data');
+      } else if (errorCode === 'CERTIFICATION_CENTER_IS_ARCHIVED') {
+        errorMessage = this.intl.t('pages.session-supervising.login.form.errors.certification-center-archived');
       }
 
       return this._displayError(errorMessage);

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -575,6 +575,7 @@
           },
           "description": "The password for the session to be invigilated has been revealed to you by a Pix Certif administrator",
           "errors": {
+            "certification-center-archived": "“You cannot access the certification centre because it is disabled.”",
             "incorrect-data": "The session number and/or the session password entered are incorrect.",
             "mandatory-fields": "The fields “Session number” and “Session password” are required."
           },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -575,6 +575,7 @@
           },
           "description": "Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif",
           "errors": {
+            "certification-center-archived": "“Vous ne pouvez pas accéder au centre de certification car ce dernier est désactivé.”",
             "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects.",
             "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires."
           },


### PR DESCRIPTION
## 🌸 Problème

Jusqu'à présent on autorisait l'accès à l'espace surveillant d'un centre de certification archivé. Cela ne devrait pas être possible, car un centre archivé ne doit plus pouvoir être modifié.

## 🌳 Proposition

Ajouter une vérification dans le usecase de supervision.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

- Se rendre sur Pix-certif,
- Se connecter avec le compte marc-alex-terrieur@example.net,
- Créer une session de certification et noter son identifiant ainsi que son mot de passe surveillant,
- Accéder à l'espace surveillant et constater qu'on peut y entrer,
- Quitter cette espace,
- Se rendre sur pix-admin,
- Se connecter avec le compte superadmin@example.net,
- Archiver le centre de certification Accessorium auquel appartien Marc-Alex,
- Retourner sur Certif,
- Tenter d'accéder à l'espace surveillant,
- Constater qu'on ne peut pas et qu'un message indique que le centre est archivé.