### PR TITLE
[FEATURE] Support nouveau type d'element `qcu-declarative`(PIX-17683)

### DIFF
--- a/api/scripts/modulix/get-elements-csv.js
+++ b/api/scripts/modulix/get-elements-csv.js
@@ -41,6 +41,7 @@ export function getElements(modules) {
     'image',
     'qcm',
     'qcu',
+    'qcu-declarative',
     'qrocm',
     'separator',
     'text',

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,4 +1,5 @@
 import { DomainError } from '../../../shared/domain/errors.js';
+import { QCUDeclarativeAnsweredEvent } from '../models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -25,6 +26,8 @@ class PassageEventFactory {
         return new FlashcardsRectoReviewedEvent(eventData);
       case 'FLASHCARDS_RETRIED':
         return new FlashcardsRetriedEvent(eventData);
+      case 'QCU_DECLARATIVE_ANSWERED':
+        return new QCUDeclarativeAnsweredEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/element/QCU-declarative.js
+++ b/api/src/devcomp/domain/models/element/QCU-declarative.js
@@ -1,0 +1,9 @@
+import { QCU } from './QCU.js';
+
+class QCUDeclarative extends QCU {
+  constructor({ id, instruction, proposals }) {
+    super({ id, instruction, proposals, type: 'qcu-declarative' });
+  }
+}
+
+export { QCUDeclarative };

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -3,7 +3,7 @@ import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals, type= 'qcu' }) {
+  constructor({ id, instruction, locales, proposals, type = 'qcu' }) {
     super({ id, type });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU');

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -3,8 +3,8 @@ import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals }) {
-    super({ id, type: 'qcu' });
+  constructor({ id, instruction, locales, proposals, type= 'qcu' }) {
+    super({ id, type });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU');
     this.#assertProposalsIsAnArray(proposals);

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -1,0 +1,24 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEventWithElement } from './PassageEventWithElement.js';
+
+class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
+    super({
+      type: 'QCU_DECLARATIVE_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { answer },
+    });
+
+    assertNotNullOrUndefined(answer, 'The answer is required for a QCUDeclarativeAnsweredEvent');
+
+    this.elementId = elementId;
+    this.answer = answer;
+  }
+}
+
+export { QCUDeclarativeAnsweredEvent };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -150,8 +150,42 @@
     {
       "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
       "type": "lesson",
-      "title": "test iframe",
+      "title": "test qcu-declarative",
       "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "6a6944be-a8a3-4138-b5dc-af664cf40b07",
+            "type": "qcu-declarative",
+            "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
+            "proposals": [
+              {
+                "id": "1",
+                "content": "Avant de mettre le dentifrice",
+                "feedback": {
+                  "state": "",
+                  "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
+                }
+              },
+              {
+                "id": "2",
+                "content": "Après avoir mis le dentifrice",
+                "feedback": {
+                  "state":  "",
+                  "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
+                }
+              },
+              {
+                "id": "3",
+                "content": "Pendant que le dentifrice est mis",
+                "feedback": {
+                  "state":  "",
+                  "diagnosis": "<p>Digne des plus grands acrobates !</p>"
+                }
+              }
+            ]
+          }
+        },
         {
           "type": "element",
           "element": {

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -16,6 +16,7 @@ import { Flashcards } from '../../domain/models/element/flashcards/Flashcards.js
 import { Image } from '../../domain/models/element/Image.js';
 import { QCM } from '../../domain/models/element/QCM.js';
 import { QCU } from '../../domain/models/element/QCU.js';
+import { QCUDeclarative } from '../../domain/models/element/QCU-declarative.js';
 import { QROCM } from '../../domain/models/element/QROCM.js';
 import { Separator } from '../../domain/models/element/Separator.js';
 import { Text } from '../../domain/models/element/Text.js';
@@ -108,6 +109,8 @@ export class ModuleFactory {
         return ModuleFactory.#buildQCM(element);
       case 'qcu':
         return ModuleFactory.#buildQCU(element);
+      case 'qcu-declarative':
+        return ModuleFactory.#buildQCUDeclarative(element);
       case 'qrocm':
         return ModuleFactory.#buildQROCM(element);
       case 'flashcards':
@@ -214,6 +217,20 @@ export class ModuleFactory {
         return new QcuProposal({
           id: proposal.id,
           content: proposal.content,
+        });
+      }),
+    });
+  }
+
+  static #buildQCUDeclarative(element) {
+    return new QCUDeclarative({
+      id: element.id,
+      instruction: element.instruction,
+      proposals: element.proposals.map((proposal) => {
+        return new QcuProposal({
+          id: proposal.id,
+          content: proposal.content,
+          feedback: proposal.feedback,
         });
       }),
     });

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -96,9 +96,10 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "3a9f2269-99ba-4631-b6fd-6802c88d5c26"\t"video"\t8\t3\t"73ac3644-7637-4cee-86d4-1a75f53f0b9c"\t"Vidéo de présentation de Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
 "71de6394-ff88-4de3-8834-a40057a50ff4"\t"qcu"\t9\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
 "79dc17f9-142b-4e19-bcbe-bfde4e170d3f"\t"qcu"\t10\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
-"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t11\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
-"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t12\t6\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"Connaissez-vous bien Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
-"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t13\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"`);
+"09dc17f9-142b-4e19-bcbe-bfde4e170d3l"\t"qcu-declarative"\t11\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
+"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t12\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
+"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t13\t6\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"Connaissez-vous bien Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
+"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t14\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -245,6 +245,25 @@
                   "solution": "2"
                 }
               ]
+            },
+            {
+              "elements": [
+                {
+                  "id": "09dc17f9-142b-4e19-bcbe-bfde4e170d3l",
+                  "type": "qcu-declarative",
+                  "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,5 +1,4 @@
 import { QCUDeclarativeAnsweredEvent } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
-import { FlashcardsVersoSeenEvent } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,0 +1,72 @@
+import { QCUDeclarativeAnsweredEvent } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
+import { FlashcardsVersoSeenEvent } from '../../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | answerable-element-events', function () {
+  describe('#QCUDeclarativeAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = 'À chaque Noël';
+
+      // when
+      const qcuDeclarativeAnsweredEvent = new QCUDeclarativeAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+      });
+
+      // then
+      expect(qcuDeclarativeAnsweredEvent.id).to.equal(id);
+      expect(qcuDeclarativeAnsweredEvent.type).to.equal('QCU_DECLARATIVE_ANSWERED');
+      expect(qcuDeclarativeAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qcuDeclarativeAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qcuDeclarativeAnsweredEvent.passageId).to.equal(passageId);
+      expect(qcuDeclarativeAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcuDeclarativeAnsweredEvent.elementId).to.equal(elementId);
+      expect(qcuDeclarativeAnsweredEvent.answer).to.equal(answer);
+      expect(qcuDeclarativeAnsweredEvent.data).to.deep.equal({ elementId, answer });
+    });
+
+    describe('when answer is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+        const answer = undefined;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new QCUDeclarativeAnsweredEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              elementId,
+              answer,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The answer is required for a QCUDeclarativeAnsweredEvent');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
+import { QCUDeclarativeAnsweredEvent } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -168,6 +169,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(FlashcardsRetriedEvent);
+      });
+    });
+
+    describe('when given a QCU_DECLARATIVE_ANSWERED event', function () {
+      it('should return a QCUDeclarativeAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCU_DECLARATIVE_ANSWERED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCUDeclarativeAnsweredEvent);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -181,6 +181,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
           sequenceNumber: 3,
           elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
           type: 'QCU_DECLARATIVE_ANSWERED',
+          answer: 'Tous les mercredis',
         };
         // when
         const builtEvent = PassageEventFactory.build(rawEvent);

--- a/api/tests/devcomp/unit/domain/models/element/QCU-declarative_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-declarative_test.js
@@ -1,0 +1,25 @@
+import { QCUDeclarative } from '../../../../../../src/devcomp/domain/models/element/QCU-declarative.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | QCU-declarative', function () {
+  describe('#constructor', function () {
+    it('should instanciate a QCU-declarative with right properties', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+
+      // When
+      const qcu = new QCUDeclarative({
+        id: '123',
+        instruction: 'instruction',
+        proposals: [proposal1, proposal2],
+      });
+
+      // Then
+      expect(qcu.id).equal('123');
+      expect(qcu.instruction).equal('instruction');
+      expect(qcu.type).equal('qcu-declarative');
+      expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -1,0 +1,19 @@
+import Joi from 'joi';
+
+import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
+import { feedbackSchema } from './feedback-schema.js';
+
+const qcuDeclarativeElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('qcu-declarative').required(),
+  instruction: htmlSchema.required(),
+  proposals: Joi.array()
+    .items({
+      id: proposalIdSchema.required(),
+      content: htmlSchema.required(),
+      feedback: feedbackSchema.required(),
+    })
+    .required(),
+});
+
+export { qcuDeclarativeElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -7,6 +7,7 @@ import { expandElementSchema } from './element/expand-schema.js';
 import { flashcardsElementSchema } from './element/flashcards-schema.js';
 import { imageElementSchema } from './element/image-schema.js';
 import { qcmElementSchema } from './element/qcm-schema.js';
+import { qcuDeclarativeElementSchema } from './element/qcu-declarative-schema.js';
 import { qcuElementSchema } from './element/qcu-schema.js';
 import { qrocmElementSchema } from './element/qrocm-schema.js';
 import { separatorElementSchema } from './element/separator-schema.js';
@@ -32,6 +33,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
     { is: 'flashcards', then: flashcardsElementSchema },
     { is: 'image', then: imageElementSchema },
     { is: 'qcu', then: qcuElementSchema },
+    { is: 'qcu-declarative', then: qcuDeclarativeElementSchema },
     { is: 'qcm', then: qcmElementSchema },
     { is: 'qrocm', then: qrocmElementSchema },
     { is: 'separator', then: separatorElementSchema },
@@ -47,6 +49,7 @@ const stepperElementSchema = Joi.alternatives().conditional('.type', {
     { is: 'expand', then: expandElementSchema },
     { is: 'image', then: imageElementSchema },
     { is: 'qcu', then: qcuElementSchema },
+    { is: 'qcu-declarative', then: qcuDeclarativeElementSchema },
     { is: 'qcm', then: qcmElementSchema },
     { is: 'qrocm', then: qrocmElementSchema },
     { is: 'separator', then: separatorElementSchema },

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -6,6 +6,7 @@ import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
+import { QCUDeclarative } from '../../../../../src/devcomp/domain/models/element/QCU-declarative.js';
 import { QROCM } from '../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { Separator } from '../../../../../src/devcomp/domain/models/element/Separator.js';
 import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
@@ -600,6 +601,73 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
         // then
         expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QCUDeclarative Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+                    type: 'qcu-declarative',
+                    instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
+                    proposals: [
+                      {
+                        id: '1',
+                        content: 'Avant de mettre le dentifrice',
+                        feedback: {
+                          state: '',
+                          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+                        },
+                      },
+                      {
+                        id: '2',
+                        content: 'Après avoir mis le dentifrice',
+                        feedback: {
+                          state: '',
+                          diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
+                        },
+                      },
+                      {
+                        id: '3',
+                        content: 'Pendant que le dentifrice est mis',
+                        feedback: {
+                          state: '',
+                          diagnosis: '<p>Digne des plus grands acrobates !</p>',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUDeclarative);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
@@ -1265,6 +1333,81 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                             },
                           ],
                           solution: '1',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a QCUDeclarative Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+                          type: 'qcu-declarative',
+                          instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
+                          proposals: [
+                            {
+                              id: '1',
+                              content: 'Avant de mettre le dentifrice',
+                              feedback: {
+                                state: '',
+                                diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+                              },
+                            },
+                            {
+                              id: '2',
+                              content: 'Après avoir mis le dentifrice',
+                              feedback: {
+                                state: '',
+                                diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
+                              },
+                            },
+                            {
+                              id: '3',
+                              content: 'Pendant que le dentifrice est mis',
+                              feedback: {
+                                state: '',
+                                diagnosis: '<p>Digne des plus grands acrobates !</p>',
+                              },
+                            },
+                          ],
                         },
                       ],
                     },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -11,6 +11,7 @@ import { Flashcards } from '../../../../../../src/devcomp/domain/models/element/
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
+import { QCUDeclarative } from '../../../../../../src/devcomp/domain/models/element/QCU-declarative.js';
 import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { Separator } from '../../../../../../src/devcomp/domain/models/element/Separator.js';
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
@@ -202,6 +203,30 @@ function getComponents() {
       }),
     }),
     new ComponentElement({
+      element: new QCUDeclarative({
+        id: 'af447a7b-6790-4b3b-b83e-296e6618ca31',
+        proposals: [
+          {
+            id: '1',
+            content: 'plop',
+            feedback: {
+              state: '',
+              diagnosis: 'blabla',
+            },
+          },
+          {
+            id: '2',
+            content: 'bam',
+            feedback: {
+              state: '',
+              diagnosis: 'blabla',
+            },
+          },
+        ],
+        instruction: 'question declarative',
+      }),
+    }),
+    new ComponentElement({
       element: new QCM({
         id: '2000',
         proposals: [
@@ -357,6 +382,34 @@ function getAttributesComponents() {
           },
         ],
         type: 'qcu',
+      },
+    },
+    {
+      type: 'element',
+      element: {
+        id: 'af447a7b-6790-4b3b-b83e-296e6618ca31',
+        instruction: 'question declarative',
+        isAnswerable: true,
+        locales: undefined,
+        proposals: [
+          {
+            content: 'plop',
+            id: '1',
+            feedback: {
+              state: '',
+              diagnosis: 'blabla',
+            },
+          },
+          {
+            content: 'bam',
+            id: '2',
+            feedback: {
+              state: '',
+              diagnosis: 'blabla',
+            },
+          },
+        ],
+        type: 'qcu-declarative',
       },
     },
     {


### PR DESCRIPTION
## 🌳 Proposition

Ajouter le nouvel élément QCU déclaratif dans les éléments de module retournés par l'API.

## 🐝 Remarques

- On a créé le fichier `answerable-element-events.js`, qui pourra regrouper l'enregistrement des réponses données par l'utilisateur à un élément du module. Pour l'instant, il permet l'enregistrement de l'event `QCU_DECLARATIVE_ANSWERED`

## 🤧 Pour tester

- Ouvrir le module bac-a-sable
- Ouvrir la console développeur et afficher l'onglet Réseau
- Vérifier que le retour de l'API pour la route 'modules/bac-a-sable' renvoie bien un JSON contenant un élément `qcu-declarative`
