### PR TITLE
[FEATURE] Modifier l'affichage de la dernière page de récupération de compte (PIX-17505)

### DIFF
--- a/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
@@ -92,12 +93,21 @@ export default class UpdateScoRecordFormComponent extends Component {
         <PixButton
           @type="submit"
           @isDisabled={{not this.isSubmitButtonEnabled}}
-          class="account-recovery__content--actions update-sco-record-form__submit"
+          class="account-recovery__content--actions update-sco-record-form__buttons"
         >
           {{t "pages.account-recovery.update-sco-record.form.login-button"}}
         </PixButton>
       </div>
     </form>
+
+    {{#if this.isNewAccountRecoveryEnabled}}
+
+      <div class="account-recovery__content--form-quit-button-container">
+        <PixButtonLink @route="logout" class="account-recovery__content--actions update-sco-record-form__buttons">
+          {{t "common.actions.quit"}}
+        </PixButtonLink>
+      </div>
+    {{/if}}
   </template>
   @service intl;
   @service url;

--- a/mon-pix/app/models/account-recovery-demand.js
+++ b/mon-pix/app/models/account-recovery-demand.js
@@ -5,6 +5,8 @@ export default class AccountRecoveryDemand extends Model {
   @attr('string') ineIna;
   @attr('string') firstName;
   @attr('string') lastName;
+  @attr('string') hasScoUsername;
+  @attr('string') hasGarAuthenticationMethod;
   @attr('date-only') birthdate;
   @attr('string') email;
   @attr('string') password;
@@ -18,6 +20,8 @@ export default class AccountRecoveryDemand extends Model {
       const payload = this.serialize();
       delete payload.data.attributes.password;
       delete payload.data.attributes['temporary-key'];
+      delete payload.data.attributes['has-sco-username'];
+      delete payload.data.attributes['has-gar-authentication-method'];
       return payload;
     },
   });

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,4 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isPixAppNewLayoutEnabled;
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isV3CertificationPageEnabled;
+  @attr('boolean') isNewAccountRecoveryEnabled;
 }

--- a/mon-pix/app/routes/account-recovery/update-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/update-sco-record.js
@@ -9,8 +9,11 @@ export default class UpdateScoRecordRoute extends Route {
   async model(params) {
     const temporaryKey = params.temporary_key;
     try {
-      const { email, firstName } = await this.store.queryRecord('account-recovery-demand', { temporaryKey });
-      return { email, firstName, temporaryKey };
+      const { email, firstName, hasScoUsername, hasGarAuthenticationMethod } = await this.store.queryRecord(
+        'account-recovery-demand',
+        { temporaryKey },
+      );
+      return { email, firstName, temporaryKey, hasScoUsername, hasGarAuthenticationMethod };
     } catch (error) {
       const status = get(error, 'errors[0].status', '');
       const code = get(error, 'errors[0].code', '');

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
-
 const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
 export default class LogoutRoute extends Route {
@@ -9,6 +8,7 @@ export default class LogoutRoute extends Route {
   @service url;
   @service campaignStorage;
   @service router;
+  @service location;
 
   beforeModel() {
     this.session.revokeGarExternalUserToken();
@@ -26,6 +26,6 @@ export default class LogoutRoute extends Route {
   }
 
   _redirectToHomePage() {
-    window.location.replace(this.url.homeUrl);
+    this.location.replace(this.url.homeUrl);
   }
 }

--- a/mon-pix/app/styles/components/account-recovery/_update-sco-record-form.scss
+++ b/mon-pix/app/styles/components/account-recovery/_update-sco-record-form.scss
@@ -1,6 +1,6 @@
 .update-sco-record-form {
 
-  &__submit {
+  &__buttons {
     width: 100%;
   }
 

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -46,6 +46,11 @@
         position: relative;
         max-width: 400px;
       }
+
+      &-quit-button-container{
+        max-width: 400px;
+      }
+
     }
 
     &--image {
@@ -137,7 +142,7 @@
 
     &--actions {
       display: flex;
-      margin-top: 32px;
+      margin-top: 24px;
 
       button:first-child {
         margin-right: 32px;

--- a/mon-pix/app/templates/account-recovery/update-sco-record.gjs
+++ b/mon-pix/app/templates/account-recovery/update-sco-record.gjs
@@ -28,6 +28,8 @@ import PixLogo from 'mon-pix/components/pix-logo';
               @email={{@model.email}}
               @updateRecord={{@controller.updateRecord}}
               @isLoading={{@controller.isLoading}}
+              @hasScoUsername={{@model.hasScoUsername}}
+              @hasGarAuthenticationMethod={{@model.hasGarAuthenticationMethod}}
             />
           {{/if}}
         </div>

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -9,33 +10,40 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | account-recovery | update-sco-record', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display a reset password form', async function (assert) {
-    // given
-    const newEmail = 'philippe.example.net';
-    const firstName = 'Philippe';
-    this.set('firstName', firstName);
-    this.set('email', newEmail);
-    // when
-    const screen = await render(
-      hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}} />`,
-    );
+  module('when newAccountRecovery feature toggle is false', function () {
+    test('displays old reset password form', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isNewAccountRecoveryEnabled: false };
+      }
 
-    // then
-    assert.ok(
-      screen.getByRole('heading', {
-        name: t('pages.account-recovery.update-sco-record.welcome-message', { firstName }),
-      }),
-    );
-    assert.ok(screen.getByText(t('pages.account-recovery.update-sco-record.fill-password'), { exact: false }));
-    assert.ok(
-      screen.getByRole('textbox', {
-        name: t('pages.account-recovery.update-sco-record.form.email-label'),
-        exact: false,
-      }),
-    );
-    assert.ok(
-      screen.getByLabelText(t('pages.account-recovery.update-sco-record.form.password-label'), { exact: false }),
-    );
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+      const newEmail = 'philippe.example.net';
+      const firstName = 'Philippe';
+      this.set('firstName', firstName);
+      this.set('email', newEmail);
+      // when
+      const screen = await render(
+        hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}} />`,
+      );
+
+      // then
+      assert.ok(
+        screen.getByRole('heading', {
+          name: t('pages.account-recovery.update-sco-record.welcome-message', { firstName }),
+        }),
+      );
+      assert.ok(screen.getByText(t('pages.account-recovery.update-sco-record.fill-password'), { exact: false }));
+      assert.ok(
+        screen.getByRole('textbox', {
+          name: t('pages.account-recovery.update-sco-record.form.email-label'),
+          exact: false,
+        }),
+      );
+      assert.ok(
+        screen.getByLabelText(t('pages.account-recovery.update-sco-record.form.password-label'), { exact: false }),
+      );
 
     const submitButton = screen.getByRole('button', {
       name: t('pages.account-recovery.update-sco-record.form.login-button'),
@@ -46,10 +54,187 @@ module('Integration | Component | account-recovery | update-sco-record', functio
     assert.dom(screen.getByRole('checkbox', { name: t('common.cgu.label') })).exists();
     assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
     assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));
+      const submitButton = screen.getByRole('button', {
+        name: t('pages.account-recovery.update-sco-record.form.login-button'),
+      });
+      assert.ok(submitButton);
+      assert.true(submitButton.disabled);
+      assert.dom(screen.getByRole('checkbox', { name: t('common.cgu.label') })).exists();
+      assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
+      assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));
+    });
+  });
+
+  module('when newAccountRecovery feature toggle is true', function () {
+    module('displays new reset password form', function (hooks) {
+      hooks.beforeEach(async function () {
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isNewAccountRecoveryEnabled: true };
+        }
+
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        const newEmail = 'philippe.example.net';
+        const firstName = 'Philippe';
+
+        this.set('firstName', firstName);
+        this.set('email', newEmail);
+      });
+
+      test('displays common content for all users', async function (assert) {
+        // given
+        this.set('hasGarAuthenticationMethod', false);
+        this.set('hasScoUsername', false);
+
+        // when
+        const screen = await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm
+  @firstName={{this.firstName}}
+  @email={{this.email}}
+  @hasGarAuthenticationMethod={{this.hasGarAuthenticationMethod}}
+  @hasScoUsername={{this.hasScoUsername}}
+/>`,
+        );
+
+        // then
+        assert.ok(
+          screen.getByRole('heading', {
+            name: t('pages.account-recovery.update-sco-record.welcome-message', { firstName: this.firstName }),
+          }),
+        );
+        assert.ok(screen.getByText(t('pages.account-recovery.update-sco-record.form.choose-password')));
+        assert.ok(
+          screen.getByRole('textbox', {
+            name: t('pages.account-recovery.update-sco-record.form.email-label'),
+            exact: false,
+          }),
+        );
+        assert.ok(
+          screen.getByLabelText(t('pages.account-recovery.update-sco-record.form.password-label'), { exact: false }),
+        );
+
+        const submitButton = screen.getByRole('button', {
+          name: t('pages.account-recovery.update-sco-record.form.login-button'),
+        });
+        assert.ok(submitButton);
+        assert.true(submitButton.disabled);
+        assert.dom(screen.getByRole('checkbox', { name: t('common.cgu.label') })).exists();
+        assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
+        assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));
+      });
+
+      test('displays no school connection removal warning when user has no school connections', async function (assert) {
+        // given
+        this.set('hasGarAuthenticationMethod', false);
+        this.set('hasScoUsername', false);
+
+        // when
+        await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm
+  @firstName={{this.firstName}}
+  @email={{this.email}}
+  @hasGarAuthenticationMethod={{this.hasGarAuthenticationMethod}}
+  @hasScoUsername={{this.hasScoUsername}}
+/>`,
+        );
+
+        // then
+        assert.dom('#removal-notice').doesNotExist();
+        assert.dom('#new-connection-info').doesNotExist();
+      });
+
+      test('displays specific removal warning when user has username and GAR authentication method', async function (assert) {
+        // given
+        this.set('hasGarAuthenticationMethod', true);
+        this.set('hasScoUsername', true);
+        const garConnection = t('pages.account-recovery.update-sco-record.form.sco-connections.gar');
+        const usernameConnection = t('pages.account-recovery.update-sco-record.form.sco-connections.username');
+        const newConnectionInfo = t('pages.account-recovery.update-sco-record.form.new-connection-info');
+
+        const formatter = new Intl.ListFormat('fr', {
+          style: 'long',
+          type: 'conjunction',
+        });
+
+        const scoConnectionsText = formatter.format([garConnection, usernameConnection]);
+
+        const expectedRemovalNotice = t(
+          'pages.account-recovery.update-sco-record.form.authentication-methods-removal-notice',
+          { connections: scoConnectionsText },
+        );
+
+        // when
+        await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm
+  @firstName={{this.firstName}}
+  @email={{this.email}}
+  @hasGarAuthenticationMethod={{this.hasGarAuthenticationMethod}}
+  @hasScoUsername={{this.hasScoUsername}}
+/>`,
+        );
+
+        // then
+        assert.dom('#removal-notice').includesText(expectedRemovalNotice);
+        assert.dom('#new-connection-info').includesText(newConnectionInfo);
+      });
+
+      test('displays specific removal warning when user has username and no GAR authentication method', async function (assert) {
+        // given
+        this.set('hasGarAuthenticationMethod', false);
+        this.set('hasScoUsername', true);
+
+        const usernameConnection = t('pages.account-recovery.update-sco-record.form.sco-connections.username');
+        const expectedRemovalNotice = t(
+          'pages.account-recovery.update-sco-record.form.authentication-methods-removal-notice',
+          { connections: usernameConnection },
+        );
+        const newConnectionInfo = t('pages.account-recovery.update-sco-record.form.new-connection-info');
+
+        // when
+        await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm
+  @firstName={{this.firstName}}
+  @email={{this.email}}
+  @hasGarAuthenticationMethod={{this.hasGarAuthenticationMethod}}
+  @hasScoUsername={{this.hasScoUsername}}
+/>`,
+        );
+
+        // then
+        assert.dom('#removal-notice').includesText(expectedRemovalNotice);
+        assert.dom('#new-connection-info').includesText(newConnectionInfo);
+      });
+
+      test('displays specific removal warning when user has GAR authentication method and no username', async function (assert) {
+        // given
+        this.set('hasGarAuthenticationMethod', true);
+        this.set('hasScoUsername', false);
+        const garConnection = t('pages.account-recovery.update-sco-record.form.sco-connections.gar');
+        const expectedRemovalNotice = t(
+          'pages.account-recovery.update-sco-record.form.authentication-methods-removal-notice',
+          { connections: garConnection },
+        );
+        const newConnectionInfo = t('pages.account-recovery.update-sco-record.form.new-connection-info');
+
+        // when
+        await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm
+  @firstName={{this.firstName}}
+  @email={{this.email}}
+  @hasGarAuthenticationMethod={{this.hasGarAuthenticationMethod}}
+  @hasScoUsername={{this.hasScoUsername}}
+/>`,
+        );
+
+        // then
+        assert.dom('#removal-notice').includesText(expectedRemovalNotice);
+        assert.dom('#new-connection-info').includesText(newConnectionInfo);
+      });
+    });
   });
 
   module('Form submission', function () {
-    test('should disable submission if password is not valid', async function (assert) {
+    test('disables submission if password is not valid', async function (assert) {
       // given
       const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
 
@@ -66,7 +251,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
       assert.true(submitButton.disabled);
     });
 
-    test('should disable submission if password is valid and cgu and data protection policy are not accepted', async function (assert) {
+    test('disables submission if password is valid and cgu and data protection policy are not accepted', async function (assert) {
       // given
       const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
 
@@ -83,7 +268,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
       assert.true(submitButton.disabled);
     });
 
-    test('should disable submission on form when is loading', async function (assert) {
+    test('disables submission on form when is loading', async function (assert) {
       // given
       const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm @isLoading={{true}} />`);
 
@@ -101,7 +286,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
       assert.true(submitButton.disabled);
     });
 
-    test('should enable submission if password is valid and cgu and data protection policy are accepted', async function (assert) {
+    test('enables submission if password is valid and cgu and data protection policy are accepted', async function (assert) {
       // given
       const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
 
@@ -122,7 +307,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
 
   module('Error messages', function () {
     module('when the user enters a valid password', function () {
-      test('should not display an error message on focus-out', async function (assert) {
+      test('does not display an error message on focus-out', async function (assert) {
         // given
         const validPassword = 'pix123A*';
         const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
@@ -140,7 +325,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
     });
 
     module('when the user enters an invalid password', function () {
-      test('should display an invalid format error message on focus-out', async function (assert) {
+      test('displays an invalid format error message on focus-out', async function (assert) {
         // given
         const newEmail = 'philippe.example.net';
         const firstName = 'Philippe';
@@ -163,7 +348,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
         assert.ok(screen.getByText(t('pages.account-recovery.update-sco-record.form.errors.invalid-password')));
       });
 
-      test('should display a required field error message on focus-out if password field is empty', async function (assert) {
+      test('displays a required field error message on focus-out if password field is empty', async function (assert) {
         // given
         const password = '';
         const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -45,15 +45,6 @@ module('Integration | Component | account-recovery | update-sco-record', functio
         screen.getByLabelText(t('pages.account-recovery.update-sco-record.form.password-label'), { exact: false }),
       );
 
-    const submitButton = screen.getByRole('button', {
-      name: t('pages.account-recovery.update-sco-record.form.login-button'),
-    });
-    assert.ok(submitButton);
-    assert.true(submitButton.disabled);
-
-    assert.dom(screen.getByRole('checkbox', { name: t('common.cgu.label') })).exists();
-    assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
-    assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));
       const submitButton = screen.getByRole('button', {
         name: t('pages.account-recovery.update-sco-record.form.login-button'),
       });

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -118,6 +118,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
         });
         assert.ok(submitButton);
         assert.true(submitButton.disabled);
+        assert.ok(screen.getByText(t('common.actions.quit')));
         assert.dom(screen.getByRole('checkbox', { name: t('common.cgu.label') })).exists();
         assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -475,13 +475,20 @@
       "update-sco-record": {
         "fill-password": "Enter your password and Pix is yours !",
         "form": {
+          "authentication-methods-removal-notice": "After this step, you will no longer be able to log in using { connections }.",
+          "choose-password": "Choose a password to continue enjoying Pix.",
           "email-label": "E-mail address",
           "errors": {
             "empty-password": "The password field is mandatory.",
             "invalid-password": "Your password must be at least 8 characters long and contain at least one upper case letter, one lower case letter and one number."
           },
           "login-button": "I want to connect",
-          "password-label": "Password"
+          "new-connection-info": "Don't worry, all you have to do to log back in is use your email address and the password you set here.",
+          "password-label": "Password",
+          "sco-connections": {
+            "gar": "the Mediacentre",
+            "username": "your Pix school ID"
+          }
         },
         "welcome-message": "Welcome back { firstName } !"
       }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -479,13 +479,20 @@
       "update-sco-record": {
         "fill-password": "¡Introduce tu contraseña y Pix será tuyo!",
         "form": {
+          "authentication-methods-removal-notice": "Después de este paso, ya no podrá iniciar sesión utilizando { connections }.",
+          "choose-password": "Elige una contraseña para seguir disfrutando de Pix.",
           "email-label": "Dirección de correo electrónico",
           "errors": {
             "empty-password": "El campo contraseña es obligatorio.",
             "invalid-password": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito."
           },
           "login-button": "Iniciar sesión",
-          "password-label": "Contraseña"
+          "new-connection-info": "No te preocupes, todo lo que tienes que hacer para volver a conectarte es utilizar tu dirección de correo electrónico y la contraseña que estableciste aquí.",
+          "password-label": "Contraseña",
+          "sco-connections":{
+            "gar": "el Mediacentre",
+            "username":  "su identificación escolar Pix"
+          }
         },
         "welcome-message": "¡Te damos de nuevo la bienvenida, { firstName }!"
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -475,13 +475,20 @@
       "update-sco-record": {
         "fill-password": "Saisissez un mot de passe et Pix est à vous !",
         "form": {
+          "authentication-methods-removal-notice": "Après cette étape, vous ne pourrez plus vous connecter avec { connections }.",
+          "choose-password": "Choisissez un mot de passe pour continuer à profiter de Pix.",
           "email-label": "Adresse e-mail",
           "errors": {
             "empty-password": "Le champ mot de passe est obligatoire.",
             "invalid-password": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre."
           },
           "login-button": "Je me connecte",
-          "password-label": "Mot de passe"
+          "new-connection-info": "Pas d’inquiétude, pour vous reconnecter il suffira désormais d’utiliser votre adresse email et le mot de passe défini ici.",
+          "password-label": "Mot de passe",
+          "sco-connections": {
+            "gar": "le Médiacentre",
+            "username": "votre identifiant scolaire Pix"
+          }
         },
         "welcome-message": "Bon retour parmi nous { firstName } !"
       }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -479,13 +479,20 @@
       "update-sco-record": {
         "fill-password": "Voer je wachtwoord in en Pix is van jou!",
         "form": {
+          "authentication-methods-removal-notice": "Na deze stap kun je niet meer inloggen met { connections }.",
+          "choose-password": "Kies een wachtwoord om verder te gaan met Pix.",
           "email-label": "E-mailadres",
           "errors": {
             "empty-password": "Het wachtwoordveld is verplicht.",
             "invalid-password": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten."
           },
           "login-button": "Inloggen",
-          "password-label": "Wachtwoord"
+          "new-connection-info": "Maak je geen zorgen, het enige wat je hoeft te doen om weer in te loggen is je e-mailadres en het wachtwoord te gebruiken dat je hier hebt ingesteld.",
+          "password-label": "Wachtwoord",
+          "sco-connections":{
+            "gar": "het Mediacenter",
+            "username":  "je Pix-school-ID"
+          }
         },
         "welcome-message": "Welkom terug { firstName }!"
       }


### PR DESCRIPTION
## 🌸 Problème

Dans le cadre de l'évolution de la sortie du sco, La dernière page du processus de récupération de compte doit être modifiée.

## 🌳 Proposition

1. Un bouton “Quitter” permet à l’utilisateur de revenir sur la mire de connexion Pix App ([app.pix.fr](http://app.pix.fr/)).

Pour le bouton “Quitter”, la bonne spécification est la suivante :

ce sera un bouton “secondary”

couleur : pix-primary/700 ou #452D9D

2. Le wording du **message invitant à choisir un mot de passe** doit être modifié pour tous les utilisateurs: 

Nouveau message statique : "Choisissez un mot de passe pour continuer à profiter de Pix." au lieu de "Saisissez un mot de passe et Pix est à vous !"

3. Un **autre message avertissant l'utilisateur** doit être dynamique sur les méthodes de connexion :

- Si l’utilisateur a le Médiacentre alors afficher Médiacentre
- Si l’utilisateur a seulement un identifiant SCO alors faire référence dans le texte à l’identifiant scolaire
- Si l’utilisateur a le Médiacentre et l’identifiant SCO alors faire référence aux 2 dans le texte
- Si l'utilisateur n'a aucune de ces deux connexions, ne pas afficher ce deuxième message

**Illustrations** : 
Cas n°1 : connexion avec Médiacentre.
![image](https://github.com/user-attachments/assets/ffcd2e63-59b6-4e6c-a1e8-c06b1ef54ca8)

Wording :

Choisissez un mot de passe pour continuer à profiter de Pix.
Après cette étape, vous ne pourrez plus vous connecter avec le Médiacentre.
Pas d’inquiétude, pour vous reconnecter il suffira désormais d’utiliser votre adresse email et le mot de passe défini ici.

Cas n°2 : connexion avec identifiant sco
![image](https://github.com/user-attachments/assets/59a48870-e3e9-4ea8-bcf7-f07b4b89de92)

Wording :

Choisissez un mot de passe pour continuer à profiter de Pix.
Après cette étape, vous ne pourrez plus vous connecter avec votre identifiant scolaire Pix.
Pas d’inquiétude, pour vous reconnecter il suffira désormais d’utiliser votre adresse email et le mot de passe défini ici.

Cas n°3 : connexion avec Médiacentre et identifiant sco
![image](https://github.com/user-attachments/assets/1439bf32-1fe1-4ce4-8035-e4bb38513570)

wording : 

Choisissez un mot de passe pour continuer à profiter de Pix.
Après cette étape, vous ne pourrez plus vous connecter avec le Médiacentre et votre identifiant scolaire Pix.
Pas d’inquiétude, pour vous reconnecter il suffira désormais d’utiliser votre adresse email et le mot de passe défini ici.

## 🐝 Remarques

ras

## 🤧 Pour tester

**Notes :** 
    Pour tous les tests il faudra reprendre le scénario de test de https://github.com/1024pix/pix/pull/12218 et les deux cas de tests (Hermione et Bob) en y ajoutant deux autres cas :
- un élève ayant une méthode de connexion GAR mais pas de Username : Emma Gnolia, 123456789EG, 04.04.2013
- une élève ayant un username mais pas de méthode de connexion GAR : Jean Serien: 123456789JS, 03.03.2013

Commandes pour les features toggles: `npm run toggles -- --key=myCustomFeatureToggle --value=false/true`  ou (en RA) `scalingo -a pix-api-review-pr12282 run "npm run toggles -- --key=myCustomFeatureToggle --value=false/true" `

**Scenario de test** 
1. Avec le FT à FALSE : 
Tester avec le compte de Bob. On attend l'ancien message statique : "Saisissez un mot de passe et Pix est à vous !" et aucun message dynamique
3. Avec le FT à TRUE : 
- Pour Hermione, on attend le nouveau message statique et aucun message dynamique
- Vérifier que le bouton "quitter" ramène bien sur la page de connexion
- Pour les trois autres, on attend le nouveau message statique et un message dynamique adapté à leurs connexions (voir ci-dessus) ;
-  sur la page du formulaire, ajoutez à la fin de l'url (`/recuperer-mon-compte/${temporaryKey}`) : `?lang=nl`, `?lang=es`, `?lang=en` pour vérifier les changements de langue

