### PR TITLE
[BUGFIX] Ajout d'un await manquant dans un test sur la page du taux de couverture (PIX-17811)

### DIFF
--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/analysis-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/analysis-repository_test.js
@@ -57,7 +57,7 @@ describe('Integration | Infrastructure | Repository | Analysis', function () {
         nb_tubes_in_competence: 1,
       });
 
-      datamartBuilder.commit();
+      await datamartBuilder.commit();
 
       // when
       const result = await analysisRepository.findByTubes({ organizationId: 111 });


### PR DESCRIPTION
## 🌸 Problème
Nous avons un test flaky dans le fichier `api/tests/prescription/organization-learner/integration/infrastructure/repositories/analysis-repository_test.js`
Il manque un await devant la ligne `datamartBuilder.commit();`


## 🌳 Proposition
Ajouter ce tout pitit await manquant 😇 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
Absolument rien a faire, juste constater prochainement que ce flaky n'apparaisse plus 👍 
🐈‍⬛ 
