### PR TITLE
[BUGFIX] Retirer la contrainte qui veut qu'une organisation fille ait le même type que l'organisation mère (PIX-17775)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -40,11 +40,6 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
             'pages.organization-children.notifications.error.unable-to-attach-child-organization-to-another-child-organization',
           );
           break;
-        case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE':
-          message = this.intl.t(
-            'pages.organization-children.notifications.error.unable-to-attach-child-organization-without-same-type',
-          );
-          break;
         case 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION':
           message = this.intl.t(
             'pages.organization-children.notifications.error.unable-to-attach-parent-organization-as-child-organization',

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
@@ -69,10 +69,6 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
           message: `Impossible d'attacher une organisation fille à une autre organisation fille.`,
         },
         {
-          code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE',
-          message: `Vérifiez et sélectionnez une organisation fille qui correspond au type de l'organisation mère.`,
-        },
-        {
           code: 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION',
           message: `Impossible d'attacher une organisation mère en tant qu'organisation fille.`,
         },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -890,7 +890,6 @@
           "unable-to-attach-already-attached-child-organization": "Child organization already linked",
           "unable-to-attach-child-organization-to-another-child-organization": "Unable to attach a child organization to another child organization",
           "unable-to-attach-child-organization-to-itself": "Unable to attach organization to itself",
-          "unable-to-attach-child-organization-without-same-type": "Check and select a child organization that matches the parent organization's type",
           "unable-to-attach-parent-organization-as-child-organization": "Unable to attach a parent organization as child organization"
         },
         "success": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -890,7 +890,6 @@
           "unable-to-attach-already-attached-child-organization": "L'organisation fille est déjà liée.",
           "unable-to-attach-child-organization-to-another-child-organization": "Impossible d'attacher une organisation fille à une autre organisation fille.",
           "unable-to-attach-child-organization-to-itself": "Impossible d'attacher l'organisation à elle-même",
-          "unable-to-attach-child-organization-without-same-type": "Vérifiez et sélectionnez une organisation fille qui correspond au type de l'organisation mère.",
           "unable-to-attach-parent-organization-as-child-organization": "Impossible d'attacher une organisation mère en tant qu'organisation fille."
         },
         "success": {

--- a/api/src/organizational-entities/domain/usecases/attach-child-organization-to-organization.js
+++ b/api/src/organizational-entities/domain/usecases/attach-child-organization-to-organization.js
@@ -23,10 +23,6 @@ const attachChildOrganizationToOrganization = withTransaction(
       });
 
       _assertParentOrganizationIsNotChildOrganization(parentOrganizationForAdmin);
-      _assertChildOrganizationHaveSameTypeAsParentOrganization({
-        childOrganizationForAdmin,
-        parentOrganizationForAdmin,
-      });
 
       childOrganizationForAdmin.updateParentOrganizationId(parentOrganizationId);
 
@@ -57,24 +53,6 @@ function _assertChildOrganizationNotAlreadyAttached(childOrganizationForAdmin) {
       message: 'Unable to attach already attached child organization',
       meta: {
         childOrganizationId: childOrganizationForAdmin.id,
-      },
-    });
-  }
-}
-
-function _assertChildOrganizationHaveSameTypeAsParentOrganization({
-  childOrganizationForAdmin,
-  parentOrganizationForAdmin,
-}) {
-  if (childOrganizationForAdmin.type !== parentOrganizationForAdmin.type) {
-    throw new UnableToAttachChildOrganizationToParentOrganizationError({
-      code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE',
-      message: 'Unable to attach child organization with a different type as the parent organization',
-      meta: {
-        childOrganizationId: childOrganizationForAdmin.id,
-        childOrganizationType: childOrganizationForAdmin.type,
-        parentOrganizationId: parentOrganizationForAdmin.id,
-        parentOrganizationType: parentOrganizationForAdmin.type,
       },
     });
   }

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -978,7 +978,6 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         it('returns a 409 HTTP status code with detailed error info', async function () {
           // given
           const parentOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
-          const childOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO' }).id;
           await databaseBuilder.commit();
 
           const options = {
@@ -986,7 +985,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             url: `/api/admin/organizations/${parentOrganizationId}/attach-child-organization`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: admin.id }),
             payload: {
-              childOrganizationIds: `${childOrganizationId}`,
+              childOrganizationIds: `${parentOrganizationId}`,
             },
           };
 
@@ -998,14 +997,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           expect(statusCode).to.equal(409);
           expect(error).to.deep.equal({
             status: '409',
-            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE',
+            code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
             title: 'Conflict',
-            detail: 'Unable to attach child organization with a different type as the parent organization',
+            detail: 'Unable to attach child organization to itself',
             meta: {
-              childOrganizationId,
-              childOrganizationType: 'PRO',
+              childOrganizationId: parentOrganizationId,
               parentOrganizationId,
-              parentOrganizationType: 'SCO',
             },
           });
         });

--- a/api/tests/organizational-entities/unit/domain/usecases/attach-child-organization-to-organization_test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/attach-child-organization-to-organization_test.js
@@ -117,52 +117,6 @@ describe('Unit | Organizational Entities | Domain | UseCases | attach-child-orga
       });
     });
 
-    context('when attaching child organization without the same type as parent organization', function () {
-      it('throws an UnableToAttachChildOrganizationToParentOrganization error', async function () {
-        // given
-        const childOrganization = domainBuilder.buildOrganizationForAdmin({
-          id: 123,
-          name: 'Child SCO Organization',
-          type: 'SCO',
-        });
-        const parentOrganization = domainBuilder.buildOrganizationForAdmin({
-          id: 1,
-          name: 'Parent PRO Organization',
-          type: 'PRO',
-        });
-        const childOrganizationId = childOrganization.id;
-        const childOrganizationType = childOrganization.type;
-        const parentOrganizationId = parentOrganization.id;
-        const parentOrganizationType = parentOrganization.type;
-
-        organizationForAdminRepository.get.onCall(0).resolves(childOrganization);
-        organizationForAdminRepository.get.onCall(1).resolves(parentOrganization);
-        organizationForAdminRepository.findChildrenByParentOrganizationId.resolves([]);
-
-        // when
-        const error = await catchErr(attachChildOrganizationToOrganization)({
-          childOrganizationIds: '123',
-          parentOrganizationId,
-          organizationForAdminRepository,
-        });
-
-        // then
-        expect(organizationForAdminRepository.get).to.have.been.calledTwice;
-        expect(organizationForAdminRepository.update).to.not.have.been.called;
-        expect(error).to.be.instanceOf(UnableToAttachChildOrganizationToParentOrganizationError);
-        expect(error.message).to.equal(
-          'Unable to attach child organization with a different type as the parent organization',
-        );
-        expect(error.code).to.equal('UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE');
-        expect(error.meta).to.deep.equal({
-          childOrganizationId,
-          childOrganizationType,
-          parentOrganizationId,
-          parentOrganizationType,
-        });
-      });
-    });
-
     context('when the child organization is already parent', function () {
       it('throws an UnableToAttachChildOrganizationToParentOrganization error', async function () {
         // given


### PR DESCRIPTION
## 🌸 Problème

On souhaite pouvoir rattacher une organisation fille à une organisation mère même si elles ne sont pas du même type.

## 🌳 Proposition

Retirer la fonction du usecase qui vérifie le type des organisations.

## 🐝 Remarques

Est-ce un BUGFIX, une FEATURE, ou autre chose?

## 🤧 Pour tester

- Se rendre sur Pix admin,
- Se connecter avec le compte superadmin@example.net,
- Sur la page des organisations, noter l'identifiant de l'organisation attestation (de type sco),
- Cliquer sur l'organisation Accis (de type Pro),
- Aller dans la section Organisation fille et ajouter l'identifiant de l'orga Attestation,
- Constater que l'ajout se fait correctement et que l'orga apparaît dans la liste.
