### PR TITLE
[FEATURE] Assurer cohérence du sequenceNumber dans les events enregistrés (PIX-17708)

### DIFF
--- a/api/db/database-builder/factory/build-passage-event.js
+++ b/api/db/database-builder/factory/build-passage-event.js
@@ -1,0 +1,18 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildPassageEvent = ({
+  id = databaseBuffer.getNextId(),
+  type = 'PASSAGE_STARTED',
+  passageId = 1,
+  sequenceNumber = 1,
+  occurredAt = new Date('2019-04-28T02:42:00Z'),
+  data = '{}',
+} = {}) => {
+  const values = { id, type, occurredAt, passageId, sequenceNumber, data };
+  return databaseBuffer.pushInsertable({
+    tableName: 'passage-events',
+    values,
+  });
+};
+
+export { buildPassageEvent };

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,0 +1,34 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+import {
+  FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
+} from '../models/passage-events/flashcard-events.js';
+import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
+
+class PassageEventFactory {
+  static build(eventData) {
+    switch (eventData.type) {
+      case 'PASSAGE_STARTED':
+        return new PassageStartedEvent(eventData);
+      case 'PASSAGE_TERMINATED':
+        return new PassageTerminatedEvent(eventData);
+      case 'FLASHCARDS_STARTED':
+        return new FlashcardsStartedEvent(eventData);
+      case 'FLASHCARDS_VERSO_SEEN':
+        return new FlashcardsVersoSeenEvent(eventData);
+      case 'FLASHCARDS_CARD_AUTO_ASSESSED':
+        return new FlashcardsCardAutoAssessedEvent(eventData);
+      case 'FLASHCARDS_RECTO_REVIEWED':
+        return new FlashcardsRectoReviewedEvent(eventData);
+      case 'FLASHCARDS_RETRIED':
+        return new FlashcardsRetriedEvent(eventData);
+      default:
+        throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
+    }
+  }
+}
+
+export { PassageEventFactory };

--- a/api/src/devcomp/domain/usecases/record-passage-events.js
+++ b/api/src/devcomp/domain/usecases/record-passage-events.js
@@ -1,42 +1,14 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
-import {
-  FlashcardsCardAutoAssessedEvent,
-  FlashcardsRectoReviewedEvent,
-  FlashcardsRetriedEvent,
-  FlashcardsStartedEvent,
-  FlashcardsVersoSeenEvent,
-} from '../models/passage-events/flashcard-events.js';
-import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
+import { PassageEventFactory } from '../factories/passage-event-factory.js';
 
 const recordPassageEvents = async function ({ events, userId, passageRepository, passageEventRepository }) {
   await PromiseUtils.mapSeries(events, async (event) => {
-    const passageEvent = _buildPassageEvent(event);
+    const passageEvent = PassageEventFactory.build(event);
     await _validatePassage({ event, userId, passageRepository });
     await passageEventRepository.record(passageEvent);
   });
 };
-
-function _buildPassageEvent(event) {
-  switch (event.type) {
-    case 'PASSAGE_STARTED':
-      return new PassageStartedEvent(event);
-    case 'PASSAGE_TERMINATED':
-      return new PassageTerminatedEvent(event);
-    case 'FLASHCARDS_STARTED':
-      return new FlashcardsStartedEvent(event);
-    case 'FLASHCARDS_VERSO_SEEN':
-      return new FlashcardsVersoSeenEvent(event);
-    case 'FLASHCARDS_CARD_AUTO_ASSESSED':
-      return new FlashcardsCardAutoAssessedEvent(event);
-    case 'FLASHCARDS_RECTO_REVIEWED':
-      return new FlashcardsRectoReviewedEvent(event);
-    case 'FLASHCARDS_RETRIED':
-      return new FlashcardsRetriedEvent(event);
-    default:
-      throw new DomainError(`Passage event with type ${event.type} does not exist`);
-  }
-}
 
 async function _validatePassage({ event, userId, passageRepository }) {
   const passage = await passageRepository.get({ passageId: event.passageId });

--- a/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
@@ -1,14 +1,24 @@
+import { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } from '../../../../db/pgsql-errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { DomainError } from '../../../shared/domain/errors.js';
 
 async function record(event) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn('passage-events').insert({
-    passageId: event.passageId,
-    sequenceNumber: event.sequenceNumber,
-    occurredAt: event.occurredAt,
-    type: event.type,
-    data: event.data,
-  });
+  try {
+    await knexConn('passage-events').insert({
+      passageId: event.passageId,
+      sequenceNumber: event.sequenceNumber,
+      occurredAt: event.occurredAt,
+      type: event.type,
+      data: event.data,
+    });
+  } catch (error) {
+    if (error.code === PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR) {
+      throw new DomainError('There is already an existing event for this passageId and sequenceNumber');
+    }
+
+    throw error;
+  }
 }
 
 export { record };

--- a/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-event-repository.js
@@ -1,6 +1,7 @@
 import { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } from '../../../../db/pgsql-errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { DomainError } from '../../../shared/domain/errors.js';
+import { PassageEventFactory } from '../../domain/factories/passage-event-factory.js';
 
 async function record(event) {
   const knexConn = DomainTransaction.getConnection();
@@ -21,4 +22,18 @@ async function record(event) {
   }
 }
 
-export { record };
+async function getAllByPassageId({ passageId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const passageEvents = await knexConn('passage-events').where('passageId', passageId).orderBy('sequenceNumber');
+
+  return passageEvents.map((passageEvent) => _toDomain(passageEvent));
+}
+
+function _toDomain(passageEvent) {
+  return PassageEventFactory.build({
+    ...passageEvent,
+    ...passageEvent.data,
+  });
+}
+
+export { getAllByPassageId, record };

--- a/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-event-repository_test.js
@@ -1,3 +1,4 @@
+import { FlashcardsCardAutoAssessedEvent } from '../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { PassageStartedEvent } from '../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import * as passageEventRepository from '../../../../src/devcomp/infrastructure/repositories/passage-event-repository.js';
 import { DomainError } from '../../../../src/shared/domain/errors.js';
@@ -60,6 +61,47 @@ describe('Integration | DevComp | Repositories | PassageEventRepository', functi
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.deep.equal('There is already an existing event for this passageId and sequenceNumber');
       });
+    });
+  });
+
+  describe('#getAllByPassageId', function () {
+    it('should get all passage events according to provided passage-id', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      const otherPassage = databaseBuilder.factory.buildPassage();
+      const event1 = databaseBuilder.factory.buildPassageEvent({
+        data: { contentHash: 'version' },
+        passageId: passage.id,
+        sequenceNumber: 2,
+        type: 'PASSAGE_STARTED',
+      });
+      const event2 = databaseBuilder.factory.buildPassageEvent({
+        data: {
+          autoAssessment: 'yes',
+          cardId: '3b9d1d5c-0441-48b6-b3f7-36de4e975715',
+          elementId: 'c4981cba-b7c6-44de-8bc6-86d3465ecc70',
+        },
+        passageId: passage.id,
+        sequenceNumber: 1,
+        type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+      });
+      databaseBuilder.factory.buildPassageEvent({
+        passageId: otherPassage.id,
+        sequenceNumber: 2,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const results = await passageEventRepository.getAllByPassageId({ passageId: passage.id });
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results[0]).to.be.instanceOf(FlashcardsCardAutoAssessedEvent);
+      expect(results[0].id).to.equal(event2.id);
+      expect(results[0].sequenceNumber).to.equal(1);
+      expect(results[1]).to.be.instanceOf(PassageStartedEvent);
+      expect(results[1].id).to.equal(event1.id);
+      expect(results[1].sequenceNumber).to.equal(2);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -1,0 +1,174 @@
+import { expect } from 'chai';
+
+import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
+import {
+  FlashcardsCardAutoAssessedEvent,
+  FlashcardsRectoReviewedEvent,
+  FlashcardsRetriedEvent,
+  FlashcardsStartedEvent,
+  FlashcardsVersoSeenEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import {
+  PassageStartedEvent,
+  PassageTerminatedEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
+  describe('#build', function () {
+    describe('when given an event with unknown type', function () {
+      it('should return a DomainError with correct message', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          contentHash: 'module-version',
+          type: 'UNKNOWN',
+        };
+
+        // when
+        const error = catchErrSync(PassageEventFactory.build)(rawEvent);
+
+        // then
+        expect(error).to.be.instanceof(DomainError);
+        expect(error.message).to.equal('Passage event with type UNKNOWN does not exist');
+      });
+    });
+
+    describe('when given a PASSAGE_STARTED event', function () {
+      it('should return a PassageStartedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          contentHash: 'module-version',
+          type: 'PASSAGE_STARTED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(PassageStartedEvent);
+      });
+    });
+
+    describe('when given a PASSAGE_TERMINATED event', function () {
+      it('should return a PassageTerminatedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          contentHash: 'module-version',
+          type: 'PASSAGE_TERMINATED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(PassageTerminatedEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_STARTED event', function () {
+      it('should return a FlashcardsStartedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          type: 'FLASHCARDS_STARTED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsStartedEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_VERSO_SEEN event', function () {
+      it('should return a FlashcardsVersoSeenEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+          type: 'FLASHCARDS_VERSO_SEEN',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsVersoSeenEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_AUTO_ASSESSED event', function () {
+      it('should return a FlashcardsAutoAssessedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+          type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+          autoAssessment: 'yes',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsCardAutoAssessedEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_RECTO_REVIEWED event', function () {
+      it('should return a FlashcardsRectoReviewedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+          type: 'FLASHCARDS_RECTO_REVIEWED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsRectoReviewedEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_RETRIED event', function () {
+      it('should return a FlashcardsRetriedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          type: 'FLASHCARDS_RETRIED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsRetriedEvent);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -21,6 +21,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
     const passage = domainBuilder.devcomp.buildPassage({ id: 2 });
     const passageEventRepositoryStub = {
       record: sinon.stub().resolves(),
+      getAllByPassageId: sinon.stub().resolves([]),
     };
     const passageRepositoryStub = {
       get: sinon.stub().resolves(passage),
@@ -137,6 +138,58 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       // then
       expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('Anonymous user cannot record event for passage with id 2 that belongs to a user');
+    });
+  });
+
+  context('when passageEvent type is "passage_terminated"', function () {
+    context('when sequenceNumber is not the highest among the events of this passage', function () {
+      it('should throw an error', async function () {
+        // given
+        const passageTerminatedEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 2,
+          type: 'PASSAGE_TERMINATED',
+        };
+
+        const passageStartedEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          type: 'PASSAGE_STARTED',
+        };
+
+        const passageNotTerminatedEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+          type: 'FLASHCARDS_VERSO_SEEN',
+        };
+
+        const passage = domainBuilder.devcomp.buildPassage({ id: 2 });
+
+        const passageRepositoryStub = {
+          get: sinon.stub().withArgs({ passageId: 2 }).resolves(passage),
+        };
+        const passageEventRepositoryStub = {
+          record: sinon.stub(),
+          getAllByPassageId: sinon.stub().resolves([passageStartedEvent, passageNotTerminatedEvent]),
+        };
+
+        // when
+        const error = await catchErr(recordPassageEvents)({
+          events: [passageTerminatedEvent],
+          userId: null,
+          passageRepository: passageRepositoryStub,
+          passageEventRepository: passageEventRepositoryStub,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('Passage event of type terminated should have the highest sequence number');
+      });
     });
   });
 

--- a/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/record-passage-events_test.js
@@ -1,15 +1,5 @@
 import { Passage } from '../../../../../src/devcomp/domain/models/Passage.js';
-import {
-  FlashcardsCardAutoAssessedEvent,
-  FlashcardsRectoReviewedEvent,
-  FlashcardsRetriedEvent,
-  FlashcardsStartedEvent,
-  FlashcardsVersoSeenEvent,
-} from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
-import {
-  PassageStartedEvent,
-  PassageTerminatedEvent,
-} from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import { FlashcardsVersoSeenEvent } from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { recordPassageEvents } from '../../../../../src/devcomp/domain/usecases/record-passage-events.js';
 import { DomainError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -26,65 +16,7 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
       type: 'FLASHCARDS_VERSO_SEEN',
     };
 
-    const flashcardsStartedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-      type: 'FLASHCARDS_STARTED',
-    };
-
-    const flashcardsCardAutoAssessedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-      cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
-      type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
-      autoAssessment: 'yes',
-    };
-
-    const flashcardsRectoReviewedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-      cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
-      type: 'FLASHCARDS_RECTO_REVIEWED',
-    };
-
-    const flashcardsRetriedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-      type: 'FLASHCARDS_RETRIED',
-    };
-
-    const passageTerminatedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      type: 'PASSAGE_TERMINATED',
-    };
-
-    const passageStartedEvent = {
-      occurredAt: new Date(),
-      passageId: 2,
-      sequenceNumber: 1,
-      contentHash: 'module-version',
-      type: 'PASSAGE_STARTED',
-    };
-
-    const events = [
-      flashcardsVersoSeenEvent,
-      flashcardsStartedEvent,
-      flashcardsCardAutoAssessedEvent,
-      flashcardsRectoReviewedEvent,
-      flashcardsRetriedEvent,
-      passageTerminatedEvent,
-      passageStartedEvent,
-    ];
+    const events = [flashcardsVersoSeenEvent];
 
     const passage = domainBuilder.devcomp.buildPassage({ id: 2 });
     const passageEventRepositoryStub = {
@@ -104,57 +36,10 @@ describe('Unit | Devcomp | Domain | UseCases | record-passage-events', function 
 
     // then
     const flashcardsVersoSeenPassageEvent = new FlashcardsVersoSeenEvent(flashcardsVersoSeenEvent);
-    const flashcardsStartedPassageEvent = new FlashcardsStartedEvent(flashcardsStartedEvent);
-    const flashcardsCardAutoAssessedPassageEvent = new FlashcardsCardAutoAssessedEvent(flashcardsCardAutoAssessedEvent);
-    const flashcardsRectoReviewedEventPassageEvent = new FlashcardsRectoReviewedEvent(flashcardsRectoReviewedEvent);
-    const flashcardsRetriedEventPassageEvent = new FlashcardsRetriedEvent(flashcardsRetriedEvent);
-    const passageTerminatedPassageEvent = new PassageTerminatedEvent(passageTerminatedEvent);
-    const passageStartedPassageEvent = new PassageStartedEvent(passageStartedEvent);
 
     expect(passageEventRepositoryStub.record.getCall(0)).to.have.been.calledWithExactly(
       flashcardsVersoSeenPassageEvent,
     );
-    expect(passageEventRepositoryStub.record.getCall(1)).to.have.been.calledWithExactly(flashcardsStartedPassageEvent);
-    expect(passageEventRepositoryStub.record.getCall(2)).to.have.been.calledWithExactly(
-      flashcardsCardAutoAssessedPassageEvent,
-    );
-    expect(passageEventRepositoryStub.record.getCall(3)).to.have.been.calledWithExactly(
-      flashcardsRectoReviewedEventPassageEvent,
-    );
-    expect(passageEventRepositoryStub.record.getCall(4)).to.have.been.calledWithExactly(
-      flashcardsRetriedEventPassageEvent,
-    );
-    expect(passageEventRepositoryStub.record.getCall(5)).to.have.been.calledWithExactly(passageTerminatedPassageEvent);
-    expect(passageEventRepositoryStub.record.getCall(6)).to.have.been.calledWithExactly(passageStartedPassageEvent);
-  });
-
-  context('when type of passage event does not exist', function () {
-    it('should throw an error', async function () {
-      // given
-      const event = {
-        type: 'NON_EXISTING_TYPE',
-      };
-
-      const passageRepositoryStub = {
-        get: sinon.stub(),
-      };
-      const passageEventRepositoryStub = {
-        record: sinon.stub().resolves(),
-      };
-
-      // when
-      const error = await catchErr(recordPassageEvents)({
-        events: [event],
-        userId: null,
-        passageRepository: passageRepositoryStub,
-        passageEventRepository: passageEventRepositoryStub,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(DomainError);
-      expect(error.message).to.equal(`Passage event with type ${event.type} does not exist`);
-      expect(passageEventRepositoryStub.record).to.not.have.been.called;
-    });
   });
 
   context('when there is no passage for given passage id', function () {


### PR DESCRIPTION
## 🌸 Problème

Lors de la création d'un passage event, on ne vérifie pas la cohérence du sequence number avec les autres events déjà existant.

## 🌳 Proposition

Ajouter deux validations dans le usecase `record-passage-events`:
- vérifier qu'il n'existe pas déjà un autre évènement pour ce passage avec le même sequence number
- dans le cas de l'event `PASSAGE_TERMINATED` vérifier qu'il a le `sequenceNumber` le plus grand

## 🐝 Remarques

Pour faciliter l’instanciation des objets de type `PassageEvent` nous avons extrait le code du usecase et créé une factory.

## 🤧 Pour tester

- Tenter de créer un évènement avec un sequence number déjà existant
- Constater que l'API retourne une erreur 400
- Tenter de créer une évènement de type `PASSAGE_STARTED` avec un `sequenceNumber` inférieur à un évènement déjà existant pour le même passage
- Constater que l'API retourne une erreur 400 -> deuxième cas ne peut pas être testé par appel API
