### PR TITLE
[BUGFIX] Ne plus retourner d'erreur BDD lors d'une violation de contrainte sur un double insertion de feature sur un learner (PIX-17734)

### DIFF
--- a/api/src/prescription/organization-learner-feature/application/organization-learner-features-controller.js
+++ b/api/src/prescription/organization-learner-feature/application/organization-learner-features-controller.js
@@ -4,12 +4,12 @@ const create = async function (request, h) {
   const organizationLearnerId = request.params.organizationLearnerId;
   const featureKey = request.params.featureKey;
 
-  const organizationLearnerFeature = await usecases.createOrganizationLearnerFeature({
+  await usecases.createOrganizationLearnerFeature({
     organizationLearnerId,
     featureKey,
   });
 
-  return h.response(organizationLearnerFeature).code(201);
+  return h.response().code(201);
 };
 
 const unlink = async function (request, h) {

--- a/api/src/prescription/organization-learner-feature/domain/usecases/create-organization-learner-feature.js
+++ b/api/src/prescription/organization-learner-feature/domain/usecases/create-organization-learner-feature.js
@@ -1,14 +1,13 @@
-const createOrganizationLearnerFeature = async ({
-  organizationLearnerId,
-  featureKey,
-  featureRepository,
-  organizationLearnerFeatureRepository,
-}) => {
-  const feature = await featureRepository.getFeatureByKey(featureKey);
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-  return await organizationLearnerFeatureRepository.create({
-    organizationLearnerId,
-    featureId: feature.id,
-  });
-};
+const createOrganizationLearnerFeature = withTransaction(
+  async ({ organizationLearnerId, featureKey, featureRepository, organizationLearnerFeatureRepository }) => {
+    const feature = await featureRepository.getFeatureByKey(featureKey);
+
+    return await organizationLearnerFeatureRepository.create({
+      organizationLearnerId,
+      featureId: feature.id,
+    });
+  },
+);
 export { createOrganizationLearnerFeature };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-feature-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-feature-repository.js
@@ -21,10 +21,8 @@ async function getOrganizationLearnersByFeature({ organizationId, featureKey }) 
 
 async function create({ organizationLearnerId, featureId }) {
   const knexConn = DomainTransaction.getConnection();
-  const createdOrganizationLearnerFeature = await knexConn('organization-learner-features')
-    .insert({ organizationLearnerId, featureId })
-    .returning('*');
-  return createdOrganizationLearnerFeature[0];
+
+  await knexConn('organization-learner-features').insert({ organizationLearnerId, featureId }).onConflict().ignore();
 }
 
 async function unlink({ organizationLearnerId, featureId }) {

--- a/api/tests/prescription/organization-learner-feature/integration/infrastructure/organization-learner-feature-repository_test.js
+++ b/api/tests/prescription/organization-learner-feature/integration/infrastructure/organization-learner-feature-repository_test.js
@@ -83,20 +83,28 @@ describe('Prescription | OrganizationLearner | Integration | Infrastructure | Or
   });
 
   describe('#create', function () {
-    it('should return the newly created OrganizationLearnerFeature link', async function () {
+    it('should active feature on learner without error', async function () {
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
       const featureId = databaseBuilder.factory.buildFeature({ key: 'A_KEY', organizationId }).id;
       await databaseBuilder.commit();
 
-      const newlyCreatedOrganizationLearnerFeature = await organizationLearnerFeatureRepository.create({
+      await organizationLearnerFeatureRepository.create({
         organizationLearnerId,
         featureId,
       });
-      expect([
-        newlyCreatedOrganizationLearnerFeature.featureId,
-        newlyCreatedOrganizationLearnerFeature.organizationLearnerId,
-      ]).to.deep.equal([featureId, organizationLearnerId]);
+      await organizationLearnerFeatureRepository.create({
+        organizationLearnerId,
+        featureId,
+      });
+
+      const result = await organizationLearnerFeatureRepository.getOrganizationLearnersByFeature({
+        organizationId,
+        featureKey: 'A_KEY',
+      });
+
+      expect(result).lengthOf(1);
+      expect(result[0].id).to.be.equal(organizationLearnerId);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

ça pète en BDD lorsque l'on fait deux insertions de suite pour activer une feature sur un learner

## 🌳 Proposition

S'il y a un conflit on ignore. Il faudra qu'on check côté front pourquoi on a ce double appel.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Ouvrir deux onglets sur la page Eleve d'une orga Pix1D et vérifier que ça passe bien a activé ( même si en vrai ça fait rien, c'est comme un refresh de la page au final )