### PR TITLE
[FEATURE] Traiter les événements "PASSAGE_TERMINATED" comme les autres enregistrements de traces d'apprentissage (PIX-17663)(PIX-16729)

### DIFF
--- a/api/src/devcomp/application/passage-events/passage-events-controller.js
+++ b/api/src/devcomp/application/passage-events/passage-events-controller.js
@@ -10,7 +10,7 @@ const create = async function (request, h, { usecases, passageEventSerializer })
       userId: requestResponseUtils.extractUserIdFromRequest(request),
     });
 
-    return h.response().created();
+    return h.response().code(204);
   } catch (error) {
     if (error instanceof DomainError) {
       throw new BadRequestError(error);

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,7 +1,5 @@
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
-const TERMINATE_PASSAGE_SEQUENCE_NUMBER = 1000;
-
 const create = async function (request, h, { usecases, passageSerializer }) {
   const {
     'module-id': moduleSlug,
@@ -38,17 +36,14 @@ const verifyAndSaveAnswer = async function (request, h, { usecases, elementAnswe
 };
 
 const terminate = async function (request, h, { usecases, passageSerializer }) {
-  const sequenceNumber = TERMINATE_PASSAGE_SEQUENCE_NUMBER;
   const { passageId } = request.params;
-  const requestTimestamp = requestResponseUtils.extractTimestampFromRequest(request);
   const updatedPassage = await usecases.terminatePassage({
     passageId,
-    sequenceNumber,
-    occurredAt: new Date(requestTimestamp),
   });
+
   return passageSerializer.serialize(updatedPassage);
 };
 
 const passageController = { create, verifyAndSaveAnswer, terminate };
 
-export { passageController, TERMINATE_PASSAGE_SEQUENCE_NUMBER };
+export { passageController };

--- a/api/src/devcomp/domain/usecases/record-passage-events.js
+++ b/api/src/devcomp/domain/usecases/record-passage-events.js
@@ -13,7 +13,7 @@ const recordPassageEvents = async function ({ events, userId, passageRepository,
 async function _validatePassage({ event, userId, passageRepository, passageEventRepository }) {
   const passage = await passageRepository.get({ passageId: event.passageId });
 
-  if (passage.terminatedAt != null) {
+  if (passage.terminatedAt != null && event.type !== 'PASSAGE_TERMINATED') {
     throw new DomainError(`Passage with id ${event.id} is terminated.`);
   }
 

--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -1,23 +1,14 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { PassageDoesNotExistError, PassageTerminatedError } from '../errors.js';
-import { PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 
-const terminatePassage = withTransaction(async function ({
-  passageId,
-  occurredAt,
-  sequenceNumber,
-  passageRepository,
-  passageEventRepository,
-}) {
+const terminatePassage = withTransaction(async function ({ passageId, passageRepository }) {
   const passage = await _getPassage({ passageId, passageRepository });
   if (passage.terminatedAt) {
     throw new PassageTerminatedError();
   }
   passage.terminate();
   const terminatedPassage = await passageRepository.update({ passage });
-  const event = new PassageTerminatedEvent({ passageId, sequenceNumber, occurredAt });
-  await passageEventRepository.record(event);
   return terminatedPassage;
 });
 

--- a/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-events-controller_test.js
@@ -36,7 +36,7 @@ describe('Acceptance | Controller | passage-events-controller', function () {
       });
 
       // then
-      expect(response.statusCode).to.equal(201);
+      expect(response.statusCode).to.equal(204);
 
       const createdEvent = await knex('passage-events').where({ passageId: passage.id, sequenceNumber: 1 }).first();
       expect(createdEvent).to.not.be.undefined;

--- a/api/tests/devcomp/unit/application/passage-events/passage-events-controller_test.js
+++ b/api/tests/devcomp/unit/application/passage-events/passage-events-controller_test.js
@@ -17,11 +17,11 @@ describe('Unit | Devcomp | Application | Passage-Events | Controller', function 
         recordPassageEvents: sinon.stub(),
       };
       usecases.recordPassageEvents.resolves();
-      const created = sinon.stub();
+      const code = sinon.stub();
       const userId = 123;
       sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userId);
       const hStub = {
-        response: () => ({ created }),
+        response: () => ({ code }),
       };
 
       // when
@@ -36,7 +36,7 @@ describe('Unit | Devcomp | Application | Passage-Events | Controller', function 
         events: deserializedPayload,
         userId,
       });
-      expect(created).to.have.been.calledOnce;
+      expect(code).to.have.been.calledOnce;
     });
     context('when recordPassageEvents usecase throws domain error', function () {
       it('should throw a "BadRequestError"', async function () {

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -1,7 +1,4 @@
-import {
-  passageController,
-  TERMINATE_PASSAGE_SEQUENCE_NUMBER,
-} from '../../../../../src/devcomp/application/passages/controller.js';
+import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
 import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
@@ -121,20 +118,14 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
   describe('#terminate', function () {
     it('should call terminate use-case and return serialized passage', async function () {
       // given
-      const requestTimestamp = new Date('2025-01-01').getTime();
       const serializedPassage = Symbol('serialized modules');
       const passageId = Symbol('passage-id');
-      const sequenceNumber = TERMINATE_PASSAGE_SEQUENCE_NUMBER;
       const passage = Symbol('passage');
-      const extractTimestampStub = sinon
-        .stub(requestResponseUtils, 'extractTimestampFromRequest')
-        .returns(requestTimestamp);
+
       const usecases = {
         terminatePassage: sinon.stub(),
       };
-      usecases.terminatePassage
-        .withArgs({ passageId, sequenceNumber, occurredAt: new Date(requestTimestamp) })
-        .returns(passage);
+      usecases.terminatePassage.withArgs({ passageId }).returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };
@@ -148,7 +139,6 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
 
       // then
       expect(returned).to.deep.equal(serializedPassage);
-      expect(extractTimestampStub).to.have.been.calledOnce;
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -1,5 +1,4 @@
 import { PassageDoesNotExistError, PassageTerminatedError } from '../../../../../src/devcomp/domain/errors.js';
-import { PassageTerminatedEvent } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
 import { terminatePassage } from '../../../../../src/devcomp/domain/usecases/terminate-passage.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -51,18 +50,13 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
         expect(error).to.be.instanceof(PassageTerminatedError);
       });
 
-      it('should call terminate method and update passage and return it, then record an event', async function () {
+      it('should call terminate method and update passage and return it', async function () {
         // given
         const passageId = 1234;
-        const sequenceNumber = 1;
-        const occurredAt = new Date('2025-01-01');
 
         const passageRepository = {
           get: sinon.stub(),
           update: sinon.stub(),
-        };
-        const passageEventRepository = {
-          record: sinon.stub(),
         };
 
         const passage = {
@@ -77,21 +71,15 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
         };
         passageRepository.update.withArgs({ passage }).resolves(updatedPassage);
 
-        const event = new PassageTerminatedEvent({ passageId, occurredAt, sequenceNumber });
-
         // when
         const returnedPassage = await terminatePassage({
           passageId,
-          occurredAt,
-          sequenceNumber,
           passageRepository,
-          passageEventRepository,
         });
 
         // then
         expect(passage.terminate).to.have.been.calledOnce;
         expect(returnedPassage).to.equal(updatedPassage);
-        expect(passageEventRepository.record).to.have.been.calledOnceWithExactly(event);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -14,6 +14,7 @@ export default class ModulePassage extends Component {
   @service metrics;
   @service store;
   @service modulixAutoScroll;
+  @service passageEvents;
 
   displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
@@ -118,6 +119,9 @@ export default class ModulePassage extends Component {
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
       'pix-event-name': `Click sur le bouton Terminer du grain : ${grainId}`,
+    });
+    this.passageEvents.record({
+      type: 'PASSAGE_TERMINATED',
     });
     return this.router.transitionTo('module.recap', this.args.module);
   }

--- a/mon-pix/app/services/passage-events.js
+++ b/mon-pix/app/services/passage-events.js
@@ -1,7 +1,9 @@
 import Service, { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
 
 export default class PassageEvents extends Service {
   @service store;
+  @service requestManager;
 
   passageId = null;
   sequenceNumber = 1;
@@ -14,16 +16,19 @@ export default class PassageEvents extends Service {
   async record({ type, data }) {
     this.sequenceNumber++;
 
-    const passageEventsCollection = this.store.createRecord('passage-events-collection');
-    passageEventsCollection.events = [
+    const events = [
       {
         type,
-        passageId: this.passageId,
-        sequenceNumber: this.sequenceNumber,
-        occurredAt: new Date().getTime(),
+        'passage-id': this.passageId,
+        'sequence-number': this.sequenceNumber,
+        'occurred-at': new Date().getTime(),
         ...data,
       },
     ];
-    passageEventsCollection.save();
+    return this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/passage-events`,
+      method: 'POST',
+      body: JSON.stringify({ data: { attributes: { events } } }),
+    });
   }
 }

--- a/mon-pix/mirage/routes/passages/create-passage-events.js
+++ b/mon-pix/mirage/routes/passages/create-passage-events.js
@@ -1,0 +1,6 @@
+export default function (schema, request) {
+  const params = JSON.parse(request.requestBody);
+  const events = params.data.attributes['events'];
+
+  return schema.create('passage-events-collection', { events });
+}

--- a/mon-pix/mirage/routes/passages/index.js
+++ b/mon-pix/mirage/routes/passages/index.js
@@ -1,4 +1,5 @@
 import createPassage from './create-passage';
+import createPassageEvents from './create-passage-events';
 import onElementAnswer from './submit-answer';
 import terminatePassage from './terminate-passage';
 
@@ -6,4 +7,5 @@ export default function index(config) {
   config.post('/passages', createPassage);
   config.post('/passages/:passageId/answers', onElementAnswer);
   config.post('/passages/:passageId/terminate', terminatePassage);
+  config.post('/passage-events', createPassageEvents);
 }

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1249,6 +1249,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = sinon.stub();
       const store = this.owner.lookup('service:store');
+      const passageEventsService = this.owner.lookup('service:passage-events');
+      passageEventsService.record = sinon.stub();
 
       const qcuElement = {
         instruction: 'instruction',
@@ -1279,6 +1281,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.id}`,
         'pix-event-name': `Click sur le bouton Terminer du grain : ${grain.id}`,
+      });
+      sinon.assert.calledWithExactly(passageEventsService.record, {
+        type: 'PASSAGE_TERMINATED',
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -701,6 +701,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       metrics.add = sinon.stub();
 
       const store = this.owner.lookup('service:store');
+      const passageEvents = this.owner.lookup('service:passage-events');
       const firstCard = {
         id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
         recto: {
@@ -747,6 +748,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const createRecordStub = sinon.stub();
       createRecordStub.returns({ save: function () {} });
       store.createRecord = createRecordStub;
+
+      passageEvents.record = sinon.stub();
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 


### PR DESCRIPTION
## 🌸 Problème

PASSAGE_TERMINATED est une classe à part dans le domain.

## 🌳 Proposition

On intègre les passages terminés aux enregistrements d'event.

## 🐝 Remarques

* _validatePassage fait désormais un peu trop de checks : à refacto avec une couche d'abstraction supplémentaire (ex: objet du domain PassageEventsSequence)
* Après discussion, l'implémentation de la méthode record sur le service `passage-events` a été modifié pour ne plus passer par l'adapter. On utilise maintenant le service request manager pour envoyer la requête 😄 
* L'API POST /passage-events a été mis à jour pour renvoyer une 204 au lieu d'une 201 pour éviter une erreur sur le requestManager (JSON.parse d'une réponse vide).


## 🤧 Pour tester

Se mettre sur un module en RA (par exemple : chatgpt-vraiment-neutre).
Terminer le module et vérifier qu'un event de type PASSAGE_TERMINATED est bien envoyé avec la route /passage-events.