### PR TITLE
[TECH] Passer le feature toggle du bouton de vocalisation au nouveau système

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -5,6 +5,12 @@ export default {
     defaultValue: false,
     tags: ['frontend'],
   },
+  isTextToSpeechButtonEnabled: {
+    type: 'boolean',
+    description: 'Enable the text to speech button on challenges',
+    defaultValue: true,
+    tags: ['frontend'],
+  },
   isAsyncQuestRewardingCalculationEnabled: {
     type: 'boolean',
     description: 'Used to switch between synchronous and asynchronous mode for quest reward calculation',

--- a/api/sample.env
+++ b/api/sample.env
@@ -823,13 +823,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: 30d
 # CERTIFICATION_RESULTS_JWT_TOKEN_LIFE_SPAN=30d
 
-# Enable the text to speech button on challenges
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_ENABLE_TEXT_TO_SPEECH_BUTTON=false
-
 # Enable quests system.
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -300,7 +300,6 @@ const configuration = (function () {
       ),
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
-      isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },


### PR DESCRIPTION
## 🌸 Problème

Le feature toggle FT_ENABLE_TEXT_TO_SPEECH_BUTTON est toujours dans une variable d'environnement.

## 🌳 Proposition

Passer ce feature toggle au nouveau système.

## 🐝 Remarques

On met sa valeur par défaut à true étant donné qu'il est utilisé en production.

## 🤧 Pour tester
- Se connecter sur Pix app,
- Aller sur une épreuve,
- Constater que le bouton pour lire à voix haute est présent,
- Désactiver le feature toggle,
```shell
scalingo -a pix-api-review-pr12253 run npm run toggles -- --key isTextToSpeechButtonEnabled --value false
```
- Recharger la page,
- Constater que le bouton pour lire à voix haute n'est plus là.