### PR TITLE
[FEATURE] Affichage du positionnement global sur la nouvelle page d'analyse de campagne (PIX-17026)

### DIFF
--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
@@ -7,9 +7,11 @@ import TagLevel from '../statistics/tag-level';
 
 <template>
   <h2 class="analysis-per-tubes-and-competences__positioning-title">{{t
-      "components.analysis-per-tubes-and-competences.detailed-positioning"
+      "components.analysis-per-tubes-and-competences.detailed-positioning.title"
     }}</h2>
-
+  <p class="analysis-per-tubes-and-competences__positioning-description">{{t
+      "components.analysis-per-tubes-and-competences.detailed-positioning.description"
+    }}</p>
   {{#each @data.levelsPerCompetence as |levelsPerCompetence|}}
     <h3 class="analysis-per-tubes-and-competences__competence-title">
       {{levelsPerCompetence.index}}

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
@@ -4,6 +4,12 @@
   &__positioning-title {
     @extend %pix-title-s;
 
+    margin-bottom: var(--pix-spacing-1x);
+  }
+
+  &__positioning-description {
+    @extend %pix-body-s;
+
     margin-bottom: var(--pix-spacing-6x);
   }
 

--- a/orga/app/components/analysis/global-positioning.gjs
+++ b/orga/app/components/analysis/global-positioning.gjs
@@ -1,0 +1,36 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixGauge from '@1024pix/pix-ui/components/pix-gauge';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class GlobalPositioning extends Component {
+  @service intl;
+
+  get stepLabels() {
+    return [
+      this.intl.t('pages.statistics.level.novice'),
+      this.intl.t('pages.statistics.level.independent'),
+      this.intl.t('pages.statistics.level.advanced'),
+      this.intl.t('pages.statistics.level.expert'),
+    ];
+  }
+
+  <template>
+    <PixBlock class="global-positioning" @variant="orga">
+      <h2 class="global-positioning__title">{{t "components.global-positioning.title"}}</h2>
+      <p class="global-positioning__description">{{t "components.global-positioning.description"}}</p>
+      <PixGauge
+        @isSmall={{false}}
+        @stepLabels={{this.stepLabels}}
+        @maxLevel={{@data.maxReachableLevel}}
+        @reachedLevel={{@data.meanReachedLevel}}
+        @label={{t
+          "components.global-positioning.gauge-label"
+          reachedLevel=@data.meanReachedLevel
+          maxLevel=@data.maxReachableLevel
+        }}
+      />
+    </PixBlock>
+  </template>
+}

--- a/orga/app/components/analysis/global-positioning.scss
+++ b/orga/app/components/analysis/global-positioning.scss
@@ -1,0 +1,17 @@
+@use 'pix-design-tokens/typography';
+
+.global-positioning {
+  margin-bottom: var(--pix-spacing-10x);
+
+  &__title {
+    @extend %pix-title-xs;
+
+    margin-bottom: var(--pix-spacing-1x);
+  }
+
+  &__description {
+    @extend %pix-body-s;
+
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -58,6 +58,7 @@
 @use 'pages/authenticated' as *;
 @use 'pages/authenticated/attestations' as *;
 @use 'pages/authenticated/campaigns/campaign' as *;
+@use 'pages/authenticated/campaigns/campaign/analysis' as *;
 @use 'pages/authenticated/campaigns/create-form' as *;
 @use 'pages/authenticated/campaigns/new-item' as *;
 @use 'pages/authenticated/campaigns/update' as *;

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -84,6 +84,7 @@
 /* App/Components */
 @use 'sco-organization-participant/generate-username-password-modal' as *;
 @use 'analysis/analysis-per-tubes-and-competences' as *;
+@use 'analysis/global-positioning' as *;
 
 body,
 html {

--- a/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
@@ -1,0 +1,11 @@
+@use 'pix-design-tokens/typography';
+
+.analysis-description {
+  @extend %pix-body-s;
+
+  margin-bottom: var(--pix-spacing-8x);
+
+  &__resume {
+    font-weight: var(--pix-font-bold);
+  }
+}

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
@@ -1,6 +1,7 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AnalysisPerTubesAndCompetences from 'pix-orga/components/analysis/analysis-per-tubes-and-competences';
+import GlobalPositioning from 'pix-orga/components/analysis/global-positioning';
 import Competences from 'pix-orga/components/campaign/analysis/competences';
 import Recommendations from 'pix-orga/components/campaign/analysis/recommendations';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
@@ -14,6 +15,7 @@ import EmptyState from 'pix-orga/components/campaign/empty-state';
         <p>{{t "pages.campaign-analysis.description.explanation"}}</p>
         <p>{{t "pages.campaign-analysis.description.nota-bene"}}</p>
       </div>
+      <GlobalPositioning @data={{@model.analysisData}} />
       <AnalysisPerTubesAndCompetences @data={{@model.analysisData}} />
     {{else}}
       <h2 class="screen-reader-only">{{t "pages.campaign-review.title"}}</h2>

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
@@ -6,9 +6,14 @@ import Recommendations from 'pix-orga/components/campaign/analysis/recommendatio
 import EmptyState from 'pix-orga/components/campaign/empty-state';
 
 <template>
-  {{pageTitle (t "pages.campaign-review.title")}}
+  {{pageTitle (t "pages.campaign-analysis.title")}}
   {{#if @model.campaign.hasSharedParticipations}}
     {{#if @model.isNewPage}}
+      <div class="analysis-description">
+        <b class="analysis-description__resume">{{t "pages.campaign-analysis.description.resume"}}</b>
+        <p>{{t "pages.campaign-analysis.description.explanation"}}</p>
+        <p>{{t "pages.campaign-analysis.description.nota-bene"}}</p>
+      </div>
       <AnalysisPerTubesAndCompetences @data={{@model.analysisData}} />
     {{else}}
       <h2 class="screen-reader-only">{{t "pages.campaign-review.title"}}</h2>

--- a/orga/tests/acceptance/campaign-analysis-test.js
+++ b/orga/tests/acceptance/campaign-analysis-test.js
@@ -67,7 +67,7 @@ module('Acceptance | Campaign Analysis', function (hooks) {
     assert.ok(
       screen.getByRole('heading', {
         level: 2,
-        name: t('components.analysis-per-tubes-and-competences.detailed-positioning'),
+        name: t('components.analysis-per-tubes-and-competences.detailed-positioning.title'),
       }),
     );
   });

--- a/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
+++ b/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
@@ -35,9 +35,10 @@ module('Integration | Component | analysis-per-tubes-and-competences', function 
       assert.ok(
         screen.getByRole('heading', {
           level: 2,
-          name: t('components.analysis-per-tubes-and-competences.detailed-positioning'),
+          name: t('components.analysis-per-tubes-and-competences.detailed-positioning.title'),
         }),
       );
+      assert.ok(screen.getByText(t('components.analysis-per-tubes-and-competences.detailed-positioning.description')));
       assert.ok(screen.getByRole('table', { name: '1 - mon super titre de competence 1' }));
       assert.ok(screen.getByRole('table', { name: '2 - mon super titre de competence 2' }));
     });

--- a/orga/tests/integration/components/analysis/global-positioning_test.gjs
+++ b/orga/tests/integration/components/analysis/global-positioning_test.gjs
@@ -1,0 +1,53 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import GlobalPositioning from 'pix-orga/components/analysis/global-positioning';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Analysis | global-positioning', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('display global-positioning', function () {
+    test('it should display global positioning', async function (assert) {
+      // given
+      const data = {
+        maxReachableLevel: 4,
+        meanReachedLevel: 2,
+      };
+
+      // when
+      const screen = await render(<template><GlobalPositioning @data={{data}} /></template>);
+
+      // then
+      assert.ok(
+        screen.getByRole('heading', {
+          level: 2,
+          name: t('components.global-positioning.title'),
+        }),
+      );
+      assert.ok(screen.getByText(t('components.global-positioning.description')));
+      assert.ok(
+        screen.getByRole('progressbar', {
+          name: t('components.global-positioning.gauge-label', { reachedLevel: 2, maxLevel: 4 }),
+        }),
+      );
+    });
+    test('the gauge should have stepLabels', async function (assert) {
+      // given
+      const data = {
+        maxReachableLevel: 4,
+        meanReachedLevel: 2,
+      };
+
+      // when
+      const screen = await render(<template><GlobalPositioning @data={{data}} /></template>);
+
+      // then
+      assert.ok(screen.getByText(t('pages.statistics.level.novice')));
+      assert.ok(screen.getByText(t('pages.statistics.level.independent')));
+      assert.ok(screen.getByText(t('pages.statistics.level.advanced')));
+      assert.ok(screen.getByText(t('pages.statistics.level.expert')));
+    });
+  });
+});

--- a/orga/tests/integration/templates/analysis_test.gjs
+++ b/orga/tests/integration/templates/analysis_test.gjs
@@ -1,0 +1,28 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import Analysis from 'pix-orga/templates/authenticated/campaigns/campaign/analysis';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Template | analysis', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  const model = {
+    campaign: {
+      hasSharedParticipations: true,
+    },
+    isNewPage: true,
+  };
+
+  module('display analysis', function () {
+    test('it should display new page description', async function (assert) {
+      // given
+      const screen = await render(<template><Analysis @model={{model}} /></template>);
+
+      // then
+      assert.ok(screen.getByText(t('pages.campaign-analysis.description.resume')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.description.explanation')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.description.nota-bene')));
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -274,7 +274,10 @@
   },
   "components": {
     "analysis-per-tubes-and-competences": {
-      "detailed-positioning": "Detailed positioning",
+      "detailed-positioning":{
+        "description":"Average level achieved by participants by topic out of the maximum level achievable in this campaign.",
+        "title" : "Detailed positioning"
+      },
       "gauge": {
         "label": "Level {reachedLevel} of {maxLevel}"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -540,6 +540,14 @@
       },
       "title": "Activity"
     },
+    "campaign-analysis": {
+      "title": "Analysis",
+      "description": {
+        "resume": "Analyse, overall and by topic, the positioning of your participants.",
+        "explanation": "Each test assesses a selection of digital skills from the Pix reference framework. Positioning reflects the average level achieved by participants in relation to the maximum level achievable on the test.",
+        "nota-bene": "All the data presented comes from shared and undeleted participation in assessment campaigns, and is updated in real time."
+      }
+    },
     "campaign-creation": {
       "actions": {
         "create": "Create a campaign",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -313,6 +313,11 @@
     "date": {
       "no-date": "No date yet"
     },
+    "global-positioning": {
+      "description": "Average level achieved by participants out of the maximum level achievable in this campaign.",
+      "gauge-label": "On this test, your participants achieved an average level of {reachedLevel} out of a maximum reachable level of {maxLevel}.",
+      "title": "Global positioning"
+    },
     "group": {
       "SCO": "Class",
       "SUP": "Group"
@@ -541,12 +546,12 @@
       "title": "Activity"
     },
     "campaign-analysis": {
-      "title": "Analysis",
       "description": {
-        "resume": "Analyse, overall and by topic, the positioning of your participants.",
         "explanation": "Each test assesses a selection of digital skills from the Pix reference framework. Positioning reflects the average level achieved by participants in relation to the maximum level achievable on the test.",
-        "nota-bene": "All the data presented comes from shared and undeleted participation in assessment campaigns, and is updated in real time."
-      }
+        "nota-bene": "All the data presented comes from shared and undeleted participation in assessment campaigns, and is updated in real time.",
+        "resume": "Analyse, overall and by topic, the positioning of your participants."
+      },
+      "title": "Analysis"
     },
     "campaign-creation": {
       "actions": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -540,6 +540,14 @@
       },
       "title": "Activité"
     },
+    "campaign-analysis": {
+      "title": "Analyse",
+      "description": {
+        "resume": "Analysez, globalement et par sujet, le positionnement de vos participants dans la campagne.",
+        "explanation": "Chaque parcours évalue sur une sélection de compétences numériques du référentiel Pix. Le positionnement reflète le niveau moyen atteint par les participants par rapport au niveau maximal accessible dans le cadre du parcours.",
+        "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation, et sont actualisées en temps réel."
+      }
+    },
     "campaign-creation": {
       "actions": {
         "create": "Créer la campagne",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -274,7 +274,10 @@
   },
   "components": {
     "analysis-per-tubes-and-competences": {
-      "detailed-positioning": "Positionnement détaillé",
+      "detailed-positioning":{
+        "description":"Niveau moyen atteint par les participants par sujet sur le niveau maximal accessible dans cette campagne.",
+        "title" : "Positionnement détaillé"
+      },
       "gauge": {
         "label": "Niveau {reachedLevel} sur {maxLevel}"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -313,6 +313,11 @@
     "date": {
       "no-date": "Pas encore de date"
     },
+    "global-positioning": {
+      "description": "Niveau moyen atteint par les participants sur le niveau maximal accessible dans cette campagne.",
+      "gauge-label": "Lors de cette campagne, vos participants ont obtenu en moyenne un niveau de {reachedLevel} sur un niveau maximum atteignable de {maxLevel}.",
+      "title": "Positionnement global"
+    },
     "group": {
       "SCO": "Classe",
       "SUP": "Groupe"
@@ -541,12 +546,12 @@
       "title": "Activité"
     },
     "campaign-analysis": {
-      "title": "Analyse",
       "description": {
-        "resume": "Analysez, globalement et par sujet, le positionnement de vos participants dans la campagne.",
         "explanation": "Chaque parcours évalue sur une sélection de compétences numériques du référentiel Pix. Le positionnement reflète le niveau moyen atteint par les participants par rapport au niveau maximal accessible dans le cadre du parcours.",
-        "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation, et sont actualisées en temps réel."
-      }
+        "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation, et sont actualisées en temps réel.",
+        "resume": "Analysez, globalement et par sujet, le positionnement de vos participants dans la campagne."
+      },
+      "title": "Analyse"
     },
     "campaign-creation": {
       "actions": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -504,6 +504,14 @@
       },
       "title": "Activiteit"
     },
+    "campaign-analysis": {
+      "title": "Uitleg",
+      "description": {
+        "resume": "Analyseer, globaal en per onderwerp, de positionering van je deelnemers.",
+        "explanation": "Elke toets beoordeelt een selectie van digitale vaardigheden uit het Pix referentiekader. De positionering weerspiegelt het gemiddelde niveau dat deelnemers hebben bereikt ten opzichte van het maximaal haalbare niveau op de toets.",
+        "nota-bene": "Alle gepresenteerde gegevens zijn afkomstig van gedeelde en niet-verwijderde deelname aan beoordelingscampagnes en worden in realtime bijgewerkt."
+      }
+    },
     "campaign-creation": {
       "actions": {
         "create": "De campagne maken",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -313,6 +313,11 @@
     "date": {
       "no-date": "Nog geen datum"
     },
+    "global-positioning":{
+      "title":"Wereldwijde positionering",
+      "description":"Gemiddeld niveau bereikt door deelnemers van het maximaal haalbare niveau in deze campagne.",
+      "gauge-label":"Bij deze test behaalden je deelnemers een gemiddeld niveau van {bereiktLevel} uit een maximaal haalbaar niveau van {maxLevel}."
+    },
     "group": {
       "SCO": "Klas",
       "SUP": "Groep"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -274,7 +274,10 @@
   },
   "components": {
     "analysis-per-tubes-and-competences": {
-      "detailed-positioning": "Gedetailleerde positionering",
+      "detailed-positioning":{
+        "description":"Gemiddeld niveau behaald door deelnemers per onderwerp van het maximaal haalbare niveau in deze campagne.",
+        "title" : "Gedetailleerde positionering"
+      },
       "gauge": {
         "label": "Niveau {reachedLevel} van {maxLevel}"
       },


### PR DESCRIPTION
## 🌸 Problème

Continuité de l'epix sur la refonte de la page d'analyse de campagne

## 🌳 Proposition

Ajouter la brique manquante se trouvant sur cette maquette :
https://www.figma.com/design/VPDkaoZIDWSCzSySQsVinm/Pix-Orga?node-id=7817-23129&m=dev

## 🐝 Remarques

- le contenu de la tooltip étant discuté, on ne la met pas pour le moment.
- vous pouvez retrouver les textes attendu dans le ticket Jira associé

## 🤧 Pour tester
- avoir le feature toggle de la nouvelle page d'analyse à true
- se rendre sur la page d'analyse d'une campagne