### PR TITLE
[BUGFIX] Les "embed" des modules n'acceptent pas le copier-coller (PIX-17602)

### DIFF
--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -41,6 +41,13 @@ export default class ModulixEmbed extends ModuleElement {
     }
   }
 
+  get permissionToClipboardWrite() {
+    if (!this.args.embed?.url) {
+      return null;
+    }
+    return isEmbedAllowedOrigin(this.args.embed.url) ? 'clipboard-write' : null;
+  }
+
   _receiveEmbedMessage(event) {
     if (!this._messageIsFromCurrentElementSimulator(event)) return;
     if (!isEmbedAllowedOrigin(event.origin)) return;
@@ -84,6 +91,7 @@ export default class ModulixEmbed extends ModuleElement {
           src={{@embed.url}}
           title={{@embed.title}}
           style={{this.heightStyle}}
+          allow="{{this.permissionToClipboardWrite}}"
           {{didInsert this.setIframeHtmlElement}}
         ></iframe>
 

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -3,6 +3,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixEmbed from 'mon-pix/components/module/element/embed';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -299,6 +300,41 @@ module('Integration | Component | Module | Embed', function (hooks) {
       // then
       const iframe = screen.getByTitle(embed.title);
       assert.strictEqual(document.activeElement, iframe);
+    });
+  });
+
+  module('when user copy pastes', function () {
+    test('it should allow `clipboard-write` when the embed origin is allowed ', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: `${ENV.APP.EMBED_ALLOWED_ORIGINS[0]}/embed-simulator.url`,
+        height: 800,
+      };
+
+      // when
+      await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // then
+      assert.strictEqual(find('.element-embed-container__iframe').allow, 'clipboard-write');
+    });
+    test('it should not allow `clipboard-write` when the embed origin is not allowed', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: `not-allowed-origin/embed-simulator.url`,
+        height: 800,
+      };
+
+      // when
+      await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // then
+      assert.notOk(find('.element-embed-container__iframe').allow);
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème
Impossible de copier-coller un élément dans un embed.

## 🌳 Proposition
[Voir la solution déjà trouvée. côté mon pix 
](https://github.com/1024pix/pix/pull/11523)

## 🤧 Pour tester
Sur n'importe quel module ayant un embed content un champ texte, tenter un copier-coller d'un mot présent à l'intérieur de l'embed.
Voir qu'on a pas d'erreur en console.
OU attendre le merge de cette PR https://github.com/1024pix/pix/pull/12076 Pour pouvoir tester sur le module au-dela-des-mots-de-passe