### PR TITLE
[BUGFIX] Supprimer les date de legal-document-version-user-acceptances lorsqu'on anonymise un utilisateur (PIX-17730)

### DIFF
--- a/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user-acceptance.repository.js
@@ -74,4 +74,9 @@ const update = async function (properties) {
   await knexConn(TABLE_NAME).where({ id }).update(data);
 };
 
-export { create, findByLegalDocumentVersionId, findByUserId, findLastForLegalDocument, update };
+const removeAllByUserId = async function (userId) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(TABLE_NAME).where({ userId }).delete();
+};
+
+export { create, findByLegalDocumentVersionId, findByUserId, findLastForLegalDocument, removeAllByUserId, update };

--- a/api/src/privacy/domain/usecases/anonymize-user.usecase.js
+++ b/api/src/privacy/domain/usecases/anonymize-user.usecase.js
@@ -65,7 +65,7 @@ const anonymizeUser = withTransaction(async function ({
 
   await _anonymizeLastUserApplicationConnections(lastUserApplicationConnectionsRepository, userId);
 
-  await _anonymizeUserLegalDocumentAcceptances({ userId, userAcceptanceRepository });
+  await userAcceptanceRepository.removeAllByUserId(userId);
 
   await _anonymizeUserLogin({ userId, userLoginRepository });
 
@@ -119,17 +119,6 @@ async function _anonymizeLastUserApplicationConnections(lastUserApplicationConne
   for (const lastUserApplicationConnection of lastUserApplicationConnections) {
     const anonymized = lastUserApplicationConnection.anonymize();
     await lastUserApplicationConnectionsRepository.upsert(anonymized);
-  }
-}
-
-async function _anonymizeUserLegalDocumentAcceptances({ userId, userAcceptanceRepository }) {
-  const userLegalDocumentAcceptances = await userAcceptanceRepository.findByUserId(userId);
-  for (const userLegalDocumentAcceptance of userLegalDocumentAcceptances) {
-    const anonymizedAcceptedAt = anonymizeGeneralizeDate(userLegalDocumentAcceptance.acceptedAt);
-    await userAcceptanceRepository.update({
-      id: userLegalDocumentAcceptance.id,
-      acceptedAt: anonymizedAcceptedAt,
-    });
   }
 }
 

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -67,7 +67,7 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId: managingStudentsOrga.id });
 
     const legalDocumentVersion = databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_ORGA, type: TOS });
-    const userAcceptanceId = databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
+    databaseBuilder.factory.buildLegalDocumentVersionUserAcceptance({
       userId: user.id,
       legalDocumentVersionId: legalDocumentVersion.id,
       acceptedAt: new Date('2023-03-23T23:23:23Z'),
@@ -132,10 +132,8 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
     const organizationLearners = await knex('organization-learners').where({ userId });
     expect(organizationLearners).to.have.lengthOf(0);
 
-    const userAcceptance = await knex('legal-document-version-user-acceptances')
-      .where({ id: userAcceptanceId })
-      .first();
-    expect(userAcceptance.acceptedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
+    const userAcceptance = await knex('legal-document-version-user-acceptances').where({ userId: user.id }).first();
+    expect(userAcceptance).to.be.undefined;
 
     const anonymizedUserLogin = await knex('user-logins').where({ id: userLogin.id }).first();
     expect(anonymizedUserLogin.createdAt.toISOString()).to.equal('2012-12-01T00:00:00.000Z');


### PR DESCRIPTION
## 🌸 Problème

Après discussion, il s'est avéré qu'il fallait supprimer les dates de la table legal-document-version-user-acceptances lorsqu'on anonymisait un utilisateur.

## 🌳 Proposition

- Ajouter une méthode au repository pour supprimer toutes les ocurences par le userId,
- Modifier le usecase pour qu'il appel cette méthode.

## 🐝 Remarques

On en profite pour faire un léger nettoyage dans le teste du usecase, notamment pour tester la suppression par userId et non par userAcceptanceId.

## 🤧 Pour tester

- Se rendre sur pix-admin,
- Se connecter avec le compte superadmin@example.net,
- Rechercher l'utilisateur allorga@example.net,
- En base, rechercher l'identifiant de l'utilisateur dans la table legal-document-version-user-acceptances:
```sql
SELECT * FROM "legal-document-version-user-acceptances" WHERE "userId" = <identifiant>
```
- Constater que des lignes sont présente,
- Anonymiser l'utilisateur depuis Pix admin,
- Réexécuter la commande et constater que cela ne renvoie plus rien.