### PR TITLE
[TECH] Améliorer des requêtes SQL des live-alerts (PIX-17318).

### DIFF
--- a/api/db/migrations/20250515141343_add-live-alert-id-index-to-certification-issue-reports.js
+++ b/api/db/migrations/20250515141343_add-live-alert-id-index-to-certification-issue-reports.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return knex.raw(
+    'CREATE INDEX "certification-issue-reports_live-alert-id_index" ON "certification-issue-reports" ("liveAlertId");',
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return knex.raw('DROP INDEX IF EXISTS "certification-issue-reports_live-alert-id_index";');
+};
+
+export { down, up };

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-companion-alert-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-companion-alert-repository_test.js
@@ -1,0 +1,57 @@
+import * as certificationCompanionAlertRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/certification-companion-alert-repository.js';
+import {
+  CertificationCompanionLiveAlert,
+  CertificationCompanionLiveAlertStatus,
+} from '../../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Session-management | Integration | Infrastructure | Repositories | Certification Companion Alert', function () {
+  describe('#getOngoingAlert', function () {
+    it('should get correct ongoing companion alert', async function () {
+      // given
+      const sessionId = 200;
+      databaseBuilder.factory.buildSession({ id: sessionId });
+
+      const { userId, assessmentId, expectedCompanionLiveAlertId } = _buildCandidateWithCompanionAlerts({ sessionId });
+      _buildCandidateWithCompanionAlerts({ sessionId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const ongoingAlert = await certificationCompanionAlertRepository.getOngoingAlert({ sessionId, userId });
+
+      // then
+      expect(ongoingAlert).to.deep.equal(
+        new CertificationCompanionLiveAlert({
+          id: expectedCompanionLiveAlertId,
+          assessmentId,
+          status: CertificationCompanionLiveAlertStatus.ONGOING,
+        }),
+      );
+    });
+  });
+});
+
+function _buildCandidateWithCompanionAlerts({ sessionId }) {
+  const user = databaseBuilder.factory.buildUser();
+  const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+    userId: user.id,
+    sessionId,
+  });
+  const assessment = databaseBuilder.factory.buildAssessment({
+    certificationCourseId: certificationCourse.id,
+    userId: user.id,
+  });
+
+  databaseBuilder.factory.buildCertificationCompanionLiveAlert({
+    assessmentId: assessment.id,
+    status: CertificationCompanionLiveAlertStatus.CLEARED,
+  });
+
+  const companionLiveAlert = databaseBuilder.factory.buildCertificationCompanionLiveAlert({
+    assessmentId: assessment.id,
+    status: CertificationCompanionLiveAlertStatus.ONGOING,
+  });
+
+  return { userId: user.id, assessmentId: assessment.id, expectedCompanionLiveAlertId: companionLiveAlert.id };
+}


### PR DESCRIPTION
## 🌸 Problème

Nous avons des full-scans des tables de live-alerts.

## 🌳 Proposition

Améliorer certaines requêtes SQL qui nous semblent non optimales.

## 🤧 Pour tester

☑️ Tests verts
