### PR TITLE
[TECH] Suppression de la colonne isV3Pilot en BDD (PIX-17580).

### DIFF
--- a/api/db/migrations/20250505132751_remove-isV3Pilot-column-in-certification-centers-table.js
+++ b/api/db/migrations/20250505132751_remove-isV3Pilot-column-in-certification-centers-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'isV3Pilot';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+export { down, up };

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -150,7 +150,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
       context('When there is a validated live alert for a challenge', function () {
         beforeEach(async function () {
           const user = databaseBuilder.factory.buildUser({ id: userId });
-          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
           const sessionId = databaseBuilder.factory.buildSession({
             certificationCenterId,
             version: SESSIONS_VERSIONS.V3,


### PR DESCRIPTION
## 🌸 Problème

Le code lié à `isV3Pilot` a été supprimé dans la PR #11931.
La colonne du même nom en BDD n'est plus utile.

## 🌳 Proposition

On supprime `isV3Pilot` de `certification-centers`

## 🐝 Remarques

Il reste quelques mentions de `isV3Pilot` dans des `_.omit('isV3Pilot')` tests qui seront supprimés une fois cette PR mergée.

## 🤧 Pour tester

Vérifier que la colonne a bien été supprimée en BDD.
CI verte.
