### PR TITLE
[TECH] Investiguer un flaky sur Saml POST /api/token-from-external-user (PIX-17670)

### DIFF
--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -184,7 +184,7 @@ function extractClientId(token, secret = config.authentication.secret) {
 }
 
 async function extractExternalUserFromIdToken(token) {
-  const externalUser = await getDecodedToken(token);
+  const externalUser = getDecodedToken(token);
 
   if (!externalUser) {
     throw new InvalidExternalUserTokenError(

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -1,3 +1,5 @@
+import { env } from 'node:process';
+
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../../src/shared/config.js';
@@ -132,7 +134,13 @@ function decodeIfValid(token) {
 function getDecodedToken(token, secret = config.authentication.secret) {
   try {
     return jsonwebtoken.verify(token, secret);
-  } catch {
+  } catch (error) {
+    // TODO: Remove this debug used to investigate a flaky test when the cause is found
+    if (env.DEBUG == 'pix:token-service:invalid-token') {
+      // eslint-disable-next-line no-console
+      console.error(`token: "${token}"`, error);
+    }
+
     return false;
   }
 }

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -10,12 +10,6 @@ import {
 
 const CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE = 'certificationResultsByRecipientEmailLink';
 
-function _createAccessToken({ userId, source, expirationDelaySeconds, audience }) {
-  return jsonwebtoken.sign({ user_id: userId, source, aud: audience }, config.authentication.secret, {
-    expiresIn: expirationDelaySeconds,
-  });
-}
-
 function createAccessTokenFromUser({ userId, source, audience }) {
   const expirationDelaySeconds = config.authentication.accessTokenLifespanMs / 1000;
   const accessToken = _createAccessToken({ userId, source, expirationDelaySeconds, audience });
@@ -30,6 +24,12 @@ function createAccessTokenFromAnonymousUser({ userId, audience }) {
 function createAccessTokenForSaml({ userId, audience }) {
   const expirationDelaySeconds = config.saml.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds, audience });
+}
+
+function _createAccessToken({ userId, source, expirationDelaySeconds, audience }) {
+  return jsonwebtoken.sign({ user_id: userId, source, aud: audience }, config.authentication.secret, {
+    expiresIn: expirationDelaySeconds,
+  });
 }
 
 /**

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -299,8 +299,9 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data.attributes['access-token']).to.exist;
-        const decodedAccessToken = await decodeIfValid(response.result.data.attributes['access-token']);
+        const token = response.result.data.attributes['access-token'];
+        expect(token).to.exist;
+        const decodedAccessToken = await decodeIfValid(token);
         expect(decodedAccessToken).to.include({
           aud: 'https://app.pix.fr',
         });

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -1,3 +1,5 @@
+import { env } from 'node:process';
+
 import _ from 'lodash';
 import samlify from 'samlify';
 
@@ -260,6 +262,8 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
     describe('when user has a reconciled Pix account and successfully authenticate to Pix from GAR (saml)', function () {
       it('returns a 200 with accessToken', async function () {
         // given
+        env.DEBUG = 'pix:token-service:invalid-token';
+
         const password = 'Pix123';
         const userAttributes = {
           firstName: 'saml',

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -270,6 +270,8 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
           username: 'saml.jackson1234',
           rawPassword: password,
         });
+        await databaseBuilder.commit();
+
         const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
 
         const options = {
@@ -291,8 +293,6 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             },
           },
         };
-
-        await databaseBuilder.commit();
 
         // when
         const response = await server.inject(options);
@@ -318,6 +318,8 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
           username: 'saml.jackson1234',
           rawPassword: password,
         });
+        await databaseBuilder.commit();
+
         const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
 
         const options = {
@@ -339,8 +341,6 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             },
           },
         };
-
-        await databaseBuilder.commit();
 
         // when
         await server.inject(options);
@@ -436,9 +436,9 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
               rawPassword: password,
             });
             databaseBuilder.factory.buildUserLogin({ userId: user.id, failureCount: 50, blockedAt: new Date() });
-            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
-
             await databaseBuilder.commit();
+
+            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
 
             const options = {
               method: 'POST',
@@ -479,9 +479,9 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
               rawPassword: password,
             });
             databaseBuilder.factory.buildUserLogin({ userId: user.id, failureCount: 50, blockedAt: new Date() });
-            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
-
             await databaseBuilder.commit();
+
+            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
 
             const options = {
               method: 'POST',


### PR DESCRIPTION
## 🌸 Problème

Le test `Acceptance | Identity Access Management | Route | Saml POST /api/token-from-external-user when user has a reconciled Pix account and successfully authenticate to Pix from GAR (saml) returns a 200 with accessToken` est parfois flaky.

## 🌳 Proposition

Des investigations n'ont pas permis de trouver les causes qui pourraient rendre ce test flaky. Aussi cette PR propose d'ajouter du debug : un `console.error` qui affichera l'erreur de validation et le token en question uniquement dans le cas du test sur lequel l'investigation est menée.

Le dernier commit constitue ce qui ajoute le debug sera à supprimer dans le futur proche (dans 2 mois), lorsqu'on aura trouvé les causes du flaky ou si ce flaky ne se manifeste plus.

## 🐝 Remarques

Faire attention que cette PR n'introduise pas de failles de sécurité.

## 🤧 Pour tester

1. Modifier le fichier `api/tests/identity-access-management/acceptance/application/saml.route.test.js` au niveau de la ligne `306` : 
   ```javascript
   const token = response.result.data.attributes['access-token'] + 'some garbage';
   ```
2. Exécuter le test  `Acceptance | Identity Access Management | Route | Saml POST /api/token-from-external-user when user has a reconciled Pix account and successfully authenticate to Pix from GAR (saml) returns a 200 with accessToken`,
3. Constater que la cause de la non-validité du token est affichée,
4. Exécuter tous les tests de l'API,
5. Constater que le debug qui est ajouté par cette PR ne provoque aucun affichage intempestif pour tous les autres tests.