### PR TITLE
[FEATURE] Élargir les contraintes de UserAnonymizedEventLoggingJob pour pouvoir traiter tous les événements  (PIX-17789)

### DIFF
--- a/api/src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js
+++ b/api/src/identity-access-management/domain/models/UserAnonymizedEventLoggingJob.js
@@ -23,5 +23,7 @@ const USER_ANONYMIZED_SCHEMA = Joi.object({
   updatedByUserId: Joi.number().integer().required(),
   client: Joi.string().valid('PIX_APP', 'PIX_ADMIN').required(),
   occurredAt: Joi.date().required(),
-  role: Joi.string().valid(USER_ROLE, PIX_ADMIN.ROLES.SUPER_ADMIN, PIX_ADMIN.ROLES.SUPPORT).required(),
+  role: Joi.string()
+    .valid(USER_ROLE, ...Object.values(PIX_ADMIN.ROLES))
+    .required(),
 });


### PR DESCRIPTION
## 🌸 Problème

Actuellement l'utilisation du script permanent d'anonymisation en masse, ajouté par #12157, ne permet pas de fournir un `anonymizerId` appartenant à un utilisateur ayant un rôle `METIER`. Ce n'est pas un problème de droits d'effectuer une action pour un rôle, mais plutôt le traitement d'événements.

## 🌳 Proposition

Élargir les rôles possiblement utilisés par le job `UserAnonymizedEventLoggingJob` en y ajoutant **tous les rôles** de Pix Admin.

Ainsi concrètement, la modification proposée par cette PR ne donne pas le droit à un utilisateur ayant le rôle `METIER` d'effectuer de l'anonymisation en masse, mais plutôt elle permet d'exécuter le script d'anonymisation en masse en spécifiant que ce script est exécuté à la demande d'un utilisateur ayant le rôle `METIER`, en l’occurrence la responsable des Données Personnelles.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Pour le test fonctionnel on pourra utiliser le script d'anonymisation en masse avec la proposition de fichier `test_anonymisation.csv` suivant : 
```csv 
userId;
1000;
90003;
10002;
```

1. Démarrer l’AuditLogger
   ```shell
   cd audit-logger/
   npm run build
   npm run db:reset
   npm start
   ```
2. Démarrer les jobs
3. Exécuter le script d'anonymisation en masse avec un `anonymizerId` correspondant à un user ayant le rôle `METIER`
   ```shell
   node src/identity-access-management/scripts/anonymize-users-in-batch.script.js --file test_anonymisation.csv --anonymizerId 90001
   ```
4. Constater que les logs correspondant à ces actions sont bien présents dans l'AuditLogger.
