### PR TITLE
[TECH] Migration DDD : migration de api/lib/infrastructure/authentication.js vers src/ (PIX-17797)

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -5,7 +5,6 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
-import { authentication } from './lib/infrastructure/authentication.js';
 import { routes } from './lib/routes.js';
 import { bannerRoutes } from './src/banner/routes.js';
 import {
@@ -22,6 +21,7 @@ import { certificationSessionRoutes } from './src/certification/session-manageme
 import { devcompRoutes } from './src/devcomp/routes.js';
 import { evaluationRoutes } from './src/evaluation/routes.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
+import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
 import { learningContentRoutes } from './src/learning-content/routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import { organizationalEntitiesRoutes } from './src/organizational-entities/application/routes.js';
@@ -213,11 +213,11 @@ const setupDeserialization = function (server) {
 };
 
 const setupAuthentication = function (server) {
-  server.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
-  Object.values(authentication.strategies).forEach((strategy) => {
+  server.auth.scheme(serverAuthentication.schemes.jwt.name, serverAuthentication.schemes.jwt.scheme);
+  Object.values(serverAuthentication.strategies).forEach((strategy) => {
     server.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration);
   });
-  server.auth.default(authentication.strategies.jwtUser.name);
+  server.auth.default(serverAuthentication.strategies.jwtUser.name);
 };
 
 const setupRoutesAndPlugins = async function (server) {

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -5,9 +5,9 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
-import { authentication } from './lib/infrastructure/authentication.js';
 import * as parcoursupRoutes from './src/certification/results/application/parcoursup-route.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
+import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
 import * as campaignsRoutes from './src/maddo/application/campaigns-routes.js';
 import * as organizationsRoutes from './src/maddo/application/organizations-routes.js';
 import * as replicationsRoutes from './src/maddo/application/replications-routes.js';
@@ -166,8 +166,8 @@ const setupDeserialization = function (server) {
 };
 
 const setupAuthentication = function (server) {
-  server.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
-  const jwtApplicationStrategy = authentication.strategies.jwtApplication;
+  server.auth.scheme(serverAuthentication.schemes.jwt.name, serverAuthentication.schemes.jwt.scheme);
+  const jwtApplicationStrategy = serverAuthentication.strategies.jwtApplication;
   server.auth.strategy(
     jwtApplicationStrategy.name,
     jwtApplicationStrategy.schemeName,

--- a/api/src/certification/results/application/livret-scolaire-route.js
+++ b/api/src/certification/results/application/livret-scolaire-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { jwtApplicationAuthenticationStrategyName } from '../../../shared/infrastructure/authentication-strategy-names.js';
 import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { certificationsResultsDoc } from '../infrastructure/open-api-doc/livret-scolaire/certifications-results-doc.js';
 import { livretScolaireController } from './livret-scolaire-controller.js';
@@ -10,7 +11,10 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/organizations/{uai}/certifications',
       config: {
-        auth: { strategy: 'jwt-application', access: { scope: 'organizations-certifications-result' } },
+        auth: {
+          strategy: jwtApplicationAuthenticationStrategyName,
+          access: { scope: 'organizations-certifications-result' },
+        },
         handler: livretScolaireController.getCertificationsByOrganizationUAI,
         notes: [
           '- **API for LSU/LSL qui nécessite une authentification de type client credential grant**\n' +

--- a/api/src/certification/results/application/parcoursup-route.js
+++ b/api/src/certification/results/application/parcoursup-route.js
@@ -4,6 +4,7 @@ import {
   certificationVerificationCodeType,
   studentIdentifierType,
 } from '../../../shared/domain/types/identifiers-type.js';
+import { jwtApplicationAuthenticationStrategyName } from '../../../shared/infrastructure/authentication-strategy-names.js';
 import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
 import { parcoursupController } from './parcoursup-controller.js';
 
@@ -13,7 +14,7 @@ const register = async function (server) {
       method: 'POST',
       path: '/api/application/parcoursup/certification/search',
       config: {
-        auth: { strategy: 'jwt-application', access: { scope: 'parcoursup' } },
+        auth: { strategy: jwtApplicationAuthenticationStrategyName, access: { scope: 'parcoursup' } },
         validate: {
           payload: Joi.alternatives()
             .try(

--- a/api/src/prescription/campaign-participation/application/pole-emploi-route.js
+++ b/api/src/prescription/campaign-participation/application/pole-emploi-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { jwtApplicationAuthenticationStrategyName } from '../../../shared/infrastructure/authentication-strategy-names.js';
 import { poleEmploiEnvoisDoc } from '../../../shared/infrastructure/open-api-doc/pole-emploi/envois-doc.js';
 import { erreurDoc } from '../../../shared/infrastructure/open-api-doc/pole-emploi/erreur-doc.js';
 import { poleEmploiController } from './pole-emploi-controller.js';
@@ -10,7 +11,10 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/pole-emploi/envois',
       config: {
-        auth: { strategy: 'jwt-application', access: { scope: 'pole-emploi-participants-result' } },
+        auth: {
+          strategy: jwtApplicationAuthenticationStrategyName,
+          access: { scope: 'pole-emploi-participants-result' },
+        },
         handler: poleEmploiController.getSendings,
         notes: [
           '- **API Pôle emploi qui nécessite une authentification de type client credential grant**\n' +

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { jwtApplicationAuthenticationStrategyName } from '../../../shared/infrastructure/authentication-strategy-names.js';
 import { organizationPlaceController } from './organization-place-controller.js';
 
 const register = async (server) => {
@@ -149,7 +150,7 @@ const register = async (server) => {
       method: 'GET',
       path: '/api/data/organization-places',
       config: {
-        auth: { strategy: 'jwt-application', access: { scope: 'statistics' } },
+        auth: { strategy: jwtApplicationAuthenticationStrategyName, access: { scope: 'statistics' } },
         handler: organizationPlaceController.getDataOrganizationsPlacesStatistics,
         tags: ['api', 'organization-places', 'data'],
         notes: [

--- a/api/src/shared/infrastructure/authentication-strategy-names.js
+++ b/api/src/shared/infrastructure/authentication-strategy-names.js
@@ -1,0 +1,2 @@
+export const jwtUserAuthenticationStrategyName = 'jwt-user';
+export const jwtApplicationAuthenticationStrategyName = 'jwt-application';

--- a/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
@@ -1,11 +1,15 @@
-import { authentication, validateClientApplication, validateUser } from '../../../lib/infrastructure/authentication.js';
-import { RevokedUserAccess } from '../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
-import { revokedUserAccessRepository } from '../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
-import { ForwardedOriginError } from '../../../src/identity-access-management/infrastructure/utils/network.js';
-import { tokenService } from '../../../src/shared/domain/services/token-service.js';
-import { expect, sinon } from '../../test-helper.js';
+import { RevokedUserAccess } from '../../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
+import { revokedUserAccessRepository } from '../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
+import {
+  schemes,
+  validateClientApplication,
+  validateUser,
+} from '../../../../src/identity-access-management/infrastructure/server-authentication.js';
+import { ForwardedOriginError } from '../../../../src/identity-access-management/infrastructure/utils/network.js';
+import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
+import { expect, sinon } from '../../../test-helper.js';
 
-describe('Unit | Infrastructure | Authentication', function () {
+describe('Unit | Identity Access Management | Infrastructure | serverAuthentication', function () {
   beforeEach(function () {
     sinon.stub(tokenService, 'extractTokenFromAuthChain');
     sinon.stub(tokenService, 'getDecodedToken');
@@ -18,7 +22,7 @@ describe('Unit | Infrastructure | Authentication', function () {
       const h = { authenticated: sinon.stub() };
 
       // when
-      const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+      const { authenticate } = schemes.jwt.scheme(undefined, {
         key: 'dummy-secret',
         validate: sinon.stub(),
       });
@@ -42,7 +46,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         tokenService.extractTokenFromAuthChain.withArgs('Bearer').returns(null);
 
         // when
-        const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+        const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: sinon.stub(),
         });
@@ -68,7 +72,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns(false);
 
         // when
-        const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+        const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: sinon.stub(),
         });
@@ -102,7 +106,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         });
 
         // when
-        const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+        const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: (decodedAccessToken, options) =>
             validateUser(decodedAccessToken, {
@@ -140,7 +144,7 @@ describe('Unit | Infrastructure | Authentication', function () {
           });
 
           // when
-          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+          const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
               validateUser(decodedAccessToken, {
@@ -182,7 +186,7 @@ describe('Unit | Infrastructure | Authentication', function () {
           });
 
           // when
-          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+          const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
               validateUser(decodedAccessToken, {
@@ -219,7 +223,7 @@ describe('Unit | Infrastructure | Authentication', function () {
           });
 
           // when & then
-          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+          const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
               validateUser(decodedAccessToken, {
@@ -249,7 +253,7 @@ describe('Unit | Infrastructure | Authentication', function () {
           });
 
           // when
-          const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+          const { authenticate } = schemes.jwt.scheme(undefined, {
             key: 'dummy-secret',
             validate: (decodedAccessToken, options) =>
               validateUser(decodedAccessToken, {
@@ -285,7 +289,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
         tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns(decodedAccessToken);
 
-        const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+        const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: validateClientApplication,
         });
@@ -307,7 +311,7 @@ describe('Unit | Infrastructure | Authentication', function () {
         tokenService.extractTokenFromAuthChain.withArgs('Bearer token').returns('token');
         tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns(decodedAccessToken);
 
-        const { authenticate } = authentication.schemes.jwt.scheme(undefined, {
+        const { authenticate } = schemes.jwt.scheme(undefined, {
           key: 'dummy-secret',
           validate: validateClientApplication,
         });

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -2,7 +2,7 @@ import Hapi from '@hapi/hapi';
 import { parse } from 'neoqs';
 
 import { setupErrorHandling } from '../../../config/server-setup-error-handling.js';
-import { authentication } from '../../../lib/infrastructure/authentication.js';
+import * as serverAuthentication from '../../../src/identity-access-management/infrastructure/server-authentication.js';
 import { deserializer } from '../../../src/shared/infrastructure/serializers/jsonapi/deserializer.js';
 import { handleFailAction } from '../../../src/shared/validate.js';
 
@@ -55,11 +55,11 @@ class HttpTestServer {
   }
 
   setupAuthentication() {
-    this.hapiServer.auth.scheme(authentication.schemes.jwt.name, authentication.schemes.jwt.scheme);
-    Object.values(authentication.strategies).forEach((strategy) =>
+    this.hapiServer.auth.scheme(serverAuthentication.schemes.jwt.name, serverAuthentication.schemes.jwt.scheme);
+    Object.values(serverAuthentication.strategies).forEach((strategy) =>
       this.hapiServer.auth.strategy(strategy.name, strategy.schemeName, strategy.configuration),
     );
-    this.hapiServer.auth.default(authentication.strategies.jwtUser.name);
+    this.hapiServer.auth.default(serverAuthentication.strategies.jwtUser.name);
   }
 
   setupDeserialization() {


### PR DESCRIPTION
## 🌸 Problème

Le fichier `api/lib/infrastructure/authentication.js` se trouve toujours dans `lib/`.

## 🌳 Proposition

Comme ce fichier contient à la fois du code clairement lié au contexte DDD identity-access-management et à la fois des stratégies d'authentification clairement partagées à toutes les routes on propose de scinder ce fichier en 2 fichiers différents : 
* `api/src/identity-access-management/infrastructure/serverAuthentication.js`
* `api/src/shared/infrastructure/authentication-strategy-names.js`

On propose de profiter de cette PR pour renommer `authentication.js` en `serverAuthentication.js` de manière à plus facilement identifier et retrouver ce fichier dans l'ensemble du code source en indiquant clairement que ce fichier se rapporte exclusivement à _hapi_ et pas à du code métier.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Le fichier modifié contient 2 stratégies d'authentification pour le server _hapi_ :
* la stratégie `jwt-user` pour gérer les accès sur la base d’Access Tokens JWT générés pour les utilisateurs,
* la stratégie `jwt-application` pour gérer les accès sur la base d’Access Tokens JWT générés pour les applications tierces.

Il faut donc tester fonctionnellement ces 2 stratégies : 
* Sur Pix App s'authentifier avec un utilisateur, n'importe lequel, par exemple `hermione@school.net` et constater que l'authentification est réussie
* Demander des résultats avec une application tierce en utilisant un Access Token d'application tierce telle que documenté dans le guide _« Comment s’authentifier en tant qu'utilisateur ou application tierce ?»_. La vérification fonctionnelle est concluante si la réponse à la requête répond un `200`.
