### PR TITLE
[FEATURE] Rendre générique le/les SSO utilisé(s) pour l'accès à Pix Admin (pouvoir utiliser ProConnect) (PIX-17895)

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -8,7 +8,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   @service session;
   @service oidcIdentityProviders;
 
-  async authenticate({ code, state, authenticationKey, email, identityProviderSlug }) {
+  async authenticate({ code, state, iss, authenticationKey, email, identityProviderSlug }) {
     const identityProvider = this.oidcIdentityProviders.list.find((provider) => provider.id === identityProviderSlug);
 
     let url = `${ENV.APP.API_HOST}/api/admin/oidc/user/reconcile`;
@@ -25,6 +25,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
         identity_provider: identityProvider.code,
         code,
         state: state,
+        iss,
       };
 
       if (this.session.isAuthenticated) {

--- a/admin/app/models/oidc-identity-provider.js
+++ b/admin/app/models/oidc-identity-provider.js
@@ -3,6 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class OidcIdentityProvider extends Model {
   @attr() code;
   @attr() organizationName;
+  @attr() slug;
   @attr() shouldCloseSession;
   @attr() source;
 }

--- a/admin/app/routes/authentication/login-oidc.js
+++ b/admin/app/routes/authentication/login-oidc.js
@@ -29,7 +29,7 @@ export default class LoginOidcRoute extends Route {
     const queryParams = transition.to.queryParams;
     const identityProviderSlug = params.identity_provider_slug;
     if (queryParams.code) {
-      return this._handleCallbackRequest(queryParams.code, queryParams.state, identityProviderSlug);
+      return this._handleCallbackRequest(queryParams.code, queryParams.state, queryParams.iss, identityProviderSlug);
     }
   }
 
@@ -63,11 +63,12 @@ export default class LoginOidcRoute extends Route {
     this.session.set('data.nextURL', undefined);
   }
 
-  async _handleCallbackRequest(code, state, identityProviderSlug) {
+  async _handleCallbackRequest(code, state, iss, identityProviderSlug) {
     try {
       await this.session.authenticate('authenticator:oidc', {
         code,
         state,
+        iss,
         identityProviderSlug,
       });
     } catch (response) {

--- a/admin/app/services/oidc-identity-providers.js
+++ b/admin/app/services/oidc-identity-providers.js
@@ -7,6 +7,10 @@ export default class OidcIdentityProviders extends Service {
     return this.store.peekAll('oidc-identity-provider').toArray();
   }
 
+  get hasIdentityProviders() {
+    return this.list.length > 0;
+  }
+
   async loadAllAvailableIdentityProviders() {
     await this.store.findAll('oidc-identity-provider');
   }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -886,6 +886,7 @@
       "api-error-messages": {
         "login-no-permission": "You don't have the permission to connect."
       },
+      "authenticate-with-sso-provider": "Log in with {ssoProviderName}",
       "button": "Log in",
       "fields": {
         "email": {
@@ -894,9 +895,6 @@
         "password": {
           "label": "Password"
         }
-      },
-      "google": {
-        "label": "Log in via Google"
       },
       "title": "Access to this Pix Admin space is limited to administrators."
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -886,6 +886,7 @@
       "api-error-messages": {
         "login-no-permission": "Vous n'avez pas les droits pour vous connecter."
       },
+      "authenticate-with-sso-provider": "S’identifier avec {ssoProviderName}",
       "button": "Je me connecte",
       "fields": {
         "email": {
@@ -894,9 +895,6 @@
         "password": {
           "label": "Mot de passe"
         }
-      },
-      "google": {
-        "label": "Se connecter avec Google"
       },
       "title": "L'accès à Pix Admin est limité aux administrateurs de la plateforme"
     },


### PR DESCRIPTION
## 🌸 Problème

Actuellement pour Pix Admin, seule l’utilisation d’un SSO OIDC en dur est possible. De plus on pourrait vouloir, tout comme sur Pix App vouloir donner la possibilité de s’authentifier par plusieurs SSO.

## 🌳 Proposition

1. Rendre possible l'utilisation de n’importe quel SSO et pas uniquement l’utilisation d’un seul SSO écrite en dur dans le code en rendant générique le code actuel et notamment en utilisant le logo de chaque OIDC Provider en ligne sur https://assets.pix.org/ plutôt qu'en dur dans l’arborescence de fichiers du code du projet,
2. Rendre possible l’utilisation de plusieurs SSO, et plus concrètement tous les OIDC Providers ayant la propriété `enabledForPixAdmin == true`.

## 🐝 Remarques

On a ajouté la prise en charge du paramètre `iss` pour le client OIDC, de manière à pouvoir utiliser le SSO _ProConnect_ qui est le SSO dont l'utilisation est la plus logique pour Pix Admin. Et pour info, l'ajout de la prise en charge du paramètre `iss` au niveau du Front de Pix App avait été faite dans #9806, on a juste repris les ajouts faits dans cette PR.

## 🤧 Pour tester

Charger Pix API avec les SSO OIDC habituels et constater qu’on peut bien toujours se connecter par SSO à Pix Admin, qu’il n’y a pas de régression à ce niveau.
