### PR TITLE
[TECH] Utiliser stage acquisition repository pour afficher le résultat dans l'export des csv (PIX-17732)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -41,7 +41,8 @@ import * as campaignMediaComplianceService from '../services/campaign-media-comp
 import * as campaignUpdateValidator from '../validators/campaign-update-validator.js';
 
 /**
- * @typedef { import ('../../../../../lib/infrastructure/repositories/badge-acquisition-repository.js')} BadgeAcquisitionRepository
+ * @typedef { import ('../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js')} BadgeAcquisitionRepository
+ * @typedef { import ('../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js')} StageAcquisitionRepository
  * @typedef { import ('../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
  * @typedef { import ('../../../../devcomp/infrastructure/repositories/tutorial-repository.js')} TutorialRepository
  * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -18,6 +18,8 @@ import { CampaignAssessmentExport } from '../../infrastructure/serializers/csv/c
  * @typedef {import ('./index.js').StageCollectionRepository} StageCollectionRepository
  * @typedef {import ('./index.js').OrganizationFeatureApi} OrganizationFeatureApi
  * @typedef {import ('./index.js').OrganizationLearnerImportFormat} OrganizationLearnerImportFormat
+ * @typedef {import ('./index.js').StageAcquisitionRepository} StageAcquisitionRepository
+ * @typedef {import ('./index.js').BadgeAcquisitionRepository} BadgeAcquisitionRepository
  */
 
 /**
@@ -35,6 +37,8 @@ import { CampaignAssessmentExport } from '../../infrastructure/serializers/csv/c
  * @param {StageCollectionRepository} params.stageCollectionRepository
  * @param {OrganizationFeatureApi} params.organizationFeatureApi
  * @param {OrganizationLearnerImportFormat} params.organizationLearnerImportFormatRepository
+ * @param {BadgeAcquisitionRepository} params.badgeAcquisitionRepository
+ * @param {StageAcquisitionRepository} params.stageAcquisitionRepository
  */
 const startWritingCampaignAssessmentResultsToStream = async function ({
   campaignId,
@@ -51,6 +55,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   stageCollectionRepository,
   organizationFeatureApi,
   organizationLearnerImportFormatRepository,
+  stageAcquisitionRepository,
 }) {
   let additionalHeaders = [];
   const campaign = await campaignRepository.get(campaignId);
@@ -93,6 +98,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
       campaignParticipationInfos,
       knowledgeElementRepository,
       badgeAcquisitionRepository,
+      stageAcquisitionRepository,
       knowledgeElementSnapshotRepository,
     )
     .then(() => {

--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -24,6 +24,7 @@ class CampaignAssessmentResultLine {
     stageCollection,
     participantKnowledgeElementsByCompetenceId,
     acquiredBadges,
+    acquiredStages,
     translate,
   }) {
     this.organization = organization;
@@ -39,10 +40,8 @@ class CampaignAssessmentResultLine {
       _.map(participantKnowledgeElementsByCompetenceId, (knowledgeElements) => knowledgeElements.length),
     );
     this.targetedKnowledgeElementsByCompetence = participantKnowledgeElementsByCompetenceId;
-    this.acquiredBadges =
-      acquiredBadges && acquiredBadges[campaignParticipationInfo.campaignParticipationId]
-        ? acquiredBadges[campaignParticipationInfo.campaignParticipationId].map((badge) => badge.title)
-        : [];
+    this.acquiredStages = acquiredStages;
+    this.acquiredBadges = acquiredBadges;
     this.campaignParticipationService = campaignParticipationService;
     this.translate = translate;
 
@@ -198,10 +197,7 @@ class CampaignAssessmentResultLine {
       return this.emptyContent;
     }
 
-    const masteryPercentage = this.campaignParticipationInfo.masteryRate * 100;
-    const validatedSkillsCount = this.campaignParticipationInfo.validatedSkillsCount;
-
-    return this.stageCollection.getReachedStage(validatedSkillsCount, masteryPercentage).reachedStage - 1;
+    return this.acquiredStages.length - 1;
   }
 
   get _studentNumber() {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
@@ -1,9 +1,12 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { CampaignParticipationInfo } from '../../domain/read-models/CampaignParticipationInfo.js';
 
 const findByCampaignId = async function (campaignId) {
-  const results = await knex
+  const knexConn = DomainTransaction.getConnection();
+
+  const results = await knexConn
     .with('campaignParticipationWithUserAndRankedAssessment', (qb) => {
       qb.select([
         'campaign-participations.*',

--- a/api/src/prescription/campaign/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/target-profile-repository.js
@@ -1,13 +1,15 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
 import { Badge } from '../../../../evaluation/domain/models/Badge.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { TargetProfile } from '../../../../shared/domain/models/index.js';
 
 const getByCampaignId = async function ({ campaignId, targetProfileApi }) {
-  const { targetProfileId } = await knex('campaigns').select('targetProfileId').where({ id: campaignId }).first();
+  const knexConn = DomainTransaction.getConnection();
+
+  const { targetProfileId } = await knexConn('campaigns').select('targetProfileId').where({ id: campaignId }).first();
 
   const targetProfile = await targetProfileApi.getById(targetProfileId);
 
-  const badges = await knex('badges').where('targetProfileId', targetProfileId);
+  const badges = await knexConn('badges').where('targetProfileId', targetProfileId);
 
   return new TargetProfile({ ...targetProfile, badges: badges.map((badge) => new Badge(badge)) });
 };

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -111,7 +111,7 @@ const get = async function (id) {
     throw new NotFoundError(`Not found organization for ID ${id}`);
   }
 
-  const tagsDB = await knex('tags')
+  const tagsDB = await knexConn('tags')
     .select(['tags.id', 'tags.name'])
     .join('organization-tags', 'organization-tags.tagId', 'tags.id')
     .where('organization-tags.organizationId', id);

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -26,6 +26,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     let i18n;
     let createdAt, sharedAt, createdAtFormated, sharedAtFormated;
     let now;
+    let stageIds;
 
     beforeEach(async function () {
       i18n = getI18n();
@@ -36,8 +37,21 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         name: '+Profile 1',
         organizationId: organization.id,
       });
-      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 0 });
-      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 1 });
+      stageIds = [
+        databaseBuilder.factory.buildStage({
+          targetProfileId: targetProfile.id,
+          threshold: 0,
+          message: '0',
+          title: '0',
+        }).id,
+        databaseBuilder.factory.buildStage({
+          targetProfileId: targetProfile.id,
+          threshold: 1,
+          message: '1',
+          title: '1',
+        }).id,
+      ];
+
       databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
 
       // participation
@@ -173,6 +187,11 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               sharedAt,
             });
 
+            databaseBuilder.factory.buildStageAcquisition({
+              stageId: stageIds[0],
+              campaignParticipationId: campaignParticipation.id,
+            });
+
             databaseBuilder.factory.buildAssessment({
               campaignParticipationId: campaignParticipation.id,
               userId: participant.id,
@@ -231,7 +250,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               `"${createdAtFormated}";` +
               '"Oui";' +
               `"${sharedAtFormated}";` +
-              '1;' +
+              '0;' +
               '"Non";' +
               '0,67;' +
               '0,67;' +
@@ -312,6 +331,11 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               sharedAt,
             });
 
+            databaseBuilder.factory.buildStageAcquisition({
+              stageId: stageIds[0],
+              campaignParticipationId: campaignParticipation.id,
+            });
+
             databaseBuilder.factory.buildAssessment({
               campaignParticipationId: campaignParticipation.id,
               userId: participant.id,
@@ -371,7 +395,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               `"${createdAtFormated}";` +
               '"Oui";' +
               `"${sharedAtFormated}";` +
-              '1;' +
+              '0;' +
               '"Non";' +
               '0,67;' +
               '0,67;' +
@@ -416,9 +440,19 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               campaignId: campaign.id,
               organizationLearnerId: organizationLearner.id,
               userId: participant.id,
-              masteryRate: 0.67,
+              masteryRate: 1,
+              validatedSkillsCount: 3,
               createdAt,
               sharedAt,
+            });
+
+            databaseBuilder.factory.buildStageAcquisition({
+              stageId: stageIds[0],
+              campaignParticipationId: campaignParticipation.id,
+            });
+            databaseBuilder.factory.buildStageAcquisition({
+              stageId: stageIds[1],
+              campaignParticipationId: campaignParticipation.id,
             });
 
             databaseBuilder.factory.buildAssessment({
@@ -443,7 +477,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               createdAt,
             });
             const ke3 = databaseBuilder.factory.buildKnowledgeElement({
-              status: 'invalidated',
+              status: 'validated',
               skillId: 'recSkillWeb3',
               competenceId: 'recCompetence1',
               userId: participant.id,
@@ -499,16 +533,16 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               '"Non";' +
               '"Oui";' +
               '"Non";' +
-              '0,67;' +
-              '0,67;' +
+              '1;' +
+              '1;' +
               '3;' +
-              '2;' +
-              '0,67;' +
               '3;' +
-              '2;' +
+              '1;' +
+              '3;' +
+              '3;' +
               '"OK";' +
               '"OK";' +
-              '"KO"';
+              '"OK"';
 
             // when
             await usecases.startWritingCampaignAssessmentResultsToStream({
@@ -641,6 +675,11 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               sharedAt,
             });
 
+            databaseBuilder.factory.buildStageAcquisition({
+              stageId: stageIds[0],
+              campaignParticipationId: campaignParticipation.id,
+            });
+
             databaseBuilder.factory.buildAssessment({
               campaignParticipationId: campaignParticipation.id,
               userId: participant.id,
@@ -751,7 +790,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
               `"${createdAtFormated}";` +
               '"Oui";' +
               `"${sharedAtFormated}";` +
-              '1;' +
+              '0;' +
               '"Non";' +
               '0,67;' +
               '0,67;' +

--- a/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/exports/campaigns/campaign-assessment-result-line_test.js
@@ -795,7 +795,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
             participantKnowledgeElementsByCompetenceId: {
               [competences[0].id]: [knowledgeElement],
             },
-            acquiredBadges: { [campaignParticipationInfo.campaignParticipationId]: [{ title: badge.title }] },
+            acquiredBadges: [badge.title],
             translate,
           });
 
@@ -956,6 +956,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               areas: learningContent.areas,
               competences: learningContent.competences,
               stageCollection,
+              acquiredStages: [{ id: 1 }, { id: 2 }, { id: 3 }],
               participantKnowledgeElementsByCompetenceId,
               translate,
             });
@@ -1009,6 +1010,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentResultLine', functio
               competences: learningContent.competences,
               areas: learningContent.areas,
               stageCollection,
+              acquiredStages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 3 }],
               participantKnowledgeElementsByCompetenceId,
               translate,
             });


### PR DESCRIPTION
## 🌸 Problème

On n'utilise pas des données stocker en BDD, donc on recalcule tout à chaque fois. c'est dommage

## 🌳 Proposition

Que ce ne soit plus dommage. On utilise les données stockées en BDD

## 🐝 Remarques

Réalignement des tests qui n'était pas cohérent avant

## 🤧 Pour tester

Faire un export de CSV et vérifier que le contenu est identique à l'affichage
