### PR TITLE
[FEATURE] Ajouter un feature toggle pour la nouvelle récupération de compte (PIX-17503)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,12 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isNewAccountRecoveryEnabled: {
+    type: 'boolean',
+    description: 'Using and testing feature account recovery process',
+    defaultValue: false,
+    tags: ['team-acces', 'frontend'],
+  },
   isResultsSharedModalEnabled: {
     description: 'Used to enable displaying the "results shared!" modal',
     type: 'boolean',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -26,6 +26,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-direct-metrics-enabled': false,
             'is-results-shared-modal-enabled': false,
+            'is-new-account-recovery-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'is-oppsy-disabled': false,
             'is-pix-app-new-layout-enabled': false,


### PR DESCRIPTION
## 🌸 Problème

On a besoin d'un feature toggle pour la future fonctionnalité de nouvelle récupération de compte.

## 🌳 Proposition

Ajouter le feature toggle isNewAccoutRecoveryEnabled, valeur false, tag frontend pour un affichage dans le front.

## 🐝 Remarques

RAS

## 🤧 Pour tester
- Afficher les feature toggles disponible:
```shell
scalingo -a pix-api-review-pr<number> npm run toggles -- --list
```
Remplacer number par le numéro de pr,
- Constater que le nouveau feature toggle est présent avec comme valeur false.