### PR TITLE
[TECH] Ajoute la gestion des juridictions dans le script de gestion des applications clientes.

### DIFF
--- a/api/scripts/identity-access-management/client-applications.js
+++ b/api/scripts/identity-access-management/client-applications.js
@@ -101,7 +101,15 @@ class ClientApplicationsScript extends Script {
   }
 
   async list() {
-    console.table(await clientApplicationRepository.list());
+    const list = await clientApplicationRepository.list();
+    console.table(
+      list.map((clientApplication) => {
+        return {
+          ...clientApplication,
+          jurisdiction: JSON.stringify(clientApplication.jurisdiction),
+        };
+      }),
+    );
   }
 
   async add({ name, clientId, clientSecret, scope: scopes }, logger) {

--- a/api/scripts/identity-access-management/client-applications.js
+++ b/api/scripts/identity-access-management/client-applications.js
@@ -36,7 +36,7 @@ class ClientApplicationsScript extends Script {
             },
             jurisdiction: {
               description:
-                "Jurisdiction definition, currently, only an object like `{ rules: [{ name: 'tag', value: ['tag name'] }] }` is supported",
+                'Jurisdiction definition, currently, only an object like `{ "rules": [{ "name": "tags", "value": ["tag name"] }] }` is supported. \nThe juridiction restricts the data access to organizations tagged with specified "tag name".',
               demandOption: true,
               type: 'object',
             },
@@ -125,7 +125,7 @@ class ClientApplicationsScript extends Script {
       clientId,
       clientSecret: hashedClientSecret,
       scopes,
-      jurisdiction,
+      jurisdiction: JSON.parse(jurisdiction),
     });
     logger.info({ clientName: name, clientId, scopes, jurisdiction }, 'client application created');
   }

--- a/api/scripts/identity-access-management/client-applications.js
+++ b/api/scripts/identity-access-management/client-applications.js
@@ -34,6 +34,12 @@ class ClientApplicationsScript extends Script {
               demandOption: true,
               type: 'array',
             },
+            jurisdiction: {
+              description:
+                "Jurisdiction definition, currently, only an object like `{ rules: [{ name: 'tag', value: ['tag name'] }] }` is supported",
+              demandOption: true,
+              type: 'object',
+            },
           },
         },
         remove: {
@@ -112,15 +118,16 @@ class ClientApplicationsScript extends Script {
     );
   }
 
-  async add({ name, clientId, clientSecret, scope: scopes }, logger) {
+  async add({ name, clientId, clientSecret, scope: scopes, jurisdiction }, logger) {
     const hashedClientSecret = await cryptoService.hashPassword(clientSecret);
     await clientApplicationRepository.create({
       name,
       clientId,
       clientSecret: hashedClientSecret,
       scopes,
+      jurisdiction,
     });
-    logger.info({ clientName: name, clientId, scopes }, 'client application created');
+    logger.info({ clientName: name, clientId, scopes, jurisdiction }, 'client application created');
   }
 
   async remove({ clientId }, logger) {

--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 import { knex } from '../../../../db/knex-database-connection.js';
 import { MissingClientApplicationScopesError } from '../../domain/errors.js';
 import { ClientApplication } from '../../domain/models/ClientApplication.js';
@@ -17,6 +19,18 @@ export const clientApplicationRepository = {
   },
 
   async create({ name, clientId, clientSecret, scopes, jurisdiction }) {
+    const jurisdictionSchema = Joi.object({
+      rules: Joi.array()
+        .items(
+          Joi.object({
+            name: Joi.string().valid('tags').required(),
+            value: Joi.array().items(Joi.string()).required().min(1),
+          }).required(),
+        )
+        .required()
+        .min(1),
+    });
+    await jurisdictionSchema.validateAsync(jurisdiction);
     await knex.insert({ name, clientId, clientSecret, scopes, jurisdiction }).into(TABLE_NAME);
   },
 

--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -16,8 +16,8 @@ export const clientApplicationRepository = {
     return dtos.map(toDomain);
   },
 
-  async create({ name, clientId, clientSecret, scopes }) {
-    await knex.insert({ name, clientId, clientSecret, scopes }).into(TABLE_NAME);
+  async create({ name, clientId, clientSecret, scopes, jurisdiction }) {
+    await knex.insert({ name, clientId, clientSecret, scopes, jurisdiction }).into(TABLE_NAME);
   },
 
   async removeByClientId(clientId) {

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -77,6 +77,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         clientId: 'clientId-appli0',
         clientSecret: 'secret-app0',
         scopes: ['scope0'],
+        jurisdiction: { rules: [{ name: 'tags', value: ['COLLEGE'] }] },
       };
 
       // when


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Le script de gestion des applications clientes ne permet pas d'ajouter une juridiction à celles-ci.

## 🌳 Proposition

On ajoute l'option `--jurisdiction` au script `./scripts/identity-access-management/client-applications.js`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Se connecter au conteneur
```
scalingo -a pix-api-maddo-review-pr12234 run bash
```

Afficher les juridictions des applications clientes : 
```
node ./scripts/identity-access-management/client-applications.js list
```

Ajouter une application cliente avec sa juridiction : 
```
node ./scripts/identity-access-management/client-applications.js add --name clientTest --clientId clientTest --clientSecret pix123 --scope testScope --jurisdiction '{"rules": [{"name": "tags", "value": ["COLLEGE"]}'
```
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
