### PR TITLE
[FEATURE] Ajout d'une route de rescoring de certification (PIX-17625).

### DIFF
--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -1,0 +1,17 @@
+import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { usecases } from '../../evaluation/domain/usecases/index.js';
+
+const rescoreCertification = async function (request, h) {
+  const certificationCourseId = request.params.certificationCourseId;
+  const locale = extractLocaleFromRequest(request);
+
+  await usecases.rescoreCertification({ certificationCourseId, locale });
+
+  return h.response().code(201);
+};
+
+const certificationRescoringController = {
+  rescoreCertification,
+};
+
+export { certificationRescoringController };

--- a/api/src/certification/evaluation/application/certification-rescoring-route.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-route.js
@@ -1,0 +1,38 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { certificationRescoringController } from './certification-rescoring-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/admin/certifications/{certificationCourseId}/rescore',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({ certificationCourseId: identifiersType.certificationCourseId }),
+        },
+        handler: certificationRescoringController.rescoreCertification,
+        tags: ['api', 'sessions', 'scoring'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle Super Admin**\n' +
+            '- Elle permet de rescorer une certification',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'certification-rescoring-api';
+export { name, register };

--- a/api/src/certification/evaluation/domain/models/Session.js
+++ b/api/src/certification/evaluation/domain/models/Session.js
@@ -1,0 +1,9 @@
+class Session {
+  constructor({ id, finalizedAt, publishedAt } = {}) {
+    this.id = id;
+    this.isFinalized = Boolean(finalizedAt);
+    this.isPublished = Boolean(publishedAt);
+  }
+}
+
+export { Session };

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as languageService from '../../../../shared/domain/services/language-se
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { services } from '../../../evaluation/domain/services/index.js';
 import * as verifyCertificateCodeService from '../../../evaluation/domain/services/verify-certificate-code-service.js';
 import * as certifiableProfileForLearningContentRepository from '../../../evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
 import * as flashAlgorithmService from '../../../flash-certification/domain/services/algorithm-methods/flash.js';
@@ -29,10 +30,12 @@ import * as userRepository from '../../../shared/infrastructure/repositories/use
 import * as certificationCandidateRepository from '../../infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCompanionAlertRepository from '../../infrastructure/repositories/certification-companion-alert-repository.js';
 import * as challengeCalibrationRepository from '../../infrastructure/repositories/challenge-calibration-repository.js';
+import * as evaluationSessionRepository from '../../infrastructure/repositories/session-repository.js';
 import * as certificationChallengesService from '../services/certification-challenges-service.js';
 import pickChallengeService from '../services/pick-challenge-service.js';
 /**
  * @typedef {certificationCompanionAlertRepository} CertificationCompanionAlertRepository
+ * @typedef {evaluationSessionRepository} EvaluationSessionRepository
  * @typedef {certificationChallengeRepository} CertificationChallengeRepository
  * @typedef {certificationAssessmentRepository} CertificationAssessmentRepository
  * @typedef {certifiableProfileForLearningContentRepository} CertifiableProfileForLearningContentRepository
@@ -40,6 +43,7 @@ import pickChallengeService from '../services/pick-challenge-service.js';
 
 const dependencies = {
   ...sessionRepositories,
+  evaluationSessionRepository,
   sessionManagementCertificationChallengeRepository,
   challengeCalibrationRepository,
   certificationCandidateRepository,
@@ -65,6 +69,7 @@ const dependencies = {
   certificationCompanionAlertRepository,
   certificationCourseRepository,
   certificationAssessmentRepository,
+  services,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/evaluation/domain/usecases/rescore-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-certification.js
@@ -1,0 +1,39 @@
+import { CertificationAlgorithmVersionError, NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
+import { SessionAlreadyPublishedError } from '../../../session-management/domain/errors.js';
+import CertificationRescoredByScript from '../../../session-management/domain/events/CertificationRescoredByScript.js';
+import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
+
+export const rescoreCertification = async ({
+  certificationCourseId,
+  locale,
+  certificationAssessmentRepository,
+  evaluationSessionRepository,
+  services,
+}) => {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
+    certificationCourseId,
+  });
+
+  if (!AlgorithmEngineVersion.isV3(certificationAssessment.version)) {
+    throw new CertificationAlgorithmVersionError();
+  }
+
+  const session = await evaluationSessionRepository.getByCertificationCourseId({
+    certificationCourseId,
+  });
+
+  if (!session.isFinalized) {
+    throw new NotFinalizedSessionError();
+  }
+
+  if (session.isPublished) {
+    throw new SessionAlreadyPublishedError();
+  }
+
+  return services.handleV3CertificationScoring({
+    event: new CertificationRescoredByScript({ certificationCourseId }),
+    certificationAssessment,
+    locale,
+    dependencies: { findByCertificationCourseIdAndAssessmentId: services.findByCertificationCourseIdAndAssessmentId },
+  });
+};

--- a/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/session-repository.js
@@ -1,0 +1,22 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { Session } from '../../domain/models/Session.js';
+
+const getByCertificationCourseId = async ({ certificationCourseId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const certificationCourseDTO = await knexConn('certification-courses').where('id', certificationCourseId).first();
+
+  if (!certificationCourseDTO) {
+    throw new NotFoundError('Certification course does not exist');
+  }
+
+  const sessionDTO = await knexConn('sessions').where('id', certificationCourseDTO.sessionId).first();
+
+  return _toDomain(sessionDTO);
+};
+
+function _toDomain(sessionDTO) {
+  return new Session(sessionDTO);
+}
+
+export { getByCertificationCourseId };

--- a/api/src/certification/evaluation/routes.js
+++ b/api/src/certification/evaluation/routes.js
@@ -1,7 +1,13 @@
 import * as companionAlert from '../evaluation/application/companion-alert-route.js';
 import * as certificationAdminRoutes from './application/certification-admin-route.js';
 import * as certificationCourseRoutes from './application/certification-course-route.js';
+import * as certificationRescoringRoutes from './application/certification-rescoring-route.js';
 
-const certificationEvaluationRoutes = [companionAlert, certificationCourseRoutes, certificationAdminRoutes];
+const certificationEvaluationRoutes = [
+  companionAlert,
+  certificationCourseRoutes,
+  certificationAdminRoutes,
+  certificationRescoringRoutes,
+];
 
 export { certificationEvaluationRoutes };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -176,6 +176,15 @@ class CertificationCenterMembershipDisableError extends DomainError {
   }
 }
 
+class CertificationAlgorithmVersionError extends DomainError {
+  constructor(
+    message = 'La version de la certification ne permet pas de réaliser cette opération',
+    code = 'CERTIFICATION_USING_INCORRECT_ALGORITHM_VERSION',
+  ) {
+    super(message, code);
+  }
+}
+
 class ChallengeAlreadyAnsweredError extends DomainError {
   constructor(message = 'La question a déjà été répondue.') {
     super(message);
@@ -1006,7 +1015,7 @@ class AuditLoggerApiError extends DomainError {
 }
 
 class NotFinalizedSessionError extends DomainError {
-  constructor(message = 'A certification course cannot be cancelled while session has not been finalized.') {
+  constructor(message = 'A certification course cannot be cancelled/rescored while session has not been finalized.') {
     super(message);
   }
 }
@@ -1041,6 +1050,7 @@ export {
   CandidateNotAuthorizedToResumeCertificationTestError,
   CantImproveCampaignParticipationError,
   CertificateVerificationCodeGenerationTooManyTrials,
+  CertificationAlgorithmVersionError,
   CertificationAttestationGenerationError,
   CertificationBadgeForbiddenDeletionError,
   CertificationCandidateByPersonalInfoNotFoundError,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -1,0 +1,148 @@
+import { config } from '../../../../../src/shared/config.js';
+import { AnswerStatus, Assessment } from '../../../../../src/shared/domain/models/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  knex,
+} from '../../../../test-helper.js';
+
+describe('Certification | Evaluation | Acceptance | Application |  certification rescoring', function () {
+  describe('GET /api/admin/certifications/{certificationCourseId}/rescore', function () {
+    let server;
+    let originalConfigValue;
+
+    beforeEach(async function () {
+      originalConfigValue = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
+      config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = 1;
+
+      server = await createServer();
+    });
+
+    afterEach(function () {
+      config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = originalConfigValue;
+    });
+
+    it('should return 201 HTTP status code', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser.withRole({
+        role: 'SUPER_ADMIN',
+      });
+
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'recArea0',
+        code: '66',
+        competenceIds: ['recCompetence0'],
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'recCompetence0',
+        name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
+        index: '1.1',
+        areaId: 'recArea0',
+        skillIds: ['recSkill0_0'],
+        origin: 'Pix',
+      });
+      databaseBuilder.factory.learningContent.buildTube({
+        id: 'recTube0_0',
+      });
+      databaseBuilder.factory.learningContent.buildSkill({
+        id: 'recSkill0_0',
+        name: '@recSkill0_0',
+        tubeId: 'recTube0_0',
+        status: 'actif',
+        level: 1,
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'recChallenge0_0_0',
+        competenceId: 'recCompetence0',
+        skillId: 'recSkill0_0',
+      });
+
+      databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+        maximumAssessmentLength: 1,
+        createdAt: new Date('2010-02-01'),
+      });
+      databaseBuilder.factory.buildScoringConfiguration({
+        createdByUserId: user.id,
+        createdAt: new Date('2010-02-01'),
+      });
+      databaseBuilder.factory.buildCompetenceScoringConfiguration({
+        createdByUserId: user.id,
+        configuration: [
+          {
+            competence: '1.1',
+            values: [
+              {
+                bounds: {
+                  max: 0,
+                  min: -5,
+                },
+                competenceLevel: 0,
+              },
+            ],
+          },
+        ],
+      });
+
+      const candidate = databaseBuilder.factory.buildUser();
+      const sessionId = databaseBuilder.factory.buildSession({
+        date: '2020/01/01',
+        time: '12:00',
+        finalizedAt: new Date('2020-01-01'),
+      }).id;
+
+      databaseBuilder.factory.buildCertificationCandidate({
+        sessionId,
+        userId: candidate.id,
+      });
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        sessionId,
+        userId: candidate.id,
+        version: 3,
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourse.id,
+        userId: candidate.id,
+        type: Assessment.types.CERTIFICATION,
+        state: Assessment.states.COMPLETED,
+      });
+      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourse.id,
+        isNeutralized: false,
+        challengeId: 'recChallenge0_0_0',
+        competenceId: 'recCompetence0',
+        associatedSkillName: '@recSkill0_0',
+        associatedSkillId: 'recSkill0_0',
+      });
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        challengeId: certificationChallenge.challengeId,
+        result: AnswerStatus.KO.status,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessment.id,
+        pixScore: 200,
+      });
+
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'POST',
+        url: `/api/admin/certifications/${certificationCourse.id}/rescore`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
+      expect(descOrderedAssessmentResults).to.have.length(2);
+      const [lastAssessmentResult] = descOrderedAssessmentResults;
+      expect(lastAssessmentResult.pixScore).to.be.equal(55);
+    });
+  });
+});

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/session-repository_test.js
@@ -1,0 +1,45 @@
+import * as sessionRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/session-repository.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Evaluation | Integration | Infrastructure | Repositories | Session', function () {
+  describe('#getByCertificationCourseId', function () {
+    context('when the certification course exists', function () {
+      it('should return a session', async function () {
+        // given
+        const certificationCourseId = 456;
+        const sessionId = databaseBuilder.factory.buildSession({ id: 123 }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: certificationCourseId,
+          sessionId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const session = await sessionRepository.getByCertificationCourseId({
+          certificationCourseId,
+        });
+
+        // then
+        const expectedSession = domainBuilder.certification.results.buildResultsSession({
+          id: session.id,
+          isFinalized: session.isFinalized,
+          isPublished: session.isPublished,
+        });
+        expect(session).to.deepEqualInstance(expectedSession);
+      });
+    });
+
+    context('when the certification does not exist', function () {
+      it('should throw a not found error', async function () {
+        // given, when
+        const error = await catchErr(sessionRepository.getByCertificationCourseId)({
+          certificationCourseId: 123,
+        });
+
+        // then
+        expect(error).to.be.an.instanceof(NotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/unit/application/certification-rescoring-route_test.js
@@ -1,0 +1,29 @@
+import { certificationRescoringController } from '../../../../../src/certification/evaluation/application/certification-rescoring-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/evaluation/application/certification-rescoring-route.js';
+import { usecases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Certification | Evaluation | Unit | Application | Certification Rescoring Route', function () {
+  describe('POST /api/admin/certifications/{certificationId}/rescore', function () {
+    it('should call the usecase with correct arguments and return 204 status code', async function () {
+      const certificationCourseId = 123;
+      const locale = 'fr-fr';
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      sinon.stub(certificationRescoringController, 'rescoreCertification').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+      sinon.stub(usecases, 'rescoreCertification').resolves('ok');
+
+      // when
+      const response = await httpTestServer.request(
+        'POST',
+        `/api/admin/certifications/${certificationCourseId}/rescore`,
+      );
+
+      // then
+      expect(usecases.rescoreCertification).to.have.been.calledWithExactly({ certificationCourseId, locale });
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/domain/usecases/rescore-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/rescore-certification_test.js
@@ -1,0 +1,169 @@
+import { rescoreCertification } from '../../../../../../src/certification/evaluation/domain/usecases/rescore-certification.js';
+import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
+import CertificationRescoredByScript from '../../../../../../src/certification/session-management/domain/events/CertificationRescoredByScript.js';
+import {
+  CertificationAlgorithmVersionError,
+  NotFinalizedSessionError,
+} from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Domain | Use Cases | rescore-certification', function () {
+  describe('when the algorithm used in certification is V3', function () {
+    describe('when the session is finalized', function () {
+      it('should rescore the given certification', async function () {
+        // given
+        const locale = 'fr-fr';
+        const certificationCourseId = 123;
+        const certificationAssessmentRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const evaluationSessionRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const services = {
+          handleV3CertificationScoring: sinon.stub(),
+          findByCertificationCourseIdAndAssessmentId: sinon.stub(),
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId,
+          version: 3,
+        });
+        const session = domainBuilder.certification.evaluation.buildResultsSession({ isFinalized: true });
+        evaluationSessionRepository.getByCertificationCourseId.withArgs({ certificationCourseId }).resolves(session);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId })
+          .resolves(certificationAssessment);
+
+        // when
+        await rescoreCertification({
+          locale,
+          certificationCourseId,
+          certificationAssessmentRepository,
+          evaluationSessionRepository,
+          services,
+        });
+
+        // then
+        expect(services.handleV3CertificationScoring).to.have.been.calledWithExactly({
+          event: new CertificationRescoredByScript({
+            certificationCourseId: certificationAssessment.certificationCourseId,
+          }),
+          certificationAssessment,
+          locale,
+          dependencies: {
+            findByCertificationCourseIdAndAssessmentId: services.findByCertificationCourseIdAndAssessmentId,
+          },
+        });
+      });
+    });
+
+    describe('when the session is published', function () {
+      it('should throw an error', async function () {
+        // given
+        const locale = 'fr-fr';
+        const certificationCourseId = 123;
+        const certificationAssessmentRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const evaluationSessionRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const services = {
+          handleV3CertificationScoring: sinon.stub(),
+          findByCertificationCourseIdAndAssessmentId: sinon.stub(),
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId,
+          version: 3,
+        });
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId })
+          .resolves(certificationAssessment);
+        const session = domainBuilder.certification.evaluation.buildResultsSession({
+          isFinalized: true,
+          isPublished: true,
+        });
+        evaluationSessionRepository.getByCertificationCourseId.withArgs({ certificationCourseId }).resolves(session);
+
+        // when
+        const error = await catchErr(rescoreCertification)({
+          locale,
+          certificationCourseId,
+          certificationAssessmentRepository,
+          evaluationSessionRepository,
+          services,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(SessionAlreadyPublishedError);
+      });
+    });
+
+    describe('when the session is not finalized', function () {
+      it('should throw an error', async function () {
+        // given
+        const locale = 'fr-fr';
+        const certificationCourseId = 123;
+        const certificationAssessmentRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const evaluationSessionRepository = {
+          getByCertificationCourseId: sinon.stub(),
+        };
+        const services = {
+          handleV3CertificationScoring: sinon.stub(),
+          findByCertificationCourseIdAndAssessmentId: sinon.stub(),
+        };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId,
+          version: 3,
+        });
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId })
+          .resolves(certificationAssessment);
+        const session = domainBuilder.certification.evaluation.buildResultsSession({ isFinalized: false });
+        evaluationSessionRepository.getByCertificationCourseId.withArgs({ certificationCourseId }).resolves(session);
+
+        // when
+        const error = await catchErr(rescoreCertification)({
+          locale,
+          certificationCourseId,
+          certificationAssessmentRepository,
+          evaluationSessionRepository,
+          services,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFinalizedSessionError);
+      });
+    });
+  });
+
+  describe('when the algorithm used in certification is V2', function () {
+    it('should throw an error', async function () {
+      // given
+      const locale = 'fr-fr';
+      const certificationCourseId = 123;
+      const certificationAssessmentRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationCourseId,
+        version: 2,
+      });
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId })
+        .resolves(certificationAssessment);
+
+      // when
+      const error = await catchErr(rescoreCertification)({
+        locale,
+        certificationCourseId,
+        certificationAssessmentRepository,
+      });
+
+      // then
+      expect(error).to.be.an.instanceof(CertificationAlgorithmVersionError);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-session.js
@@ -1,0 +1,11 @@
+import { Session } from '../../../../../../src/certification/evaluation/domain/models/Session.js';
+
+const buildSession = function ({ id = 123, isFinalized = false, isPublished = false } = {}) {
+  return new Session({
+    id,
+    finalizedAt: isFinalized ? new Date('2020-01-01') : null,
+    publishedAt: isPublished ? new Date('2020-01-01') : null,
+  });
+};
+
+export { buildSession as buildResultsSession };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -190,6 +190,7 @@ import { buildUserEnrolment } from './certification/enrolment/build-user.js';
 import { buildUserCertificationEligibility } from './certification/enrolment/build-user-certification-eligibility.js';
 import { buildV3CertificationEligibility } from './certification/enrolment/build-v3-certification-eligibility.js';
 import { buildEvaluationCandidate } from './certification/evaluation/build-candidate.js';
+import { buildResultsSession } from './certification/evaluation/build-session.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
 import { buildGlobalCertificationLevel } from './certification/results/build-global-mesh-level.js';
 import { buildCertificationResult as parcoursupCertificationResult } from './certification/results/parcoursup/build-certification-result.js';
@@ -258,6 +259,7 @@ const certification = {
   },
   evaluation: {
     buildCandidate: buildEvaluationCandidate,
+    buildResultsSession,
   },
   sessionManagement: {
     buildCertificationSessionComplementaryCertification,
@@ -276,6 +278,7 @@ const certification = {
   results: {
     buildGlobalCertificationLevel,
     buildCertificate,
+    buildResultsSession,
     parcoursup: {
       buildCertificationResult: parcoursupCertificationResult,
       buildCompetence: parcoursupCompetence,


### PR DESCRIPTION
## 🌸 Problème

Pour rescorer une certification, le métier doit aujourd'hui passer par un rejet/dérejet de la certification, pouvant entraîner des effets de bords.

## 🌳 Proposition

Nous ajoutons une route de scoring afin de n'effectuer d'un rescoring de la certification (création d'un nouvel assessment-result)

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Lancer la requête ci-dessous dans les situations suivantes : 

Sur pix-certif, se connecter avec `sup-center-member@example.net`
Sur pix-admin, se connecter avec `superadmin@example.net`

- Session 7402 non finalisée (Erreur attendue)
- Session 7402 finalisée et publiée (Erreur attendue)
- Sessio 7402 finalisée et non publiée (Cas passant)

Dans le cadre du cas passant, chaque lancement de requête doit générer un nouvel assessment résult identique au précédent.

```
TOKEN=$(curl 'https://api-pr12202.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl -i https://api-pr12202.review.pix.fr/api/admin/certifications/128943/rescore \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST
```