### PR TITLE
[TECH] Déplacer le feature toggle Companion dans le front mon-pix (PIX-17805)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -828,13 +828,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
 
-# Consider the Pix Companion extension as active
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_PIX_COMPANION_ENABLED=false
-
 # Enable quests system.
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -136,7 +136,6 @@ const schema = Joi.object({
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
-  FT_PIX_COMPANION_ENABLED: Joi.string().optional().valid('true', 'false'),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
@@ -302,7 +301,6 @@ const configuration = (function () {
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
-      isPixCompanionEnabled: toBoolean(process.env.FT_PIX_COMPANION_ENABLED),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
@@ -517,7 +515,6 @@ const configuration = (function () {
     config.featureToggles.isDirectMetricsEnabled = false;
     config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
-    config.featureToggles.isPixCompanionEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;
 

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,7 +29,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-need-to-adjust-certification-accessibility-enabled': false,
             'is-oppsy-disabled': false,
             'is-pix-app-new-layout-enabled': false,
-            'is-pix-companion-enabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': false,

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,5 +2,4 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isNeedToAdjustCertificationAccessibilityEnabled;
-  @attr('boolean') isPixCompanionEnabled;
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -3,7 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isPixAppNewLayoutEnabled;
-  @attr('boolean') isPixCompanionEnabled;
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isV3CertificationPageEnabled;
 }

--- a/mon-pix/app/services/pix-companion.js
+++ b/mon-pix/app/services/pix-companion.js
@@ -1,5 +1,6 @@
 import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import ENV from 'mon-pix/config/environment';
 
 const MINIMAL_VERSION_FOR_CERTIFICATION_SESSION = [0, 0, 5];
 
@@ -12,25 +13,25 @@ export default class PixCompanion extends Service {
   #eventTarget = new EventTarget();
 
   startCertification(windowRef = window) {
-    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
+    if (ENV.companion.disabled) return;
     windowRef.dispatchEvent(new CustomEvent('pix:certification:start'));
     windowRef.postMessage({ event: 'pix:certification:start' }, windowRef.location.origin);
   }
 
   stopCertification(windowRef = window) {
-    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
+    if (ENV.companion.disabled) return;
     windowRef.dispatchEvent(new CustomEvent('pix:certification:stop'));
     windowRef.postMessage({ event: 'pix:certification:stop' }, windowRef.location.origin);
   }
 
   startCheckingExtensionIsEnabled(windowRef = window) {
-    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
+    if (ENV.companion.disabled) return;
     this.checkExtensionIsEnabled(windowRef);
     this.#checkExtensionIsEnabledInterval = windowRef.setInterval(() => this.checkExtensionIsEnabled(windowRef), 1000);
   }
 
   stopCheckingExtensionIsEnabled(windowRef = window) {
-    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return;
+    if (ENV.companion.disabled) return;
     windowRef.clearInterval(this.#checkExtensionIsEnabledInterval);
   }
 
@@ -75,7 +76,7 @@ export default class PixCompanion extends Service {
   }
 
   get isExtensionEnabled() {
-    if (!this.featureToggles.featureToggles.isPixCompanionEnabled) return true;
+    if (ENV.companion.disabled) return true;
     return this._isExtensionEnabled;
   }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -113,6 +113,10 @@ module.exports = function (environment) {
       matomoUrl: process.env.WEB_ANALYTICS_URL,
     },
 
+    companion: {
+      disabled: false,
+    },
+
     '@sentry/ember': {
       disablePerformance: true,
       sentry: {
@@ -147,6 +151,8 @@ module.exports = function (environment) {
     ENV.APP.LOG_TRANSITIONS = false;
     ENV.APP.LOG_TRANSITIONS_INTERNAL = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.companion.disabled = true;
   }
 
   if (environment === 'test') {
@@ -166,6 +172,8 @@ module.exports = function (environment) {
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.metrics.enabled = false;
+
+    ENV.companion.disabled = true;
   }
 
   if (environment === 'production') {

--- a/mon-pix/tests/unit/services/feature-toggles-test.js
+++ b/mon-pix/tests/unit/services/feature-toggles-test.js
@@ -10,7 +10,6 @@ module('Unit | Service | feature-toggles', function (hooks) {
   module('feature toggles are loaded', function (hooks) {
     const featureToggles = Object.create({
       isTextToSpeechButtonEnabled: false,
-      isPixCompanionEnabled: false,
     });
 
     let storeStub;
@@ -43,18 +42,6 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.false(featureToggleService.featureToggles.isTextToSpeechButtonEnabled);
-    });
-
-    test('it initializes the feature toggle isPixCompanionEnabled to false', async function (assert) {
-      // given
-      const featureToggleService = this.owner.lookup('service:featureToggles');
-      featureToggleService.set('store', storeStub);
-
-      // when
-      await featureToggleService.load();
-
-      // then
-      assert.false(featureToggleService.featureToggles.isPixCompanionEnabled);
     });
   });
 });

--- a/mon-pix/tests/unit/services/pix-companion-test.js
+++ b/mon-pix/tests/unit/services/pix-companion-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -8,7 +9,11 @@ module('Unit | Service | pix-companion', function (hooks) {
 
   hooks.beforeEach(function () {
     pixCompanion = this.owner.lookup('service:pix-companion');
-    pixCompanion.featureToggles = { featureToggles: { isPixCompanionEnabled: true } };
+    ENV.companion.disabled = false;
+  });
+
+  hooks.afterEach(function () {
+    ENV.companion.disabled = true;
   });
 
   module('#startCertification', function () {
@@ -29,10 +34,10 @@ module('Unit | Service | pix-companion', function (hooks) {
       assert.ok(true);
     });
 
-    module('when the feature toggle isPixCompanionEnabled is false', function () {
+    module('when Pix Companion is disabled', function () {
       test('do nothing', async function (assert) {
         // Given
-        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        ENV.companion.disabled = true;
         const windowStub = {
           dispatchEvent: sinon.stub(),
           postMessage: sinon.stub(),
@@ -68,10 +73,10 @@ module('Unit | Service | pix-companion', function (hooks) {
       assert.ok(true);
     });
 
-    module('when the feature toggle isPixCompanionEnabled is false', function () {
+    module('when Pix Companion is disabled', function () {
       test('do nothing', async function (assert) {
         // Given
-        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        ENV.companion.disabled = true;
         const windowStub = {
           dispatchEvent: sinon.stub(),
           postMessage: sinon.stub(),
@@ -147,7 +152,7 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#startCheckingExtensionIsEnabled', function () {
-    module('when the feature toggle isPixCompanionEnabled is false', function () {
+    module('when Pix Companion is disabled', function () {
       test('do nothing', async function (assert) {
         // Given
         const windowStub = {
@@ -157,7 +162,7 @@ module('Unit | Service | pix-companion', function (hooks) {
           setInterval: sinon.stub(),
           setTimeout: sinon.stub(),
         };
-        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        ENV.companion.disabled = true;
 
         // When
         pixCompanion.startCheckingExtensionIsEnabled(windowStub);
@@ -175,13 +180,13 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#stopCheckingExtensionIsEnabled', function () {
-    module('when the feature toggle isPixCompanionEnabled is false', function () {
+    module('when Pix Companion is disabled', function () {
       test('do nothing', async function (assert) {
         // Given
         const windowStub = {
           clearInterval: sinon.stub(),
         };
-        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        ENV.companion.disabled = true;
 
         // When
         pixCompanion.stopCheckingExtensionIsEnabled(windowStub);
@@ -194,10 +199,10 @@ module('Unit | Service | pix-companion', function (hooks) {
   });
 
   module('#isExtensionEnabled', function () {
-    module('when the feature toggle isPixCompanionEnabled is false', function () {
+    module('when Pix Companion is disabled', function () {
       test('always returns true', function (assert) {
         // Given
-        pixCompanion.featureToggles.featureToggles.isPixCompanionEnabled = false;
+        ENV.companion.disabled = true;
 
         // When
         pixCompanion._isExtensionEnabled = false;


### PR DESCRIPTION
## 🌸 Problème

Le feature toggle Companion a été créé dans l’API mais n’est utilisé que dans le front mon-pix.
On ne souhaite pas conserver la possibilité de désactiver Companion en prod, cela n’est utile que en dev et en test.

## 🌳 Proposition

Déplacer le FT dans le front mon-pix.

## 🐝 Remarques

Il faudra supprimer la variable `FT_PIX_COMPANION_ENABLED` sur les différents environnements pix-api.

## 🤧 Pour tester

Vérifier qu’en RA Companion est nécessaire pour démarrer une certif’.
Vérifier qu’en dev Companion n’est pas nécessaire pour démarrer une certif’.