### PR TITLE
[BUGFIX] Corriger le script de rattrapage de données sur la suppression des dates (PIX-17731)

### DIFF
--- a/api/src/legal-documents/scripts/backfill-data-for-anonymized-users.script.js
+++ b/api/src/legal-documents/scripts/backfill-data-for-anonymized-users.script.js
@@ -1,7 +1,6 @@
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
-import { anonymizeGeneralizeDate } from '../../shared/infrastructure/utils/date-utils.js';
 
 export class BackfillDataForAnonymizedUsersScript extends Script {
   constructor() {
@@ -28,10 +27,7 @@ export class BackfillDataForAnonymizedUsersScript extends Script {
     logger.info(`Found ${rows.length} anonymized rows to ${dryRun ? 'process (dry run)' : 'update'}`);
     if (!dryRun) {
       for (const row of rows) {
-        const generalizedDate = anonymizeGeneralizeDate(row.acceptedAt);
-        await knexConnection('legal-document-version-user-acceptances')
-          .where('id', row.id)
-          .update({ acceptedAt: generalizedDate });
+        await knexConnection('legal-document-version-user-acceptances').where('id', row.id).del();
       }
       logger.info(`✅ Successfully updated ${rows.length} rows.`);
     } else {

--- a/api/tests/legal-documents/integration/scripts/backfill-data-for-anonymized-users.script.test.js
+++ b/api/tests/legal-documents/integration/scripts/backfill-data-for-anonymized-users.script.test.js
@@ -1,4 +1,4 @@
-import { BackfillDataForAnonymizedUsersScript } from '../../../../src/legal-documents/scripts/backfill-data-for-anonymized-users-script.js';
+import { BackfillDataForAnonymizedUsersScript } from '../../../../src/legal-documents/scripts/backfill-data-for-anonymized-users.script.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 
@@ -59,8 +59,8 @@ describe('Integration | LegalDocuments | Scripts | backfill-data-for-anonymized-
       .where({ userId: notAnonymousUser.id })
       .first();
 
-    expect(foundUser1Acceptances.acceptedAt.toISOString()).to.deep.equal('2023-03-01T00:00:00.000Z');
-    expect(foundUser2Acceptances.acceptedAt.toISOString()).to.deep.equal('2022-02-01T00:00:00.000Z');
+    expect(foundUser1Acceptances).to.be.undefined;
+    expect(foundUser2Acceptances).to.be.undefined;
     expect(foundNonAnonymizedUserAcceptances.acceptedAt.toISOString()).to.deep.equal('2022-02-22T22:22:22.000Z');
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Lors de la première exécution de ce script, on croyait qu'il fallait généraliser les dates de la table legal-document-version-user-acceptances pour les utilisateurs anonymisés. Or, il fallait en fait supprimer toutes les informations concernant l'utilisateur de la table.

## 🌳 Proposition

Modifier le script pour supprimer au lieu de généraliser.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

- Prendre une grande inspiration,
- Se connecter en base:
```shell
scalingo -a pix-api-review-pr12260 psql-console
```
- Récupérer l'identifiant du compte allorga@example.net,
```sql
SELECT "id" FROM "users" WHERE "email" = 'allorga@example.net';
```
- Mettre à jour la valeur hasBeenAnonymised soit par l'id, soit par l'email,
```sql
UPDATE "users" SET "hasBeenAnonymised" = true WHERE "email" = 'allorga@example.net';
```
- Exécuter le script avec le dryRun:
```shell
scalingo -a pix-api-review-pr12260 run node src/legal-documents/scripts/backfill-data-for-anonymized-users.script.js --dryRun
```
- Constater qu'une ligne va être modifiée,
- Réexécuter le script sans le dryRun,
- Vérifier dans la table que les lignes ont été supprimées:
```sql
SELECT * FROM "legal-document-version-user-acceptances" WHERE "userId" = '<identifiant>';
```
- Constater qu'il n'y a plus rien:)