### PR TITLE
[FEATURE] Afficher les titres des grains dans la navbar (PIX-17587)

### DIFF
--- a/mon-pix/app/components/module/layout/navbar.gjs
+++ b/mon-pix/app/components/module/layout/navbar.gjs
@@ -34,15 +34,15 @@ export default class ModulixNavbar extends Component {
     this.sidebarOpened = false;
   }
 
-  get grainsWithIdAndTranslatedType() {
+  get grainsWithIdAndTitle() {
     return this.args.grainsToDisplay.map((grain) => ({
-      type: this.intl.t(`pages.modulix.grain.tag.${grain.type}`),
+      title: grain.title,
       id: grain.id,
     }));
   }
 
   get currentGrainIndex() {
-    return this.grainsWithIdAndTranslatedType.length - 1;
+    return this.grainsWithIdAndTitle.length - 1;
   }
 
   @action
@@ -79,7 +79,7 @@ export default class ModulixNavbar extends Component {
       <:content>
         <nav>
           <ul>
-            {{#each this.grainsWithIdAndTranslatedType as |grain index|}}
+            {{#each this.grainsWithIdAndTitle as |grain index|}}
               <li>
                 <button
                   type="button"
@@ -87,7 +87,7 @@ export default class ModulixNavbar extends Component {
                   aria-current={{if (eq index this.currentGrainIndex) "step"}}
                   {{on "click" (fn this.onMenuItemClick grain.id)}}
                 >
-                  {{grain.type}}
+                  {{grain.title}}
                 </button>
               </li>
             {{/each}}

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -1,6 +1,5 @@
 import { clickByName, clickByText, render } from '@1024pix/ember-testing-library';
 import { click, tab } from '@ember/test-helpers';
-import { t } from 'ember-intl/test-support';
 import ModulixNavbar from 'mon-pix/components/module/layout/navbar';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -136,21 +135,12 @@ module('Integration | Component | Module | Navbar', function (hooks) {
       await waitForDialog();
 
       // then
-      assert.strictEqual(
-        screen.getByRole('button', { name: 'Découverte' }).textContent.trim(),
-        t('pages.modulix.grain.tag.discovery'),
-      );
-      assert.strictEqual(
-        screen.getByRole('button', { name: 'Activité' }).textContent.trim(),
-        t('pages.modulix.grain.tag.activity'),
-      );
-      assert.strictEqual(
-        screen.getByRole('button', { name: 'Leçon' }).textContent.trim(),
-        t('pages.modulix.grain.tag.lesson'),
-      );
-      assert.dom(screen.getByRole('button', { name: 'Leçon' })).hasAria('current', 'step');
+      assert.strictEqual(screen.getByRole('button', { name: 'Grain title 1' }).textContent.trim(), 'Grain title 1');
+      assert.strictEqual(screen.getByRole('button', { name: 'Grain title 2' }).textContent.trim(), 'Grain title 2');
+      assert.strictEqual(screen.getByRole('button', { name: 'Grain title 3' }).textContent.trim(), 'Grain title 3');
+      assert.dom(screen.getByRole('button', { name: 'Grain title 3' })).hasAria('current', 'step');
 
-      assert.dom(screen.queryByRole('button', { name: "Récap'" })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Grain title 4' })).doesNotExist();
     });
 
     test('should allow tabulation in sidebar', async function (assert) {
@@ -177,13 +167,13 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
       // then
       await tab();
-      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.discovery'));
+      assert.strictEqual(document.activeElement.textContent.trim(), 'Grain title 1');
 
       await tab();
-      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.activity'));
+      assert.strictEqual(document.activeElement.textContent.trim(), 'Grain title 2');
 
       await tab();
-      assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.lesson'));
+      assert.strictEqual(document.activeElement.textContent.trim(), 'Grain title 3');
     });
 
     module('when user clicks on grain’s type', function () {
@@ -209,12 +199,12 @@ module('Integration | Component | Module | Navbar', function (hooks) {
         );
         await clickByName('Afficher les étapes du module');
         await waitForDialog();
-        await clickByText('Activité');
+        await clickByText('Grain title 2');
 
         // then
         sinon.assert.calledOnce(goToGrainSpy);
         sinon.assert.calledWithExactly(goToGrainSpy, '234-abc');
-        assert.strictEqual(document.activeElement.textContent.trim(), t('pages.modulix.grain.tag.activity'));
+        assert.strictEqual(document.activeElement.textContent.trim(), 'Grain title 2');
         assert.ok(true);
       });
 
@@ -240,7 +230,7 @@ module('Integration | Component | Module | Navbar', function (hooks) {
         );
         await clickByName('Afficher les étapes du module');
         await waitForDialog();
-        await clickByText('Activité');
+        await clickByText('Grain title 2');
         await waitForDialogClose();
 
         // then
@@ -252,10 +242,10 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
 function createModule(owner) {
   const store = owner.lookup('service:store');
-  const grain1 = store.createRecord('grain', { title: 'Grain title', type: 'discovery', id: '123-abc' });
-  const grain2 = store.createRecord('grain', { title: 'Grain title', type: 'activity', id: '234-abc' });
-  const grain3 = store.createRecord('grain', { title: 'Grain title', type: 'lesson', id: '345-abc' });
-  const grain4 = store.createRecord('grain', { title: 'Grain title', type: 'summary', id: '456-abc' });
+  const grain1 = store.createRecord('grain', { title: 'Grain title 1', type: 'discovery', id: '123-abc' });
+  const grain2 = store.createRecord('grain', { title: 'Grain title 2', type: 'activity', id: '234-abc' });
+  const grain3 = store.createRecord('grain', { title: 'Grain title 3', type: 'lesson', id: '345-abc' });
+  const grain4 = store.createRecord('grain', { title: 'Grain title 4', type: 'summary', id: '456-abc' });
   return store.createRecord('module', {
     title: 'Didacticiel',
     grains: [grain1, grain2, grain3, grain4],

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1324,19 +1324,19 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('when user clicks on grain’s type in sidebar', function () {
+  module('when user clicks on grain’s title in sidebar', function () {
     test('should focus and scroll on matching grain element', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false, content: 'Ceci est un grain dans un test d‘intégration' };
       const grain1 = store.createRecord('grain', {
-        title: 'Grain title',
+        title: 'Grain title 1',
         type: 'discovery',
         id: '123-abc',
         components: [{ type: 'element', element }],
       });
       const grain2 = store.createRecord('grain', {
-        title: 'Grain title',
+        title: 'Grain title 2',
         type: 'activity',
         id: '234-abc',
         components: [{ type: 'element', element }],
@@ -1353,7 +1353,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       await clickByName('Afficher les étapes du module');
       await waitForDialog();
-      const item = screen.getByRole('button', { name: 'Découverte' });
+      const item = screen.getByRole('button', { name: 'Grain title 1' });
       await click(item);
 
       //  then
@@ -1365,13 +1365,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false, content: 'Ceci est un grain dans un test d‘intégration' };
       const grain1 = store.createRecord('grain', {
-        title: 'Grain title',
+        title: 'Grain title 1',
         type: 'discovery',
         id: '123-abc',
         components: [{ type: 'element', element }],
       });
       const grain2 = store.createRecord('grain', {
-        title: 'Grain title',
+        title: 'Grain title 2',
         type: 'activity',
         id: '234-abc',
         components: [{ type: 'element', element }],
@@ -1388,7 +1388,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       await clickByName('Afficher les étapes du module');
       await waitForDialog();
-      const item = screen.getByRole('button', { name: 'Découverte' });
+      const item = screen.getByRole('button', { name: 'Grain title 1' });
       await click(item);
 
       // then


### PR DESCRIPTION
## 🌸 Problème

Dans la sidebar de la navbar, on affiche les types de grain pour naviguer. Ce n’est pas évident de comprendre la navigation maintenant qu’on a caché les tags.

## 🌳 Proposition

Remplacer les types par les titres des grains.

## 🐝 Remarques

- Dans le cas d'un titre très long, est-ce qu'on tronque le texte ? Que veut dire "très long" (nb de caractères) ? ✂️

## 🤧 Pour tester

- Afficher le module bac-a-sable
- Passer 3 grains
- Ouvrir la barre de navigation
- Vérifier que les titres des grains s'affichent, au lieu des types
