### PR TITLE
[FEATURE] Aligner les columns de tableaux dans la page d'analyse de résultats (PIX-17803)

### DIFF
--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
@@ -31,7 +31,7 @@ import TagLevel from '../statistics/tag-level';
       @data={{levelsPerCompetence.levelsPerTube}}
     >
       <:columns as |tubeLevel context|>
-        <PixTableColumn @context={{context}}>
+        <PixTableColumn @context={{context}} class="analysis-per-tubes-and-competences__description-column">
           <:header>
             {{t "components.analysis-per-tubes-and-competences.table.column.tubes"}}
           </:header>

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
@@ -59,7 +59,7 @@ import TagLevel from '../statistics/tag-level';
           </:cell>
         </PixTableColumn>
 
-        <PixTableColumn @context={{context}}>
+        <PixTableColumn @context={{context}} class="analysis-per-tubes-and-competences__level-column">
           <:header>
             {{t "components.analysis-per-tubes-and-competences.table.column.level"}}
           </:header>

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
@@ -23,6 +23,10 @@
     margin-bottom: var(--pix-spacing-6x);
   }
 
+  &__description-column {
+    width: 65%;
+  }
+
   &__tube-title {
     @extend %pix-body-s;
 

--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.scss
@@ -27,6 +27,10 @@
     width: 65%;
   }
 
+  &__level-column {
+    width: 10%;
+  }
+
   &__tube-title {
     @extend %pix-body-s;
 


### PR DESCRIPTION
## 🌸 Problème

C'est pas aligné

## 🌳 Proposition

Alignons en donnant une largeur fixe à la 1ère et la dernière colonne

## 🐝 Remarques

Non

## 🤧 Pour tester

- avoir le feature toggle pour afficher la nouvelle page d'analyse à true
- aller sur la page d'analyse
- vérifier 
- 🎉 
