### PR TITLE
[TECH] Ne pas configurer les jobs PgBoss si PGBOSS_CONNECTION_POOL_MAX_SIZE=0 (PIX-17727)

### DIFF
--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -7,139 +7,28 @@ import { UserAnonymizedEventLoggingJobController } from '../../src/shared/applic
 import { JobGroup } from '../../src/shared/application/jobs/job-controller.js';
 import { config } from '../../src/shared/config.js';
 import { JobExpireIn } from '../../src/shared/infrastructure/repositories/jobs/job-repository.js';
-import { registerJobs } from '../../worker.js';
+import { registerJobs, startPgBoss } from '../../worker.js';
 import { catchErr, expect, sinon } from '../test-helper.js';
 
-describe('#registerJobs', function () {
-  let startPgBossStub, createJobQueueStub, jobQueueStub;
+describe('Unit | Worker', function () {
+  context('#registerJobs', function () {
+    let startPgBossStub, createJobQueueStub, jobQueueStub;
 
-  beforeEach(function () {
-    const pgBossStub = Symbol('pgBoss');
-    jobQueueStub = { register: sinon.stub(), scheduleCronJob: sinon.stub(), unscheduleCronJob: sinon.stub() };
-    startPgBossStub = sinon.stub();
-    startPgBossStub.resolves(pgBossStub);
-    createJobQueueStub = sinon.stub();
-    createJobQueueStub.withArgs(pgBossStub).returns(jobQueueStub);
-  });
-
-  afterEach(function () {
-    sinon.restore();
-  });
-
-  it('should register UserAnonymizedEventLoggingJob', async function () {
-    // when
-    await registerJobs({
-      jobGroups: [JobGroup.DEFAULT],
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
+    beforeEach(function () {
+      const pgBossStub = Symbol('pgBoss');
+      jobQueueStub = { register: sinon.stub(), scheduleCronJob: sinon.stub(), unscheduleCronJob: sinon.stub() };
+      startPgBossStub = sinon.stub();
+      startPgBossStub.resolves(pgBossStub);
+      createJobQueueStub = sinon.stub();
+      createJobQueueStub.withArgs(pgBossStub).returns(jobQueueStub);
     });
 
-    // then
-    expect(jobQueueStub.register).to.have.been.calledWithExactly(
-      new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
-      UserAnonymizedEventLoggingJob.name,
-      UserAnonymizedEventLoggingJobController,
-    );
-  });
-
-  it('should register legacyName from UserAnonymizedEventLoggingJob', async function () {
-    // when
-    sinon
-      .stub(UserAnonymizedEventLoggingJobController.prototype, 'legacyName')
-      .get(() => 'legyNameForUserAnonymizedEventLoggingJobController');
-    await registerJobs({
-      jobGroups: [JobGroup.DEFAULT],
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
+    afterEach(function () {
+      sinon.restore();
     });
 
-    // then
-    expect(jobQueueStub.register).to.have.been.calledWithExactly(
-      new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
-      'legyNameForUserAnonymizedEventLoggingJobController',
-      UserAnonymizedEventLoggingJobController,
-    );
-  });
-
-  it('should register ValidateOrganizationImportFileJob when job is enabled', async function () {
-    //given
-    sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(true);
-
-    // when
-    await registerJobs({
-      jobGroups: [JobGroup.DEFAULT],
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
-    });
-
-    // then
-    expect(jobQueueStub.register).to.have.been.calledWithExactly(
-      new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
-      ValidateOrganizationImportFileJob.name,
-      ValidateOrganizationLearnersImportFileJobController,
-    );
-  });
-
-  it('should not register ValidateOrganizationImportFileJob when job is disabled', async function () {
-    //given
-    sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(false);
-
-    // when
-    await registerJobs({
-      jobGroups: [JobGroup.DEFAULT],
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
-    });
-
-    // then
-    expect(jobQueueStub.register).to.not.have.been.calledWithExactly(
-      ValidateOrganizationImportFileJob.name,
-      ValidateOrganizationLearnersImportFileJobController,
-    );
-  });
-
-  it('should throws an error when no groups is invalid', async function () {
-    // given
-    const error = await catchErr(registerJobs)({
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
-    });
-
-    // then
-    expect(error).to.be.instanceOf(Error);
-    expect(error.message).to.equal('Job groups are mandatory');
-  });
-
-  it('should throws an error when group is invalid', async function () {
-    // given
-    const error = await catchErr(registerJobs)({
-      jobGroups: ['pouet'],
-      dependencies: {
-        startPgBoss: startPgBossStub,
-        createJobQueue: createJobQueueStub,
-      },
-    });
-
-    // then
-    expect(error).to.be.instanceOf(Error);
-    expect(error.message).to.equal(`Job group invalid, allowed Job groups are [${Object.values(JobGroup)}]`);
-  });
-
-  describe('cron Job', function () {
-    it('schedule ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
-      //given
-      sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
-
+    it('should register UserAnonymizedEventLoggingJob', async function () {
+      // when
       await registerJobs({
         jobGroups: [JobGroup.DEFAULT],
         dependencies: {
@@ -149,40 +38,127 @@ describe('#registerJobs', function () {
       });
 
       // then
-      expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
-        name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
-        cron: '0 21 * * *',
-        options: { tz: 'Europe/Paris', expireIn: JobExpireIn.INFINITE },
-      });
-    });
-
-    it('unschedule legacyName from ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
-      //given
-      sinon
-        .stub(ScheduleComputeOrganizationLearnersCertificabilityJobController.prototype, 'legacyName')
-        .get(() => 'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController');
-
-      sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
-
-      await registerJobs({
-        jobGroups: [JobGroup.DEFAULT],
-        dependencies: {
-          startPgBoss: startPgBossStub,
-          createJobQueue: createJobQueueStub,
-        },
-      });
-
-      // then
-      expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly(
-        'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
+      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        UserAnonymizedEventLoggingJob.name,
+        UserAnonymizedEventLoggingJobController,
       );
     });
 
-    context('when a cron job is disabled', function () {
-      it('unschedule the job', async function () {
+    it('should register legacyName from UserAnonymizedEventLoggingJob', async function () {
+      // when
+      sinon
+        .stub(UserAnonymizedEventLoggingJobController.prototype, 'legacyName')
+        .get(() => 'legyNameForUserAnonymizedEventLoggingJobController');
+      await registerJobs({
+        jobGroups: [JobGroup.DEFAULT],
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        'legyNameForUserAnonymizedEventLoggingJobController',
+        UserAnonymizedEventLoggingJobController,
+      );
+    });
+
+    it('should register ValidateOrganizationImportFileJob when job is enabled', async function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(true);
+
+      // when
+      await registerJobs({
+        jobGroups: [JobGroup.DEFAULT],
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(jobQueueStub.register).to.have.been.calledWithExactly(
+        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        ValidateOrganizationImportFileJob.name,
+        ValidateOrganizationLearnersImportFileJobController,
+      );
+    });
+
+    it('should not register ValidateOrganizationImportFileJob when job is disabled', async function () {
+      //given
+      sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(false);
+
+      // when
+      await registerJobs({
+        jobGroups: [JobGroup.DEFAULT],
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(jobQueueStub.register).to.not.have.been.calledWithExactly(
+        ValidateOrganizationImportFileJob.name,
+        ValidateOrganizationLearnersImportFileJobController,
+      );
+    });
+
+    it('should not register jobs when pgboss is null', async function () {
+      //given
+      startPgBossStub.resolves(null);
+
+      // when
+      await registerJobs({
+        jobGroups: [JobGroup.DEFAULT],
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(createJobQueueStub).to.not.have.been.called;
+      expect(jobQueueStub.register).to.not.have.been.called;
+      expect(jobQueueStub.scheduleCronJob).to.not.have.been.called;
+    });
+
+    it('should throws an error when no groups is invalid', async function () {
+      // given
+      const error = await catchErr(registerJobs)({
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Job groups are mandatory');
+    });
+
+    it('should throws an error when group is invalid', async function () {
+      // given
+      const error = await catchErr(registerJobs)({
+        jobGroups: ['pouet'],
+        dependencies: {
+          startPgBoss: startPgBossStub,
+          createJobQueue: createJobQueueStub,
+        },
+      });
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal(`Job group invalid, allowed Job groups are [${Object.values(JobGroup)}]`);
+    });
+
+    describe('cron Job', function () {
+      it('schedule ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
         //given
-        sinon.stub(config.cpf.sendEmailJob, 'cron').value('0 21 * * *');
-        sinon.stub(config.pgBoss, 'exportSenderJobEnabled').value(false);
+        sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
 
         await registerJobs({
           jobGroups: [JobGroup.DEFAULT],
@@ -193,8 +169,66 @@ describe('#registerJobs', function () {
         });
 
         // then
-        expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
+        expect(jobQueueStub.scheduleCronJob).to.have.been.calledWithExactly({
+          name: 'ScheduleComputeOrganizationLearnersCertificabilityJob',
+          cron: '0 21 * * *',
+          options: { tz: 'Europe/Paris', expireIn: JobExpireIn.INFINITE },
+        });
       });
+
+      it('unschedule legacyName from ScheduleComputeOrganizationLearnersCertificabilityJob', async function () {
+        //given
+        sinon
+          .stub(ScheduleComputeOrganizationLearnersCertificabilityJobController.prototype, 'legacyName')
+          .get(() => 'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController');
+
+        sinon.stub(config.features.scheduleComputeOrganizationLearnersCertificability, 'cron').value('0 21 * * *');
+
+        await registerJobs({
+          jobGroups: [JobGroup.DEFAULT],
+          dependencies: {
+            startPgBoss: startPgBossStub,
+            createJobQueue: createJobQueueStub,
+          },
+        });
+
+        // then
+        expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly(
+          'legyNameForScheduleComputeOrganizationLearnersCertificabilityJobController',
+        );
+      });
+
+      context('when a cron job is disabled', function () {
+        it('unschedule the job', async function () {
+          //given
+          sinon.stub(config.cpf.sendEmailJob, 'cron').value('0 21 * * *');
+          sinon.stub(config.pgBoss, 'exportSenderJobEnabled').value(false);
+
+          await registerJobs({
+            jobGroups: [JobGroup.DEFAULT],
+            dependencies: {
+              startPgBoss: startPgBossStub,
+              createJobQueue: createJobQueueStub,
+            },
+          });
+
+          // then
+          expect(jobQueueStub.unscheduleCronJob).to.have.been.calledWithExactly('CpfExportSenderJob');
+        });
+      });
+    });
+  });
+
+  context('#startPgBoss', function () {
+    it('should return null when pgboss connexionPoolMaxSize is 0', async function () {
+      //given
+      sinon.stub(config.pgBoss, 'connexionPoolMaxSize').value(0);
+
+      //when
+      const pgboss = await startPgBoss();
+
+      //then
+      expect(pgboss).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Quand PGBOSS_CONNECTION_POOL_MAX_SIZE=0 les logs de l’API laisse penser que PgBoss démarre et que les jobs vont être traités, alors que ce n’est pas le cas.

## 🌳 Proposition

Revoir le démarrage du worker pour que les logs soient moins trompeurs.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Regarder les logs de l’API MaDDo sur la RA.

Si la variable d'env PGBOSS_CONNECTION_POOL_MAX_SIZE est à 0, le log suivant sera affiché : 
> Pgboss will not be started and configured as connexionPoolMaxSize is set to 0. Please set a value greater than zero on environment variable \"PGBOSS_CONNECTION_POOL_MAX_SIZE\" to be able to process jobs.

Sinon, pgboss est démarré et les jobs configurés. Les logs suivants sont alors affichés : 
> Starting pg-boss
> Job \"xxxx\" registered from module \"xxxx.\"