### PR TITLE
[FEATURE] Ajouter le type d'élément custom dans le get-element-csv (PIX-17426)

### DIFF
--- a/api/scripts/modulix/get-elements-csv.js
+++ b/api/scripts/modulix/get-elements-csv.js
@@ -46,6 +46,7 @@ export function getElements(modules) {
     'separator',
     'text',
     'video',
+    'custom',
   ];
 
   const elements = [];

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -99,7 +99,8 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "09dc17f9-142b-4e19-bcbe-bfde4e170d3l"\t"qcu-declarative"\t11\t4\t"533c69b8-a836-41be-8ffc-8d4636e31224"\t"Voici un vrai-faux"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
 "30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t12\t5\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"Les 3 piliers de Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
 "c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t13\t6\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"Connaissez-vous bien Pix"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
-"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t14\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"`);
+"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t14\t7\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"Embed non-auto"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"
+"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t15\t8\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"Elément custom"\t"bac-a-sable"\t"6282925d-4775-4bca-b513-4c3009ec5886"`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -9,7 +9,10 @@
     "duration": 5,
     "level": "Débutant",
     "tabletSupport": "inconvenient",
-    "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
+    "objectives": [
+      "Naviguer dans Modulix",
+      "Découvrir les leçons et les activités"
+    ]
   },
   "grains": [
     {
@@ -306,7 +309,11 @@
               "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>",
               "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span><p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
             },
-            "solutions": ["1", "3", "4"]
+            "solutions": [
+              "1",
+              "3",
+              "4"
+            ]
           }
         }
       ]
@@ -336,8 +343,13 @@
                 "placeholder": "",
                 "ariaLabel": "Mot à trouver",
                 "defaultValue": "",
-                "tolerances": ["t1", "t3"],
-                "solutions": ["Groupement"]
+                "tolerances": [
+                  "t1",
+                  "t3"
+                ],
+                "solutions": [
+                  "Groupement"
+                ]
               },
               {
                 "type": "text",
@@ -353,7 +365,9 @@
                 "ariaLabel": "Année à trouver",
                 "defaultValue": "",
                 "tolerances": [],
-                "solutions": ["2016"]
+                "solutions": [
+                  "2016"
+                ]
               }
             ],
             "feedbacks": {
@@ -378,6 +392,24 @@
             "title": "Simulateur de visioconférence",
             "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
             "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+            "height": 600
+          }
+        }
+      ]
+    },
+    {
+      "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb5",
+      "type": "activity",
+      "title": "Elément custom",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "0e3315fd-98ad-492f-9046-4aa867495d85",
+            "type": "custom",
+            "isCompletionRequired": false,
+            "title": "Element custom",
+            "instruction": "<p>Vous visualisez un événement custom.</p>",
             "height": 600
           }
         }


### PR DESCRIPTION
## 🌸 Problème
On avait oublié d'ajouter le type "custom" dans les types d'éléments gérés par get-element-csv.

## 🌳 Proposition
L'ajouter.

## 🤧 Pour tester
On peut lancer le script avec node : node ./api/scripts/modulix/get-elements-csv.js