### PR TITLE
[TECH] Ajouter de la validation sur la route POST passage-events (PIX-17591)

### DIFF
--- a/api/src/devcomp/application/passage-events/index.js
+++ b/api/src/devcomp/application/passage-events/index.js
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
 import { passageEventsController } from './passage-events-controller.js';
 
@@ -9,6 +11,26 @@ const register = async function (server) {
       config: {
         auth: false,
         handler: handlerWithDependencies(passageEventsController.create),
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                'passage-events': Joi.array()
+                  .items(
+                    Joi.object({
+                      'occurred-at': Joi.number().required(),
+                      'sequence-number': Joi.number().required(),
+                      type: Joi.string().required(),
+                    }),
+                  )
+                  .min(1),
+              }).required(),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
         notes: ['- Permet de créer un évènement utilisateur pour un passage'],
         tags: ['api', 'passages', 'modules', 'events'],
       },

--- a/api/tests/devcomp/integration/application/passage-events/index_test.js
+++ b/api/tests/devcomp/integration/application/passage-events/index_test.js
@@ -1,0 +1,42 @@
+import * as moduleUnderTest from '../../../../../src/devcomp/application/passage-events/index.js';
+import { expect } from '../../../../test-helper.js';
+import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+
+describe('Integration | Devcomp | Application | Module | Router | passage-events-router', function () {
+  describe('POST /api/passage-events', function () {
+    context('when payload is empty', function () {
+      it('should return a 400 HTTP code error', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {};
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/passage-events', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+    context('when payload does not pass validation', function () {
+      it('should return a 400 HTTP code error', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'passage-events': [],
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/passage-events', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Actuellement il n'y a pas de validation de paramètres sur la route POST passage-events.

## 🌳 Proposition

Ajouter cette validation.

## 🐝 Remarques

RAS

## 🤧 Pour tester

CI au vert
