### PR TITLE
[TECH] Enregistrer les champs supplémentaires envoyés depuis Pix APP lors de la création d'un passage-event (PIX-17551)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,22 +1,23 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
-const CREATE_PASSAGE_SEQUENCE_NUMBER = 1;
 const TERMINATE_PASSAGE_SEQUENCE_NUMBER = 1000;
 
 const create = async function (request, h, { usecases, passageSerializer }) {
-  const { 'module-id': moduleSlug } = request.payload.data.attributes;
-  const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
+  const {
+    'module-id': moduleSlug,
+    'module-version': moduleVersion,
+    'occurred-at': occurredAt,
+    'sequence-number': sequenceNumber,
+  } = request.payload.data.attributes;
   const userId = requestResponseUtils.extractUserIdFromRequest(request);
-  const sequenceNumber = CREATE_PASSAGE_SEQUENCE_NUMBER;
   const passage = await usecases.createPassage({
     moduleSlug,
     userId,
   });
-  const version = 'NOT_IMPLEMENTED';
 
   const passageStartedData = {
-    contentHash: version,
-    occurredAt: new Date(requestTimestamp),
+    contentHash: moduleVersion,
+    occurredAt: new Date(occurredAt),
     passageId: passage.id,
     sequenceNumber,
     type: 'PASSAGE_STARTED',
@@ -50,4 +51,4 @@ const terminate = async function (request, h, { usecases, passageSerializer }) {
 
 const passageController = { create, verifyAndSaveAnswer, terminate };
 
-export { CREATE_PASSAGE_SEQUENCE_NUMBER, passageController, TERMINATE_PASSAGE_SEQUENCE_NUMBER };
+export { passageController, TERMINATE_PASSAGE_SEQUENCE_NUMBER };

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -4,6 +4,8 @@ import { identifiersType } from '../../../shared/domain/types/identifiers-type.j
 import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
 import { passageController } from './controller.js';
 
+const ARBITRARY_MIN_TIMESTAMP = new Date('2025-04-30').getTime();
+
 const register = async function (server) {
   server.route([
     {
@@ -17,9 +19,9 @@ const register = async function (server) {
             data: Joi.object({
               attributes: Joi.object({
                 'module-id': Joi.string().required(),
-                'module-version': Joi.string().required(),
-                'sequence-number': Joi.number().required(),
-                'occurred-at': Joi.number().required(),
+                'module-version': Joi.string().length(64).required(),
+                'sequence-number': Joi.number().valid(1).required(),
+                'occurred-at': Joi.number().min(ARBITRARY_MIN_TIMESTAMP).required(),
               }).required(),
             }).required(),
           }).required(),

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -17,6 +17,9 @@ const register = async function (server) {
             data: Joi.object({
               attributes: Joi.object({
                 'module-id': Joi.string().required(),
+                'module-version': Joi.string().required(),
+                'sequence-number': Joi.number().required(),
+                'occurred-at': Joi.number().required(),
               }).required(),
             }).required(),
           }).required(),

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -9,6 +9,7 @@ function serialize(module) {
         id: module.slug,
         title: module.title,
         isBeta: module.isBeta,
+        version: module.version,
         details: module.details,
         grains: module.grains.map((grain) => {
           return {
@@ -20,7 +21,7 @@ function serialize(module) {
         }),
       };
     },
-    attributes: ['title', 'isBeta', 'grains', 'details'],
+    attributes: ['title', 'isBeta', 'version', 'grains', 'details'],
     grains: {
       ref: 'id',
       includes: true,

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -33,6 +33,9 @@ describe('Acceptance | Controller | passage-controller', function () {
               type: 'passages',
               attributes: {
                 'module-id': 'bien-ecrire-son-adresse-mail',
+                'occurred-at': new Date('2025-04-29').getTime(),
+                'module-version': 'version',
+                'sequence-number': 1,
               },
             },
           },
@@ -51,10 +54,11 @@ describe('Acceptance | Controller | passage-controller', function () {
         // given
         const user = databaseBuilder.factory.buildUser();
         await databaseBuilder.commit();
+        const moduleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
         const expectedResponse = {
           type: 'passages',
           attributes: {
-            'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            'module-id': moduleId,
           },
         };
 
@@ -67,6 +71,9 @@ describe('Acceptance | Controller | passage-controller', function () {
               type: 'passages',
               attributes: {
                 'module-id': 'bien-ecrire-son-adresse-mail',
+                'occurred-at': new Date('2025-04-29').getTime(),
+                'module-version': 'version',
+                'sequence-number': 1,
               },
             },
           },
@@ -74,13 +81,16 @@ describe('Acceptance | Controller | passage-controller', function () {
         });
 
         // then
+        const { id: passageId, userId } = await knex('passages').where({ id: response.result.data.id }).first();
+        const passageEvents = await knex('passage-events').where({ passageId }).first();
+
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.type).to.equal(expectedResponse.type);
         expect(response.result.data.id).to.exist;
         expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
 
-        const { userId } = await knex('passages').where({ id: response.result.data.id }).first();
         expect(userId).to.equal(user.id);
+        expect(passageEvents.type).to.equal('PASSAGE_STARTED');
       });
     });
   });

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -33,8 +33,8 @@ describe('Acceptance | Controller | passage-controller', function () {
               type: 'passages',
               attributes: {
                 'module-id': 'bien-ecrire-son-adresse-mail',
-                'occurred-at': new Date('2025-04-29').getTime(),
-                'module-version': 'version',
+                'occurred-at': new Date('2025-04-30').getTime(),
+                'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
                 'sequence-number': 1,
               },
             },
@@ -71,8 +71,8 @@ describe('Acceptance | Controller | passage-controller', function () {
               type: 'passages',
               attributes: {
                 'module-id': 'bien-ecrire-son-adresse-mail',
-                'occurred-at': new Date('2025-04-29').getTime(),
-                'module-version': 'version',
+                'occurred-at': new Date('2025-04-30').getTime(),
+                'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
                 'sequence-number': 1,
               },
             },

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -20,6 +20,9 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
           data: {
             attributes: {
               'module-id': 'not existing id',
+              'module-version': 'not existing version',
+              'sequence-number': '1',
+              'occurred-at': new Date('2025-04-29').getTime(),
             },
           },
         };
@@ -42,6 +45,9 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
           data: {
             attributes: {
               'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+              'module-version': 'version',
+              'sequence-number': '1',
+              'occurred-at': new Date('2025-04-29').getTime(),
             },
           },
         };

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -20,9 +20,9 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
           data: {
             attributes: {
               'module-id': 'not existing id',
-              'module-version': 'not existing version',
+              'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
               'sequence-number': '1',
-              'occurred-at': new Date('2025-04-29').getTime(),
+              'occurred-at': new Date('2025-04-30').getTime(),
             },
           },
         };
@@ -45,9 +45,9 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
           data: {
             attributes: {
               'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              'module-version': 'version',
+              'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
               'sequence-number': '1',
-              'occurred-at': new Date('2025-04-29').getTime(),
+              'occurred-at': new Date('2025-04-30').getTime(),
             },
           },
         };

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -27,6 +27,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
+      const version = Symbol('version');
       const details = {
         image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -39,7 +40,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta });
+      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta, version });
       const expectedJson = {
         data: {
           type: 'modules',
@@ -48,6 +49,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             title,
             'is-beta': isBeta,
             details,
+            version,
           },
           relationships: {
             grains: {
@@ -70,6 +72,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
+      const version = Symbol('version');
       const details = {
         image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
         description:
@@ -87,6 +90,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         slug,
         title,
         isBeta,
+        version,
         details,
         grains: [
           {
@@ -102,6 +106,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           attributes: {
             title: 'Bien écrire son adresse mail',
             'is-beta': isBeta,
+            version,
             details,
           },
           id: 'bien-ecrire-son-adresse-mail',

--- a/mon-pix/app/adapters/passage.js
+++ b/mon-pix/app/adapters/passage.js
@@ -1,6 +1,20 @@
 import ApplicationAdapter from './application';
 
 export default class Passage extends ApplicationAdapter {
+  createRecord(store, type, snapshot) {
+    const passageData = this.serialize(snapshot);
+    const { moduleVersion, occurredAt, sequenceNumber } = snapshot.adapterOptions;
+    passageData.data.attributes = {
+      ...passageData.data.attributes,
+      'module-version': moduleVersion,
+      'occurred-at': occurredAt,
+      'sequence-number': sequenceNumber,
+    };
+
+    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+    return this.ajax(url, 'POST', { data: passageData });
+  }
+
   async terminate({ passageId }) {
     const url = `${this.host}/${this.namespace}/passages/${passageId}/terminate`;
     await this.ajax(url, 'POST');

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -4,5 +4,6 @@ export default class Module extends Model {
   @attr('string') title;
   @attr('boolean') isBeta;
   @attr() details;
+  @attr('string') version;
   @hasMany('grain', { async: false, inverse: 'module' }) grains;
 }

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -6,7 +6,13 @@ export default class ModulePassageRoute extends Route {
 
   async model() {
     const module = this.modelFor('module');
-    const passage = await this.store.createRecord('passage', { moduleId: module.id }).save();
+    const passage = await this.store.createRecord('passage', { moduleId: module.id }).save({
+      adapterOptions: {
+        occurredAt: new Date().getTime(),
+        sequenceNumber: 1,
+        moduleVersion: module.version,
+      },
+    });
 
     return { module, passage };
   }

--- a/mon-pix/tests/unit/adapters/passage-test.js
+++ b/mon-pix/tests/unit/adapters/passage-test.js
@@ -5,6 +5,62 @@ import sinon from 'sinon';
 module('Unit | Adapter | Module | Passage', function (hooks) {
   setupTest(hooks);
 
+  module('#createRecord', function () {
+    test('should trigger an ajax call with the right url and method', async function (assert) {
+      // given
+      const moduleId = Symbol('moduleId');
+      const sequenceNumber = 1;
+      const occurredAt = Symbol('timestamp');
+      const moduleVersion = Symbol('moduleVersion');
+      const adapterOptions = {
+        moduleId,
+        moduleVersion,
+        occurredAt,
+        sequenceNumber,
+      };
+      const snapshot = {
+        adapterOptions,
+        serialize: function () {
+          return {
+            data: {
+              attributes: {
+                'module-id': moduleId,
+              },
+              type: 'passages',
+            },
+          };
+        },
+      };
+
+      const store = this.owner.lookup('service:store');
+      const adapter = this.owner.lookup('adapter:passage');
+      const type = { modelName: 'passage' };
+      sinon.stub(adapter, 'ajax').resolves();
+      const expectedUrl = `http://localhost:3000/api/passages`;
+
+      // when
+      await adapter.createRecord(store, type, snapshot);
+
+      // then
+      const expectedPayload = {
+        data: {
+          data: {
+            attributes: {
+              'module-id': moduleId,
+              'module-version': moduleVersion,
+              'sequence-number': sequenceNumber,
+              'occurred-at': occurredAt,
+            },
+            type: 'passages',
+          },
+        },
+      };
+
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
+      assert.ok(true);
+    });
+  });
+
   module('#terminate', function () {
     test('should trigger an ajax call with the right url and method', async function (assert) {
       // given

--- a/mon-pix/tests/unit/models/modules/module-test.js
+++ b/mon-pix/tests/unit/models/modules/module-test.js
@@ -9,15 +9,17 @@ module('Unit | Model | Module | Module', function (hooks) {
     const title = 'Bien écrire son adresse mail';
     const details = Symbol('details');
     const store = this.owner.lookup('service:store');
+    const version = Symbol('version');
     const grain = store.createRecord('grain', {});
 
     // when
-    const module = store.createRecord('module', { title, details, grains: [grain] });
+    const module = store.createRecord('module', { title, details, version, grains: [grain] });
 
     // then
     assert.ok(module);
     assert.strictEqual(module.title, title);
     assert.strictEqual(module.details, details);
+    assert.strictEqual(module.version, version);
     assert.strictEqual(module.grains[0], grain);
   });
 });

--- a/mon-pix/tests/unit/models/modules/module-test.js
+++ b/mon-pix/tests/unit/models/modules/module-test.js
@@ -10,14 +10,16 @@ module('Unit | Model | Module | Module', function (hooks) {
     const details = Symbol('details');
     const store = this.owner.lookup('service:store');
     const version = Symbol('version');
+    const isBeta = Symbol('isBeta');
     const grain = store.createRecord('grain', {});
 
     // when
-    const module = store.createRecord('module', { title, details, version, grains: [grain] });
+    const module = store.createRecord('module', { title, isBeta, details, version, grains: [grain] });
 
     // then
     assert.ok(module);
     assert.strictEqual(module.title, title);
+    assert.strictEqual(module.isBeta, isBeta);
     assert.strictEqual(module.details, details);
     assert.strictEqual(module.version, version);
     assert.strictEqual(module.grains[0], grain);

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -52,5 +52,12 @@ module('Unit | Route | modules | passage', function (hooks) {
 
     // then
     assert.strictEqual(model.passage, passage);
+    sinon.assert.calledWith(save, {
+      adapterOptions: {
+        occurredAt: new Date().getTime(),
+        sequenceNumber: 1,
+        moduleVersion: module.version,
+      },
+    });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Actuellement, l'enregistrement d'un passage-event de type `STARTED` met en dur les valeurs dans les colonnes `occurredAt`, `sequenceNumber` et `data.contentHash`.

## 🌳 Proposition

- Envoyer, lors de la création d'un passage, ces champs à l'API
- Enlever les valeurs par défaut dans le controller `create-passage` utilisées pour enregistrer un `passage-event`

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Ouvrir la console navigateur -> onglet network
- Commencer un module (ex: https://app-pr12190.review.pix.fr/modules/bac-a-sable/passage)
- Vérifier que l'appel POST /api/passages envoie bien maintenant les champs `occurred-at`, `sequence-number` et `module-version`
- Vérifier, dans la base de donnée, que le passage-event crée contient bien, dans les colonnes occurredAt, sequenceNumber et version, les valeurs des champs envoyées à l'API
