### PR TITLE
[TECH] Ajout d'un index sur mission-assessments.organizationLearnerId

### DIFF
--- a/api/db/migrations/20250502095103_add_index_on_table_mission-assessments.js
+++ b/api/db/migrations/20250502095103_add_index_on_table_mission-assessments.js
@@ -1,0 +1,18 @@
+const indexesToAdd = [{ tableName: 'mission-assessments', index: ['organizationLearnerId'] }];
+
+const up = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.index(index);
+    });
+  }
+};
+
+const down = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.dropIndex(index);
+    });
+  }
+};
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Il manque un index sur mission-assessments pour les requêtes par organizationlearnerId (6000 scans / 0.5j)