### PR TITLE
[BUGFIX] Positionner le résultat global à partiellement atteint quand au moins une étape est réussie

### DIFF
--- a/api/src/school/domain/services/compute-global-result.js
+++ b/api/src/school/domain/services/compute-global-result.js
@@ -12,7 +12,7 @@ export function computeGlobalResult(stepResults, dareResult) {
     return REACHED;
   }
 
-  if (lastStepResult === NOT_REACHED && stepResults.length > 1) {
+  if (stepResults.length > 1) {
     return PARTIALLY_REACHED;
   }
 

--- a/api/tests/school/unit/domain/services/compute-global-result_test.js
+++ b/api/tests/school/unit/domain/services/compute-global-result_test.js
@@ -50,13 +50,16 @@ describe('Unit | Domain | Pix Junior | compute global result', function () {
       });
 
       context('with multiple step (first should be reached by design)', function () {
-        it(`should return ${Assessment.results.PARTIALLY_REACHED}`, function () {
-          const stepResults = [Assessment.results.REACHED, Assessment.results.NOT_REACHED];
-          const dareResult = undefined;
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [Assessment.results.NOT_REACHED, Assessment.results.PARTIALLY_REACHED].forEach(function (status) {
+          it(`should return ${Assessment.results.PARTIALLY_REACHED} if last step status is ${status}`, function () {
+            const stepResults = [Assessment.results.REACHED, status];
+            const dareResult = undefined;
 
-          const result = computeGlobalResult(stepResults, dareResult);
+            const result = computeGlobalResult(stepResults, dareResult);
 
-          expect(result).to.equal(Assessment.results.PARTIALLY_REACHED);
+            expect(result).to.equal(Assessment.results.PARTIALLY_REACHED);
+          });
         });
       });
     });


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Actuellement, lorsque la 1ère étape d’une mission est à l'état “Atteint” et la 2ème étape, à l'état Partiellement Atteint, le résultat global est Non Atteint alors qu’il devrait être Partiellement Atteint (voir copie d'écran).

![image](https://github.com/user-attachments/assets/910ee50a-fa18-4c99-9c38-dc3285cf7087)


## 🌳 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Revoir le calcul du résultat global de la mission.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Une reprise de données pourra être faite dans un second temps pour passer les résultats de type : 
A + PA = NA
vers
A + PA = PA

## 🤧 Pour tester

Passer une mission en réussissant la 1ère étape et en échouant la 2ème sur la validation.
Consulter le résultat dans Pix Orga : le résultat global est bien "Partiellement Atteint".