### PR TITLE
[BUGFIX] Corriger le calcul de résultat d'une étape partiellement atteinte (PIX-17751)

### DIFF
--- a/api/src/school/domain/services/compute-step-result.js
+++ b/api/src/school/domain/services/compute-step-result.js
@@ -8,12 +8,8 @@ export function computeStepResult(lastActivity) {
     return undefined;
   }
 
-  if (lastActivity.level === Activity.levels.VALIDATION && lastActivity.status === Activity.status.SUCCEEDED) {
-    return REACHED;
-  }
-
-  if (lastActivity.level === Activity.levels.VALIDATION && lastActivity.status === Activity.status.FAILED) {
-    return PARTIALLY_REACHED;
+  if (lastActivity.level === Activity.levels.VALIDATION) {
+    return lastActivity.status === Activity.status.SUCCEEDED ? REACHED : PARTIALLY_REACHED;
   }
 
   return NOT_REACHED;

--- a/api/tests/school/unit/domain/services/compute-step-result_test.js
+++ b/api/tests/school/unit/domain/services/compute-step-result_test.js
@@ -30,6 +30,19 @@ describe('Unit | Domain | Pix Junior | compute step result', function () {
       expect(result).to.equal(Assessment.results.PARTIALLY_REACHED);
     });
   });
+  context('When the last activity is a skipped VALIDATION', function () {
+    it(`should return ${Assessment.results.PARTIALLY_REACHED}`, async function () {
+      const lastActivity = domainBuilder.buildActivity({
+        level: Activity.levels.VALIDATION,
+        status: Activity.status.SKIPPED,
+        stepIndex: 1,
+      });
+
+      const result = await computeStepResult(lastActivity);
+
+      expect(result).to.equal(Assessment.results.PARTIALLY_REACHED);
+    });
+  });
   context('When the last activity is a failed TRAINING', function () {
     it(`should return ${Assessment.results.NOT_REACHED}`, async function () {
       const lastActivity = domainBuilder.buildActivity({


### PR DESCRIPTION
## 🌸 Problème

Lorsque l’on clique sur “Je ne sais pas” sur l'étape de validation d’une activité après être passé par le didacticiel et avoir réussi l’entraînement, le status de l'étape est “Non atteint” alors qu’il devrait être “Partiellement atteint”.

## 🌳 Proposition

Corriger le calcul du résultat par étape.

## 🐝 Remarques
RAS

## 🤧 Pour tester

Lancer une mission résussir la 1ere étape puis échoué à la validation au cours de la 2ème étape.
Consulter le résultat dans Pix Orga : la 2ème étape est à l'état "Partiellement atteint".