### PR TITLE
[FEATURE] Afficher la nouvelle page d'analyse de résultat

### DIFF
--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -34,6 +34,7 @@ const serialize = function (campaignReports, meta) {
       'averageResult',
       'campaignCollectiveResult',
       'campaignAnalysis',
+      'campaignResultLevelsPerTubesAndCompetence',
       'divisions',
       'stages',
       'totalStage',
@@ -70,6 +71,16 @@ const serialize = function (campaignReports, meta) {
       relationshipLinks: {
         related(record, current, parent) {
           return `/api/campaigns/${parent.id}/analyses`;
+        },
+      },
+    },
+    campaignResultLevelsPerTubesAndCompetence: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: {
+        related(record, current, parent) {
+          return `/api/campaigns/${parent.id}/level-per-tubes-and-competences`;
         },
       },
     },

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js
@@ -4,16 +4,31 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (results) {
   return new Serializer('campaign-result-levels-per-tubes-and-competences', {
-    attributes: ['levelsPerTube', 'levelsPerCompetence', 'maxReachableLevel', 'meanReachedLevel'],
+    attributes: ['levelsPerCompetence', 'maxReachableLevel', 'meanReachedLevel'],
+    transform(results) {
+      const levelsPerCompetence = results.levelsPerCompetence.map((competence) => {
+        return {
+          ...competence,
+          levelsPerTube: results.levelsPerTube.filter((tube) => tube.competenceId === competence.id),
+        };
+      }, []);
+
+      return {
+        id: results.id,
+        maxReachableLevel: results.maxReachableLevel,
+        meanReachedLevel: results.meanReachedLevel,
+        levelsPerCompetence,
+      };
+    },
     levelsPerCompetence: {
       ref: 'id',
       includes: true,
-      attributes: ['index', 'name', 'description', 'maxLevel', 'meanLevel'],
-    },
-    levelsPerTube: {
-      ref: 'id',
-      includes: true,
-      attributes: ['competenceId', 'competenceName', 'title', 'description', 'maxLevel', 'meanLevel'],
+      attributes: ['index', 'name', 'description', 'maxLevel', 'meanLevel', 'levelsPerTube'],
+      levelsPerTube: {
+        ref: 'id',
+        includes: true,
+        attributes: ['competenceId', 'competenceName', 'title', 'description', 'maxLevel', 'meanLevel'],
+      },
     },
   }).serialize(results);
 };

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -77,6 +77,11 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
                 related: '/api/campaigns/campaign_report_id/analyses',
               },
             },
+            'campaign-result-levels-per-tubes-and-competence': {
+              links: {
+                related: '/api/campaigns/campaign_report_id/level-per-tubes-and-competences',
+              },
+            },
             'campaign-collective-result': {
               links: {
                 related: '/api/campaigns/campaign_report_id/collective-results',

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer_test.js
@@ -27,14 +27,6 @@ describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-com
                 },
               ],
             },
-            'levels-per-tube': {
-              data: [
-                {
-                  id: 'tube1',
-                  type: 'levelsPerTubes',
-                },
-              ],
-            },
           },
         },
         included: [
@@ -57,6 +49,16 @@ describe('Unit | Serializer | JSONAPI | campaign-result-levels-per-tubes-and-com
               'max-level': 1,
               'mean-level': 0.5,
               name: 'compétence 1',
+            },
+            relationships: {
+              'levels-per-tube': {
+                data: [
+                  {
+                    id: 'tube1',
+                    type: 'levelsPerTubes',
+                  },
+                ],
+              },
             },
             id: 'competence1',
             type: 'levelsPerCompetences',

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
@@ -1,0 +1,71 @@
+import PixGauge from '@1024pix/pix-ui/components/pix-gauge';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { t } from 'ember-intl';
+
+import TagLevel from '../statistics/tag-level';
+
+<template>
+  <h2 class="analysis-per-tubes-and-competences__positioning-title">{{t
+      "components.analysis-per-tubes-and-competences.detailed-positioning"
+    }}</h2>
+
+  {{#each @data.levelsPerCompetence as |levelsPerCompetence|}}
+    <h3 class="analysis-per-tubes-and-competences__competence-title">
+      {{levelsPerCompetence.index}}
+      -
+      {{levelsPerCompetence.name}}
+    </h3>
+
+    <PixTable
+      class="analysis-per-tubes-and-competences__competence-table"
+      @condensed={{true}}
+      @variant="orga"
+      @caption={{t
+        "components.analysis-per-tubes-and-competences.table.caption"
+        index=levelsPerCompetence.index
+        name=levelsPerCompetence.name
+      }}
+      @data={{levelsPerCompetence.levelsPerTube}}
+    >
+      <:columns as |tubeLevel context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.analysis-per-tubes-and-competences.table.column.tubes"}}
+          </:header>
+          <:cell>
+            <span class="analysis-per-tubes-and-competences__tube-title">{{tubeLevel.title}}</span>
+            <span class="analysis-per-tubes-and-competences__tube-description">{{tubeLevel.description}}</span>
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.analysis-per-tubes-and-competences.table.column.positioning"}}
+          </:header>
+          <:cell>
+            <PixGauge
+              @isSmall={{true}}
+              @maxLevel={{tubeLevel.maxLevel}}
+              @reachedLevel={{tubeLevel.meanLevel}}
+              @label={{t
+                "components.analysis-per-tubes-and-competences.gauge.label"
+                maxLevel=tubeLevel.maxLevel
+                reachedLevel=tubeLevel.meanLevel
+              }}
+            />
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.analysis-per-tubes-and-competences.table.column.level"}}
+          </:header>
+          <:cell>
+            <TagLevel @level={{tubeLevel.meanLevel}} />
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{/each}}
+</template>

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
@@ -1,0 +1,33 @@
+@use 'pix-design-tokens/typography';
+
+.analysis-per-tubes-and-competences {
+  &__positioning-title {
+    @extend %pix-title-s;
+
+    margin-bottom: var(--pix-spacing-6x);
+  }
+
+  &__competence-title {
+    @extend %pix-title-xxs;
+
+    margin-bottom: var(--pix-spacing-3x);
+  }
+
+  &__competence-table {
+    margin-bottom: var(--pix-spacing-6x);
+  }
+
+  &__tube-title {
+    @extend %pix-body-s;
+
+    display: block;
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-bold);
+  }
+
+  &__tube-description {
+    @extend %pix-body-s;
+
+    display: block;
+  }
+}

--- a/orga/app/models/campaign-result-levels-per-tubes-and-competence.js
+++ b/orga/app/models/campaign-result-levels-per-tubes-and-competence.js
@@ -1,0 +1,9 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class CampaignResultLevelsPerTubesAndCompetence extends Model {
+  @attr('number') maxReachableLevel;
+  @attr('number') meanReachedLevel;
+  @attr levelsPerTube;
+
+  @hasMany('levels-per-competence', { async: false, inverse: null }) levelsPerCompetence;
+}

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -35,6 +35,8 @@ export default class Campaign extends Model {
   @belongsTo('target-profile', { async: true, inverse: null }) targetProfile;
   @belongsTo('campaign-collective-result', { async: true, inverse: null }) campaignCollectiveResult;
   @belongsTo('campaign-analysis', { async: true, inverse: null }) campaignAnalysis;
+  @belongsTo('campaign-result-levels-per-tubes-and-competence', { async: true, inverse: null })
+  campaignResultLevelsPerTubesAndCompetence;
 
   @hasMany('badge', { async: true, inverse: null }) badges;
   @hasMany('stage', { async: true, inverse: null }) stages;

--- a/orga/app/models/levels-per-competence.js
+++ b/orga/app/models/levels-per-competence.js
@@ -1,0 +1,13 @@
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+
+export default class LevelsPerCompetence extends Model {
+  @attr('string') index;
+  @attr('number') maxLevel;
+  @attr('number') meanLevel;
+  @attr('string') name;
+  @attr('string') description;
+
+  @belongsTo('campaign-analysis-by-tubes-and-competence', { async: false, inverse: null })
+  campaignAnalysisBytubesAndCompetences;
+  @hasMany('levels-per-tube', { async: false, inverse: null }) levelsPerTube;
+}

--- a/orga/app/models/levels-per-tube.js
+++ b/orga/app/models/levels-per-tube.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class LevelsPerTube extends Model {
+  @attr('string') competenceId;
+  @attr('number') maxLevel;
+  @attr('number') meanLevel;
+  @attr('string') description;
+  @attr('string') title;
+
+  @belongsTo('levels-per-competence', { async: false, inverse: null })
+  levelsPerCompetence;
+}

--- a/orga/app/routes/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/analysis.js
@@ -1,10 +1,16 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class AnalysisRoute extends Route {
+  @service featureToggles;
+
   async model() {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
-    await campaign.belongsTo('campaignAnalysis').reload();
+    const isNewPage = this.featureToggles.featureToggles.shouldDisplayNewAnalysisPage;
+    const analysisModel = isNewPage ? 'campaignResultLevelsPerTubesAndCompetence' : 'campaignAnalysis';
+
+    const analysisData = await campaign[analysisModel];
     await campaign.belongsTo('campaignCollectiveResult').reload();
-    return campaign;
+    return { campaign, analysisData, isNewPage };
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -82,6 +82,7 @@
 
 /* App/Components */
 @use 'sco-organization-participant/generate-username-password-modal' as *;
+@use 'analysis/analysis-per-tubes-and-competences' as *;
 
 body,
 html {

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
@@ -1,24 +1,33 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
+import AnalysisPerTubesAndCompetences from 'pix-orga/components/analysis/analysis-per-tubes-and-competences';
 import Competences from 'pix-orga/components/campaign/analysis/competences';
 import Recommendations from 'pix-orga/components/campaign/analysis/recommendations';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
+
 <template>
   {{pageTitle (t "pages.campaign-review.title")}}
+  {{#if @model.campaign.hasSharedParticipations}}
+    {{#if @model.isNewPage}}
+      <AnalysisPerTubesAndCompetences @data={{@model.analysisData}} />
+    {{else}}
+      <h2 class="screen-reader-only">{{t "pages.campaign-review.title"}}</h2>
+      <Recommendations
+        @campaignTubeRecommendations={{@model.campaign.campaignAnalysis.campaignTubeRecommendations}}
+        @displayAnalysis={{@model.campaign.hasSharedParticipations}}
+      />
 
-  {{#if @model.hasSharedParticipations}}
-    <h2 class="screen-reader-only">{{t "pages.campaign-review.title"}}</h2>
-    <Recommendations
-      @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}
-      @displayAnalysis={{@model.hasSharedParticipations}}
-    />
+      <Competences
+        @campaignId={{@model.campaign.id}}
+        @campaignCollectiveResult={{@model.campaign.campaignCollectiveResult}}
+      />
+    {{/if}}
 
-    <Competences @campaignId={{@model.id}} @campaignCollectiveResult={{@model.campaignCollectiveResult}} />
   {{else}}
     {{#if @controller.isGarAuthenticationMethod}}
       <EmptyState />
     {{else}}
-      <EmptyState @campaignCode={{@model.code}} />
+      <EmptyState @campaignCode={{@model.campaign.code}} />
     {{/if}}
   {{/if}}
 </template>

--- a/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
+++ b/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
@@ -1,0 +1,110 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import AnalysisPerTubesAndCompetences from 'pix-orga/components/analysis/analysis-per-tubes-and-competences';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | analysis-per-tubes-and-competences', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('display analysis by competence and tubes', function () {
+    test('it should display all table ', async function (assert) {
+      // given
+      const campaignAnalysisByTubesAndCompetence = {
+        levelsPerCompetence: [
+          {
+            index: 1,
+            name: 'mon super titre de competence 1',
+            levelsPerTube: [],
+          },
+          {
+            index: 2,
+            name: 'mon super titre de competence 2',
+            levelsPerTube: [],
+          },
+        ],
+      };
+
+      // when
+      const screen = await render(
+        <template><AnalysisPerTubesAndCompetences @data={{campaignAnalysisByTubesAndCompetence}} /></template>,
+      );
+
+      // then
+      assert.ok(
+        screen.getByRole('heading', {
+          level: 2,
+          name: t('components.analysis-per-tubes-and-competences.detailed-positioning'),
+        }),
+      );
+      assert.ok(screen.getByRole('table', { name: '1 - mon super titre de competence 1' }));
+      assert.ok(screen.getByRole('table', { name: '2 - mon super titre de competence 2' }));
+    });
+
+    test('it should display content table', async function (assert) {
+      // given
+      const campaignAnalysisByTubesAndCompetence = {
+        levelsPerCompetence: [
+          {
+            index: 1,
+            name: 'mon super titre de competence 1',
+            levelsPerTube: [
+              { title: 'tube 1 cp 1', description: 'desc tube 1 cp 1', maxLevel: 8, meanLevel: 2 },
+              { title: 'tube 2 cp 1', description: 'desc tube 2 cp 1', maxLevel: 4, meanLevel: 3.45 },
+            ],
+          },
+          {
+            index: 2,
+            name: 'mon super titre de competence 2',
+            levelsPerTube: [],
+          },
+        ],
+      };
+
+      // when
+      const screen = await render(
+        <template><AnalysisPerTubesAndCompetences @data={{campaignAnalysisByTubesAndCompetence}} /></template>,
+      );
+
+      // then
+      const filledTable = within(screen.getByRole('table', { name: '1 - mon super titre de competence 1' }));
+      assert.strictEqual(filledTable.getAllByRole('row').length, 3);
+
+      assert.ok(
+        filledTable.getByRole('columnheader', {
+          name: t('components.analysis-per-tubes-and-competences.table.column.tubes'),
+        }),
+      );
+      assert.ok(filledTable.getByRole('cell', { name: 'tube 1 cp 1 desc tube 1 cp 1' }));
+      assert.ok(
+        filledTable.getByRole('cell', {
+          name: t('components.analysis-per-tubes-and-competences.gauge.label', { reachedLevel: 2, maxLevel: 8 }),
+        }),
+      );
+      assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.novice') }));
+
+      assert.ok(filledTable.getByRole('cell', { name: 'tube 2 cp 1 desc tube 2 cp 1' }));
+      assert.ok(
+        filledTable.getByRole('cell', {
+          name: t('components.analysis-per-tubes-and-competences.gauge.label', { reachedLevel: 3.45, maxLevel: 4 }),
+        }),
+      );
+      assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.advanced') }));
+
+      assert.ok(
+        filledTable.getByRole('columnheader', {
+          name: t('components.analysis-per-tubes-and-competences.table.column.positioning'),
+        }),
+      );
+      assert.ok(
+        filledTable.getByRole('columnheader', {
+          name: t('components.analysis-per-tubes-and-competences.table.column.level'),
+        }),
+      );
+
+      const emptyTable = within(screen.getByRole('table', { name: '2 - mon super titre de competence 2' }));
+      assert.strictEqual(emptyTable.getAllByRole('row').length, 1);
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
@@ -1,0 +1,48 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hooks) {
+  setupTest(hooks);
+  let route;
+  let featureToggles;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/campaigns/campaign/analysis');
+    featureToggles = this.owner.lookup('service:feature-toggles');
+  });
+
+  module('when feature toggle shouldDisplayNewAnalysisPage is true', function () {
+    test('it sets isNewPage as true', async function (assert) {
+      const campaign = {
+        campaignAnalysis: {},
+        belongsTo: () => ({ reload: () => {} }),
+      };
+      sinon.stub(route, 'modelFor').returns(campaign);
+      featureToggles.featureToggles = {
+        shouldDisplayNewAnalysisPage: true,
+      };
+
+      const result = await route.model();
+
+      assert.true(result.isNewPage);
+    });
+  });
+
+  module('when feature toggle shouldDisplayNewAnalysisPage is false', function () {
+    test('it sets isNewPage as false', async function (assert) {
+      const campaign = {
+        campaignAnalysis: {},
+        belongsTo: () => ({ reload: () => {} }),
+      };
+      sinon.stub(route, 'modelFor').returns(campaign);
+      featureToggles.featureToggles = {
+        shouldDisplayNewAnalysisPage: false,
+      };
+
+      const result = await route.model();
+
+      assert.false(result.isNewPage);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -273,6 +273,20 @@
     }
   },
   "components": {
+    "analysis-per-tubes-and-competences": {
+      "detailed-positioning": "Detailed positioning",
+      "gauge": {
+        "label": "Level {reachedLevel} of {maxLevel}"
+      },
+      "table": {
+        "caption": "{index} - {name}",
+        "column": {
+          "level": "Level",
+          "positioning": "Positioning",
+          "tubes": "Subject name and description"
+        }
+      }
+    },
     "campaign": {
       "type": {
         "explanation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -273,6 +273,20 @@
     }
   },
   "components": {
+    "analysis-per-tubes-and-competences": {
+      "detailed-positioning": "Positionnement détaillé",
+      "gauge": {
+        "label": "Niveau {reachedLevel} sur {maxLevel}"
+      },
+      "table": {
+        "caption": "{index} - {name}",
+        "column": {
+          "level": "Niveau",
+          "positioning": "Positionnement",
+          "tubes": "Nom et descriptif du sujet"
+        }
+      }
+    },
     "campaign": {
       "type": {
         "explanation": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -273,6 +273,20 @@
     "no-content": "Geen inhoud"
   },
   "components": {
+    "analysis-per-tubes-and-competences": {
+      "detailed-positioning": "Gedetailleerde positionering",
+      "gauge": {
+        "label": "Niveau {reachedLevel} van {maxLevel}"
+      },
+      "table": {
+        "caption": "{index} - {name}",
+        "column": {
+          "level": "Niveau",
+          "positioning": "Positionering",
+          "tubes": "Onderwerpnaam en -beschrijving"
+        }
+      }
+    },
     "campaign": {
       "type": {
         "explanation": {


### PR DESCRIPTION
## 🌸 Problème

C'est vieux

## 🌳 Proposition

On fait du neuf, tout mignon

## 🐝 Remarques

- [x] test front sur la page d'analyse
- [x] ajout des trads en nl etc...

## 🤧 Pour tester
Aller sur la page Analayse de résultat d'une campagne. 

Vérifier qu'avec le flag shouldDisplayNewAnalysisPage à true on voit la nouvelle page. 
Vérifier qu'avec le flag shouldDisplayNewAnalysisPage à false on voit l'ancienne page 
