### PR TITLE
[TECH] Ajout du juryId sur la route de rescoring (PIX-17781).

### DIFF
--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -2,10 +2,11 @@ import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/r
 import { usecases } from '../../evaluation/domain/usecases/index.js';
 
 const rescoreCertification = async function (request, h) {
+  const juryId = request.auth.credentials.userId;
   const certificationCourseId = request.params.certificationCourseId;
   const locale = extractLocaleFromRequest(request);
 
-  await usecases.rescoreCertification({ certificationCourseId, locale });
+  await usecases.rescoreCertification({ certificationCourseId, juryId, locale });
 
   return h.response().code(201);
 };

--- a/api/src/certification/evaluation/domain/events/CertificationRescored.js
+++ b/api/src/certification/evaluation/domain/events/CertificationRescored.js
@@ -4,9 +4,11 @@ export default class CertificationRescored {
   /**
    * @param {Object} params
    * @param {number} params.certificationCourseId - certification course that will be rescored
+   * @param {number} params.juryId - ID of the jury member that performs the rescoring action
    */
-  constructor({ certificationCourseId }) {
+  constructor({ certificationCourseId, juryId }) {
     assertNotNullOrUndefined(certificationCourseId);
     this.certificationCourseId = certificationCourseId;
+    this.juryId = juryId;
   }
 }

--- a/api/src/certification/evaluation/domain/usecases/rescore-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-certification.js
@@ -6,6 +6,7 @@ import CertificationRescored from '../events/CertificationRescored.js';
 export const rescoreCertification = async ({
   certificationCourseId,
   locale,
+  juryId,
   certificationAssessmentRepository,
   evaluationSessionRepository,
   services,
@@ -31,7 +32,7 @@ export const rescoreCertification = async ({
   }
 
   return services.handleV3CertificationScoring({
-    event: new CertificationRescored({ certificationCourseId }),
+    event: new CertificationRescored({ certificationCourseId, juryId }),
     certificationAssessment,
     locale,
     dependencies: { findByCertificationCourseIdAndAssessmentId: services.findByCertificationCourseIdAndAssessmentId },

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -143,6 +143,7 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
       expect(descOrderedAssessmentResults).to.have.length(2);
       const [lastAssessmentResult] = descOrderedAssessmentResults;
       expect(lastAssessmentResult.pixScore).to.be.equal(55);
+      expect(lastAssessmentResult.juryId).to.be.equal(user.id);
     });
   });
 });

--- a/api/tests/certification/evaluation/unit/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/unit/application/certification-rescoring-route_test.js
@@ -9,20 +9,24 @@ describe('Certification | Evaluation | Unit | Application | Certification Rescor
     it('should call the usecase with correct arguments and return 204 status code', async function () {
       const certificationCourseId = 123;
       const locale = 'fr-fr';
+      const juryId = 456;
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       sinon.stub(certificationRescoringController, 'rescoreCertification').returns('ok');
       sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
       sinon.stub(usecases, 'rescoreCertification').resolves('ok');
+      const auth = { credentials: { userId: juryId }, strategy: {} };
 
       // when
       const response = await httpTestServer.request(
         'POST',
         `/api/admin/certifications/${certificationCourseId}/rescore`,
+        {},
+        auth,
       );
 
       // then
-      expect(usecases.rescoreCertification).to.have.been.calledWithExactly({ certificationCourseId, locale });
+      expect(usecases.rescoreCertification).to.have.been.calledWithExactly({ certificationCourseId, juryId, locale });
       expect(response.statusCode).to.equal(201);
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/usecases/rescore-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/rescore-certification_test.js
@@ -14,6 +14,7 @@ describe('Certification | Results | Unit | Domain | Use Cases | rescore-certific
         // given
         const locale = 'fr-fr';
         const certificationCourseId = 123;
+        const juryId = 456;
         const certificationAssessmentRepository = {
           getByCertificationCourseId: sinon.stub(),
         };
@@ -37,6 +38,7 @@ describe('Certification | Results | Unit | Domain | Use Cases | rescore-certific
         // when
         await rescoreCertification({
           locale,
+          juryId,
           certificationCourseId,
           certificationAssessmentRepository,
           evaluationSessionRepository,
@@ -47,6 +49,7 @@ describe('Certification | Results | Unit | Domain | Use Cases | rescore-certific
         expect(services.handleV3CertificationScoring).to.have.been.calledWithExactly({
           event: new CertificationRescored({
             certificationCourseId: certificationAssessment.certificationCourseId,
+            juryId,
           }),
           certificationAssessment,
           locale,


### PR DESCRIPTION
## 🌸 Problème

Pour rescorer une certification, il fallait jusqu'à maintenant passer par un "hack" de rejet/dérejet de celle-ci.
Cette opération pouvait entraîner des effets de bords et est en passe d'être remplacée par une nouvelle route dédiée à cette opération de rescoring #12202 .

Nous avons toutefois remarqué que lors de la création d'un nouvel `assessment-result` via un rejet/dérejet, le juryId (ID de l'utilisateur effectuant l'opération sur pix-admin) était ajouté à l'entrée en BDD, ce qui n'est pas le cas avec cette nouvelle route de rescoring.

## 🌳 Proposition

On passe l'ID de l'utilisateur effectuant l'opération à la route pour l'ajouter en BDD lors de la création de l'`assessment-result` lié au rescoring

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Lancer la requête cURL ci-dessous
- Vérifier que l'ID de l'utilisateur `superadmin@example.net` a bien été ajoutée à l'`assessment-result` créé.

```bash
TOKEN=$(curl 'https://api-pr12238.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl -i https://api-pr12238.review.pix.fr/api/admin/certifications/2/rescore \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST
```