### PR TITLE
[TECH] Améliorer les models swagger de Maddo

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -56,12 +56,12 @@ const register = async function (server) {
                         reachedLevel: Joi.number().description('Niveau obtenu dans cette campagne'),
                         practicalDescription: Joi.string().description('Description du sujet'),
                         practicalTitle: Joi.string().description('Titre du sujet'),
-                      }).label('Tube'),
+                      }).label('CampaignParticipationTube'),
                     )
                     .description(
                       'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
                     )
-                    .label('Tubes'),
+                    .label('CampaignParticipationTubes'),
                 }).label('CampaignParticipation'),
               )
               .label('CampaignParticipations'),

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -95,12 +95,12 @@ const register = async function (server) {
                           meanLevel: Joi.number().description('Niveau moyen obtenu dans cette campagne'),
                           practicalDescription: Joi.string().description('Description du sujet'),
                           practicalTitle: Joi.string().description('Titre du sujet'),
-                        }).label('Tube'),
+                        }).label('CampaignTube'),
                       )
+                      .label('CampaignTubes')
                       .description(
                         'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
-                      )
-                      .label('Tubes'),
+                      ),
                   }).label('Campaign'),
                 )
                 .label('Campaigns'),
@@ -109,7 +109,7 @@ const register = async function (server) {
                 size: Joi.number().description('Taille de la page courante'),
                 count: Joi.number().description('Nombre total de page'),
               }).description('Information de pagination'),
-            }),
+            }).label('CampaignsResult'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/domain/usecases/extract-transform-and-load-data.js
+++ b/api/src/maddo/domain/usecases/extract-transform-and-load-data.js
@@ -10,9 +10,9 @@ export async function extractTransformAndLoadData({
 
   let context = { datawarehouseKnex, datamartKnex };
 
-  const additionnalContext = await replication.before?.(context);
+  const additionalContext = await replication.before?.(context);
 
-  context = { ...additionnalContext, ...context };
+  context = { ...additionalContext, ...context };
 
   const queryBuilder = replication.from(context);
   let chunk = [];


### PR DESCRIPTION
## 🌸 Problème

Actuellement les modèles en doublons sont nommés : Model1 et Model2, ce qui pert de l'intérêt. 

![Screenshot 2025-05-07 at 15 32 17](https://github.com/user-attachments/assets/0d40ec9c-aace-481e-8148-5a81a1844130)


## 🌳 Proposition

Nommer de manière différentes les tubes des campaigns participations vs les tubes des campaigns.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Se rendre sur le swagger de Maddo et constater qu'il n'y a plus Model1 et Model2 : `/api/documentation`
