### PR TITLE
[TECH] Création d'une table dans le datamart permettant de servir les taux de couverture par organisation via Maddo (PIX-17715).

### DIFF
--- a/api/datamart/migrations/20250430132217_create-organizations_cover_rates-table.js
+++ b/api/datamart/migrations/20250430132217_create-organizations_cover_rates-table.js
@@ -1,0 +1,36 @@
+const TABLE_NAME = 'organizations_cover_rates';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.text('tag_name');
+    table.text('domain_name');
+    table.text('competence_code');
+    table.text('competence_name');
+    table.integer('campaign_id');
+    table.integer('target_profile_id');
+    table.integer('orga_id');
+    table.text('tube_id');
+    table.text('tube_practical_title');
+    table.date('extraction_date');
+    table.smallint('max_level');
+    table.bigint('sum_user_max_level');
+    table.bigint('nb_user');
+    table.integer('nb_tubes_in_competence');
+
+    table.index(['orga_id', 'campaign_id']);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Le taux de couverture par organisation est actuellement servie par l'API Data.
Cette architecture n'est plus conforme avec nos choix concernant la Mise A Disposition de Données (MADDO), dans lesquels l'API Data est supprimée.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌳 Proposition

On crée une table `organizations_cover_rates` qui contient pour le moment les mêmes colonnes que la table `data_pro_campaigns_kpi_aggregated` du datamart de l'API Data.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Se connecter au serveur pgsql de la review app de maddo et vérifier la présence de la table `organizations_cover_rates`.
Vérifier que le schéma de la table correspond à celui de la table du datamart de l'API data.

```
         Column         |   Type   | Collation | Nullable | Default
------------------------+----------+-----------+----------+---------
 tag_name               | text     |           |          |
 domain_name            | text     |           |          |
 competence_code        | text     |           |          |
 competence_name        | text     |           |          |
 campaign_id            | integer  |           |          |
 target_profile_id      | integer  |           |          |
 orga_id                | integer  |           |          |
 tube_id                | text     |           |          |
 tube_practical_title   | text     |           |          |
 extraction_date        | date     |           |          |
 max_level              | smallint |           |          |
 sum_user_max_level     | bigint   |           |          |
 nb_user                | bigint   |           |          |
 nb_tubes_in_competence | integer  |           |          |
```

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
