### PR TITLE
[FEATURE] Ajouter une action "Archiver en masse des organisations" dans Pix Admin (PIX-17151)

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -48,4 +48,10 @@ export default class OrganizationAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${parentOrganizationId}/attach-child-organization`;
     return this.ajax(url, 'POST', { data: { childOrganizationIds } });
   }
+
+  archiveOrganizations(files) {
+    if (!files || files.length === 0) return;
+    const url = `${this.host}/${this.namespace}/organizations/batch-archive`;
+    return this.ajax(url, 'POST', { data: files[0] });
+  }
 }

--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -48,10 +48,4 @@ export default class OrganizationAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${parentOrganizationId}/attach-child-organization`;
     return this.ajax(url, 'POST', { data: { childOrganizationIds } });
   }
-
-  archiveOrganizations(files) {
-    if (!files || files.length === 0) return;
-    const url = `${this.host}/${this.namespace}/organizations/batch-archive`;
-    return this.ajax(url, 'POST', { data: files[0] });
-  }
 }

--- a/admin/app/components/administration/deployment/index.gjs
+++ b/admin/app/components/administration/deployment/index.gjs
@@ -1,6 +1,7 @@
 import CertificationCentersBatchArchive from './certification-centers-batch-archive';
 import NewTag from './new-tag';
 import OrganizationTagsImport from './organization-tags-import';
+import OrganizationsBatchArchive from './organizations-batch-archive';
 import OrganizationsImport from './organizations-import';
 import UpdateOrganizationsInBatch from './update-organizations-in-batch';
 
@@ -12,6 +13,8 @@ import UpdateOrganizationsInBatch from './update-organizations-in-batch';
   <OrganizationsImport />
 
   <UpdateOrganizationsInBatch />
+
+  <OrganizationsBatchArchive />
 
   <CertificationCentersBatchArchive />
 </template>

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -3,20 +3,33 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
 
 export default class OrganizationsBatchArchive extends Component {
   @service intl;
   @service pixToast;
+  @service requestManager;
   @service router;
   @service store;
 
   @action
   async archiveOrganizations(files) {
-    const adapter = this.store.adapterFor('organization');
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', files[0]);
+
     try {
-      await adapter.archiveOrganizations(files);
+      await this.requestManager.request({
+        url: `${ENV.APP.API_HOST}/api/admin/organizations/batch-archive`,
+        method: 'POST',
+        body: formData,
+      });
+
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.administration.organizations-batch-archive.notifications.success'),
       });

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -1,0 +1,68 @@
+import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class OrganizationsBatchArchive extends Component {
+  @service intl;
+  @service pixToast;
+  @service router;
+  @service store;
+
+  @action
+  async archiveOrganizations(files) {
+    const adapter = this.store.adapterFor('organization');
+    try {
+      await adapter.archiveOrganizations(files);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.administration.organizations-batch-archive.notifications.success'),
+      });
+    } catch (errorResponse) {
+      const errors = errorResponse.errors;
+
+      if (!errors) {
+        return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
+      }
+
+      errors.forEach((error) => {
+        switch (error.code) {
+          case 'MISSING_REQUIRED_FIELD_NAMES':
+            this.pixToast.sendErrorNotification({ message: `${error.meta}` });
+            break;
+          case 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR':
+            this.pixToast.sendErrorNotification({
+              message: this.intl.t(
+                'components.administration.organizations-batch-archive.notifications.errors.error-in-batch',
+                {
+                  currentLine: error.meta.currentLine,
+                  totalLines: error.meta.totalLines,
+                },
+              ),
+            });
+            break;
+          default:
+            this.pixToast.sendErrorNotification({ message: error.detail });
+        }
+      });
+    }
+  }
+
+  <template>
+    <AdministrationBlockLayout
+      @title={{t "components.administration.organizations-batch-archive.title"}}
+      @description={{t "components.administration.organizations-batch-archive.description"}}
+    >
+      <PixButtonUpload
+        @id="organizations-file-upload"
+        @onChange={{this.archiveOrganizations}}
+        @variant="secondary"
+        accept=".csv"
+      >
+        {{t "components.administration.organizations-batch-archive.upload-button"}}
+      </PixButtonUpload>
+    </AdministrationBlockLayout>
+  </template>
+}

--- a/admin/app/services/current-domain.js
+++ b/admin/app/services/current-domain.js
@@ -1,7 +1,13 @@
 import Service from '@ember/service';
 import last from 'lodash/last';
 
+const FRANCE_TLD = 'fr';
+
 export default class CurrentDomainService extends Service {
+  get isFranceDomain() {
+    return this.getExtension() === FRANCE_TLD;
+  }
+
   getExtension() {
     return last(location.hostname.split('.'));
   }

--- a/admin/app/services/request-manager-handlers/app-info-handler.js
+++ b/admin/app/services/request-manager-handlers/app-info-handler.js
@@ -1,0 +1,15 @@
+import ENV from 'pix-admin/config/environment';
+
+/**
+ * Request manager handler adding application info in request headers.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class AppInfoHandler {
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    headers.append('X-App-Version', ENV.APP.APP_VERSION);
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/admin/app/services/request-manager-handlers/auth-handler.js
+++ b/admin/app/services/request-manager-handlers/auth-handler.js
@@ -1,0 +1,20 @@
+import { inject as service } from '@ember/service';
+
+/**
+ * Request manager handler adding authentication credentials in the request.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class AuthHandler {
+  @service session;
+
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    const { isAuthenticated, data } = this.session;
+    if (isAuthenticated) {
+      headers.append('Authorization', `Bearer ${data.authenticated.access_token}`);
+    }
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/admin/app/services/request-manager-handlers/json-handler.js
+++ b/admin/app/services/request-manager-handlers/json-handler.js
@@ -1,0 +1,17 @@
+/**
+ * Request manager handler to manage JSON request.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class JsonHandler {
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    headers.append('Accept', 'application/json');
+
+    if (!(context.request.body instanceof FormData)) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+}

--- a/admin/app/services/request-manager-handlers/locale-handler.js
+++ b/admin/app/services/request-manager-handlers/locale-handler.js
@@ -1,0 +1,25 @@
+import { inject as service } from '@ember/service';
+
+const FRENCH_FRANCE_LOCALE = 'fr-fr';
+
+/**
+ * Request manager handler adding user locale in request header.
+ * See: https://github.com/emberjs/data/blob/main/guides/requests/examples/1-auth.md
+ */
+export default class LocaleHandler {
+  @service currentDomain;
+  @service intl;
+
+  request(context, next) {
+    const headers = new Headers(context.request.headers);
+
+    headers.append('Accept-Language', this._locale);
+
+    return next(Object.assign({}, context.request, { headers }));
+  }
+
+  get _locale() {
+    if (this.currentDomain.isFranceDomain) return FRENCH_FRANCE_LOCALE;
+    return this.intl.primaryLocale;
+  }
+}

--- a/admin/app/services/request-manager.js
+++ b/admin/app/services/request-manager.js
@@ -1,0 +1,32 @@
+import { getOwner, setOwner } from '@ember/application';
+import RequestManager from '@ember-data/request';
+import Fetch from '@ember-data/request/fetch';
+
+import AppInfoHandler from './request-manager-handlers/app-info-handler.js';
+import AuthHandler from './request-manager-handlers/auth-handler.js';
+import JsonHandler from './request-manager-handlers/json-handler.js';
+import LocaleHandler from './request-manager-handlers/locale-handler.js';
+
+/**
+ * Request manager preconfigured for authenticated or not HTTP requests.
+ * see: https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest
+ */
+export default class RequestManagerService extends RequestManager {
+  constructor(createArgs) {
+    super(createArgs);
+
+    const authHandler = new AuthHandler();
+    setOwner(authHandler, getOwner(this));
+
+    const localHandler = new LocaleHandler();
+    setOwner(localHandler, getOwner(this));
+
+    const appInfoHandler = new AppInfoHandler();
+    setOwner(appInfoHandler, getOwner(this));
+
+    const jsonHandler = new JsonHandler();
+    setOwner(jsonHandler, getOwner(this));
+
+    this.use([authHandler, localHandler, appInfoHandler, jsonHandler, Fetch]);
+  }
+}

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -1,0 +1,98 @@
+import { render } from '@1024pix/ember-testing-library';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import { triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import OrganizationsBatchArchive from 'pix-admin/components/administration/deployment/organizations-batch-archive';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | administration/organizations-batch-archive', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when batch archive succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+      window.fetch.resolves(
+        _fetchResponse({
+          status: 204,
+        }),
+      );
+
+      // when
+      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.organizations-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(t('components.administration.organizations-batch-archive.notifications.success')),
+      );
+    });
+  });
+
+  module('when batch archiving of organizations fails', function () {
+    test('it displays an error notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+
+      window.fetch.resolves(
+        _fetchResponse({
+          body: {
+            errors: [
+              {
+                status: '422',
+                title: "Un souci avec l'archivage des organisations",
+                code: 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR',
+                detail: `Erreur lors de l'archivage`,
+                meta: {
+                  currentLine: 2,
+                  totalLines: 4,
+                },
+              },
+            ],
+          },
+          status: 422,
+        }),
+      );
+
+      // when
+      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(
+        t('components.administration.organizations-batch-archive.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(
+          t('components.administration.organizations-batch-archive.notifications.errors.error-in-batch', {
+            currentLine: 2,
+            totalLines: 4,
+          }),
+        ),
+      );
+    });
+  });
+});
+
+function _fetchResponse({ body, status }) {
+  return new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+}

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -84,29 +84,4 @@ module('Unit | Adapters | organization', function (hooks) {
       );
     });
   });
-
-  module('#archiveOrganizations', function () {
-    test('should not call ajax if files is empty', async function (assert) {
-      // given
-      const files = [];
-
-      // when
-      await adapter.archiveOrganizations(files);
-
-      // then
-      assert.notOk(adapter.ajax.called);
-    });
-
-    test('should call ajax with the correct URL and method', async function (assert) {
-      // given
-      const files = ['file1', 'file2'];
-      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organizations/batch-archive`;
-
-      // when
-      await adapter.archiveOrganizations(files);
-
-      // then
-      assert.ok(adapter.ajax.calledWith(expectedUrl, 'POST'));
-    });
-  });
 });

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -84,4 +84,29 @@ module('Unit | Adapters | organization', function (hooks) {
       );
     });
   });
+
+  module('#archiveOrganizations', function () {
+    test('should not call ajax if files is empty', async function (assert) {
+      // given
+      const files = [];
+
+      // when
+      await adapter.archiveOrganizations(files);
+
+      // then
+      assert.notOk(adapter.ajax.called);
+    });
+
+    test('should call ajax with the correct URL and method', async function (assert) {
+      // given
+      const files = ['file1', 'file2'];
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organizations/batch-archive`;
+
+      // when
+      await adapter.archiveOrganizations(files);
+
+      // then
+      assert.ok(adapter.ajax.calledWith(expectedUrl, 'POST'));
+    });
+  });
 });

--- a/admin/tests/unit/services/request-manager-test.js
+++ b/admin/tests/unit/services/request-manager-test.js
@@ -1,0 +1,101 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | request-manager', function (hooks) {
+  setupTest(hooks);
+  let requestManagerService;
+  let sessionService;
+  let currentDomainService;
+  let intlService;
+
+  hooks.beforeEach(function () {
+    sinon.stub(window, 'fetch');
+
+    requestManagerService = this.owner.lookup('service:requestManager');
+
+    sessionService = this.owner.lookup('service:session');
+    sinon.stub(sessionService, 'isAuthenticated').value(false);
+    sinon.stub(sessionService, 'data').value(null);
+
+    currentDomainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(currentDomainService, 'isFranceDomain').value(false);
+
+    intlService = this.owner.lookup('service:intl');
+    sinon.stub(intlService, 'primaryLocale').value('fr');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('request()', function () {
+    test('it requests successfully with default headers', async function (assert) {
+      // given
+      window.fetch.resolves(responseMock({ status: 200, data: { foo: 'bar' } }));
+
+      // when
+      const result = await requestManagerService.request({ url: '/test', method: 'GET' });
+
+      // then
+      assert.strictEqual(result.response.status, 200);
+      assert.deepEqual(result.content, { foo: 'bar' });
+
+      const [url, { headers }] = window.fetch.getCall(0).args;
+      assert.strictEqual(url, '/test');
+      assert.strictEqual(headers.get('Accept-Language'), 'fr');
+      assert.strictEqual(headers.get('X-App-Version'), 'development');
+      assert.strictEqual(headers.get('Accept'), 'application/json');
+      assert.strictEqual(headers.get('Content-Type'), 'application/json');
+    });
+
+    module('when user is authenticated', function () {
+      test('it sets the Authorization header with the access token', async function (assert) {
+        // given
+        window.fetch.resolves(responseMock({ status: 200, data: { foo: 'bar' } }));
+        sinon.stub(sessionService, 'isAuthenticated').value(true);
+        sinon.stub(sessionService, 'data').value({ authenticated: { access_token: 'baz' } });
+
+        // when
+        await requestManagerService.request({ url: '/test', method: 'GET' });
+
+        // then
+        const [url, { headers }] = window.fetch.getCall(0).args;
+        assert.strictEqual(url, '/test');
+        assert.strictEqual(headers.get('Authorization'), 'Bearer baz');
+      });
+    });
+
+    module('when it is on France domain', function () {
+      test('it sets the header Accept-Language to fr-fr', async function (assert) {
+        // given
+        window.fetch.resolves(responseMock({ status: 200, data: { foo: 'bar' } }));
+        sinon.stub(currentDomainService, 'isFranceDomain').value(true);
+
+        // when
+        await requestManagerService.request({ url: '/test', method: 'GET' });
+
+        // then
+        const [url, { headers }] = window.fetch.getCall(0).args;
+        assert.strictEqual(url, '/test');
+        assert.strictEqual(headers.get('Accept-Language'), 'fr-fr');
+      });
+    });
+
+    module('when an error occured on HTTP call', function () {
+      test('it throws an exception with error details', async function (assert) {
+        // given
+        window.fetch.resolves(responseMock({ status: 400, data: { error: 'KO' } }));
+
+        // when
+        assert.rejects(requestManagerService.request({ url: '/test', method: 'GET' }), function (err) {
+          return err.status === 400 && err.content.error === 'KO';
+        });
+      });
+    });
+  });
+});
+
+function responseMock({ status, data }) {
+  return new window.Response(JSON.stringify(data), { status });
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -156,6 +156,17 @@
         "title": "Bulk addition of tags on organisations",
         "upload-button": "Import CSV file"
       },
+      "organizations-batch-archive": {
+        "description": "Archive organizations in batch. Each line must contain a organization ID to archive.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "The organizations archiving has failed. The organization ID line n°{currentLine} failed, out of {totalLines} lines."
+          },
+          "success": "The organizations have been archived."
+        },
+        "title": "Archiving of organizations in batch",
+        "upload-button": "Import a CSV file"
+      },
       "organizations-import": {
         "description": "Existing organizations will not be changed.",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -156,6 +156,17 @@
         "title": "Ajout de tags en masse sur des organisations",
         "upload-button": "Importer un fichier CSV"
       },
+      "organizations-batch-archive": {
+        "description": "Permet d'archiver des organisations par lot. Chaque ligne doit porter l'identifiant de l'organisation à archiver.",
+        "notifications": {
+          "errors": {
+            "error-in-batch": "L'archivage d'une des organisations a échoué. L'organization concernée est à la ligne {currentLine} du fichier comportant {totalLines} lignes. Corrigez la ligne concernée et ré-importez le fichier."
+          },
+          "success": "Les organisations ont bien été archivées."
+        },
+        "title": "Archivage des organisations en masse",
+        "upload-button": "Importer un fichier CSV"
+      },
       "organizations-import": {
         "description": "Les organisations déjà existantes ne seront pas modifiées.",
         "notifications": {

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -2,6 +2,7 @@ import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
 import {
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,
@@ -42,6 +43,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: ArchiveCertificationCentersInBatchError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: ArchiveOrganizationsInBatchError.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -72,7 +72,8 @@ const createInBatch = async function (request, h) {
 
 const archiveInBatch = async function (request, h) {
   const userId = extractUserIdFromRequest(request);
-  const organizationIds = await csvSerializer.deserializeForOrganizationBatchArchive(request.payload.path);
+
+  const organizationIds = await csvSerializer.deserializeForOrganizationBatchArchive(request.payload.file.path);
   await usecases.archiveOrganizationsInBatch({ organizationIds, userId });
 
   return h.response().code(204);

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -70,6 +70,14 @@ const createInBatch = async function (request, h) {
   return h.response(organizationForAdminSerializer.serialize(createdOrganizations)).code(204);
 };
 
+const archiveInBatch = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
+  const organizationIds = await csvSerializer.deserializeForOrganizationBatchArchive(request.payload.path);
+  await usecases.archiveOrganizationsInBatch({ organizationIds, userId });
+
+  return h.response().code(204);
+};
+
 const getOrganizationDetails = async function (request, h, dependencies = { organizationForAdminSerializer }) {
   const organizationId = request.params.id;
 
@@ -121,6 +129,7 @@ const organizationAdminController = {
   create,
   createInBatch,
   archiveOrganization,
+  archiveInBatch,
   attachChildOrganization,
   getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -240,6 +240,40 @@ const register = async function (server) {
     },
     {
       method: 'POST',
+      path: '/api/admin/organizations/batch-archive',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        payload: {
+          maxBytes: MAX_FILE_SIZE_UPLOAD,
+          output: 'file',
+          failAction: (request, h) => {
+            return sendJsonApiError(
+              new PayloadTooLargeError('An error occurred, payload is too large', ERRORS.PAYLOAD_TOO_LARGE, {
+                maxSize: '20',
+              }),
+              h,
+            );
+          },
+        },
+        handler: (request, h) => organizationAdminController.archiveInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet d'archiver plusieurs organizations dont les ID sont transmis par un CSV",
+        ],
+      },
+    },
+    {
+      method: 'POST',
       path: '/api/admin/organizations/{organizationId}/attach-child-organization',
       config: {
         pre: [

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -254,6 +254,7 @@ const register = async function (server) {
         ],
         payload: {
           maxBytes: MAX_FILE_SIZE_UPLOAD,
+          multipart: true,
           output: 'file',
           failAction: (request, h) => {
             return sendJsonApiError(

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -20,6 +20,13 @@ class ArchiveCertificationCentersInBatchError extends DomainError {
   }
 }
 
+class ArchiveOrganizationsInBatchError extends DomainError {
+  constructor({ meta } = {}) {
+    super('Error during organizations batch archiving', 'ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
+    this.meta = meta;
+  }
+}
+
 class DpoEmailInvalid extends DomainError {
   constructor({ code = 'DPO_EMAIL_INVALID', message = 'DPO email invalid', meta } = {}) {
     super(message);
@@ -69,6 +76,7 @@ class FeatureParamsNotProcessable extends DomainError {
 
 export {
   ArchiveCertificationCentersInBatchError,
+  ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,

--- a/api/src/organizational-entities/domain/usecases/archive-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-organizations-in-batch.usecase.js
@@ -1,0 +1,31 @@
+import { ArchiveOrganizationsInBatchError } from '../errors.js';
+
+/**
+ * @param {Object} params
+ * @param {Array} params.organizationIds
+ * @param {Number} params.userId
+ * @param {Object} params.organizationForAdminRepository
+ */
+export const archiveOrganizationsInBatch = async function ({
+  organizationIds,
+  userId,
+  organizationForAdminRepository,
+}) {
+  // we don't use a transaction here not to rollback lines 0 to N-1 in case of an error on line N
+
+  for (const [index, organizationId] of organizationIds.entries()) {
+    try {
+      await organizationForAdminRepository.archive({
+        id: organizationId,
+        archivedBy: userId,
+      });
+    } catch {
+      throw new ArchiveOrganizationsInBatchError({
+        meta: {
+          currentLine: index + 1,
+          totalLines: organizationIds.length,
+        },
+      });
+    }
+  }
+};

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -80,6 +80,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {getOrganizationDetails} getOrganizationDetails
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch
  * @property {updateOrganizationInformation} updateOrganizationInformation
+ * @property {archiveOrganizationsInBatch} archiveOrganizationsInBatch
  */
 
 /**

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -19,9 +19,14 @@ const ORGANIZATIONS_TABLE_NAME = 'organizations';
  * @param {Object} params
  * @param {string|number} params.id
  * @param {string|number} params.archivedBy
- * @return {Promise<void|MissingAttributesError>}
+ * @return {Promise<void|MissingAttributesError|NotFoundError>}
  */
 const archive = async function ({ id, archivedBy }) {
+  const organization = await knex(ORGANIZATIONS_TABLE_NAME).where({ id }).first();
+  if (!organization) {
+    throw new NotFoundError();
+  }
+
   if (!archivedBy) {
     throw new MissingAttributesError();
   }

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -207,6 +207,34 @@ async function deserializeForCertificationCenterBatchArchive(
   return parsedData.map((data) => data['ID du centre de certification']);
 }
 
+async function deserializeForOrganizationBatchArchive(file, { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper) {
+  const columnName = "ID de l'organisation";
+
+  await checkCsvHeader({ filePath: file, requiredFieldNames: [columnName] });
+  const cleanedData = await readCsvFile(file);
+
+  const batchOrganizationOptionsWithHeader = {
+    skipEmptyLines: true,
+    header: true,
+    transformHeader: (header) => header?.trim(),
+    transform: (value, columnName) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (!isEmpty(value)) {
+        if (columnName === columnName) {
+          value = Number(value);
+        }
+      }
+      return value;
+    },
+  };
+
+  const parsedData = await parseCsvData(cleanedData, batchOrganizationOptionsWithHeader);
+
+  return parsedData.map((data) => data[columnName]);
+}
+
 const requiredFieldNamesForCampaignsImport = [
   "Identifiant de l'organisation*",
   'Nom de la campagne*',
@@ -482,6 +510,7 @@ function serializeLine(lineArray) {
 export {
   deserializeForCampaignsImport,
   deserializeForCertificationCenterBatchArchive,
+  deserializeForOrganizationBatchArchive,
   deserializeForOrganizationsImport,
   deserializeForSessionsImport,
   parseForCampaignsImport,

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -656,6 +656,110 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('POST /api/admin/organizations/batch-archive', function () {
+    context('success case', function () {
+      it('returns a 204 http request', async function () {
+        // given
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+        const organizationId1 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        await databaseBuilder.commit();
+        const buffer = `ID de l'organisation\n` + `${organizationId1}\n` + `${organizationId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/organizations/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId1 }).first();
+
+        expect(response.statusCode).to.equal(204);
+        expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization1.archivedAt).not.to.be.null;
+        expect(archivedOrganization2.archivedAt).not.to.be.null;
+      });
+    });
+
+    context('error cases', function () {
+      it('returns an error with meta info', async function () {
+        // given
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+        const organizationId1 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({
+          archivedAt: null,
+          archivedBy: null,
+        }).id;
+
+        const nonExistingOrganizationId1 = 7895;
+        const nonExistingOrganizationId2 = 8513;
+
+        await databaseBuilder.commit();
+        const buffer =
+          `ID de l'organisation\n` +
+          `${organizationId1}\n` +
+          `${organizationId2}\n` +
+          `${nonExistingOrganizationId1}\n` +
+          `${nonExistingOrganizationId2}\n`;
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/organizations/batch-archive`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        });
+
+        // then
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
+
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0].code).to.deep.equal('ARCHIVE_ORGANIZATIONS_IN_BATCH_ERROR');
+        expect(response.result.errors[0].meta).to.deep.equal({
+          currentLine: 3,
+          totalLines: 4,
+        });
+        expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
+        expect(archivedOrganization1.archivedAt).not.to.be.null;
+        expect(archivedOrganization2.archivedAt).not.to.be.null;
+      });
+
+      it('fails when the file payload is too large', async function () {
+        const buffer = Buffer.alloc(1048576 * 22, 'B'); // > 10 Mo buffer
+        const adminMember = databaseBuilder.factory.buildUser.withRole();
+
+        const options = {
+          method: 'POST',
+          url: '/api/admin/organizations/batch-archive',
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          payload: buffer,
+        };
+
+        const response = await server.inject(options);
+        expect(response.statusCode).to.equal(413);
+        expect(response.result.errors[0].code).to.equal('PAYLOAD_TOO_LARGE');
+        expect(response.result.errors[0].meta.maxSize).to.equal('20');
+      });
+    });
+  });
+
   describe('GET /api/admin/organizations/add-organization-features/template', function () {
     it('responds with a 200', async function () {
       // given

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -659,33 +659,40 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   describe('POST /api/admin/organizations/batch-archive', function () {
     context('success case', function () {
       it('returns a 204 http request', async function () {
-        // given
         const adminMember = databaseBuilder.factory.buildUser.withRole();
-        const organizationId1 = databaseBuilder.factory.buildOrganization({
-          archivedAt: null,
-          archivedBy: null,
-        }).id;
-        const organizationId2 = databaseBuilder.factory.buildOrganization({
-          archivedAt: null,
-          archivedBy: null,
-        }).id;
-
+        const organizationId1 = databaseBuilder.factory.buildOrganization({ archivedAt: null, archivedBy: null }).id;
+        const organizationId2 = databaseBuilder.factory.buildOrganization({ archivedAt: null, archivedBy: null }).id;
         await databaseBuilder.commit();
-        const buffer = `ID de l'organisation\n` + `${organizationId1}\n` + `${organizationId2}\n`;
 
-        // when
+        const csvData = `ID de l'organisation\n${organizationId1}\n${organizationId2}\n`;
+
+        const boundary = 'simple-boundary-12345';
+
+        const payloadBuffer = _createMultipartPayload({
+          boundary,
+          filename: 'organizations.csv',
+          fieldName: 'file',
+          contentType: 'text/csv',
+          content: csvData,
+        });
+
+        const headers = {
+          ...generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        };
+
         const response = await server.inject({
           method: 'POST',
           url: `/api/admin/organizations/batch-archive`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
-          payload: buffer,
+          headers,
+          payload: payloadBuffer,
         });
 
-        // then
-        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
-        const archivedOrganization2 = await knex('organizations').where({ id: organizationId1 }).first();
-
         expect(response.statusCode).to.equal(204);
+
+        const archivedOrganization1 = await knex('organizations').where({ id: organizationId1 }).first();
+        const archivedOrganization2 = await knex('organizations').where({ id: organizationId2 }).first();
+
         expect(archivedOrganization1.archivedBy).to.deep.equal(adminMember.id);
         expect(archivedOrganization2.archivedBy).to.deep.equal(adminMember.id);
         expect(archivedOrganization1.archivedAt).not.to.be.null;
@@ -710,19 +717,35 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         const nonExistingOrganizationId2 = 8513;
 
         await databaseBuilder.commit();
-        const buffer =
+
+        const csvData =
           `ID de l'organisation\n` +
           `${organizationId1}\n` +
           `${organizationId2}\n` +
           `${nonExistingOrganizationId1}\n` +
           `${nonExistingOrganizationId2}\n`;
 
+        const boundary = 'simple-boundary-12345';
+
+        const payloadBuffer = _createMultipartPayload({
+          boundary,
+          filename: 'organizations.csv',
+          fieldName: 'file',
+          contentType: 'text/csv',
+          content: csvData,
+        });
+
+        const headers = {
+          ...generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        };
+
         // when
         const response = await server.inject({
           method: 'POST',
           url: `/api/admin/organizations/batch-archive`,
-          headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
-          payload: buffer,
+          headers,
+          payload: payloadBuffer,
         });
 
         // then
@@ -1275,3 +1298,18 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 });
+
+function _createMultipartPayload({ boundary, filename, fieldName, contentType, content }) {
+  return Buffer.from(
+    [
+      `--${boundary}`,
+      `Content-Disposition: form-data; name="${fieldName}"; filename="${filename}"`,
+      `Content-Type: ${contentType}`,
+      '',
+      content,
+      `--${boundary}--`,
+      '',
+    ].join('\r\n'),
+    'utf-8',
+  );
+}

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -1,26 +1,47 @@
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
-import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | archive-organization', function () {
-  it('archives the organization', async function () {
-    // given
-    const now = new Date('2022-02-22');
-    const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    const superAdminUser = databaseBuilder.factory.buildUser();
-    const organization = databaseBuilder.factory.buildOrganization();
-    await databaseBuilder.commit();
+  context('when the organization does exist', function () {
+    it('archives the organization', async function () {
+      // given
+      const now = new Date('2022-02-22');
+      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      const superAdminUser = databaseBuilder.factory.buildUser();
+      const organization = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
 
-    // when
-    const archivedOrganization = await usecases.archiveOrganization({
-      organizationId: organization.id,
-      userId: superAdminUser.id,
+      // when
+      const archivedOrganization = await usecases.archiveOrganization({
+        organizationId: organization.id,
+        userId: superAdminUser.id,
+      });
+
+      // then
+      expect(archivedOrganization.archivedAt).to.deep.equal(now);
+      expect(archivedOrganization.archivistFirstName).to.deep.equal(superAdminUser.firstName);
+      expect(archivedOrganization.archivistLastName).to.deep.equal(superAdminUser.lastName);
+
+      clock.restore();
     });
+  });
 
-    // then
-    expect(archivedOrganization.archivedAt).to.deep.equal(now);
-    expect(archivedOrganization.archivistFirstName).to.deep.equal(superAdminUser.firstName);
-    expect(archivedOrganization.archivistLastName).to.deep.equal(superAdminUser.lastName);
+  context('when the organization does not exist', function () {
+    it('throws an error', async function () {
+      // given
+      const nonExistingOrganizationId = 123456;
+      const superAdminUser = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
 
-    clock.restore();
+      // when
+      const error = await catchErr(usecases.archiveOrganization)({
+        organizationId: nonExistingOrganizationId,
+        userId: superAdminUser.id,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
   });
 });

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
@@ -1,0 +1,154 @@
+import { ArchiveOrganizationsInBatchError } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | UseCase | archive-organizations-in-batch', function () {
+  let now, clock;
+
+  beforeEach(function () {
+    now = new Date('2025-01-01');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('success', function () {
+    it('archives the organizations properly', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization1.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization1.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization1.id,
+        disabledAt: null,
+      });
+
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization2.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization2.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization2.id,
+        disabledAt: null,
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+
+      const organizationIds = [organization1.id, organization2.id];
+
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.archiveOrganizationsInBatch({
+        organizationIds,
+        userId: user.id,
+      });
+
+      // then
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, archivedAt: now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization1.id,
+        updatedAt: now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization1.id, archivedAt: now });
+      await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
+
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization2.id, user, archivedAt: now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization2.id,
+        updatedAt: now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization2.id, archivedAt: now });
+      await _assertMembershipAreDisabled({ organizationId: organization2.id, disabledAt: now });
+    });
+  });
+
+  context('failure', function () {
+    it('processes until it throws an error if one of the organizations cannot be archived', async function () {
+      // given
+      const nonExistingOrganizationId = 1234;
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization1.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization1.id,
+        archivedAt: null,
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization1.id,
+        disabledAt: null,
+      });
+
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      const organizationIds = [organization1.id, nonExistingOrganizationId];
+
+      // when
+      const error = await catchErr(usecases.archiveOrganizationsInBatch)({
+        organizationIds,
+        userId: user.id,
+      });
+
+      // then
+      expect(error).to.deepEqualInstance(
+        new ArchiveOrganizationsInBatchError({
+          meta: {
+            currentLine: 2,
+            totalLines: 2,
+          },
+        }),
+      );
+      await _assertOrganizationIsArchived({ archivedOrganizationId: organization1.id, user, archivedAt: now });
+      await _assertPendingInvitationsAreCanceled({
+        archivedOrganizationId: organization1.id,
+        updatedAt: now,
+      });
+      await _assertCampaignAreArchived({ organizationId: organization1.id, archivedAt: now });
+      await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
+    });
+  });
+});
+
+async function _assertMembershipAreDisabled({ organizationId, disabledAt }) {
+  const archivedMembership1 = await knex('memberships').where({ organizationId }).first();
+
+  expect(archivedMembership1.disabledAt).to.deep.equal(disabledAt);
+}
+
+async function _assertCampaignAreArchived({ organizationId, archivedAt }) {
+  const archivedCampaign1 = await knex('campaigns').where({ organizationId }).first();
+  expect(archivedCampaign1.archivedAt).to.deep.equal(archivedAt);
+}
+
+async function _assertPendingInvitationsAreCanceled({ archivedOrganizationId, updatedAt }) {
+  const archivedPendingOrganizationInvitation = await knex('organization-invitations')
+    .where({ organizationId: archivedOrganizationId })
+    .first();
+
+  expect(archivedPendingOrganizationInvitation.status).to.deep.equal(OrganizationInvitation.StatusType.CANCELLED);
+  expect(archivedPendingOrganizationInvitation.updatedAt).to.deep.equal(updatedAt);
+}
+
+async function _assertOrganizationIsArchived({ archivedOrganizationId, user, archivedAt }) {
+  const archivedOrganization = await knex('organizations').where({ id: archivedOrganizationId }).first();
+
+  expect(archivedOrganization.archivedBy).to.deep.equal(user.id);
+  expect(archivedOrganization.archivedAt).to.deep.equal(archivedAt);
+}

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1479,6 +1479,30 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     });
   });
 
+  describe('#deserializeForOrganizationBatchArchive', function () {
+    it('should check the required header', async function () {
+      // given
+      const filePath = 'file://organizations.csv';
+      const checkCsvHeaderStub = sinon.stub();
+      const readCsvFileStub = sinon.stub();
+      const parseCsvDataStub = sinon.stub();
+      parseCsvDataStub.resolves([{ "ID de l'organisation": 1234 }, { "ID de l'organisation": 5678 }]);
+
+      const requiredFieldNames = ["ID de l'organisation"];
+
+      // when
+      const serializedData = await csvSerializer.deserializeForOrganizationBatchArchive(filePath, {
+        checkCsvHeader: checkCsvHeaderStub,
+        readCsvFile: readCsvFileStub,
+        parseCsvData: parseCsvDataStub,
+      });
+
+      // then
+      expect(checkCsvHeaderStub).to.have.been.calledWithExactly({ filePath, requiredFieldNames });
+      expect(serializedData).to.deep.equal([1234, 5678]);
+    });
+  });
+
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
       "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";


### PR DESCRIPTION
## 🌸 Problème
Il peut être nécessaire, pour les agents Pix, d’archiver plusieurs organisations

Dans Pix Admin, ajouter une action d’administration dans l’onglet “Deploiement”: Archiver en masse des organisations.

## 🌳 Proposition

Dans Pix Admin, ajouter une action d’administration dans l’onglet “Deploiement”: Archiver en masse des organisations.

## 🐝 Remarques

On introduit ici le requestManager sur pix-admin.

⚠️  Ce que ça change: 

- Avant : adapter.post(...) envoyait un fichier CSV brut → back attendait text/csv.

- Maintenant : requestManager envoie le fichier dans un FormData → back reçoit du multipart/form-data.

- Le back devait s’adapter à ce nouveau format pour pouvoir lire correctement le fichier CSV envoyé.

## 🤧 Pour tester

- Récupérer ce fichier:
[archivage-organisations.csv](https://github.com/user-attachments/files/20158585/archivage-organisations.csv)

- Aller sur Pix Admin en tant que Super Admin
- Se rendre sur la page Administration puis sur l'onglet Déploiement
- Sous le titre "Archivage des organisations en masse", cliquer sur Importer un fichier CSV
- Constater qu'une fois le téléversement réalisé, une notification de succès s'affiche. 