### PR TITLE
[FEATURE] : Envoyer tous les passage events de type FLASHCARDS au service passage-events (PIX-17779)

### DIFF
--- a/api/src/devcomp/domain/models/passage-events/flashcard-events.js
+++ b/api/src/devcomp/domain/models/passage-events/flashcard-events.js
@@ -7,7 +7,7 @@ import { PassageEventWithElement } from './PassageEventWithElement.js';
 
 const AutoAssessmentEnumValues = Object.freeze({
   YES: 'yes',
-  MAYBE: 'maybe',
+  ALMOST: 'almost',
   NO: 'no',
 });
 
@@ -74,7 +74,7 @@ class FlashcardsCardAutoAssessedEvent extends PassageEventWithElement {
     assertEnumValue(
       AutoAssessmentEnumValues,
       autoAssessment,
-      'The autoAssessment value must be one of these : [‘yes‘, ‘maybe‘, ‘no‘]',
+      'The autoAssessment value must be one of these : [‘yes‘, ‘almost‘, ‘no‘]',
     );
 
     this.elementId = elementId;

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -13,6 +13,126 @@
   },
   "grains": [
     {
+      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
+      "type": "discovery",
+      "title": "Voici un grain de découverte",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
+            "type": "flashcards",
+            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
+            "title": "Introduction à la poésie",
+            "introImage": {
+              "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
+            },
+            "cards": [
+              {
+                "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
+                "recto": {
+                  "image": {
+                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                  },
+                  "text": "Qui a écrit « Le Dormeur du Val ? »"
+                },
+                "verso": {
+                  "image": {
+                    "url": ""
+                  },
+                  "text": "<p>Arthur Rimbaud</p>"
+                }
+              },
+              {
+                "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
+                "recto": {
+                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
+                },
+                "verso": {
+                  "text": "<p>Léopoldine</p>"
+                }
+              },
+              {
+                "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
+                "recto": {
+                  "image": {
+                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                  },
+                  "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
+                },
+                "verso": {
+                  "image": {
+                    "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
+                  },
+                  "text": "<p>Le chat</p>"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
+            "type": "expand",
+            "title": "Voici un indice pour répondre à la magnifique flashcard",
+            "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
+            "type": "text",
+            "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "84726001-1665-457d-8f13-4a74dc4768ea",
+            "type": "text",
+            "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
+            "type": "separator"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
+            "type": "text",
+            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
+            "type": "text",
+            "content": "<p>Et là, voici une image&#8239;!</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+            "type": "image",
+            "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
+            "alt": "Dessin détaillé dans l'alternative textuelle",
+            "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
+            "legend": "Faite avant le séminaire de juin 2023",
+            "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
+          }
+        }
+      ]
+    },
+    {
       "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
       "type": "transition",
       "title": "",
@@ -204,126 +324,6 @@
             "url": "https://epreuves.pix.fr/fr/qcu_image/1d_iconewriter.html",
             "instruction": "<p>Instruction</p>",
             "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
-      "type": "discovery",
-      "title": "Voici un grain de découverte",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
-            "type": "flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
-            "title": "Introduction à la poésie",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Qui a écrit « Le Dormeur du Val ? »"
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p>Arthur Rimbaud</p>"
-                }
-              },
-              {
-                "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
-                "recto": {
-                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
-                },
-                "verso": {
-                  "text": "<p>Léopoldine</p>"
-                }
-              },
-              {
-                "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
-                  },
-                  "text": "<p>Le chat</p>"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
-            "type": "expand",
-            "title": "Voici un indice pour répondre à la magnifique flashcard",
-            "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
-            "type": "text",
-            "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "84726001-1665-457d-8f13-4a74dc4768ea",
-            "type": "text",
-            "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
-            "type": "text",
-            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
-            "type": "text",
-            "content": "<p>Et là, voici une image&#8239;!</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
-            "legend": "Faite avant le séminaire de juin 2023",
-            "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
           }
         }
       ]

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/flashcard-events_test.js
@@ -263,7 +263,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | flashcard-e
 
         // then
         expect(error).to.be.instanceOf(TypeError);
-        expect(error.message).to.equal('The autoAssessment value must be one of these : [‘yes‘, ‘maybe‘, ‘no‘]');
+        expect(error.message).to.equal('The autoAssessment value must be one of these : [‘yes‘, ‘almost‘, ‘no‘]');
       });
     });
   });

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -126,6 +126,16 @@ export default class ModulixFlashcards extends Component {
       cardId: this.currentCard.id,
     };
     this.args.onSelfAssessment(selfAssessmentData);
+
+    this.passageEvents.record({
+      type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+      data: {
+        autoAssessment: userAssessment,
+        cardId: this.currentCard.id,
+        elementId: this.args.flashcards.id,
+      },
+    });
+
     this.incrementCounterFor(userAssessment);
     this.goToNextCard();
 

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -92,6 +92,15 @@ export default class ModulixFlashcards extends Component {
   @action
   flipCard() {
     this.displayedSideName = this.displayedSideName === 'recto' ? 'verso' : 'recto';
+    if (this.displayedSideName === 'verso') {
+      this.passageEvents.record({
+        type: 'FLASHCARDS_VERSO_SEEN',
+        data: {
+          cardId: this.currentCard.id,
+          elementId: this.args.flashcards.id,
+        },
+      });
+    }
   }
 
   incrementCounterFor(userAssessment) {

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -92,15 +92,14 @@ export default class ModulixFlashcards extends Component {
   @action
   flipCard() {
     this.displayedSideName = this.displayedSideName === 'recto' ? 'verso' : 'recto';
-    if (this.displayedSideName === 'verso') {
-      this.passageEvents.record({
-        type: 'FLASHCARDS_VERSO_SEEN',
-        data: {
-          cardId: this.currentCard.id,
-          elementId: this.args.flashcards.id,
-        },
-      });
-    }
+    const eventType = this.displayedSideName === 'recto' ? 'FLASHCARDS_RECTO_REVIEWED' : 'FLASHCARDS_VERSO_SEEN';
+    this.passageEvents.record({
+      type: eventType,
+      data: {
+        cardId: this.currentCard.id,
+        elementId: this.args.flashcards.id,
+      },
+    });
   }
 
   incrementCounterFor(userAssessment) {

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -75,6 +75,13 @@ export default class ModulixFlashcards extends Component {
     this.currentCardIndex = 0;
     this.displayedSideName = 'recto';
     this.counters = { ...INITIAL_COUNTERS_VALUE };
+
+    this.passageEvents.record({
+      type: 'FLASHCARDS_RETRIED',
+      data: {
+        elementId: this.args.flashcards.id,
+      },
+    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -212,7 +212,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     });
 
     module('when the user self-assesses their response', function () {
-      test('should display the next card and send self-assessment', async function (assert) {
+      test('should display the next card and send self-assessment event', async function (assert) {
         // given
         const { flashcards } = _getFlashcards();
 
@@ -232,6 +232,13 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         assert.ok(screen.getByText('Qui a écrit le Dormeur du Val ?'));
         assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 2, totalCards: 2 })));
         assert.true(onSelfAssessmentStub.calledOnce);
+
+        assert.ok(
+          passageEventsService.record.calledWith({
+            type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
+            data: { autoAssessment: 'no', cardId: 'e1de6394-ff88-4de3-8834-a40057a50ff4', elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+          }),
+        );
       });
     });
 

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -317,7 +317,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   });
 
   module('when user clicks on the "Retry" button', function () {
-    test('should display intro card', async function (assert) {
+    test('should display intro card and send flashcards retried event', async function (assert) {
       // given
       const { flashcards } = _getFlashcards();
 
@@ -338,6 +338,12 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') })).exists();
+      assert.ok(
+        passageEventsService.record.calledWith({
+          type: 'FLASHCARDS_RETRIED',
+          data: { elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+        }),
+      );
     });
 
     module('when user click on the "start" button', function () {

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -236,7 +236,11 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         assert.ok(
           passageEventsService.record.calledWith({
             type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
-            data: { autoAssessment: 'no', cardId: 'e1de6394-ff88-4de3-8834-a40057a50ff4', elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+            data: {
+              autoAssessment: 'no',
+              cardId: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+              elementId: '71de6394-ff88-4de3-8834-a40057a50ff4',
+            },
           }),
         );
       });
@@ -264,6 +268,27 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         // then
         assert.ok(screen.getByText('Terminé'));
       });
+    });
+  });
+
+  module('when user clicks on "See again" button', function () {
+    test('should send a flashcards recto reviewed event', async function (assert) {
+      // given
+      const { flashcards } = _getFlashcards();
+
+      // when
+      await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
+      await clickByName(t('pages.modulix.buttons.flashcards.start'));
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
+      await clickByName(t('pages.modulix.buttons.flashcards.seeAgain'));
+
+      // then
+      assert.ok(
+        passageEventsService.record.calledWith({
+          type: 'FLASHCARDS_RECTO_REVIEWED',
+          data: { cardId: 'e1de6394-ff88-4de3-8834-a40057a50ff4', elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+        }),
+      );
     });
   });
 

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -190,7 +190,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
   });
 
   module('when users clicks on the "Continue" button', function () {
-    test('should display options buttons to answer', async function (assert) {
+    test('should display options buttons to answer and send a flashcards verso seen event', async function (assert) {
       // given
       const { flashcards } = _getFlashcards();
 
@@ -202,6 +202,13 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       // then
       assert.ok(screen.getByText(t('pages.modulix.flashcards.answerDirection')));
       assert.ok(screen.getByText(t('pages.modulix.buttons.flashcards.answers.no')));
+
+      assert.ok(
+        passageEventsService.record.calledWith({
+          type: 'FLASHCARDS_VERSO_SEEN',
+          data: { cardId: 'e1de6394-ff88-4de3-8834-a40057a50ff4', elementId: '71de6394-ff88-4de3-8834-a40057a50ff4' },
+        }),
+      );
     });
 
     module('when the user self-assesses their response', function () {

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -744,9 +744,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain1] });
       const passage = store.createRecord('passage');
 
-      const createRecordMock = sinon.mock();
-      createRecordMock.returns({ save: function () {} });
-      store.createRecord = createRecordMock;
+      const createRecordStub = sinon.stub();
+      createRecordStub.returns({ save: function () {} });
+      store.createRecord = createRecordStub;
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 


### PR DESCRIPTION
## 🌸 Problème

On a besoin d'enregistrer les traces d'apprentissage liées aux flashcards en base à partir d'actions utilisateurs.

## 🌳 Proposition
On a ajouté l'appel au service passage-events et à sa méthode record pour enregistrer les événements en base dans les méthodes concernées dans le fichier flashcards.gjs.

## 🐝 Remarques
Remarque 1 
Actuellement, on a tous les événements Matomo au niveau de passage.gjs, ils sont centralisés.
En l'état actuel du code, l’enregistrement des traces d’apprentissage nécessite de créer des envois à partir du composant flashcards.gjs.
Problème : on aurait donc des envois d'événement Matomo à un endroit / des envois d'événements type trace d’apprentissage pour les passages à un endroit, et des envois d'événements flashcards dans un autre.

Besoin de faire une refacto éventuellement pour ça dans un second temps, à voir en équipe.

Remarque 2
On en a profité pour modifier le "maybe" comme valeur d'auto-assessment en "almost", il y avait une incohérence front-back qui créait une erreur 500.

## 🤧 Pour tester
Aller sur le module modules/bac-a-sable en RA
Et aller jusqu'à l'étape Flashcards
- Au clic sur "Commencer", un flashcards started event doit être lancé et enregistré en base
- Au clic sur "Voir la réponse", un flashcards verso seen event doit être lancé et enregistré en base
- Au clic sur "Revoir la question", un flashcards recto reviewed event doit être lancé et enregistré en base
- Au clic sur "Réessayer", un flashcards retried event doit être lancé et enregistré en base
