### PR TITLE
[FEATURE] Créer un service pour enregistrer une séquence d'événements dans un passage (PIX-16955)

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/passage-event-serializer.js
@@ -5,7 +5,7 @@ const { Deserializer } = jsonapiSerializer;
 const deserialize = async function (payload) {
   const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
   const passageEventsCollection = await deserializer.deserialize(payload);
-  return passageEventsCollection.passageEvents.map((passageEvent) => {
+  return passageEventsCollection.events.map((passageEvent) => {
     return {
       ...passageEvent,
       occurredAt: new Date(passageEvent.occurredAt),

--- a/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
@@ -21,7 +21,7 @@ describe('Acceptance | Controller | passage-events-controller', function () {
           data: {
             type: 'passage-event-collection',
             attributes: {
-              'passage-events': [
+              events: [
                 {
                   type: 'FLASHCARDS_STARTED',
                   'occurred-at': 1556419320000,

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-event-serializer_test.js
@@ -14,13 +14,13 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
       const json = {
         data: {
           attributes: {
-            'passage-events': [
+            events: [
               {
-                elementId: elementId,
-                'occurred-at': occurredAt,
-                'passage-id': passageId,
-                'sequence-number': sequenceNumber,
+                occurredAt,
+                passageId,
+                sequenceNumber,
                 type,
+                elementId,
               },
             ],
             type: 'passage-event-collection',
@@ -34,11 +34,11 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageEvent
       // then
       expect(results).to.deep.equal([
         {
-          elementId,
           occurredAt: new Date('2019-04-28T02:42:00Z'),
           passageId,
           sequenceNumber,
           type,
+          elementId,
         },
       ]);
     });

--- a/mon-pix/app/adapters/passage-events-collection.js
+++ b/mon-pix/app/adapters/passage-events-collection.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class PassageEventsCollection extends ApplicationAdapter {
+  urlForCreateRecord() {
+    const baseUrl = this.buildURL();
+    return `${baseUrl}/passage-events`;
+  }
+}

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -15,6 +15,7 @@ const INITIAL_COUNTERS_VALUE = { yes: 0, almost: 0, no: 0 };
 
 export default class ModulixFlashcards extends Component {
   @service modulixPreviewMode;
+  @service passageEvents;
 
   @tracked
   /**
@@ -79,6 +80,13 @@ export default class ModulixFlashcards extends Component {
   @action
   start() {
     this.currentStep = 'cards';
+
+    this.passageEvents.record({
+      type: 'FLASHCARDS_STARTED',
+      data: {
+        elementId: this.args.flashcards.id,
+      },
+    });
   }
 
   @action

--- a/mon-pix/app/models/passage-events-collection.js
+++ b/mon-pix/app/models/passage-events-collection.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class PassageEventsCollection extends Model {
+  @attr('array') events;
+}

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class ModulePassageRoute extends Route {
   @service store;
+  @service passageEvents;
 
   async model() {
     const module = this.modelFor('module');
@@ -13,6 +14,8 @@ export default class ModulePassageRoute extends Route {
         moduleVersion: module.version,
       },
     });
+
+    this.passageEvents.initialize({ passageId: passage.id });
 
     return { module, passage };
   }

--- a/mon-pix/app/services/passage-events.js
+++ b/mon-pix/app/services/passage-events.js
@@ -17,7 +17,7 @@ export default class PassageEvents extends Service {
     passageEventsCollection.events = [
       {
         type,
-        passageId,
+        passageId: this.passageId,
         sequenceNumber: this.sequenceNumber,
         occurredAt: new Date().getTime(),
         ...data,

--- a/mon-pix/app/services/passage-events.js
+++ b/mon-pix/app/services/passage-events.js
@@ -1,0 +1,28 @@
+import Service, { service } from '@ember/service';
+
+export default class PassageEvents extends Service {
+  @service store;
+
+  passageId = null;
+  sequenceNumber = 1;
+
+  initialize({ passageId }) {
+    this.passageId = Number(passageId);
+  }
+
+  async record({ type, data }) {
+    this.sequenceNumber++;
+
+    const passageEventsCollection = this.store.createRecord('passage-events-collection');
+    passageEventsCollection.events = [
+      {
+        type,
+        passageId,
+        sequenceNumber: this.sequenceNumber,
+        occurredAt: new Date().getTime(),
+        ...data,
+      },
+    ];
+    passageEventsCollection.save();
+  }
+}

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -11,6 +11,13 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Flashcards', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let passageEventsService;
+
+  hooks.beforeEach(async function () {
+    passageEventsService = this.owner.lookup('service:passage-events');
+    passageEventsService.record = sinon.stub();
+  });
+
   test('should display provided instructions about Flashcards', async function (assert) {
     // given
     const { flashcards } = _getFlashcards();
@@ -156,7 +163,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   });
 
   module('when user clicks on the "Start" button', function () {
-    test('should display the first card', async function (assert) {
+    test('should display the first card and record a FLASHCARDS_STARTED event', async function (assert) {
       // given
       const { flashcards } = _getFlashcards();
 
@@ -173,6 +180,12 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
       assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
       assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 1, totalCards: 2 })));
+      assert.ok(
+        passageEventsService.record.calledWith({
+          type: 'FLASHCARDS_STARTED',
+          data: { elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+        }),
+      );
     });
   });
 

--- a/mon-pix/tests/unit/adapters/passage-events-collection-test.js
+++ b/mon-pix/tests/unit/adapters/passage-events-collection-test.js
@@ -1,0 +1,19 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapter | PassageEventsCollection', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForCreateRecord', function () {
+    test('should use custom url when creating passage-event-collection', function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:passage-events-collection');
+
+      // when
+      const url = adapter.urlForCreateRecord();
+
+      // then
+      assert.true(url.endsWith('/api/passage-events'));
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -22,7 +22,8 @@ module('Unit | Route | modules | passage', function (hooks) {
     route.modelFor.withArgs('module').returns(module);
 
     store.createRecord = sinon.stub();
-    store.createRecord.returns({ save: () => {} });
+    const passage = { id: 2048 };
+    store.createRecord.returns({ save: () => passage });
 
     // when
     const model = await route.model({ slug: 'the-module' });
@@ -31,9 +32,9 @@ module('Unit | Route | modules | passage', function (hooks) {
     assert.strictEqual(model.module, module);
   });
 
-  test('should create and return a new passage', async function (assert) {
+  test('should create and return a new passage and initialize event service', async function (assert) {
     // given
-    const passage = Symbol('passage');
+    const passage = { id: 2019 };
 
     const route = this.owner.lookup('route:module.passage');
     const store = this.owner.lookup('service:store');
@@ -47,6 +48,9 @@ module('Unit | Route | modules | passage', function (hooks) {
 
     store.createRecord.withArgs('passage', { moduleId: 'my-module' }).returns({ save: save });
 
+    const passageEventService = this.owner.lookup('service:passage-events');
+    passageEventService.initialize = sinon.stub();
+
     // when
     const model = await route.model({ slug: 'my-module' });
 
@@ -58,6 +62,9 @@ module('Unit | Route | modules | passage', function (hooks) {
         sequenceNumber: 1,
         moduleVersion: module.version,
       },
+    });
+    sinon.assert.calledWith(passageEventService.initialize, {
+      passageId: 2019,
     });
   });
 });

--- a/mon-pix/tests/unit/services/passage-events-test.js
+++ b/mon-pix/tests/unit/services/passage-events-test.js
@@ -1,0 +1,84 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Services | PassageEvents', function (hooks) {
+  setupTest(hooks);
+
+  let clock;
+  const now = new Date('2019-04-28T02:42:00Z');
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers({ now });
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
+
+  module('#record', function () {
+    test('it should record a passageEvent', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+
+      const store = this.owner.lookup('service:store');
+      sinon.stub(store, 'createRecord');
+      const saveStub = sinon.stub().resolves({});
+      const passageEventCollection = { save: saveStub };
+      store.createRecord.returns(passageEventCollection);
+
+      // when
+      await passageEventService.record({
+        type: 'FlashcardsStartedEvent',
+        passageId: 1,
+        data: {
+          elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
+        },
+      });
+
+      // then
+      assert.deepEqual(passageEventCollection.events, [
+        {
+          type: 'FlashcardsStartedEvent',
+          passageId: 1,
+          occurredAt: 1556419320000,
+          elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
+          sequenceNumber: 2,
+        },
+      ]);
+      assert.true(saveStub.called);
+    });
+
+    test('it should increment sequenceNumber when called multiple times', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+
+      const store = this.owner.lookup('service:store');
+      const passageEventCollection1 = { save: sinon.stub() };
+      const passageEventCollection2 = { save: sinon.stub() };
+      sinon.stub(store, 'createRecord');
+      store.createRecord.onCall(0).returns(passageEventCollection1);
+      store.createRecord.onCall(1).returns(passageEventCollection2);
+
+      // when
+      await passageEventService.record({
+        type: 'FlashcardsStartedEvent',
+        passageId: 1,
+        data: {
+          elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
+        },
+      });
+
+      await passageEventService.record({
+        type: 'FlashcardsRectoSeenEvent',
+        passageId: 1,
+        data: {
+          elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
+        },
+      });
+
+      assert.strictEqual(passageEventCollection1.events[0].sequenceNumber, 2);
+      assert.strictEqual(passageEventCollection2.events[0].sequenceNumber, 3);
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/passage-events-test.js
+++ b/mon-pix/tests/unit/services/passage-events-test.js
@@ -16,6 +16,19 @@ module('Unit | Services | PassageEvents', function (hooks) {
     clock.restore();
   });
 
+  module('#initialize', function () {
+    test('should save passage id', function (assert) {
+      // given
+      const service = this.owner.lookup('service:passageEvents');
+
+      // when
+      service.initialize({ passageId: '1984' });
+
+      // then
+      assert.strictEqual(service.passageId, 1984);
+    });
+  });
+
   module('#record', function () {
     test('it should record a passageEvent', async function (assert) {
       // given
@@ -26,11 +39,11 @@ module('Unit | Services | PassageEvents', function (hooks) {
       const saveStub = sinon.stub().resolves({});
       const passageEventCollection = { save: saveStub };
       store.createRecord.returns(passageEventCollection);
+      passageEventService.initialize({ passageId: 1 });
 
       // when
       await passageEventService.record({
         type: 'FlashcardsStartedEvent',
-        passageId: 1,
         data: {
           elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
         },
@@ -59,11 +72,11 @@ module('Unit | Services | PassageEvents', function (hooks) {
       sinon.stub(store, 'createRecord');
       store.createRecord.onCall(0).returns(passageEventCollection1);
       store.createRecord.onCall(1).returns(passageEventCollection2);
+      passageEventService.initialize({ passageId: 1 });
 
       // when
       await passageEventService.record({
         type: 'FlashcardsStartedEvent',
-        passageId: 1,
         data: {
           elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
         },


### PR DESCRIPTION
## 🌸 Problème

L'API peut recevoir des évènements mais le front n'en n'envoie pas.

## 🌳 Proposition

- Ajouter un service pour permettre à un composant front d'envoyer des évènements à l'API.
- Envoyer l'évènement `FlashcardsStartedEvent` lorsque l'utilisateur commence un élément Flashcards.

## 🐝 Remarques

On renomme la propriété `passageEvents` du modèle `PassageEventCollections` en `events` pour éviter la redondance.

## 🤧 Pour tester

1. Ouvrir un module contenant des flash cards (par exemple le bac à sable)
2. Commencer un élément Flashcards
3. Conster qu'un évènement `FlashcardsStartedEvent` est enregistré en base.