### PR TITLE
[FEATURE] Ajouter une action "Archiver en masse des organisations" dans Pix Admin (PIX-17151)

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -48,4 +48,10 @@ export default class OrganizationAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${parentOrganizationId}/attach-child-organization`;
     return this.ajax(url, 'POST', { data: { childOrganizationIds } });
   }
+
+  archiveOrganizations(files) {
+    if (!files || files.length === 0) return;
+    const url = `${this.host}/${this.namespace}/organizations/batch-archive`;
+    return this.ajax(url, 'POST', { data: files[0] });
+  }
 }

--- a/admin/app/components/administration/deployment/index.gjs
+++ b/admin/app/components/administration/deployment/index.gjs
@@ -1,6 +1,7 @@
 import CertificationCentersBatchArchive from './certification-centers-batch-archive';
 import NewTag from './new-tag';
 import OrganizationTagsImport from './organization-tags-import';
+import OrganizationsBatchArchive from './organizations-batch-archive';
 import OrganizationsImport from './organizations-import';
 import UpdateOrganizationsInBatch from './update-organizations-in-batch';
 
@@ -12,6 +13,8 @@ import UpdateOrganizationsInBatch from './update-organizations-in-batch';
   <OrganizationsImport />
 
   <UpdateOrganizationsInBatch />
+
+  <OrganizationsBatchArchive />
 
   <CertificationCentersBatchArchive />
 </template>

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -1,0 +1,70 @@
+import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class OrganizationsBatchArchive extends Component {
+  @service intl;
+  @service pixToast;
+  @service router;
+  @service store;
+
+  @action
+  async archiveOrganizations(files) {
+    const adapter = this.store.adapterFor('organization');
+    try {
+      await adapter.archiveOrganizations(files);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.administration.organizations-batch-archive.notifications.success'),
+      });
+    } catch (errorResponse) {
+      const errors = errorResponse.errors;
+
+      if (!errors) {
+        return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
+      }
+
+      errors.forEach((error) => {
+        switch (error.code) {
+          case 'MISSING_REQUIRED_FIELD_NAMES':
+            this.pixToast.sendErrorNotification({ message: `${error.meta}` });
+            break;
+          case 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR':
+            this.pixToast.sendErrorNotification({
+              message: this.intl.t(
+                'components.administration.organizations-batch-archive.notifications.errors.error-in-batch',
+                {
+                  currentLine: error.meta.currentLine,
+                  totalLines: error.meta.totalLines,
+                },
+              ),
+            });
+            break;
+          default:
+            this.pixToast.sendErrorNotification({ message: error.detail });
+        }
+      });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <AdministrationBlockLayout
+      @title={{t "components.administration.organizations-batch-archive.title"}}
+      @description={{t "components.administration.organizations-batch-archive.description"}}
+    >
+      <PixButtonUpload
+        @id="organizations-file-upload"
+        @onChange={{this.archiveOrganizations}}
+        @variant="secondary"
+        accept=".csv"
+      >
+        {{t "components.administration.organizations-batch-archive.upload-button"}}
+      </PixButtonUpload>
+    </AdministrationBlockLayout>
+  </template>
+}

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -1,0 +1,98 @@
+import { render } from '@1024pix/ember-testing-library';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import OrganizationsBatchArchive from 'pix-admin/components/administration/deployment/organizations-batch-archive';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | administration/organizations-batch-archive', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when batch archive succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+      window.fetch.resolves(
+        _fetchResponse({
+          status: 204,
+        }),
+      );
+
+      // when
+      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.organizations-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(t('components.administration.organizations-batch-archive.notifications.success')),
+      );
+    });
+  });
+
+  module('when batch archiving of organizations fails', function () {
+    test('it displays an error notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+
+      window.fetch.resolves(
+        _fetchResponse({
+          body: {
+            errors: [
+              {
+                status: '422',
+                title: "Un souci avec l'archivage des organisations",
+                code: 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR',
+                detail: `Erreur lors de l'archivage`,
+                meta: {
+                  currentLine: 2,
+                  totalLines: 4,
+                },
+              },
+            ],
+          },
+          status: 422,
+        }),
+      );
+
+      // when
+      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.organizations-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(
+          t('components.administration.organizations-batch-archive.notifications.errors.error-in-batch', {
+            currentLine: 2,
+            totalLines: 4,
+          }),
+        ),
+      );
+    });
+  });
+});
+
+function _fetchResponse({ body, status }) {
+  return new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+}

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -84,4 +84,29 @@ module('Unit | Adapters | organization', function (hooks) {
       );
     });
   });
+
+  module('#archiveOrganizations', function () {
+    test('should not call ajax if files is empty', async function (assert) {
+      // given
+      const files = [];
+
+      // when
+      await adapter.archiveOrganizations(files);
+
+      // then
+      assert.notOk(adapter.ajax.called);
+    });
+
+    test('should call ajax with the correct URL and method', async function (assert) {
+      // given
+      const files = ['file1', 'file2'];
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organizations/batch-archive`;
+
+      // when
+      await adapter.archiveOrganizations(files);
+
+      // then
+      assert.ok(adapter.ajax.calledWith(expectedUrl, 'POST'));
+    });
+  });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -156,6 +156,17 @@
         "title": "Bulk addition of tags on organisations",
         "upload-button": "Import CSV file"
       },
+      "organizations-batch-archive": {
+        "description": "Archive organizations in batch. Each line must contain a organization ID to archive.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "The organizations archiving has failed. The organization ID line n°{currentLine} failed, out of {totalLines} lines."
+          },
+          "success": "The organizations have been archived."
+        },
+        "title": "Archiving of organizations in batch",
+        "upload-button": "Import a CSV file"
+      },
       "organizations-import": {
         "description": "Existing organizations will not be changed.",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -156,6 +156,17 @@
         "title": "Ajout de tags en masse sur des organisations",
         "upload-button": "Importer un fichier CSV"
       },
+      "organizations-batch-archive": {
+        "description": "Permet d'archiver des organisations par lot. Chaque ligne doit porter l'identifiant de l'organisation à archiver.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "L'archivage d'une des organisations a échoué. L'organization concernée est à la ligne {currentLine} du fichier comportant {totalLines} lignes. Corrigez la ligne concernée et ré-importez le fichier."
+          },
+          "success": "Les organisations ont bien été archivées."
+        },
+        "title": "Archivage des organisations en masse",
+        "upload-button": "Importer un fichier CSV"
+      },
       "organizations-import": {
         "description": "Les organisations déjà existantes ne seront pas modifiées.",
         "notifications": {

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -2,6 +2,7 @@ import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
 import {
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,
@@ -42,6 +43,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: ArchiveCertificationCentersInBatchError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: ArchiveOrganizationsInBatchError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -70,6 +70,14 @@ const createInBatch = async function (request, h) {
   return h.response(organizationForAdminSerializer.serialize(createdOrganizations)).code(204);
 };
 
+const archiveInBatch = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
+  const organizationIds = await csvSerializer.deserializeForOrganizationBatchArchive(request.payload.path);
+  await usecases.archiveOrganizationsInBatch({ organizationIds, userId });
+
+  return h.response().code(204);
+};
+
 const getOrganizationDetails = async function (request, h, dependencies = { organizationForAdminSerializer }) {
   const organizationId = request.params.id;
 
@@ -121,6 +129,7 @@ const organizationAdminController = {
   create,
   createInBatch,
   archiveOrganization,
+  archiveInBatch,
   attachChildOrganization,
   getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -240,6 +240,40 @@ const register = async function (server) {
     },
     {
       method: 'POST',
+      path: '/api/admin/organizations/batch-archive',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        payload: {
+          maxBytes: MAX_FILE_SIZE_UPLOAD,
+          output: 'file',
+          failAction: (request, h) => {
+            return sendJsonApiError(
+              new PayloadTooLargeError('An error occurred, payload is too large', ERRORS.PAYLOAD_TOO_LARGE, {
+                maxSize: '20',
+              }),
+              h,
+            );
+          },
+        },
+        handler: (request, h) => organizationAdminController.archiveInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet d'archiver plusieurs organizations dont les ID sont transmis par un CSV",
+        ],
+      },
+    },
+    {
+      method: 'POST',
       path: '/api/admin/organizations/{organizationId}/attach-child-organization',
       config: {
         pre: [

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -20,6 +20,14 @@ class ArchiveCertificationCentersInBatchError extends DomainError {
   }
 }
 
+class ArchiveOrganizationsInBatchError extends DomainError {
+  constructor({ code = 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR', meta } = {}) {
+    super();
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class DpoEmailInvalid extends DomainError {
   constructor({ code = 'DPO_EMAIL_INVALID', message = 'DPO email invalid', meta } = {}) {
     super(message);
@@ -69,6 +77,7 @@ class FeatureParamsNotProcessable extends DomainError {
 
 export {
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,

--- a/api/src/organizational-entities/domain/usecases/archive-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-organizations-in-batch.usecase.js
@@ -1,0 +1,33 @@
+import { ArchiveOrganizationsInBatchError } from '../errors.js';
+
+/**
+ * @param {Object} params
+ * @param {Array} params.organizationIds
+ * @param {Number} params.userId
+ * @param {Object} params.organizationForAdminRepository
+ */
+export const archiveOrganizationsInBatch = async function ({
+  organizationIds,
+  userId,
+  organizationForAdminRepository,
+}) {
+  // we don't use a transaction here not to rollback lines 0 to N-1 in case of an error on line N
+
+  for (const [index, organizationId] of organizationIds.entries()) {
+    const hasOrganizationBeenArchived = Boolean(
+      await organizationForAdminRepository.archive({
+        id: organizationId,
+        archivedBy: userId,
+      }),
+    );
+
+    if (!hasOrganizationBeenArchived) {
+      throw new ArchiveOrganizationsInBatchError({
+        meta: {
+          currentLine: index + 1,
+          totalLines: organizationIds.length,
+        },
+      });
+    }
+  }
+};

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -80,6 +80,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {getOrganizationDetails} getOrganizationDetails
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch
  * @property {updateOrganizationInformation} updateOrganizationInformation
+ * @property {archiveOrganizationsInBatch} archiveOrganizationsInBatch
  */
 
 /**

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -36,7 +36,7 @@ const archive = async function ({ id, archivedBy }) {
 
   await knex('memberships').where({ organizationId: id, disabledAt: null }).update({ disabledAt: archiveDate });
 
-  await knex(ORGANIZATIONS_TABLE_NAME)
+  return knex(ORGANIZATIONS_TABLE_NAME)
     .where({ id: id, archivedBy: null })
     .update({ archivedBy: archivedBy, archivedAt: archiveDate });
 };

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -207,6 +207,34 @@ async function deserializeForCertificationCenterBatchArchive(
   return parsedData.map((data) => data['ID du centre de certification']);
 }
 
+async function deserializeForOrganizationBatchArchive(file, { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper) {
+  const columnName = "ID de l'organisation";
+
+  await checkCsvHeader({ filePath: file, requiredFieldNames: [columnName] });
+  const cleanedData = await readCsvFile(file);
+
+  const batchOrganizationOptionsWithHeader = {
+    skipEmptyLines: true,
+    header: true,
+    transformHeader: (header) => header?.trim(),
+    transform: (value, columnName) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (!isEmpty(value)) {
+        if (columnName === columnName) {
+          value = Number(value);
+        }
+      }
+      return value;
+    },
+  };
+
+  const parsedData = await parseCsvData(cleanedData, batchOrganizationOptionsWithHeader);
+
+  return parsedData.map((data) => data[columnName]);
+}
+
 const requiredFieldNamesForCampaignsImport = [
   "Identifiant de l'organisation*",
   'Nom de la campagne*',
@@ -482,6 +510,7 @@ function serializeLine(lineArray) {
 export {
   deserializeForCampaignsImport,
   deserializeForCertificationCenterBatchArchive,
+  deserializeForOrganizationBatchArchive,
   deserializeForOrganizationsImport,
   deserializeForSessionsImport,
   parseForCampaignsImport,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -656,6 +656,110 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('POST /api/admin/organizations/batch-archive', function () {
+    context('success case', function () {
+      it('returns a 204 http request', async function () {
+        // given
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+        const organizationId1 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        await databaseBuilder.commit();
+        const buffer = `ID de l'organisation\n` + `${organizationId1}\n` + `${organizationId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/organizations/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId1 }).first();
+
+        expect(response.statusCode).to.equal(204);
+        expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization1.archivedAt).not.to.be.null;
+        expect(archivedOrganization2.archivedAt).not.to.be.null;
+      });
+    });
+
+    context('error cases', function () {
+      it('returns an error with meta info', async function () {
+        // given
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+        const organizationId1 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        const nonExistingOrganizationId1 = 7895;
+        const nonExistingOrganizationId2 = 8513;
+
+        await databaseBuilder.commit();
+        const buffer =
+          `ID de l'organisation\n` +
+          `${organizationId1}\n` +
+          `${organizationId2}\n` +
+          `${nonExistingOrganizationId1}\n` +
+          `${nonExistingOrganizationId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/organizations/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
+
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0].code).to.deep.equal('ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
+        expect(response.result.errors[0].meta).to.deep.equal({
+          currentLine: 3,
+          totalLines: 4,
+        });
+        expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization1.archivedAt).not.to.be.null;
+        expect(archivedOrganization2.archivedAt).not.to.be.null;
+      });
+
+      it('fails when the file payload is too large', async function () {
+        const buffer = Buffer.alloc(1048576 * 22, 'B'); // > 10 Mo buffer
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+
+        const options = {
+          method: 'POST',
+          url: '/api/admin/organizations/batch-archive',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        };
+
+        const response = await server.inject(options);
+        expect(response.statusCode).to.equal(413);
+        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
+        expect(response.result.errors[0].meta.maxSize).to.equal('20');
+      });
+    });
+  });
+
   describe('GET /api/admin/organizations/add-organization-features/template', function () {
     it('responds with a 200', async function () {
       // given

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
@@ -1,0 +1,154 @@
+import { ArchiveOrganizationsInBatchError } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | archive-organizations-in-batch', function () {
+  let now, clock;
+
+  beforeEach(function () {
+    now = new Date('2025-01-01');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('success', function () {
+    it('archives the organizations properly', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization1.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization1.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization1.id,
+        disabledAt: null,
+      });
+
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization2.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization2.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization2.id,
+        disabledAt: null,
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+
+      const organizationIds = [organization1.id, organization2.id];
+
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.archiveOrganizationsInBatch({
+        organizationIds,
+        userId: user.id,
+      });
+
+      // then
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization1.id,
+        now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization1.id, now });
+      await _assertMembershipAreDisabled({ organizationId: organization1.id, now });
+
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization2.id, user, now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization2.id,
+        now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization2.id, now });
+      await _assertMembershipAreDisabled({ organizationId: organization2.id, now });
+    });
+  });
+
+  context('failure', function () {
+    it('processes until it throws an error if one of the organizations cannot be archived', async function () {
+      // given
+      const nonExistingOrganizationId = 1234;
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization1.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization1.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization1.id,
+        disabledAt: null,
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      const organizationIds = [organization1.id, nonExistingOrganizationId];
+
+      // when
+      const error = await catchErr(usecases.archiveOrganizationsInBatch)({
+        organizationIds,
+        userId: user.id,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(
+        new ArchiveOrganizationsInBatchError({
+          meta: {
+            currentLine: 2,
+            totalLines: 2,
+          },
+        }),
+      );
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization1.id,
+        now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization1.id, now });
+      await _assertMembershipAreDisabled({ organizationId: organization1.id, now });
+    });
+  });
+});
+
+async function _assertMembershipAreDisabled({ organizationId, now }) {
+  const archivedMembership1 = await knex('memberships').where({ organizationId }).first();
+
+  expect(archivedMembership1.disabledAt).to.deep.equal(now);
+}
+
+async function _assertCampaignAreArchived({ organizationId, now }) {
+  const archivedCampaign1 = await knex('campaigns').where({ organizationId }).first();
+  expect(archivedCampaign1.archivedAt).to.deep.equal(now);
+}
+
+async function _assertPendingInvitationsAreCanceled({ archivedOrganizationId, now }) {
+  const archivedPendingOrganizationInvitation = await knex('organization-invitations')
+    .where({ organizationId: archivedOrganizationId })
+    .first();
+
+  expect(archivedPendingOrganizationInvitation.status).to.deep.equal(OrganizationInvitation.StatusType.CANCELLED);
+  expect(archivedPendingOrganizationInvitation.updatedAt).to.deep.equal(now);
+}
+
+async function _assertOrganizationIsArchived({ archivedOrganizationId, user, now }) {
+  const archivedOrganization = await knex('organizations').where({ id: archivedOrganizationId }).first();
+
+  expect(archivedOrganization.archivedBy).to.deep.equal(user.id);
+  expect(archivedOrganization.archivedAt).to.deep.equal(now);
+}

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -329,9 +329,15 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       await databaseBuilder.commit();
 
       // when
-      await organizationForAdminRepository.archive({ id: organizationId, archivedBy: superAdminUserId });
+      const hasOrganizationBeenArchived = Boolean(
+        await organizationForAdminRepository.archive({
+          id: organizationId,
+          archivedBy: superAdminUserId,
+        }),
+      );
 
       // then
+      expect(hasOrganizationBeenArchived).to.be.true;
       const pendingInvitations = await knex('organization-invitations').where({
         organizationId,
         status: pendingStatus,

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1479,6 +1479,30 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     });
   });
 
+  describe('#deserializeForOrganizationBatchArchive', function () {
+    it('should check the required header', async function () {
+      // given
+      const filePath = 'file://organizations.csv';
+      const checkCsvHeaderStub = sinon.stub();
+      const readCsvFileStub = sinon.stub();
+      const parseCsvDataStub = sinon.stub();
+      parseCsvDataStub.resolves([{ "ID de l'organisation": 1234 }, { "ID de l'organisation": 5678 }]);
+
+      const requiredFieldNames = ["ID de l'organisation"];
+
+      // when
+      const serializedData = await csvSerializer.deserializeForOrganizationBatchArchive(filePath, {
+        checkCsvHeader: checkCsvHeaderStub,
+        readCsvFile: readCsvFileStub,
+        parseCsvData: parseCsvDataStub,
+      });
+
+      // then
+      expect(checkCsvHeaderStub).to.have.been.calledWithExactly({ filePath, requiredFieldNames });
+      expect(serializedData).to.deep.equal([1234, 5678]);
+    });
+  });
+
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
       "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";


### PR DESCRIPTION
## 🌸 Problème
Il peut être nécessaire, pour les agents Pix, d’archiver plusieurs organisations

Dans Pix Admin, ajouter une action d’administration dans l’onglet “Deploiement”: Archiver en masse des organisations.

## 🌳 Proposition

Dans Pix Admin, ajouter une action d’administration dans l’onglet “Deploiement”: Archiver en masse des organisations.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Récupérer ce fichier:
[archivage-organisations.csv](https://github.com/user-attachments/files/20158585/archivage-organisations.csv)

- Aller sur Pix Admin en tant que Super Admin
- Se rendre sur la page Administration puis sur l'onglet Déploiement
- Sous le titre "Archivage des organisations en masse", cliquer sur Importer un fichier CSV
- Constater qu'une fois le téléversement réalisé, une notification de succès s'affiche. 