### PR TITLE
[TECH] Ajoute un index sur la table organizations (colonne parentOrganizationId)

### DIFF
--- a/api/db/migrations/20250502123012_add_index_on_table_organizations.js
+++ b/api/db/migrations/20250502123012_add_index_on_table_organizations.js
@@ -1,0 +1,18 @@
+const indexesToAdd = [{ tableName: 'organizations', index: ['parentOrganizationId'] }];
+
+const up = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.index(index);
+    });
+  }
+};
+
+const down = async function (knex) {
+  for (const { tableName, index } of indexesToAdd) {
+    await knex.schema.table(tableName, function (table) {
+      table.dropIndex(index);
+    });
+  }
+};
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Il manque un index sur la table `organizations` pour les recherches par organisation parente.