### PR TITLE
[TECH] Migrer le feature toggle pour les missions expérimentales de Junior vers le nouveaux système

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -53,4 +53,10 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'pix-app', 'team-certification'],
   },
+  showExperimentalMissions: {
+    type: 'boolean',
+    description: 'Consider experimental missions as active',
+    defaultValue: false,
+    tags: ['team-junior'],
+  },
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -828,13 +828,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
 
-# Consider experimental missions as active
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_SHOW_EXPERIMENTAL_MISSIONS=false
-
 # Consider the Pix Companion extension as active
 #
 # presence: optional

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,6 +1,6 @@
-import { config } from '../../../shared/config.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { getTranslatedKey } from '../../../shared/domain/services/get-translated-text.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { LearningContentRepository } from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { Mission, MissionContent, MissionStep } from '../../domain/models/Mission.js';
 import { MissionNotFoundError } from '../../domain/school-errors.js';
@@ -22,7 +22,7 @@ export async function get(id, locale = FRENCH_SPOKEN) {
 
 export async function findAllActiveMissions(locale = FRENCH_SPOKEN) {
   const cacheKey = 'findAllActiveMissions()';
-  const acceptedStatuses = config.featureToggles.showExperimentalMissions
+  const acceptedStatuses = (await featureToggles.get('showExperimentalMissions'))
     ? ['VALIDATED', 'EXPERIMENTAL']
     : ['VALIDATED'];
   const findActiveCallback = (knex) => knex.whereIn('status', acceptedStatuses).orderBy('id');

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -307,7 +307,6 @@ const configuration = (function () {
       isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
-      showExperimentalMissions: toBoolean(process.env.FT_SHOW_EXPERIMENTAL_MISSIONS),
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {
@@ -526,7 +525,6 @@ const configuration = (function () {
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;
-    config.featureToggles.showExperimentalMissions = false;
 
     config.lti.authorizedPlatforms = ['https://moodle.example.net'];
     config.lti.jwkModulusLength = 2048;

--- a/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
+++ b/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
@@ -1,6 +1,6 @@
 import { Mission } from '../../../../../src/school/domain/models/Mission.js';
 import { usecases } from '../../../../../src/school/domain/usecases/index.js';
-import { config } from '../../../../../src/shared/config.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | find-all-active-missions', function () {
@@ -87,8 +87,8 @@ describe('Integration | UseCases | find-all-active-missions', function () {
     });
 
     context('when FT_SHOW_EXPERIMENTAL_MISSION is false', function () {
-      beforeEach(function () {
-        config.featureToggles.showExperimentalMissions = false;
+      beforeEach(async function () {
+        await featureToggles.set('showExperimentalMissions', false);
       });
 
       it('returns validated missions from LCMS', async function () {
@@ -123,8 +123,8 @@ describe('Integration | UseCases | find-all-active-missions', function () {
     });
 
     context('when FT_SHOW_EXPERIMENTAL_MISSION is true', function () {
-      beforeEach(function () {
-        config.featureToggles.showExperimentalMissions = true;
+      beforeEach(async function () {
+        await featureToggles.set('showExperimentalMissions', true);
       });
 
       it('returns validated and experimental missions from LCMS', async function () {

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -37,7 +37,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-text-to-speech-button-enabled': false,
             'setup-ecosystem-before-start': false,
             'should-display-new-analysis-page': false,
-            'show-experimental-missions': false,
             'show-new-result-page': false,
             'is-v3-certification-page-enabled': false,
           },


### PR DESCRIPTION
## 🌸 Problème

Le feature toggle showExperimentalMissions utilise toujours une variable d'environnement. Or on a pas prévu de le supprimer tout de suite.

## 🌳 Proposition

Basculer ce feature toggle vers le nouveau système de feature toggles.

## 🐝 Remarques

RAS

## 🤧 Pour tester
Vérifier que la CI est verte. 

Positionner le FT `showExperimentalMissions` à **true** et redémarrer.
```
scalingo -a pix-api-review-pr12206 run npm run toggles -- --key=showExperimentalMissions --value=true
```
-> https://junior-pr12206.review.pix.fr/ Les missions expérimentales apparaissent en plus des missions validées (plus de 5 missions).

Positionner le FT `showExperimentalMissions` à **false** et redémarrer.
```
scalingo -a pix-api-review-pr12206 run npm run toggles -- --key=showExperimentalMissions --value=false
```
-> https://junior-pr12206.review.pix.fr/ Seules les missions validées sont affichées. (5 missions).

