### PR TITLE
[FEATURE] Ajout d'un boolean pour activer/désactiver la nouvelle suppression (PIX-17706)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -17,6 +17,12 @@ export default {
     defaultValue: true,
     tags: ['team-prescription', 'frontend'],
   },
+  isAnonymizationWithDeletionEnabled: {
+    type: 'boolean',
+    description: 'Used to enable anonymization and deletion on prescriber context',
+    defaultValue: false,
+    tags: ['team-prescription', 'pix-api', 'backend'],
+  },
   isNewAccountRecoveryEnabled: {
     type: 'boolean',
     description: 'Using and testing feature account recovery process',


### PR DESCRIPTION
## 🌸 Problème

Pour développer la nouvelle suppression nous allons devoir passer sur plusieurs usecases, et de ce fait de ne pas pouvoir tout faire en un seul coup

## 🌳 Proposition

Ajout d'un boolean qui nous permettra d'activer/désactiver la feature pour la tester en recette / local sans mettre des données incohérentes en prod

## 🐝 Remarques

RAS

## 🤧 Pour tester

activer le feature toggle sur la RA et vérifier qu'il est bien a true

- [ ] vérifier qu'il est bien a false par défaut

```
npm run toggles -- -l
npm run toggles -- -k enableAnonymisationWithDeletion -v true 
```

- [ ] vérifier qu'il est bien mis à true après avoir lancer le script

```
npm run toggles -- -k enableAnonymisationWithDeletion -v true 
```