### PR TITLE
[TECH] Migrer le suivi matomo vers plausible sur mon-pix

### DIFF
--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -30,7 +30,7 @@ export default class AttestationContent extends Component {
   }
 
   sendMetrics() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Page Mes Attestations',
       'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -63,7 +63,7 @@ export default class Ended extends Component {
 
   @action
   onClick() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Campaign participation',
       'pix-event-action': `Voir le détail d'une participation partagée`,

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -36,7 +36,7 @@ export default class AttestationResult extends Component {
   }
 
   sendMetrics() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -27,7 +27,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   @action
   handleCustomButtonDisplay() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': "Affichage du bloc de l'organisation",
@@ -37,7 +37,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   @action
   handleCustomButtonClick() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': "Affichage du bloc de l'organisation",

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -81,7 +81,7 @@ export default class EvaluationResultsHero extends Component {
       const adapter = this.store.adapterFor('campaign-participation-result');
       await adapter.beginImprovement(campaignParticipationResult.id);
 
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Amélioration des résultats',
@@ -113,7 +113,7 @@ export default class EvaluationResultsHero extends Component {
       campaignParticipationResult.isShared = true;
       campaignParticipationResult.canImprove = false;
 
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Envoi des résultats',
@@ -133,7 +133,7 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   handleBackToHomepageDisplay() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Sortie de parcours',
@@ -143,7 +143,7 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   handleBackToHomepageClick() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Sortie de parcours',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -21,7 +21,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
     super(...arguments);
 
     if (this.args.campaignParticipationResult.canRetry) {
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -30,7 +30,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
     }
 
     if (this.args.campaignParticipationResult.canReset) {
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -41,7 +41,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   @action
   handleRetryClick() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -52,7 +52,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   @action
   toggleResetModalVisibility() {
     if (!this.isResetModalVisible) {
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -65,7 +65,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   @action
   handleResetClick() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -9,8 +9,7 @@ export default class EvaluationResultsDetailsTab extends Component {
 
   constructor() {
     super(...arguments);
-
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -11,7 +11,7 @@ export default class Rewards extends Component {
   constructor() {
     super(...arguments);
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -19,7 +19,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
   constructor() {
     super(...arguments);
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',
@@ -48,7 +48,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
       campaignParticipationResultToShare.isShared = true;
       campaignParticipationResultToShare.canImprove = false;
 
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Envoi des résultats',

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -261,7 +261,7 @@ export default class ChallengeStatement extends Component {
   }
 
   addMetrics() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Vocalisation',
       'pix-event-action': "Lecture d'une épreuve",

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -24,7 +24,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStart() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -35,7 +35,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStartUsingSmallScreen() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -46,7 +46,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onSmallScreenModalOpen() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -57,7 +57,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onSmallScreenModalClose() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -53,7 +53,7 @@ export default class ModulePassage extends Component {
 
     this.addNextGrainToDisplay();
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -67,7 +67,7 @@ export default class ModulePassage extends Component {
 
     this.addNextGrainToDisplay();
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -79,7 +79,7 @@ export default class ModulePassage extends Component {
   onStepperNextStep(currentStepPosition) {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -114,7 +114,7 @@ export default class ModulePassage extends Component {
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -138,7 +138,7 @@ export default class ModulePassage extends Component {
         adapterOptions: { passageId: this.args.passage.id },
       });
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -148,7 +148,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onSelfAssessment({ userAssessment, cardId }) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -158,7 +158,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onElementRetry(answerData) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -168,7 +168,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onImageAlternativeTextOpen(imageElementId) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -178,7 +178,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoTranscriptionOpen(videoElementId) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -188,7 +188,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoPlay({ elementId }) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -198,7 +198,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onFileDownload({ elementId, downloadedFormat }) {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -208,7 +208,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onSidebarOpen() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -221,7 +221,7 @@ export default class ModulePassage extends Component {
     const element = document.getElementById(`grain_${grainId}`);
     this.modulixAutoScroll.focusAndScroll(element);
 
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -232,7 +232,7 @@ export default class ModulePassage extends Component {
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -104,7 +104,7 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Accès Contenu Formatif',
       'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -153,7 +153,7 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Accès tuto',
       'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -249,7 +249,7 @@ export default class ChallengeController extends Controller {
   }
 
   addMetrics() {
-    this.metrics.add({
+    this.metrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Vocalisation',
       'pix-event-action': 'Activation globale de la vocalisation',

--- a/mon-pix/app/metrics-adapters/plausible-adapter.js
+++ b/mon-pix/app/metrics-adapters/plausible-adapter.js
@@ -1,0 +1,52 @@
+import BaseAdapter from 'ember-metrics/metrics-adapters/base';
+
+export default class PlausibleAdapter extends BaseAdapter {
+  toStringExtension() {
+    return PlausibleAdapter.name;
+  }
+
+  install() {
+    const { siteId, scriptUrl } = this.config;
+
+    window.plausible =
+      window.plausible ||
+      function (...args) {
+        (window.plausible.q = window.plausible.q || []).push(args);
+      };
+
+    const scriptElement = document.createElement('script');
+    const firstScriptElement = document.getElementsByTagName('script')[0];
+    scriptElement.type = 'text/javascript';
+    scriptElement.defer = true;
+    scriptElement.async = true;
+    scriptElement.src = scriptUrl;
+    scriptElement.setAttribute('data-domain', siteId);
+    firstScriptElement.parentNode.insertBefore(scriptElement, firstScriptElement);
+  }
+
+  identify() {}
+
+  /**
+   * Custom events allow you to measure button clicks, form completions...
+   *
+   * @param {Object} params
+   * @param {string} params.eventName - must not contain spaces, examples: verify-this or That+Completion
+   * @param {Objects} params.props - event metadatas, must not contain any personally identifiable information
+   */
+  trackEvent({ eventName, plausibleAttributes = {}, ...props }) {
+    window.plausible(eventName, { ...plausibleAttributes, props });
+  }
+
+  trackPage({ plausibleAttributes = {}, ...props }) {
+    window.plausible('pageview', { ...plausibleAttributes, props });
+  }
+
+  alias() {}
+
+  uninstall() {
+    document.querySelectorAll('script[src*="plausible"]').forEach((el) => {
+      el.parentElement?.removeChild(el);
+    });
+    delete window.plausible;
+  }
+}

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -18,7 +18,7 @@ export default class ApplicationRoute extends Route {
     super(...arguments);
 
     const trackRouteChange = (transition) => {
-      if (!transition.to || transition.to.metadata?.blockPageview) {
+      if (!transition.to || transition.to.metadata?.doNotTrackPage) {
         return;
       }
       const params = extractParamsFromRouteInfo(transition.to);

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -10,7 +10,7 @@ export default class ApplicationRoute extends Route {
   @service oidcIdentityProviders;
   @service session;
   @service splash;
-  @service metrics;
+  @service pixMetrics;
   @service store;
   @service router;
 
@@ -21,10 +21,7 @@ export default class ApplicationRoute extends Route {
       if (!transition.to || transition.to.metadata?.doNotTrackPage) {
         return;
       }
-      const params = extractParamsFromRouteInfo(transition.to);
-
-      const page = redactUrlForAnalytics(this.router.currentURL, params);
-      this.metrics.trackPage({ plausibleAttributes: { u: page } });
+      this.pixMetrics.trackPage();
     };
     this.router.on('routeDidChange', trackRouteChange);
   }
@@ -85,21 +82,4 @@ export default class ApplicationRoute extends Route {
       this.poller = null;
     }
   }
-}
-
-export function redactUrlForAnalytics(url, params) {
-  const [base, queryParams] = url.split('?');
-  const redactedUrl = base
-    .split('/')
-    .map((token) => {
-      return params.includes(token) ? '_ID_' : token;
-    })
-    .join('/');
-  return queryParams ? `${redactedUrl}?${queryParams}` : redactedUrl;
-}
-
-function extractParamsFromRouteInfo(routeInfo, params = []) {
-  return routeInfo.parent == null
-    ? params
-    : extractParamsFromRouteInfo(routeInfo.parent, params.concat(Object.values(routeInfo.params)));
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -88,11 +88,14 @@ export default class ApplicationRoute extends Route {
 }
 
 export function redactUrlForAnalytics(url, params) {
-  const splittedUrl = url.split('/');
-  const redactedUrl = splittedUrl.map((token) => {
-    return params.includes(token) ? '_ID_' : token;
-  });
-  return redactedUrl.join('/');
+  const [base, queryParams] = url.split('?');
+  const redactedUrl = base
+    .split('/')
+    .map((token) => {
+      return params.includes(token) ? '_ID_' : token;
+    })
+    .join('/');
+  return queryParams ? `${redactedUrl}?${queryParams}` : redactedUrl;
 }
 
 function extractParamsFromRouteInfo(routeInfo, params = []) {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
-
 export default class ApplicationRoute extends Route {
   @service authentication;
   @service featureToggles;
@@ -12,13 +11,33 @@ export default class ApplicationRoute extends Route {
   @service splash;
   @service metrics;
   @service store;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    const stripIdFromPageUrl = (url) => {
+      const id = /(\w+\d+\w+|(?!recommandes)(rec\w+))/g;
+      // TODO les routes qui finissent par un id
+      // ex: /assessments/_ID_/challenges/0
+      return url.replace(id, '_ID_');
+    };
+
+    const trackRouteChange = (transition) => {
+      if (transition.to.metadata?.blockPageview) {
+        return;
+      }
+      const routeName = this.router.currentRouteName || 'unknown';
+      const page = stripIdFromPageUrl(this.router.currentURL);
+      this.metrics.trackPage({ page, routeName });
+    };
+    this.router.on('routeDidChange', trackRouteChange);
+  }
 
   activate() {
     this.splash.hide();
   }
 
   async beforeModel(transition) {
-    this.metrics.initialize();
     await this.session.setup();
 
     await this.featureToggles.load().catch();

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -14,7 +14,7 @@ export default class ResumeRoute extends Route {
   assessmentHasNoMoreQuestions = false;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   async beforeModel(transition) {

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -13,6 +13,10 @@ export default class ResumeRoute extends Route {
   competenceLeveled = null;
   assessmentHasNoMoreQuestions = false;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   async beforeModel(transition) {
     this.hasSeenCheckpoint = transition.to.queryParams.hasSeenCheckpoint;
     this.campaignCode = transition.to.queryParams.campaignCode;

--- a/mon-pix/app/routes/authenticated/certifications/resume.js
+++ b/mon-pix/app/routes/authenticated/certifications/resume.js
@@ -6,7 +6,7 @@ export default class ResumeRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   model(params) {

--- a/mon-pix/app/routes/authenticated/certifications/resume.js
+++ b/mon-pix/app/routes/authenticated/certifications/resume.js
@@ -5,6 +5,10 @@ export default class ResumeRoute extends Route {
   @service store;
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   model(params) {
     const store = this.store;
     const certificationCourse = store.peekRecord('certification-course', params.certification_course_id);

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -7,6 +7,10 @@ export default class ResumeRoute extends Route {
 
   competenceId = null;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   model(params, transition) {
     const competenceId = transition.to.parent.params.competence_id;
     return this.store.queryRecord('competence-evaluation', { competenceId, startOrResume: true });

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -8,7 +8,7 @@ export default class ResumeRoute extends Route {
   competenceId = null;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   model(params, transition) {

--- a/mon-pix/app/routes/authenticated/index.js
+++ b/mon-pix/app/routes/authenticated/index.js
@@ -5,7 +5,7 @@ export default class AuthenticatedIndexRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   redirect() {

--- a/mon-pix/app/routes/authenticated/index.js
+++ b/mon-pix/app/routes/authenticated/index.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class AuthenticatedIndexRoute extends Route {
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   redirect() {
     this.router.replaceWith('authenticated.user-dashboard');
   }

--- a/mon-pix/app/routes/authenticated/user-account/delete-account.js
+++ b/mon-pix/app/routes/authenticated/user-account/delete-account.js
@@ -5,6 +5,10 @@ export default class DeleteAccountRoute extends Route {
   @service router;
   @service store;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   async model() {
     const user = this.modelFor('authenticated.user-account');
     return { user };

--- a/mon-pix/app/routes/authenticated/user-account/delete-account.js
+++ b/mon-pix/app/routes/authenticated/user-account/delete-account.js
@@ -6,7 +6,7 @@ export default class DeleteAccountRoute extends Route {
   @service store;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   async model() {

--- a/mon-pix/app/routes/authenticated/user-account/index.js
+++ b/mon-pix/app/routes/authenticated/user-account/index.js
@@ -5,7 +5,7 @@ export default class IndexRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   redirect() {

--- a/mon-pix/app/routes/authenticated/user-account/index.js
+++ b/mon-pix/app/routes/authenticated/user-account/index.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class IndexRoute extends Route {
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   redirect() {
     this.router.replaceWith('authenticated.user-account.personal-information');
   }

--- a/mon-pix/app/routes/authenticated/user-tutorials/index.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/index.js
@@ -5,7 +5,7 @@ export default class IndexRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   redirect() {

--- a/mon-pix/app/routes/authenticated/user-tutorials/index.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/index.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class IndexRoute extends Route {
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   redirect() {
     this.router.replaceWith('authenticated.user-tutorials.recommended');
   }

--- a/mon-pix/app/routes/authentication/sso-selection.js
+++ b/mon-pix/app/routes/authentication/sso-selection.js
@@ -11,7 +11,7 @@ export default class SsoSelectionRoute extends Route {
   templateName = 'authentication.sso-selection';
 
   buildRouteInfoMetadata() {
-    return { blockPageview: !this.currentDomain.isFranceDomain };
+    return { doNotTrackPage: !this.currentDomain.isFranceDomain };
   }
 
   redirect() {

--- a/mon-pix/app/routes/authentication/sso-selection.js
+++ b/mon-pix/app/routes/authentication/sso-selection.js
@@ -10,6 +10,10 @@ export default class SsoSelectionRoute extends Route {
   controllerName = 'authentication.sso-selection';
   templateName = 'authentication.sso-selection';
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: !this.currentDomain.isFranceDomain };
+  }
+
   redirect() {
     if (this.currentDomain.isFranceDomain) return;
 

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -11,7 +11,7 @@ export default class AccessRoute extends Route {
   @service oidcIdentityProviders;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   beforeModel(transition) {

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -10,6 +10,10 @@ export default class AccessRoute extends Route {
   @service store;
   @service oidcIdentityProviders;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   beforeModel(transition) {
     if (!transition.from) {
       return this.router.replaceWith('campaigns.entry-point');

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -18,7 +18,7 @@ export default class EvaluationStartOrResumeRoute extends Route {
   }
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   async redirect({ assessment, campaign }) {

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -17,6 +17,10 @@ export default class EvaluationStartOrResumeRoute extends Route {
     return this.modelFor('campaigns.assessment');
   }
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   async redirect({ assessment, campaign }) {
     if (this._shouldShowTutorial(assessment, campaign.isForAbsoluteNovice)) {
       this.router.replaceWith('campaigns.assessment.tutorial', campaign.code);

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -10,7 +10,7 @@ export default class Entrance extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   beforeModel(transition) {

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -9,6 +9,10 @@ export default class Entrance extends Route {
   @service session;
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   beforeModel(transition) {
     if (!transition.from) {
       return this.router.replaceWith('campaigns.entry-point');

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -37,7 +37,7 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'participantExternalId', participantExternalId);
     }
     if (queryParams.retry) {
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Campagnes',
         'pix-event-action': 'Retenter la campagne',
@@ -46,7 +46,7 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
     if (queryParams.reset) {
-      this.metrics.add({
+      this.metrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Campagnes',
         'pix-event-action': 'Remise à zéro de la campagne',

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -12,6 +12,10 @@ export default class EntryPoint extends Route {
   @service store;
   @service metrics;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   async beforeModel() {
     if (this.session.isAuthenticated && this.currentUser.user.isAnonymous) {
       await this.session.invalidate();

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -13,7 +13,7 @@ export default class EntryPoint extends Route {
   @service metrics;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   async beforeModel() {

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -6,6 +6,10 @@ export default class InvitedRoute extends Route {
   @service session;
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   beforeModel(transition) {
     if (!transition.from) {
       return this.router.replaceWith('campaigns.entry-point');

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -7,7 +7,7 @@ export default class InvitedRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   beforeModel(transition) {

--- a/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
@@ -6,7 +6,7 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   beforeModel(transition) {

--- a/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
@@ -5,6 +5,10 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   @service session;
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   beforeModel(transition) {
     this.session.requireAuthenticationAndApprovedTermsOfService(transition);
   }

--- a/mon-pix/app/routes/courses/start.js
+++ b/mon-pix/app/routes/courses/start.js
@@ -5,6 +5,10 @@ export default class CreateAssessmentRoute extends Route {
   @service store;
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   model(params) {
     return this.store.findRecord('course', params.course_id);
   }

--- a/mon-pix/app/routes/courses/start.js
+++ b/mon-pix/app/routes/courses/start.js
@@ -6,7 +6,7 @@ export default class CreateAssessmentRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   model(params) {

--- a/mon-pix/app/routes/module/index.js
+++ b/mon-pix/app/routes/module/index.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class ModuleIndexRoute extends Route {
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   redirect() {
     this.router.replaceWith('module.details');
   }

--- a/mon-pix/app/routes/module/index.js
+++ b/mon-pix/app/routes/module/index.js
@@ -5,7 +5,7 @@ export default class ModuleIndexRoute extends Route {
   @service router;
 
   buildRouteInfoMetadata() {
-    return { blockPageview: true };
+    return { doNotTrackPage: true };
   }
 
   redirect() {

--- a/mon-pix/app/routes/not-found.js
+++ b/mon-pix/app/routes/not-found.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class NotFoundRoute extends Route {
   @service router;
 
+  buildRouteInfoMetadata() {
+    return { blockPageview: true };
+  }
+
   afterModel(model, transition) {
     transition.abort();
     this.router.transitionTo('authenticated');

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -17,6 +17,7 @@ export default class LocaleService extends Service {
   @service currentDomain;
   @service intl;
   @service dayjs;
+  @service metrics;
 
   isSupportedLocale(locale) {
     try {
@@ -46,6 +47,7 @@ export default class LocaleService extends Service {
   }
 
   setLocale(locale) {
+    this.metrics.context.locale = locale;
     this.intl.setLocale(locale);
     this.dayjs.setLocale(locale);
   }

--- a/mon-pix/app/services/pix-metrics.js
+++ b/mon-pix/app/services/pix-metrics.js
@@ -1,0 +1,34 @@
+import Service, { service } from '@ember/service';
+
+export default class PixMetricsService extends Service {
+  @service metrics;
+  @service router;
+
+  trackEvent({ event: _, 'pix-event-name': eventName, ...props }) {
+    const url = this.getRedactedPageUrl();
+    this.metrics.trackEvent({ eventName, plausibleAttributes: { u: url }, ...props });
+  }
+
+  trackPage(props) {
+    const url = this.getRedactedPageUrl();
+    this.metrics.trackPage({ plausibleAttributes: { u: url }, ...props });
+  }
+
+  getRedactedPageUrl() {
+    const params = extractParamsFromRouteInfo(this.router.currentRoute);
+    const currentUrl = this.router.currentURL;
+    const [base, queryParams] = currentUrl.split('?');
+    const redactedUrl = base
+      .split('/')
+      .map((token) => {
+        return params.includes(token) ? '_ID_' : token;
+      })
+      .join('/');
+    return queryParams ? `${redactedUrl}?${queryParams}` : redactedUrl;
+  }
+}
+
+const extractParamsFromRouteInfo = (routeInfo = {}, params = []) =>
+  !routeInfo?.parent
+    ? params
+    : extractParamsFromRouteInfo(routeInfo.parent, params.concat(Object.values(routeInfo.params)));

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -1,4 +1,5 @@
 'use strict';
+
 require('dotenv').config();
 
 function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue, minValue }) {
@@ -117,6 +118,17 @@ module.exports = function (environment) {
       disabled: false,
     },
 
+    metricsAdapters: [
+      {
+        name: 'PlausibleAdapter',
+        environments: analyticsEnabled ? ['all'] : [],
+        config: {
+          siteId: process.env.ANALYTICS_SITE_ID,
+          scriptUrl: process.env.ANALYTICS_SCRIPT_URL,
+        },
+      },
+    ],
+
     '@sentry/ember': {
       disablePerformance: true,
       sentry: {
@@ -179,6 +191,5 @@ module.exports = function (environment) {
   if (environment === 'production') {
     // here you can enable a production-specific feature
   }
-
   return ENV;
 };

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,6 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
-        "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/epreuves-components": "^0.1.0",
         "@1024pix/eslint-plugin": "^2.1.3",
@@ -59,6 +58,7 @@
         "ember-keyboard": "^9.0.0",
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.0",
+        "ember-metrics": "^2.0.0",
         "ember-modifier": "^4.0.0",
         "ember-page-title": "^9.0.0",
         "ember-qunit": "^9.0.0",
@@ -791,16 +791,6 @@
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
         "rsvp": "^4.8.4"
-      }
-    },
-    "node_modules/@1024pix/ember-matomo-tag-manager": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/ember-matomo-tag-manager/-/ember-matomo-tag-manager-2.4.3.tgz",
-      "integrity": "sha512-gsoFCZxMXO5purZh92WwgWyydRS/PftFr7+HRF9bRAHbPrqkd6NCmLEHvFZ9ETXKPB3SkF79Qh28SaljXTkb5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {
@@ -25026,6 +25016,906 @@
       },
       "peerDependencies": {
         "ember-source": ">= 5"
+      }
+    },
+    "node_modules/ember-metrics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-metrics/-/ember-metrics-2.0.0.tgz",
+      "integrity": "sha512-r62LSNiivGKdhV7UOC9H9lmmApO/zaCnVo9BStVDkHTgcdzoq6iENft/ZDsCihQt3loevCi/BXb+DLffOBjKxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-funnel": "^3.0.2",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.1.1"
+      },
+      "engines": {
+        "node": "18.* || 20.* || >= 22"
+      },
+      "peerDependencies": {
+        "@ember/string": ">= 3.0.0",
+        "ember-source": ">= 3.28.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.3.0.tgz",
+      "integrity": "sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/find-babel-config": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
+      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^1.0.2",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
       }
     },
     "node_modules/ember-modifier": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
-    "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/epreuves-components": "^0.1.0",
     "@1024pix/eslint-plugin": "^2.1.3",
@@ -92,6 +91,7 @@
     "ember-keyboard": "^9.0.0",
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.0",
+    "ember-metrics": "^2.0.0",
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^9.0.0",
     "ember-qunit": "^9.0.0",

--- a/mon-pix/tests/acceptance/application-test.js
+++ b/mon-pix/tests/acceptance/application-test.js
@@ -28,6 +28,7 @@ module('Acceptance | Application', function (hooks) {
     hooks.beforeEach(async function () {
       class MetricServiceStub extends Service {
         trackPage = sinon.stub();
+        context = {};
       }
 
       this.owner.register('service:metrics', MetricServiceStub);

--- a/mon-pix/tests/acceptance/application-test.js
+++ b/mon-pix/tests/acceptance/application-test.js
@@ -46,7 +46,6 @@ module('Acceptance | Application', function (hooks) {
       assert.ok(
         metricService.trackPage.calledOnceWithExactly({
           plausibleAttributes: { u: '/accueil' },
-          routeName: 'authenticated.user-dashboard',
         }),
       );
     });
@@ -77,7 +76,6 @@ module('Acceptance | Application', function (hooks) {
       await visit('/assessments/1/challenges/0');
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
         plausibleAttributes: { u: '/assessments/_ID_/challenges/_ID_' },
-        routeName: 'assessments.challenge',
       });
       assert.ok(true);
     });
@@ -91,7 +89,25 @@ module('Acceptance | Application', function (hooks) {
       // then
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
         plausibleAttributes: { u: '/connexion' },
-        routeName: 'authentication.login',
+      });
+
+      assert.ok(true);
+    });
+
+    test('should forward query params', async function (assert) {
+      // given
+      const metricService = this.owner.lookup('service:metrics');
+      server.create('assessment', 'ofCompetenceEvaluationType', {
+        id: 1,
+      });
+      server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {});
+
+      // when
+      await visit('/assessments/1/challenges/0?id=1');
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricService.trackPage, {
+        plausibleAttributes: { u: '/assessments/_ID_/challenges/_ID_?id=1' },
       });
 
       assert.ok(true);

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -78,7 +78,8 @@ module('Acceptance | Challenge page banner', function (hooks) {
       test("should display text-to-speech button in challenge instruction when it's been activated in the banner", async function (assert) {
         // given
         class MetricsStubService extends Service {
-          add = sinon.stub();
+          trackPage = sinon.stub();
+          trackEvent = sinon.stub();
           initialize = sinon.stub();
         }
         this.owner.register('service:metrics', MetricsStubService);

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -80,7 +80,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
         class MetricsStubService extends Service {
           trackPage = sinon.stub();
           trackEvent = sinon.stub();
-          initialize = sinon.stub();
+          context = {};
         }
         this.owner.register('service:metrics', MetricsStubService);
 

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
@@ -95,7 +95,7 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
         const router = this.owner.lookup('service:router');
         router.transitionTo = sinon.stub();
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
           isShared: true,
@@ -118,7 +118,7 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
         await click(screen.getByRole('button', { name: 'Voir le détail' }));
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Campaign participation',
           'pix-event-action': `Voir le détail d'une participation partagée`,

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -70,7 +70,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       this.owner.register('service:fileSaver', FileSaverStub);
 
       class MetricsStub extends Service {
-        add = metricsAddStub;
+        trackEvent = metricsAddStub;
       }
       const metricsAddStub = sinon.stub().resolves();
 

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -274,10 +274,10 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                   id: 'rec_challenge4',
                   locales: ['fr'],
                 });
-                const add = sinon.stub();
+                const trackEvent = sinon.stub();
 
                 class MetricsStubService extends Service {
-                  add = add;
+                  trackEvent = trackEvent;
                 }
                 this.owner.register('service:metrics', MetricsStubService);
 
@@ -289,7 +289,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 await click(screen.getByRole('button', { name: t('pages.challenge.statement.text-to-speech.play') }));
 
                 // then
-                sinon.assert.calledWithExactly(add, {
+                sinon.assert.calledWithExactly(trackEvent, {
                   event: 'custom-event',
                   'pix-event-category': 'Vocalisation',
                   'pix-event-action': "Lecture d'une épreuve",

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -49,7 +49,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Détails du module : ${module.slug}`,
@@ -85,7 +85,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(metrics.add, {
+          sinon.assert.calledWithExactly(metrics.trackEvent, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
             'pix-event-action': `Détails du module : ${module.slug}`,
@@ -120,7 +120,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(metrics.add, {
+          sinon.assert.calledWithExactly(metrics.trackEvent, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
             'pix-event-action': `Détails du module : ${module.slug}`,
@@ -167,7 +167,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(metrics.add, {
+            sinon.assert.calledWithExactly(metrics.trackEvent, {
               event: 'custom-event',
               'pix-event-category': 'Modulix',
               'pix-event-action': `Détails du module : ${module.slug}`,
@@ -214,7 +214,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(metrics.add, {
+            sinon.assert.calledWithExactly(metrics.trackEvent, {
               event: 'custom-event',
               'pix-event-category': 'Modulix',
               'pix-event-action': `Détails du module : ${module.slug}`,
@@ -252,7 +252,7 @@ function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
   const router = this.owner.lookup('service:router');
   router.transitionTo = sinon.stub();
   const metrics = this.owner.lookup('service:metrics');
-  metrics.add = sinon.stub();
+  metrics.trackEvent = sinon.stub();
   const store = this.owner.lookup('service:store');
 
   const details = {

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -321,14 +321,14 @@ module('Integration | Component | Module | Passage', function (hooks) {
           const passage = store.createRecord('passage');
 
           const metrics = this.owner.lookup('service:metrics');
-          metrics.add = sinon.stub();
+          metrics.trackEvent = sinon.stub();
 
           // when
           await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
           await clickByName('Afficher les étapes du module');
 
           // then
-          sinon.assert.calledWithExactly(metrics.add, {
+          sinon.assert.calledWithExactly(metrics.trackEvent, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
             'pix-event-action': `Passage du module : ${module.slug}`,
@@ -395,14 +395,14 @@ module('Integration | Component | Module | Passage', function (hooks) {
           const passage = store.createRecord('passage');
 
           const metrics = this.owner.lookup('service:metrics');
-          metrics.add = sinon.stub();
+          metrics.trackEvent = sinon.stub();
 
           // when
           await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
           await clickByName('Afficher les étapes du module');
 
           // then
-          sinon.assert.calledWithExactly(metrics.add, {
+          sinon.assert.calledWithExactly(metrics.trackEvent, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
             'pix-event-action': `Passage du module : ${module.slug}`,
@@ -469,13 +469,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // when
       await clickByName(t('pages.modulix.buttons.grain.skip'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -603,13 +603,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // when
       await clickByName(continueButtonName);
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -623,7 +623,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should save the element answer', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       const store = this.owner.lookup('service:store');
       const qcuElement = {
@@ -665,7 +665,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       const store = this.owner.lookup('service:store');
       const qcuElement = {
@@ -699,7 +699,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.activity.verify'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -713,7 +713,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // given
       const store = this.owner.lookup('service:store');
@@ -735,7 +735,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.activity.retry'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -749,7 +749,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       const store = this.owner.lookup('service:store');
       const passageEvents = this.owner.lookup('service:passage-events');
@@ -815,7 +815,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.flashcards.answers.no'));
 
       // then
-      sinon.assert.calledOnceWithExactly(metrics.add, {
+      sinon.assert.calledOnceWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -829,7 +829,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // given
       const store = this.owner.lookup('service:store');
@@ -854,7 +854,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName("Afficher l'alternative textuelle");
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -867,7 +867,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       test('should push metrics event', async function (assert) {
         // given
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         // given
         const store = this.owner.lookup('service:store');
@@ -896,7 +896,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName("Afficher l'alternative textuelle");
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.slug}`,
@@ -911,7 +911,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push metrics event', async function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // given
       const store = this.owner.lookup('service:store');
@@ -937,7 +937,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName('Afficher la transcription');
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -950,7 +950,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       test('should push metrics event', async function (assert) {
         // given
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         // given
         const store = this.owner.lookup('service:store');
@@ -980,7 +980,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName('Afficher la transcription');
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1016,13 +1016,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       // when
       await clickByName(onStepperNextStepButtonName);
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1158,7 +1158,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       const videoElement = {
         id: 'id',
@@ -1190,7 +1190,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1203,7 +1203,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       test('should push metrics event', async function (assert) {
         // given
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         // given
         const store = this.owner.lookup('service:store');
@@ -1235,7 +1235,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1251,7 +1251,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       const downloadedFormat = '.pdf';
       const downloadElement = {
@@ -1284,7 +1284,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       downloadLink.click();
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1297,7 +1297,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       test('should push metrics event', async function (assert) {
         // given
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         // given
         const store = this.owner.lookup('service:store');
@@ -1330,7 +1330,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         link.click();
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1351,7 +1351,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const router = this.owner.lookup('service:router');
       router.transitionTo = sinon.stub();
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
       const store = this.owner.lookup('service:store');
       const passageEventsService = this.owner.lookup('service:passage-events');
       passageEventsService.record = sinon.stub();
@@ -1381,7 +1381,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.grain.terminate'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1418,14 +1418,14 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       //  when
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       await clickByName('Afficher les étapes du module');
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1495,7 +1495,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       //  when
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1505,7 +1505,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(item);
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1540,7 +1540,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       //  when
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1549,7 +1549,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1585,7 +1585,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         });
         const passage = store.createRecord('passage');
         const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
+        metrics.trackEvent = sinon.stub();
 
         //  when
         await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1594,7 +1594,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await click(expandSummarySelector);
 
         // then
-        sinon.assert.calledWithExactly(metrics.add, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
           'pix-event-action': `Passage du module : ${module.slug}`,
@@ -1630,7 +1630,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
 
       //  when
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1642,7 +1642,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${module.slug}`,

--- a/mon-pix/tests/unit/components/module/video_test.gjs
+++ b/mon-pix/tests/unit/components/module/video_test.gjs
@@ -76,7 +76,7 @@ module('Unit | Component | Module | Video', function (hooks) {
       const video = { id: 'video-id' };
 
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = () => {};
+      metrics.trackEvent = () => {};
 
       const component = createGlimmerComponent('module/element/video', {
         video,

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -191,7 +191,7 @@ module('Unit | Component | Training | card', function (hooks) {
     test('should push event on click', function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
       const trainingTitle = 'Mon super CF';
       const component = createGlimmerComponent('training/card', {
         training: { title: trainingTitle, link: 'https://exemple.net/' },
@@ -203,7 +203,7 @@ module('Unit | Component | Training | card', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Accès Contenu Formatif',
         'pix-event-action': `Click depuis : ${currentRouteName}`,

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -210,7 +210,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
     test('should push event on click', function (assert) {
       // given
       const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
+      metrics.trackEvent = sinon.stub();
       const tutorialTitle = 'Mon super tutoriel';
       component = createGlimmerComponent('tutorials/card', {
         tutorial: { ...tutorial, title: tutorialTitle, link: 'https://exemple.net/' },
@@ -222,7 +222,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.add, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, {
         event: 'custom-event',
         'pix-event-category': 'Accès tuto',
         'pix-event-action': `Click depuis : ${currentRouteName}`,

--- a/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -1,0 +1,102 @@
+import { setupTest } from 'ember-qunit';
+import PlausibleAdapter from 'mon-pix/metrics-adapters/plausible-adapter';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    const config = {
+      scriptUrl: 'https://plausible.io/js/script.manual.js',
+      siteId: 'review.pix.fr',
+    };
+
+    this.adapter = new PlausibleAdapter(config);
+    this.adapter.install();
+  });
+
+  hooks.afterEach(function () {
+    this.adapter.uninstall();
+  });
+
+  test('#install installs container correctly', function (assert) {
+    const script = document.querySelector('script[src*="plausible"]');
+    assert.strictEqual(script.getAttribute('src'), 'https://plausible.io/js/script.manual.js');
+    assert.strictEqual(script.getAttribute('data-domain'), 'review.pix.fr');
+  });
+
+  test('#trackEvent calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackEvent({
+      'pix-event-category': 'button',
+      'pix-event-action': 'click',
+      eventName: 'nav buttons',
+      'pix-event-value': 4,
+    });
+    assert.ok(
+      stub.calledWith('nav buttons', {
+        props: {
+          'pix-event-category': 'button',
+          'pix-event-action': 'click',
+          'pix-event-value': 4,
+        },
+      }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackEvent calls Plausible with the overriden plausible props', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackEvent({
+      'pix-event-category': 'button',
+      'pix-event-action': 'click',
+      eventName: 'nav buttons',
+      'pix-event-value': 4,
+      plausibleAttributes: { u: 'hello' },
+    });
+    assert.ok(
+      stub.calledWith('nav buttons', {
+        u: 'hello',
+        props: {
+          'pix-event-category': 'button',
+          'pix-event-action': 'click',
+          'pix-event-value': 4,
+        },
+      }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackPage calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({
+      page: '/my-overridden-page?id=1',
+    });
+    sinon.assert.calledOnceWithExactly(stub, 'pageview', { props: { page: '/my-overridden-page?id=1' } });
+    assert.ok(
+      stub.calledWith('pageview', { props: { page: '/my-overridden-page?id=1' } }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackPage calls Plausible with the overriden plausible props', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({ plausibleAttributes: { u: '/page/_ID_/test?id=1' }, page: 'page' });
+    assert.ok(
+      stub.calledWith('pageview', { u: '/page/_ID_/test?id=1', props: { page: 'page' } }),
+      'it sends the correct arguments',
+    );
+  });
+});

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -28,6 +28,11 @@ module('Unit | Route | application', function (hooks) {
           params: ['competence123', '789'],
           expected: '/competences/_ID_/resultats/_ID_',
         },
+        {
+          actual: '/competences/competence123/resultats/789?id=789',
+          params: ['competence123', '789'],
+          expected: '/competences/_ID_/resultats/_ID_?id=789',
+        },
       ],
       function (assert, input) {
         const redatedUrl = redactUrlForAnalytics(input.actual, input.params);

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -1,45 +1,11 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
-import { redactUrlForAnalytics } from 'mon-pix/routes/application.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 module('Unit | Route | application', function (hooks) {
   setupTest(hooks);
 
-  module('#redactUrlForAnalytics', function () {
-    test.each(
-      'should rewrite url with redacted IDs',
-      [
-        { actual: '/candidat/123/informations', params: ['123'], expected: '/candidat/_ID_/informations' },
-        { actual: '/candidat/1/informations', params: ['1'], expected: '/candidat/_ID_/informations' },
-        {
-          actual: '/competences/rec123/resultats/0',
-          params: ['rec123', '0'],
-          expected: '/competences/_ID_/resultats/_ID_',
-        },
-        {
-          actual: '/competences/rec123/resultats/789',
-          params: ['rec123', '789'],
-          expected: '/competences/_ID_/resultats/_ID_',
-        },
-        {
-          actual: '/competences/competence123/resultats/789',
-          params: ['competence123', '789'],
-          expected: '/competences/_ID_/resultats/_ID_',
-        },
-        {
-          actual: '/competences/competence123/resultats/789?id=789',
-          params: ['competence123', '789'],
-          expected: '/competences/_ID_/resultats/_ID_?id=789',
-        },
-      ],
-      function (assert, input) {
-        const redatedUrl = redactUrlForAnalytics(input.actual, input.params);
-        assert.strictEqual(redatedUrl, input.expected);
-      },
-    );
-  });
   test('hides the splash when the route is activated', function (assert) {
     // Given
     const SplashServiceStub = Service.create({

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -1,11 +1,40 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
+import { redactUrlForAnalytics } from 'mon-pix/routes/application.js';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 module('Unit | Route | application', function (hooks) {
   setupTest(hooks);
 
+  module('#redactUrlForAnalytics', function () {
+    test.each(
+      'should rewrite url with redacted IDs',
+      [
+        { actual: '/candidat/123/informations', params: ['123'], expected: '/candidat/_ID_/informations' },
+        { actual: '/candidat/1/informations', params: ['1'], expected: '/candidat/_ID_/informations' },
+        {
+          actual: '/competences/rec123/resultats/0',
+          params: ['rec123', '0'],
+          expected: '/competences/_ID_/resultats/_ID_',
+        },
+        {
+          actual: '/competences/rec123/resultats/789',
+          params: ['rec123', '789'],
+          expected: '/competences/_ID_/resultats/_ID_',
+        },
+        {
+          actual: '/competences/competence123/resultats/789',
+          params: ['competence123', '789'],
+          expected: '/competences/_ID_/resultats/_ID_',
+        },
+      ],
+      function (assert, input) {
+        const redatedUrl = redactUrlForAnalytics(input.actual, input.params);
+        assert.strictEqual(redatedUrl, input.expected);
+      },
+    );
+  });
   test('hides the splash when the route is activated', function (assert) {
     // Given
     const SplashServiceStub = Service.create({

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -11,10 +11,12 @@ module('Unit | Services | locale', function (hooks) {
   let currentDomainService;
   let dayjsService;
   let intlService;
+  let metricsService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
     cookiesService = this.owner.lookup('service:cookies');
+
     sinon.stub(cookiesService, 'write');
     sinon.stub(cookiesService, 'exists');
     currentDomainService = this.owner.lookup('service:currentDomain');
@@ -25,6 +27,9 @@ module('Unit | Services | locale', function (hooks) {
 
     intlService = this.owner.lookup('service:intl');
     sinon.stub(intlService, 'setLocale');
+
+    metricsService = this.owner.lookup('service:metrics');
+    sinon.stub(metricsService, 'context').value({});
   });
 
   module('#isSupportedLocale', function () {
@@ -190,7 +195,7 @@ module('Unit | Services | locale', function (hooks) {
       // then
       sinon.assert.calledWith(intlService.setLocale, locale);
       sinon.assert.calledWith(dayjsService.setLocale, locale);
-      assert.ok(true);
+      assert.strictEqual(metricsService.context.locale, locale);
     });
   });
 });

--- a/mon-pix/tests/unit/services/pix-metrics-test.js
+++ b/mon-pix/tests/unit/services/pix-metrics-test.js
@@ -1,0 +1,153 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | PixMetrics', function (hooks) {
+  setupTest(hooks);
+
+  let pixMetricsService;
+  let metricsService;
+  let routerService;
+
+  hooks.beforeEach(function () {
+    pixMetricsService = this.owner.lookup('service:pix-metrics');
+    metricsService = this.owner.lookup('service:metrics');
+    routerService = this.owner.lookup('service:router');
+    sinon.stub(metricsService, 'trackPage');
+    sinon.stub(metricsService, 'trackEvent');
+  });
+
+  module('trackPage', function () {
+    test('it should redact id from url', function (assert) {
+      // given
+      const currentURL = '/campagnes/SCOASSMUL/presentation';
+      const currentRoute = {
+        name: 'campaigns.campaign-landing-page',
+        params: {},
+        parent: {
+          name: 'campaigns',
+          params: {
+            id: 'SCOASSMUL',
+          },
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackPage({ params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
+        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+    test('it should forward query parameters', function (assert) {
+      // given
+      const currentURL = '/assessments/1234/checkpoint?finalCheckpoint=true';
+      const currentRoute = {
+        name: 'assessments.checkpoint',
+        params: {},
+        parent: {
+          name: 'assessments',
+          params: {
+            id: '1234',
+          },
+
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackPage({ params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
+        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+  });
+  module('trackEvent', function () {
+    test('it should redact id from url', function (assert) {
+      // given
+      const currentURL = '/campagnes/SCOASSMUL/presentation';
+      const currentRoute = {
+        name: 'campaigns.campaign-landing-page',
+        params: {},
+        parent: {
+          name: 'campaigns',
+          params: {
+            id: 'SCOASSMUL',
+          },
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
+        eventName: 'mon-event',
+        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+
+    test('it should forward query parameters', function (assert) {
+      // given
+      const currentURL = '/assessments/1234/checkpoint?finalCheckpoint=true';
+      const currentRoute = {
+        name: 'assessments.checkpoint',
+        params: {},
+        parent: {
+          name: 'assessments',
+          params: {
+            id: '1234',
+          },
+
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
+        eventName: 'mon-event',
+        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :egg: Problème
Le support de matomo arrive à échéance.

## :bowl_with_spoon: Proposition

On bascule sur Plausible. Integration d'un adapter.

## :milk_glass: Remarques

On a remplacé le plugin existant (ember-matomo-tag-manager) par ember-metrics dont il était inspiré et on a ajouté 1 nouvel adapter pour Plausible
- [x] on a rajouté le fait de ne pas suivre les pages intermédiaires (redirection) en ajoutant une métadonnée sur les routes
- [x] on caviarde les parametre d'url pour éviter d'avoir plusieurs pageview pour la même page
- [x] rajouter la locale dans le context
- [x] rajouter les searchparams dans l'url qu'on envoie à plausible
- [x] l'url n'est pas caviardé pour les trackEvent :/ (remplacer par _ID_ les id)

ℹ️ Si vous voulez tester en local, prendre note des nouvelles variables necessaire pour activer les metrics
Exemple de lancement: `WEB_ANALYTICS_ENABLED=true ANALYTICS_SITE_ID=review.pix.fr ANALYTICS_SCRIPT_URL=https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.local.manual.js npm run dev`

## :butter: Pour tester

- Ouvrir les devtools 
- Naviguer sur le site, declencher ainsi des changements de pages
  - Cela cree des evenement plausible en console
- Declencher des evenements "custom"
  - par exemple a l'acces des tutoriels  
- Grace aux identifiants sur notre plateforme interne, se connecter a Plausible
- Vérifier que le suivi fonctionne sur plausible 
