### PR TITLE
[FEATURE] Réinitialiser le numéro de séquence lors du démarrage d'un passage dans Pix App (PIX-17710)

### DIFF
--- a/mon-pix/app/services/passage-events.js
+++ b/mon-pix/app/services/passage-events.js
@@ -8,6 +8,7 @@ export default class PassageEvents extends Service {
 
   initialize({ passageId }) {
     this.passageId = Number(passageId);
+    this.sequenceNumber = 1;
   }
 
   async record({ type, data }) {

--- a/mon-pix/tests/unit/services/passage-events-test.js
+++ b/mon-pix/tests/unit/services/passage-events-test.js
@@ -27,6 +27,18 @@ module('Unit | Services | PassageEvents', function (hooks) {
       // then
       assert.strictEqual(service.passageId, 1984);
     });
+
+    test('should reset passage number', async function (assert) {
+      // given
+      const service = this.owner.lookup('service:passageEvents');
+      service.sequenceNumber = 10;
+
+      // when
+      service.initialize({ passageId: '1984' });
+
+      // then
+      assert.strictEqual(service.sequenceNumber, 1);
+    });
   });
 
   module('#record', function () {


### PR DESCRIPTION
## 🌸 Problème

Actuellement, le numéro de séquence ne se réinitialise pas lorsqu'on change de module et de passage. 

## 🌳 Proposition

Ajouter, dans la fonction `initialize` du service `passage-events`, cette fonctionnalité.

## 🐝 Remarques

RAS

## 🤧 Pour tester

- CI au vert (on ne peut pas tester car il n'y a pas de liens vers un modulix dans l'app)