### PR TITLE
[BUGFIX] Corrige un bug qui permettait la prise en compte de participations à des campagnes d'autres organisations dans les quêtes (PIX-17783)

### DIFF
--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -10,6 +10,7 @@ import { buildUser } from './build-user.js';
 const { STARTED, SHARED, TO_SHARE } = CampaignParticipationStatuses;
 
 const build = function ({
+  organizationLearnerId,
   userId,
   createdAt,
   sharedAt,
@@ -23,6 +24,7 @@ const build = function ({
   const status = assessmentState === Assessment.states.COMPLETED ? TO_SHARE : STARTED;
 
   const campaignParticipation = buildCampaignParticipation({
+    organizationLearnerId,
     userId,
     campaignId,
     createdAt: createdAt,

--- a/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js
@@ -28,9 +28,8 @@ const findOrganizationLearnersWithParticipations = withTransaction(async functio
   return Promise.all(
     organizationLearners.map(async (organizationLearner) => {
       const organization = await organizationRepository.get(organizationLearner.organizationId);
-      const campaignParticipationOverviews = await _getCampaignParticipationOverviewsWithoutPagination({
-        userId: organizationLearner.userId,
-        campaignParticipationOverviewRepository,
+      const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByOrganizationLearnerId({
+        organizationLearnerId: organizationLearner.id,
       });
       const tags = await tagRepository.findByIds(organization.tags.map((tag) => tag.id));
 
@@ -44,26 +43,4 @@ const findOrganizationLearnersWithParticipations = withTransaction(async functio
   );
 });
 
-async function _getCampaignParticipationOverviewsWithoutPagination({
-  userId,
-  campaignParticipationOverviewRepository,
-}) {
-  const allCampaignParticipationOverviews = [];
-  let call = 1;
-  let totalPages;
-
-  do {
-    const { campaignParticipationOverviews, pagination } =
-      await campaignParticipationOverviewRepository.findByUserIdWithFilters({
-        userId,
-        page: { number: call, size: 100 },
-      });
-    totalPages = pagination.pageCount;
-    allCampaignParticipationOverviews.push(...campaignParticipationOverviews);
-    call++;
-  } while (call <= totalPages);
-
-  return allCampaignParticipationOverviews;
-}
-
-export { _getCampaignParticipationOverviewsWithoutPagination, findOrganizationLearnersWithParticipations };
+export { findOrganizationLearnersWithParticipations };

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -24,26 +24,30 @@ export const rewardUser = async ({
     const rewardIds = rewards.map((reward) => reward.rewardId);
 
     for (const quest of quests) {
-      const dataForQuest = eligibilities
+      const dataForQuests = eligibilities
         .map((eligibility) => new DataForQuest({ eligibility }))
-        .find((dataForQuest) => quest.isEligible(dataForQuest));
+        .filter((dataForQuest) => quest.isEligible(dataForQuest));
 
-      if (!dataForQuest) {
+      if (dataForQuests.length === 0) {
         continue;
       }
 
       if (rewardIds.includes(quest.rewardId)) {
         continue;
       }
-      const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
-      const targetProfileIds = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
-      const success = await successRepository.find({ userId, campaignParticipationIds, targetProfileIds });
-      dataForQuest.success = success;
-      const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
 
-      if (userHasSucceedQuest) {
-        await rewardRepository.reward({ userId, rewardId: quest.rewardId });
-        rewardIds.push(quest.rewardId);
+      for (const dataForQuest of dataForQuests) {
+        const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+        const targetProfileIds =
+          quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+        const success = await successRepository.find({ userId, campaignParticipationIds, targetProfileIds });
+        dataForQuest.success = success;
+        const userHasSucceedQuest = quest.isSuccessful(dataForQuest);
+
+        if (userHasSucceedQuest) {
+          await rewardRepository.reward({ userId, rewardId: quest.rewardId });
+          rewardIds.push(quest.rewardId);
+        }
       }
     }
   } catch (error) {

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -24,15 +24,15 @@ export const rewardUser = async ({
     const rewardIds = rewards.map((reward) => reward.rewardId);
 
     for (const quest of quests) {
+      if (rewardIds.includes(quest.rewardId)) {
+        continue;
+      }
+
       const dataForQuests = eligibilities
         .map((eligibility) => new DataForQuest({ eligibility }))
         .filter((dataForQuest) => quest.isEligible(dataForQuest));
 
       if (dataForQuests.length === 0) {
-        continue;
-      }
-
-      if (rewardIds.includes(quest.rewardId)) {
         continue;
       }
 

--- a/api/src/quest/domain/usecases/reward-user.js
+++ b/api/src/quest/domain/usecases/reward-user.js
@@ -47,6 +47,7 @@ export const rewardUser = async ({
         if (userHasSucceedQuest) {
           await rewardRepository.reward({ userId, rewardId: quest.rewardId });
           rewardIds.push(quest.rewardId);
+          break;
         }
       }
     }

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
@@ -59,9 +59,10 @@ describe('Integration | UseCases | find-organization-learners-with-participation
 
   it('should return organization learners list and their campaign participations', async function () {
     // given
+    const userId = databaseBuilder.factory.buildUser().id;
     const organization = databaseBuilder.factory.buildOrganization();
     const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
-      userId: databaseBuilder.factory.buildUser().id,
+      userId,
       organizationId: organization.id,
       division: '5eme',
     });
@@ -80,6 +81,19 @@ describe('Integration | UseCases | find-organization-learners-with-participation
       userId: organizationLearner.userId,
     });
 
+    const secondOrganization = databaseBuilder.factory.buildOrganization();
+    const secondOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+      userId,
+      organizationId: secondOrganization.id,
+      division: '5eme',
+    });
+
+    const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: databaseBuilder.factory.buildCampaign({ organizationId: secondOrganization.id }).id,
+      organizationLearnerId: secondOrganizationLearner.id,
+      userId: secondOrganizationLearner.userId,
+    });
+
     await databaseBuilder.commit();
 
     // when
@@ -92,7 +106,7 @@ describe('Integration | UseCases | find-organization-learners-with-participation
     });
 
     // then
-    expect(organizationLearnersWithParticipations).to.have.lengthOf(1);
+    expect(organizationLearnersWithParticipations).to.have.lengthOf(2);
 
     expect(organizationLearnersWithParticipations[0].organizationLearner).to.be.an.instanceOf(OrganizationLearner);
     expect(organizationLearnersWithParticipations[0].organizationLearner.id).to.equal(organizationLearner.id);
@@ -111,5 +125,17 @@ describe('Integration | UseCases | find-organization-learners-with-participation
       (participation) => participation.id,
     );
     expect(participationOverviewIds).to.have.members([campaignParticipation1.id, campaignParticipation2.id]);
+
+    expect(organizationLearnersWithParticipations[1].organizationLearner).to.be.an.instanceOf(OrganizationLearner);
+    expect(organizationLearnersWithParticipations[1].organizationLearner.id).to.equal(secondOrganizationLearner.id);
+
+    expect(organizationLearnersWithParticipations[1].organization).to.be.an.instanceOf(Organization);
+    expect(organizationLearnersWithParticipations[1].organization.id).to.equal(secondOrganization.id);
+
+    expect(organizationLearnersWithParticipations[1].campaignParticipations).to.have.lengthOf(1);
+    expect(organizationLearnersWithParticipations[1].campaignParticipations[0]).to.be.an.instanceOf(
+      CampaignParticipationOverview,
+    );
+    expect(organizationLearnersWithParticipations[1].campaignParticipations[0].id).to.equal(campaignParticipation3.id);
   });
 });

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-organization-learners-with-participations_test.js
@@ -1,7 +1,4 @@
-import {
-  _getCampaignParticipationOverviewsWithoutPagination,
-  findOrganizationLearnersWithParticipations,
-} from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
+import { findOrganizationLearnersWithParticipations } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -22,56 +19,6 @@ describe('Unit | UseCase | find-organization-learners-with-participations', func
 
       // then
       expect(libOrganizationLearnerRepository.findByUserId).to.not.have.been.called;
-    });
-  });
-
-  context('#_getCampaignParticipationOverviewsWithoutPagination', function () {
-    it('should return all campaign participations', async function () {
-      // given
-      const userId = 1234;
-      const campaignParticipationOverviewRepository = {
-        findByUserIdWithFilters: sinon.stub(),
-      };
-
-      const campaignParticipationOverview1 = {
-        id: 1234,
-        userId,
-      };
-      const campaignParticipationOverview2 = {
-        id: 1235,
-        userId,
-      };
-
-      campaignParticipationOverviewRepository.findByUserIdWithFilters
-        .withArgs({
-          userId,
-          page: { number: 1, size: 100 },
-        })
-        .resolves({
-          campaignParticipationOverviews: [campaignParticipationOverview1],
-          pagination: { pageSize: 100, pageCount: 2, rowCount: 110, page: 1 },
-        });
-      campaignParticipationOverviewRepository.findByUserIdWithFilters
-        .withArgs({
-          userId,
-          page: { number: 2, size: 100 },
-        })
-        .resolves({
-          campaignParticipationOverviews: [campaignParticipationOverview2],
-          pagination: { pageSize: 100, pageCount: 2, rowCount: 110, page: 2 },
-        });
-
-      // when
-      const campaignParticipationOverviews = await _getCampaignParticipationOverviewsWithoutPagination({
-        userId,
-        campaignParticipationOverviewRepository,
-      });
-
-      // then
-      expect(campaignParticipationOverviews).to.be.deep.have.members([
-        campaignParticipationOverview1,
-        campaignParticipationOverview2,
-      ]);
     });
   });
 });

--- a/api/tests/quest/integration/domain/usecases/reward-user_test.js
+++ b/api/tests/quest/integration/domain/usecases/reward-user_test.js
@@ -262,6 +262,98 @@ describe('Quest | Integration | Domain | Usecases | RewardUser', function () {
       });
     });
 
+    context('when user is eligible with two organization learner for the same quest', function () {
+      let userId;
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        const questOrganization = 'PRO';
+        const userKnowledgeElements = [
+          {
+            userId,
+            skillId: 'skillId1',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId2',
+            status: VALIDATED,
+          },
+          {
+            userId,
+            skillId: 'skillId3',
+            status: VALIDATED,
+          },
+        ];
+        userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+
+        const firstOrganization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
+        const secondOrganization = databaseBuilder.factory.buildOrganization({ type: questOrganization });
+
+        [firstOrganization.id, secondOrganization.id].forEach((organizationId) => {
+          const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+            userId,
+            organizationId,
+          });
+
+          const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+            organizationId,
+          });
+          const { id: secondCampaignId } = databaseBuilder.factory.buildCampaign({
+            organizationId,
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            organizationLearnerId,
+            userId,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: secondCampaignId,
+            organizationLearnerId,
+            userId,
+          });
+        });
+
+        const rewardId = databaseBuilder.factory.buildAttestation().id;
+
+        databaseBuilder.factory.buildQuest({
+          rewardId,
+          eligibilityRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.OBJECT.ORGANIZATION,
+              comparison: REQUIREMENT_COMPARISONS.ALL,
+              data: {
+                type: {
+                  data: questOrganization,
+                  comparison: CRITERION_COMPARISONS.EQUAL,
+                },
+              },
+            },
+          ],
+          successRequirements: [
+            {
+              requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+              data: {
+                skillIds: ['skillId1', 'skillId2', 'skillId3'],
+                threshold: 50,
+              },
+            },
+          ],
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should reward the user only once', async function () {
+        //when
+        await usecases.rewardUser({ userId });
+
+        // then
+        const profileRewards = await knex(PROFILE_REWARDS_TABLE_NAME).where({ userId });
+        expect(profileRewards).to.have.lengthOf(1);
+      });
+    });
+
     context('when user is eligible at two quests with the same rewardId', function () {
       let userId;
       beforeEach(async function () {


### PR DESCRIPTION
## 🌸 Problème

Le système de quêtes utilise les données des prescrits pour savoir si l'utilisateur a validé une quête ou non. Pour ce faire, elle fait appel à l'api interne OrganizationLearnersWithParticipations. Il s'avère que l'api envoyait l'ensemble des données de participations non regroupé par prescrit.

## 🌳 Proposition

Faire correctement la ségrégation des données par prescrits.

## 🐝 Remarques

Il est possible que des prescrits aient obtenu leur attestation en fait une partie de la quête pour une organisation et une autre partie pour une autre organisation.

## 🤧 Pour tester

Tester la quête des attestations pour les 6ème.