### PR TITLE
[BUGFIX] Utiliser l'action de release de la branche main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version-file: 'package.json'
 
-      - uses: 1024pix/pix-actions/release@tech/allow-monorepo-release
+      - uses: 1024pix/pix-actions/release@main
         id: semantic
         with:
           changelogTitle: "# Pix Changelog"


### PR DESCRIPTION
## 🌸 Problème
La PR d'ajout du workflow de release pour le monorepo utilisait l'action présente sur une branch de dev plutôt que la branche main.

## 🌳 Proposition
Utiliser l'action de release de la branche main.
