### PR TITLE
[TECH] Migrer le feature toggle de l'activation des quêtes vers le nouveaux système (PIX-17760)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,12 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isQuestEnabled: {
+    type: 'boolean',
+    description: 'Used to enable quests feature',
+    defaultValue: true,
+    tags: ['team-prescription', 'frontend'],
+  },
   isNewAccountRecoveryEnabled: {
     type: 'boolean',
     description: 'Using and testing feature account recovery process',

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { config } from '../../../shared/config.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
@@ -44,7 +45,7 @@ const save = async function (
   if (
     userId &&
     !config.featureToggles.isAsyncQuestRewardingCalculationEnabled &&
-    config.featureToggles.isQuestEnabled
+    (await featureToggles.get('isQuestEnabled'))
   ) {
     await questUsecases.rewardUser({ userId });
   }

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,6 +1,7 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { JobRepository } from '../../../shared/infrastructure/repositories/jobs/job-repository.js';
 
@@ -17,7 +18,8 @@ export class AnswerJobRepository extends JobRepository {
   }
 
   async performAsync(job) {
-    if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled || !config.featureToggles.isQuestEnabled) return;
+    if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled || !(await featureToggles.get('isQuestEnabled')))
+      return;
 
     const knexConn = DomainTransaction.getConnection();
 

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -10,10 +10,10 @@ import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
-import { config } from '../../config.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
+import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';
@@ -71,7 +71,7 @@ const completeAssessment = async function (request) {
     const assessment = await usecases.completeAssessment({ assessmentId, locale });
     await evaluationUsecases.handleBadgeAcquisition({ assessment });
     await evaluationUsecases.handleStageAcquisition({ assessment });
-    if (assessment.userId && config.featureToggles.isQuestEnabled) {
+    if (assessment.userId && (await featureToggles.get('isQuestEnabled'))) {
       await questUsecases.rewardUser({ userId: assessment.userId });
     }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -304,7 +304,6 @@ const configuration = (function () {
       ),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
       isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
-      isQuestEnabled: toBoolean(process.env.FT_ENABLE_QUESTS),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
@@ -520,7 +519,6 @@ const configuration = (function () {
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isPixCompanionEnabled = false;
-    config.featureToggles.isQuestEnabled = false;
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -5,6 +5,7 @@ import {
 } from '../../../../../src/quest/domain/models/Quest.js';
 import { config } from '../../../../../src/shared/config.js';
 import { LOCALE } from '../../../../../src/shared/domain/constants.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
   createServer,
   databaseBuilder,
@@ -201,9 +202,9 @@ describe('Acceptance | Controller | answer-controller-save', function () {
       });
 
       describe('when there are quests', function () {
-        beforeEach(function () {
+        beforeEach(async function () {
           sinon.stub(config.featureToggles, 'isAsyncQuestRewardingCalculationEnabled').value(false);
-          sinon.stub(config.featureToggles, 'isQuestEnabled').value(true);
+          await featureToggles.set('isQuestEnabled', true);
         });
 
         it('should return 201 HTTP status code', async function () {

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -4,6 +4,7 @@ import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecase
 import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { config } from '../../../../../src/shared/config.js';
 import { Assessment } from '../../../../../src/shared/domain/models/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | answer-controller', function () {
@@ -255,7 +256,7 @@ describe('Unit | Controller | answer-controller', function () {
       context('when quest feature is not enabled', function () {
         it('should not call rewardUser', async function () {
           // given
-          config.featureToggles.isQuestEnabled = false;
+          await featureToggles.set('isQuestEnabled', false);
 
           // when
           await answerController.save(request, hFake, {
@@ -272,7 +273,7 @@ describe('Unit | Controller | answer-controller', function () {
       context('when quest feature enabled', function () {
         it('should not call rewardUser if async is enabled', async function () {
           // given
-          config.featureToggles.isQuestEnabled = true;
+          await featureToggles.set('isQuestEnabled', true);
           config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
 
           // when
@@ -288,7 +289,7 @@ describe('Unit | Controller | answer-controller', function () {
 
         it('should call rewardUser if async is not enabled', async function () {
           // given
-          config.featureToggles.isQuestEnabled = true;
+          await featureToggles.set('isQuestEnabled', true);
           config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
 
           // when
@@ -304,7 +305,7 @@ describe('Unit | Controller | answer-controller', function () {
 
         it('should not call the reward user usecase if userId is not provided', async function () {
           // given
-          config.featureToggles.isQuestEnabled = true;
+          await featureToggles.set('isQuestEnabled', true);
           config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
           requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(null);
 

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -1,15 +1,16 @@
 import { AnswerJobRepository } from '../../../../../src/evaluation/infrastructure/repositories/answer-job-repository.js';
 import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepository', function () {
-  beforeEach(function () {
+  beforeEach(async function () {
     sinon.stub(config, 'featureToggles');
     sinon.stub(knex, 'batchInsert').callsFake(() => ({
       transacting: sinon.stub().resolves([{ rowCount: 1 }]),
     }));
-    config.featureToggles.isQuestEnabled = true;
+    await featureToggles.set('isQuestEnabled', true);
     config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
   });
 
@@ -22,7 +23,7 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
-      config.featureToggles.isQuestEnabled = false;
+      await featureToggles.set('isQuestEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
         dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,7 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-pix-app-new-layout-enabled': false,
             'is-pix-admin-new-sidebar-enabled': false,
             'is-pix-companion-enabled': false,
-            'is-quest-enabled': false,
+            'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': false,
             'setup-ecosystem-before-start': false,

--- a/api/tests/shared/unit/application/assessements/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessements/assessment-controller_test.js
@@ -4,10 +4,10 @@ import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/u
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
-import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import * as events from '../../../../../src/shared/domain/events/index.js';
 import { sharedUsecases } from '../../../../../src/shared/domain/usecases/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | assessment-controller', function () {
@@ -116,7 +116,7 @@ describe('Unit | Controller | assessment-controller', function () {
 
     it('should not call the rewardUser usecase if the questEnabled flag is false', async function () {
       // given
-      config.featureToggles.isQuestEnabled = false;
+      await featureToggles.set('isQuestEnabled', false);
       usecases.completeAssessment.resolves({ userId: 12 });
 
       // when
@@ -128,7 +128,7 @@ describe('Unit | Controller | assessment-controller', function () {
 
     it('should call the rewardUser use case if there is a userId', async function () {
       // given
-      config.featureToggles.isQuestEnabled = true;
+      await featureToggles.set('isQuestEnabled', true);
       usecases.completeAssessment.resolves({ userId: 12 });
 
       // when


### PR DESCRIPTION
## 🌸 Problème
Le feature toggle "is-quest-enabled" est encore avec une variable d'environnement

## 🌳 Proposition
Passer celui-ci vers le nouveau système 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Passer le feature toggle a false afin de désactiver le système de quête : 
- `scalingo -a pix-api-review-pr12228 run npm run toggles -- --key=isQuestEnabled --value=false`
- Se connecter a PixApp avec 'attestation-success@example.net'
- Aller sur le parcours, et vérifier que l'encart de l'attestation est absent.
- Remettre le feature toggle a true afin de réactiver le système de quête 
- `scalingo -a pix-api-review-pr12228 run npm run toggles -- --key=isQuestEnabled --value=true`
- Retourner sur PixApp et vérifier que l'encart attestation est cette fois ci présent
