### PR TITLE
[FEATURE] Supprimer les contraintes non génériques dans AuditLogger (PIX-17790)

### DIFF
--- a/audit-logger/src/lib/controllers/create-audit-log.controller.ts
+++ b/audit-logger/src/lib/controllers/create-audit-log.controller.ts
@@ -2,7 +2,6 @@ import { type Request, type ResponseObject, type ResponseToolkit, type ServerRou
 import Joi from 'joi';
 
 import { type AuditLog } from '../domain/models/audit-log.js';
-import { AuditLogActionTypes, AuditLogClientTypes, AuditLogRoleTypes } from '../domain/models/models.definition.js';
 import { type CreateAuditLogUseCase } from '../domain/usecases/create-audit-log.usecase.js';
 import { createAuditLogUseCase } from '../domain/usecases/usecases.js';
 
@@ -41,16 +40,10 @@ export const CREATE_AUDIT_LOG_ROUTE: ServerRoute = {
           Joi.object({
             targetUserId: Joi.string().required(),
             userId: Joi.string().required(),
-            action: Joi.string()
-              .valid(...AuditLogActionTypes)
-              .required(),
+            action: Joi.string().required(),
             occurredAt: Joi.string().isoDate().required(),
-            role: Joi.string()
-              .valid(...AuditLogRoleTypes)
-              .required(),
-            client: Joi.string()
-              .valid(...AuditLogClientTypes)
-              .required(),
+            role: Joi.string().required(),
+            client: Joi.string().required(),
             data: Joi.object().optional(),
           }),
         )

--- a/audit-logger/src/lib/domain/models/audit-log.ts
+++ b/audit-logger/src/lib/domain/models/audit-log.ts
@@ -1,13 +1,12 @@
-import { type AuditLogAction, type AuditLogClient, type AuditLogRole } from './models.definition.js';
 
 export class AuditLog {
   id?: string;
   occurredAt: Date;
-  action: AuditLogAction;
+  action: string;
   userId: string;
   targetUserId: string;
-  client: AuditLogClient;
-  role: AuditLogRole;
+  client: string;
+  role: string;
   data?: Record<string, unknown> | null;
   createdAt?: Date;
 

--- a/audit-logger/src/lib/domain/models/models.definition.ts
+++ b/audit-logger/src/lib/domain/models/models.definition.ts
@@ -1,8 +1,0 @@
-export const AuditLogActionTypes = ['ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED'] as const;
-export type AuditLogAction = (typeof AuditLogActionTypes)[number];
-
-export const AuditLogClientTypes = ['PIX_ADMIN', 'PIX_APP'] as const;
-export type AuditLogClient = (typeof AuditLogClientTypes)[number];
-
-export const AuditLogRoleTypes = ['SUPER_ADMIN', 'SUPPORT', 'USER'] as const;
-export type AuditLogRole = (typeof AuditLogRoleTypes)[number];


### PR DESCRIPTION
## 🌸 Problème

L'audit logger doit être générique

## 🌳 Proposition

Supprimer les contraintes non génériques du code de l'audit logger sur l'action, le rôle, le client.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Pour tester en local :
```shell
cd audit-logger/
npm run build
npm run db:reset
npm start
```
  
Faites cette commande curl
```shell
curl -X POST http://localhost:3001/api/audit-logs \
-H "Content-Type: application/json" \
-u pix-api:pixApiClientSecretTest \
-d '{
  "targetUserId": "1",
  "userId": "2",
  "action": "DIFFERENT",
  "occurredAt": "2023-07-05",
  "role": "OTHER",
  "client": "ELSE"
}'
```

Vérifiez la réponse 204 et l'inscription dans la base de données
Allez sur la branche dev et vérifiez que la commande renvoie une erreur