### PR TITLE
[FEATURE] Supprimer les contraintes non génériques dans la table audit-log (PIX-17737)

### DIFF
--- a/audit-logger/src/db/migrations/20250507131419_drop-non-generic-constraints.ts
+++ b/audit-logger/src/db/migrations/20250507131419_drop-non-generic-constraints.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'audit-log';
+const ACTION_COLUMN_NAME = 'action';
+const ACTION_COLUMN_CONSTRAINT_NAME = 'audit-log_action_check';
+const CLIENT_COLUMN_NAME = 'client';
+const CLIENT_COLUMN_CONSTRAINT_NAME = 'audit-log_client_check';
+const ROLE_COLUMN_NAME = 'role';
+const ROLE_COLUMN_CONSTRAINT_NAME = 'audit-log_role_check';
+
+const up = async function (knex: Knex): Promise<void> {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${ACTION_COLUMN_CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CLIENT_COLUMN_CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${ROLE_COLUMN_CONSTRAINT_NAME}"`);
+};
+
+const down = async function (knex: Knex): Promise<void> {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${ACTION_COLUMN_CONSTRAINT_NAME}" CHECK ( "${ACTION_COLUMN_NAME}" IN ('ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED') )`,
+  );
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CLIENT_COLUMN_CONSTRAINT_NAME}" CHECK ( "${CLIENT_COLUMN_NAME}" IN ('PIX_ADMIN', 'PIX_APP') )`,
+  );
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${ROLE_COLUMN_CONSTRAINT_NAME}" CHECK ( "${ROLE_COLUMN_NAME}" IN ('SUPER_ADMIN', 'SUPPORT', 'USER') )`,
+  );
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Actuellement AuditLogger a des contraintes de type métier sur 3 des types de données qu’il manipule : 
* contrainte métier sur les actions,
* contrainte métier sur les rôles,
* contrainte métier sur les clients.

Ces contraintes sont notamment présentes au niveau de la base de données.

## 🌳 Proposition

Proposition : enlever toutes les contraintes métier sur les colonnes `action`, `role`, `client`.

## 🐝 Remarques

RAS

## 🤧 Pour tester

1. Réaliser la validation de la migration de la DB : 
   1. Exécuter la commande `npm run db:migrate` en local,
   2. Vérifier que la table `audit-log` a bien été modifiée avec la suppression de toutes les contraintes sur les colonnes `action`, `role`, `client`.
2. Exécuter un test d’insertion d'un enregistrement quelconque ne correspondant pas aux précédentes contraintes, par exemple :  
```sql
pix_audit_logging=# insert into "audit-log" ("action", "client", "role", "occurredAt", "userId", "targetUserId") values ('someAction', 'someClient', 'someRole', now(), 1, 1);
```
3. Effectuer le rollback en exécutant les commandes suivantes : 
```shell
npm run db:reset
npm run db:rollback:latest
```
4.  Constater que la table `audit-log` a de nouveau des contraintes sur les colonnes `action`, `role`, `client`.



