### PR TITLE
[TECH] Migrer le feature toggle pour le bouton magique vers le nouveau système

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,13 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isAlwaysOkValidateNextChallengeEndpointEnabled: {
+    description:
+      "Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint. The api musts bee restarted after modification",
+    type: 'boolean',
+    defaultValue: false,
+    tags: ['restarted'],
+  },
   isAsyncQuestRewardingCalculationEnabled: {
     type: 'boolean',
     description: 'Used to switch between synchronous and asynchronous mode for quest reward calculation',

--- a/api/sample.env
+++ b/api/sample.env
@@ -793,13 +793,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # FEATURE TOGGLES
 # ===================
 
-# Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=false
-
 # Control the scope of certification result tokens
 #
 # presence: optional

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -2,11 +2,9 @@ import Joi from 'joi';
 
 import { assessmentAuthorization } from '../../../evaluation/application/pre-handlers/assessment-authorization.js';
 import { securityPreHandlers } from '../../application/security-pre-handlers.js';
-import { config } from '../../config.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
 import { assessmentController } from './assessment-controller.js';
-
-const { featureToggles } = config;
 
 const register = async function (server) {
   const routes = [
@@ -175,7 +173,10 @@ const register = async function (server) {
     },
   ];
 
-  if (featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled) {
+  const isAlwaysOkValidateNextChallengeEndpointEnabled = await featureToggles.get(
+    'isAlwaysOkValidateNextChallengeEndpointEnabled',
+  );
+  if (isAlwaysOkValidateNextChallengeEndpointEnabled) {
     routes.push({
       method: 'POST',
       path: '/api/admin/assessments/{id}/always-ok-validate-next-challenge',

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -133,7 +133,6 @@ const schema = Joi.object({
   EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN: Joi.string().optional().default('3d'),
   ENABLE_KNEX_PERFORMANCE_MONITORING: Joi.string().optional().valid('true', 'false'),
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
-  FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
@@ -292,9 +291,6 @@ const configuration = (function () {
     },
     featureToggles: {
       deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
-      isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
-        process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
-      ),
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
@@ -507,7 +503,6 @@ const configuration = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
-    config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isDirectMetricsEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -87,5 +87,21 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
       expect(lastAnswer.result).to.eql('ok');
       expect(lastAnswer.value).to.eql('FAKE_ANSWER_WITH_AUTO_VALIDATE_NEXT_CHALLENGE');
     });
+
+    it('return a htp 404 when feature toggle is set to false', async function () {
+      // given
+      await featureToggles.set('isAlwaysOkValidateNextChallengeEndpointEnabled', false);
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/admin/assessments/${assessmentId}/always-ok-validate-next-challenge`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      });
+
+      // then
+      expect(response.statusCode).to.equal(404);
+      const lastAnswer = await knex.select('*').from('answers').where({ assessmentId }).first();
+      expect(lastAnswer).to.not.exist;
+    });
   });
 });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -1,5 +1,5 @@
-import { config as settings } from '../../../../../src/shared/config.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
   createServer,
   databaseBuilder,
@@ -46,21 +46,15 @@ const learningContent = [
 ];
 
 describe('Acceptance | API | assessment-controller-auto-validate-next-challenge', function () {
-  let originalEnvValue;
   let server;
   let assessmentId;
 
   beforeEach(async function () {
-    originalEnvValue = settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled;
-    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
+    await featureToggles.set('isAlwaysOkValidateNextChallengeEndpointEnabled', true);
 
     server = await createServer();
     const learningContentObjects = learningContentBuilder(learningContent);
     await mockLearningContent(learningContentObjects);
-  });
-
-  afterEach(function () {
-    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
   });
 
   describe('POST /api/admin/assessments/:id/always-ok-validate-next-challenge', function () {

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'deprecate-pole-emploi-push-notification': false,
             'dynamic-feature-toggle-system': false,
-            'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-direct-metrics-enabled': false,
             'is-new-account-recovery-enabled': false,

--- a/api/tests/shared/unit/application/assessements/index_test.js
+++ b/api/tests/shared/unit/application/assessements/index_test.js
@@ -2,8 +2,8 @@ import { assessmentAuthorization } from '../../../../../src/evaluation/applicati
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
 import * as moduleUnderTest from '../../../../../src/shared/application/assessments/index.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { config as settings } from '../../../../../src/shared/config.js';
 import { Assessment } from '../../../../../src/shared/domain/models/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Router | assessment-router', function () {
@@ -139,15 +139,8 @@ describe('Unit | Application | Router | assessment-router', function () {
   });
 
   describe('POST /api/admin/assessments/{id}/always-ok-validate-next-challenge', function () {
-    let originalEnvValue;
-
     beforeEach(async function () {
-      originalEnvValue = settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled;
-      settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
-    });
-
-    afterEach(function () {
-      settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
+      await featureToggles.set('isAlwaysOkValidateNextChallengeEndpointEnabled', true);
     });
 
     it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {


### PR DESCRIPTION
## 🌸 Problème

Il est temps de passer le feature toggle FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT au nouveau système:)

## 🌳 Proposition

- Migrer le feature toggle dans la nouvelle configuration,

## 🐝 Remarques

On a ajouté un teste vérifiant que la route répond bien 404 si le ft est à false. 

## 🤧 Pour tester
- Se munir du bouton magique (non détaillable ici),
- Se rendre sur une page d'épreuves,
- Déclancher le bouton,
- Constater qu'il ne se passe rien,
- Modifier la valeur du ft:
```shell
scalingo -a pix-api-review-pr12250 run npm run toggles -- --key isAlwaysOkValidateNextChallengeEndpointEnabled --value true
```
- Redémarrer l'api:
```shell
scalingo -a pix-api-review-pr12250 restart
```
- Constater que lorsqu'on clique sur le bouton, la route répond correctement.