### PR TITLE
[FEATURE] Ajout de la pagination et de la traduction au endpoint `/api/organizations/{organizationId}/campaigns` (PIX-17662).

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -177,6 +177,7 @@
     "preinstall": "npx check-engine",
     "scalingo-postbuild": "node scripts/generate-cron > cron.json && node scripts/generate-procfile",
     "dev": "nodemon index.js",
+    "dev:maddo": "MADDO=true nodemon index.maddo.js",
     "start": "node index.js",
     "start:maddo": "MADDO=true node index.maddo.js",
     "start:watch": "npm run dev",

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -6,7 +6,11 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 }
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
+  const { page } = request.query;
   const requestedOrganizationId = request.params.organizationId;
-  const campaigns = await dependencies.findCampaigns({ organizationId: requestedOrganizationId });
-  return h.response(campaigns).code(200);
+  const result = await dependencies.findCampaigns({
+    organizationId: requestedOrganizationId,
+    page,
+  });
+  return h.response(result).code(200);
 }

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,3 +1,4 @@
+import { extractLocaleFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 
 export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
@@ -7,10 +8,12 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
   const { page } = request.query;
+  const locale = extractLocaleFromRequest(request);
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,
     page,
+    locale,
   });
   return h.response(result).code(200);
 }

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -50,11 +50,18 @@ const register = async function (server) {
             page: Joi.object({
               size: Joi.number().default(1000),
               number: Joi.number().default(1),
-            }).default({
-              size: 1000,
-              number: 1,
-            }),
+            })
+              .default({
+                size: 1000,
+                number: 1,
+              })
+              .description('Informations de pagination'),
           }),
+          headers: Joi.object({
+            'Accept-Language': Joi.string().description(
+              'Header de sélection de langue au format [RFC9110](https://httpwg.org/specs/rfc9110.html#field.accept-language)',
+            ),
+          }).unknown(),
         },
         pre: [organizationPreHandler, isOrganizationInJurisdictionPreHandler],
         handler: getOrganizationCampaigns,

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -46,6 +46,15 @@ const register = async function (server) {
           params: Joi.object({
             organizationId: identifiersType.organizationId,
           }),
+          query: Joi.object({
+            page: Joi.object({
+              size: Joi.number().default(1000),
+              number: Joi.number().default(1),
+            }).default({
+              size: 1000,
+              number: 1,
+            }),
+          }),
         },
         pre: [organizationPreHandler, isOrganizationInJurisdictionPreHandler],
         handler: getOrganizationCampaigns,
@@ -58,35 +67,42 @@ const register = async function (server) {
         response: {
           failAction: 'log',
           status: {
-            200: Joi.array()
-              .items(
-                Joi.object({
-                  id: Joi.number().description('ID de la campagne'),
-                  name: Joi.string().description('Nom de la campagne'),
-                  type: Joi.string().description('Type de la campagne : ASSESSMENT, EXAM, PROFILES_COLLECTION'),
-                  targetProfileName: Joi.string().description(
-                    'Nom du profil cible lié à la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
-                  ),
-                  code: Joi.string().description('Code campagne'),
-                  createdAt: Joi.date().description('Date de création de la campagne'),
-                  tubes: Joi.array()
-                    .items(
-                      Joi.object({
-                        competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
-                        id: Joi.string().description('ID du sujet'),
-                        maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
-                        meanLevel: Joi.number().description('Niveau moyen obtenu dans cette campagne'),
-                        practicalDescription: Joi.string().description('Description du sujet'),
-                        practicalTitle: Joi.string().description('Titre du sujet'),
-                      }).label('Tube'),
-                    )
-                    .description(
-                      'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
-                    )
-                    .label('Tubes'),
-                }).label('Campaign'),
-              )
-              .label('Campaigns'),
+            200: Joi.object({
+              campaigns: Joi.array()
+                .items(
+                  Joi.object({
+                    id: Joi.number().description('ID de la campagne'),
+                    name: Joi.string().description('Nom de la campagne'),
+                    type: Joi.string().description('Type de la campagne : ASSESSMENT, EXAM, PROFILES_COLLECTION'),
+                    targetProfileName: Joi.string().description(
+                      'Nom du profil cible lié à la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                    ),
+                    code: Joi.string().description('Code campagne'),
+                    createdAt: Joi.date().description('Date de création de la campagne'),
+                    tubes: Joi.array()
+                      .items(
+                        Joi.object({
+                          competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
+                          id: Joi.string().description('ID du sujet'),
+                          maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
+                          meanLevel: Joi.number().description('Niveau moyen obtenu dans cette campagne'),
+                          practicalDescription: Joi.string().description('Description du sujet'),
+                          practicalTitle: Joi.string().description('Titre du sujet'),
+                        }).label('Tube'),
+                      )
+                      .description(
+                        'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                      )
+                      .label('Tubes'),
+                  }).label('Campaign'),
+                )
+                .label('Campaigns'),
+              page: Joi.object({
+                number: Joi.number().description('Numéro de la page courante'),
+                size: Joi.number().description('Taille de la page courante'),
+                count: Joi.number().description('Nombre total de page'),
+              }).description('Information de pagination'),
+            }),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/domain/usecases/find-campaigns.js
+++ b/api/src/maddo/domain/usecases/find-campaigns.js
@@ -1,3 +1,3 @@
-export async function findCampaigns({ organizationId, campaignRepository }) {
-  return campaignRepository.findByOrganizationId(organizationId);
+export async function findCampaigns({ organizationId, campaignRepository, page }) {
+  return campaignRepository.findByOrganizationId(organizationId, page);
 }

--- a/api/src/maddo/domain/usecases/find-campaigns.js
+++ b/api/src/maddo/domain/usecases/find-campaigns.js
@@ -1,3 +1,3 @@
-export async function findCampaigns({ organizationId, campaignRepository, page }) {
-  return campaignRepository.findByOrganizationId(organizationId, page);
+export async function findCampaigns({ organizationId, campaignRepository, page, locale }) {
+  return campaignRepository.findByOrganizationId(organizationId, page, locale);
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -2,11 +2,12 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import * as campaignAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
-export async function findByOrganizationId(organizationId, page) {
+export async function findByOrganizationId(organizationId, page, locale) {
   const campaigns = await campaignAPI.findAllForOrganization({
     organizationId,
     withCoverRate: true,
     page,
+    locale,
   });
   return {
     page: toPage(campaigns.meta),

--- a/api/src/maddo/infrastructure/repositories/campaign-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-repository.js
@@ -2,13 +2,16 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import * as campaignAPI from '../../../prescription/campaign/application/api/campaigns-api.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
-export async function findByOrganizationId(organizationId) {
+export async function findByOrganizationId(organizationId, page) {
   const campaigns = await campaignAPI.findAllForOrganization({
     organizationId,
     withCoverRate: true,
-    page: { size: 1000, number: 1 },
+    page,
   });
-  return campaigns.models.map(toDomain);
+  return {
+    page: toPage(campaigns.meta),
+    campaigns: campaigns.models.map(toDomain),
+  };
 }
 
 export async function getOrganizationId(campaignId) {
@@ -18,4 +21,8 @@ export async function getOrganizationId(campaignId) {
 
 function toDomain(rawCampaign) {
   return new Campaign(rawCampaign);
+}
+
+function toPage(meta) {
+  return { number: meta.page, size: meta.pageSize, count: meta.pageCount };
 }

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -137,6 +137,7 @@ export const findAllForOrganization = async (payload) => {
   const { models: campaigns, meta } = await usecases.findPaginatedFilteredOrganizationCampaigns({
     organizationId: payload.organizationId,
     page: payload.page,
+    locale: payload.locale,
     withCoverRate: payload.withCoverRate ?? false,
   });
 

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -67,9 +67,14 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
       await databaseBuilder.commit();
 
       // when
-      const campaigns = await findByOrganizationId(organization.id);
+      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 2 });
 
       // then
+      expect(page).to.deep.equal({
+        number: 1,
+        size: 2,
+        count: 1,
+      });
       expect(campaigns).to.deep.equal([
         new Campaign({
           id: campaign1.id,

--- a/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/campaign-repository_test.js
@@ -67,7 +67,7 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
       await databaseBuilder.commit();
 
       // when
-      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 2 });
+      const { campaigns, page } = await findByOrganizationId(organization.id, { number: 1, size: 2 }, 'en');
 
       // then
       expect(page).to.deep.equal({
@@ -89,8 +89,8 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
               id: tube.id,
               maxLevel: skill.level,
               meanLevel: 2,
-              practicalDescription: tube.practicalDescription_i18n['fr'],
-              practicalTitle: tube.practicalTitle_i18n['fr'],
+              practicalDescription: tube.practicalDescription_i18n.en,
+              practicalTitle: tube.practicalTitle_i18n.en,
             },
           ],
         }),
@@ -107,8 +107,8 @@ describe('Maddo | Infrastructure | Repositories | Integration | campaign', funct
               id: tube.id,
               maxLevel: skill.level,
               meanLevel: 0,
-              practicalDescription: tube.practicalDescription_i18n['fr'],
-              practicalTitle: tube.practicalTitle_i18n['fr'],
+              practicalDescription: tube.practicalDescription_i18n.en,
+              practicalTitle: tube.practicalTitle_i18n.en,
             },
           ],
         }),

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -208,6 +208,7 @@ describe('Unit | API | Campaigns', function () {
       it('should return paginated campaign list from organizationId without cover rate', async function () {
         const organizationId = Symbol('organizationId');
         const page = Symbol('page');
+        const locale = Symbol('locale');
         const meta = Symbol('meta');
         const targetProfileName = Symbol('targetProfileName');
 
@@ -222,13 +223,16 @@ describe('Unit | API | Campaigns', function () {
           targetProfileName,
         });
 
-        const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
-        getCampaignStub
-          .withArgs({ organizationId, page, withCoverRate: false })
+        const findPaginatedFilteredOrganizationCampaignsStub = sinon.stub(
+          usecases,
+          'findPaginatedFilteredOrganizationCampaigns',
+        );
+        findPaginatedFilteredOrganizationCampaignsStub
+          .withArgs({ organizationId, page, locale, withCoverRate: false })
           .resolves({ models: [campaignInformation1], meta });
 
         // when
-        const result = await campaignApi.findAllForOrganization({ organizationId, page });
+        const result = await campaignApi.findAllForOrganization({ organizationId, page, locale });
 
         // then
         const firstCampaignListItem = result.models[0];
@@ -246,6 +250,7 @@ describe('Unit | API | Campaigns', function () {
       it('should return paginated campaign list from organizationId with cover rate', async function () {
         const organizationId = Symbol('organizationId');
         const page = Symbol('page');
+        const locale = Symbol('locale');
         const meta = Symbol('meta');
         const targetProfileName = Symbol('targetProfileName');
         const coverRate = domainBuilder.prescription.campaign.buildCampaignResultLevelsPerTubesAndCompetences();
@@ -263,13 +268,16 @@ describe('Unit | API | Campaigns', function () {
 
         campaignInformation1.setCoverRate(coverRate);
 
-        const getCampaignStub = sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
-        getCampaignStub
-          .withArgs({ organizationId, page, withCoverRate: true })
+        const findPaginatedFilteredOrganizationCampaignsStub = sinon.stub(
+          usecases,
+          'findPaginatedFilteredOrganizationCampaigns',
+        );
+        findPaginatedFilteredOrganizationCampaignsStub
+          .withArgs({ organizationId, page, locale, withCoverRate: true })
           .resolves({ models: [campaignInformation1], meta });
 
         // when
-        const result = await campaignApi.findAllForOrganization({ organizationId, page, withCoverRate: true });
+        const result = await campaignApi.findAllForOrganization({ organizationId, page, locale, withCoverRate: true });
 
         // then
         const firstCampaignListItem = result.models[0];


### PR DESCRIPTION
## 🌸 Problème

Le endpoint `/api/organizations/{organizationId}/campaigns` peut retourner beaucoup de campagnes ce qui peut avoir des conséquences négatives sur les performances.

Les titres et descriptions des tubes sont toujours renvoyées en français.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌳 Proposition

On ajoute des query parameters permettant de paginer les requêtes.

On réceptionne le header `Accept-Language` pour traduire les infos des tubes.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

On en a profité pour ajouter la commande `npm run dev:maddo` qui exécute le serveur maddo en mode "watch".

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12182.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```

Appeler la route `/api/organizations/1000/campaigns` avec le token et en ajoutant des paramètres de pagination : 

```
curl 'https://pix-api-maddo-review-pr12182.osc-fr1.scalingo.io/api/organizations/1000/campaigns?page%5Bsize%5D=1&page%5Bnumber%5D=2' -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```


Appeler la route `/api/organizations/1000/campaigns` avec le token et le header `Accept-Language` : 

```
curl https://pix-api-maddo-review-pr12182.osc-fr1.scalingo.io/api/organizations/1000/campaigns -H "Authorization: Bearer $ACCESS_TOKEN" -H 'Accept-Language: en' | jq .
```
