### PR TITLE
[BUGFIX] Retirer un texte inutile dans la boîte de dialog d'archivage d'un centre de certification (PIX-17686)

### DIFF
--- a/admin/app/components/certification-centers/information-view.gjs
+++ b/admin/app/components/certification-centers/information-view.gjs
@@ -175,7 +175,6 @@ export default class InformationView extends Component {
           <ul class="certification-center-confirmation-modal__list">
             <li>{{t "pages.certification-centers.archive-confirmation-modal.members"}}</li>
             <li>{{t "pages.certification-centers.archive-confirmation-modal.invitations"}}</li>
-            <li>{{t "pages.certification-centers.archive-confirmation-modal.campaigns"}}</li>
             <li>{{t "pages.certification-centers.archive-confirmation-modal.attachment"}}</li>
           </ul>
           <p class="certification-center-confirmation-modal__warning">{{t

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -671,7 +671,6 @@
     "certification-centers": {
       "archive-confirmation-modal": {
         "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
-        "campaigns": "Les campagnes actives vont être archivées",
         "invitations": "Les invitations en attente vont être annulées",
         "members": "Les membres actifs vont être désactivés",
         "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -671,7 +671,6 @@
     "certification-centers": {
       "archive-confirmation-modal": {
         "attachment": "Le rattachement et l'invitation de nouvelles personnes seront bloqués",
-        "campaigns": "Les campagnes actives vont être archivées",
         "invitations": "Les invitations en attente vont être annulées",
         "members": "Les membres actifs vont être désactivés",
         "question": "Êtes-vous sûr de vouloir archiver ce centre de certification?",


### PR DESCRIPTION
## 🌸 Problème

Lors de l'archivage d'un centre de certification, la liste des actions qui vont être exécutées comporte une erreur. On parle de campagne alors qu'il n'y a pas de campagne dans un centre de certification.

## 🌳 Proposition

Retirer l'allusion aux campagne dans le composant et dans le fichier français de traduction.

## 🐝 Remarques

RAS

## 🤧 Pour tester
- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Se rendre dans la section des centres de certifications,
- Aller sur le centre Accessorium,
- Cliquer sur le bouton pour archiver,
- Dans la boîte de dialogue qui s'affiche, constater qu'il n'est plus fait mention des campagnes,
- Mettre une coche 😁