### PR TITLE
[TECH] Migrer le feature toggle de basculement synchrone/asynchrone des quêtes vers le nouveaux système (PIX-17761)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,12 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isAsyncQuestRewardingCalculationEnabled: {
+    type: 'boolean',
+    description: 'Used to switch between synchronous and asynchronous mode for quest reward calculation',
+    defaultValue: false,
+    tags: ['team-prescription', 'frontend'],
+  },
   isQuestEnabled: {
     type: 'boolean',
     description: 'Used to enable quests feature',

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,6 +1,5 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
-import { config } from '../../../shared/config.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
@@ -44,7 +43,7 @@ const save = async function (
   }
   if (
     userId &&
-    !config.featureToggles.isAsyncQuestRewardingCalculationEnabled &&
+    !(await featureToggles.get('isAsyncQuestRewardingCalculationEnabled')) &&
     (await featureToggles.get('isQuestEnabled'))
   ) {
     await questUsecases.rewardUser({ userId });

--- a/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/answer-job-repository.js
@@ -1,5 +1,4 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
-import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
@@ -18,7 +17,10 @@ export class AnswerJobRepository extends JobRepository {
   }
 
   async performAsync(job) {
-    if (!config.featureToggles.isAsyncQuestRewardingCalculationEnabled || !(await featureToggles.get('isQuestEnabled')))
+    if (
+      !(await featureToggles.get('isAsyncQuestRewardingCalculationEnabled')) ||
+      !(await featureToggles.get('isQuestEnabled'))
+    )
       return;
 
     const knexConn = DomainTransaction.getConnection();

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -297,7 +297,6 @@ const configuration = (function () {
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      isAsyncQuestRewardingCalculationEnabled: toBoolean(process.env.FT_ENABLE_ASYNC_QUESTS_REWARDS_CALCULATION),
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
@@ -519,7 +518,6 @@ const configuration = (function () {
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isPixCompanionEnabled = false;
-    config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;
 

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -3,7 +3,6 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../../src/quest/domain/models/Quest.js';
-import { config } from '../../../../../src/shared/config.js';
 import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
@@ -13,7 +12,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   mockLearningContent,
-  sinon,
 } from '../../../../test-helper.js';
 
 const { FRENCH_FRANCE, ENGLISH_SPOKEN } = LOCALE;
@@ -203,7 +201,7 @@ describe('Acceptance | Controller | answer-controller-save', function () {
 
       describe('when there are quests', function () {
         beforeEach(async function () {
-          sinon.stub(config.featureToggles, 'isAsyncQuestRewardingCalculationEnabled').value(false);
+          await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
           await featureToggles.set('isQuestEnabled', true);
         });
 

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -274,7 +274,7 @@ describe('Unit | Controller | answer-controller', function () {
         it('should not call rewardUser if async is enabled', async function () {
           // given
           await featureToggles.set('isQuestEnabled', true);
-          config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
+          await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', true);
 
           // when
           await answerController.save(request, hFake, {
@@ -290,7 +290,7 @@ describe('Unit | Controller | answer-controller', function () {
         it('should call rewardUser if async is not enabled', async function () {
           // given
           await featureToggles.set('isQuestEnabled', true);
-          config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
+          await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
 
           // when
           await answerController.save(request, hFake, {
@@ -306,7 +306,7 @@ describe('Unit | Controller | answer-controller', function () {
         it('should not call the reward user usecase if userId is not provided', async function () {
           // given
           await featureToggles.set('isQuestEnabled', true);
-          config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
+          await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
           requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(null);
 
           // when

--- a/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
+++ b/api/tests/evaluation/unit/infrastructure/repositories/answer-job-repository_test.js
@@ -11,7 +11,7 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
       transacting: sinon.stub().resolves([{ rowCount: 1 }]),
     }));
     await featureToggles.set('isQuestEnabled', true);
-    config.featureToggles.isAsyncQuestRewardingCalculationEnabled = true;
+    await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', true);
   });
 
   describe('#performAsync', function () {
@@ -44,7 +44,7 @@ describe('Evaluation | Unit | Infrastructure | Repositories | AnswerJobRepositor
       sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
         return callback();
       });
-      config.featureToggles.isAsyncQuestRewardingCalculationEnabled = false;
+      await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
       const userId = Symbol('userId');
       const answerJobRepository = new AnswerJobRepository({
         dependencies: { profileRewardTemporaryStorage: profileRewardTemporaryStorageStub },


### PR DESCRIPTION
## 🌸 Problème
Le feature toggle "is-async-quest-rewarding-calculation-enabled" est encore avec une variable d'environnement

## 🌳 Proposition
Passer celui-ci vers le nouveau système 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
- Preparer un café, ça va être ~chiant~ long
- S'assurer que le toggle est à false (et redemarrer l'api) : 
```
node src/shared/infrastructure/feature-toggles/feature-toggles-script.js --key=isAsyncQuestRewardingCalculationEnabled --value=false
```  
- Aller vérifier en base sur la table pgboss.job qu'aucun job attendu est présent : 
```sql
SELECT name, state, data FROM pgboss.job WHERE name ='AnswerJob';
```
- Se connecter a PixApp avec attestation-blank@example.net
- Aller sur le parcours 'ATTEST003' par exemple
- Répondre a une question faux/vrai peut importe
- Refaire la requête pour vérifier qu'avec le toggle a false aucun job n'est inséré : 
```sql
SELECT name, state, data FROM pgboss.job WHERE name ='AnswerJob';
```
- Maintenant mettre le FT a true (et redemarrer) : 
```
node src/shared/infrastructure/feature-toggles/feature-toggles-script.js --key=isAsyncQuestRewardingCalculationEnabled --value=true
```  
- Retourner répondre a une question sur le parcours en cours
- Vérifier que cette fois un job 'AnswerJob' a bien été inséré : 
```sql
SELECT name, state, data FROM pgboss.job WHERE name ='AnswerJob';
```
- Finir votre café vous l'avez bien mérité
- 🐈‍⬛ 