### PR TITLE
[TECH] Simplification de la création des routes dans le point d'entrée de MADDO.

### DIFF
--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -185,12 +185,8 @@ const setupRoutesAndPlugins = async function (server) {
     replicationsRoutes,
     parcoursupRoutes,
   ];
-  const routesWithOptions = routes.map((route) => ({
-    plugin: route,
-    options: { tags: ['maddo'] },
-  }));
 
-  await server.register([...plugins, ...routesWithOptions]);
+  await server.register([...plugins, ...routes]);
 };
 
 const setupOpenApiSpecification = async function (server) {


### PR DESCRIPTION
## 🌸 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de la création du point d'entrée du serveur MADDO, nous ajoutons le tag `maddo` aux options de toutes les routes.
Cela n'est pas nécessaire car il n'y a pas de code qui s'en sert.

## 🌳 Proposition

On supprime le code qui ajoute le tag inutile.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🐝 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Vérifier que le serveur maddo démarre correctement.
Vérifier que la route servant la documentation liste bien toutes les routes de MADDO.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
