### PR TITLE
[FEATURE] Replication de data_pro_campaigns_kpi_aggregated vers organizations_cover_rates (PIX-17716)

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -50,6 +50,33 @@ export const replications = [
       return datamartKnex('certification_results').insert(chunk);
     },
   },
+  {
+    name: 'organizations_cover_rates',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('organizations_cover_rates').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_pro_campaigns_kpi_aggregated').select(
+        'tag_name',
+        'domain_name',
+        'competence_code',
+        'competence_name',
+        'campaign_id',
+        'target_profile_id',
+        'orga_id',
+        'tube_id',
+        'tube_practical_title',
+        'extraction_date',
+        'max_level',
+        'sum_user_max_level',
+        'nb_user',
+        'nb_tubes_in_competence',
+      );
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('organizations_cover_rates').insert(chunk);
+    },
+  },
 ];
 
 export function getByName(name, dependencies = { replications }) {


### PR DESCRIPTION
## 🌸 Problème

La table `organizations_cover_rates` n’est pas alimentée.

## 🌳 Proposition

Permettre d’alimenter `organizations_cover_rates` par une réplication des données de la table `data_pro_campaigns_kpi_aggregated`.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Créer un token avec le scope `replication` :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12205.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer la réplication :

```
curl -X POST "https://pix-api-maddo-review-pr12205.osc-fr1.scalingo.io/api/replications/organizations_cover_rates" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```
