### PR TITLE
[TECH] Améliore la partie SQL de la vérification du code de certification (Pix-17791)

### DIFF
--- a/api/db/migrations/20250513134311_remove-uppercase-index-on-certif-courses-table.js
+++ b/api/db/migrations/20250513134311_remove-uppercase-index-on-certif-courses-table.js
@@ -1,0 +1,16 @@
+const up = async function (knex) {
+  await knex.raw('DROP INDEX index_certification_courses_upper_verification_code');
+  await knex.raw(
+    'CREATE UNIQUE INDEX certification_courses_verification_code_index ON "certification-courses" ("verificationCode")',
+  );
+};
+
+const down = async function (knex) {
+  await knex.raw('DROP INDEX certification_courses_verification_code_index');
+  await knex.raw('CREATE UNIQUE INDEX index_certification_courses_upper_verification_code ON ?? (UPPER(??))', [
+    'certification-courses',
+    'verificationCode',
+  ]);
+};
+
+export { down, up };

--- a/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
+++ b/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
@@ -10,7 +10,7 @@ const NB_CHAR = 8;
 const NB_OF_TRIALS = 1000;
 
 function _generateCode() {
-  return 'P-' + _.times(NB_CHAR, _randomCharacter).join('');
+  return 'P-' + _.times(NB_CHAR, _randomCharacter).join('').toUpperCase();
 }
 
 function _randomCharacter() {

--- a/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
+++ b/api/src/certification/evaluation/domain/services/verify-certificate-code-service.js
@@ -4,13 +4,14 @@ import { config } from '../../../../shared/config.js';
 import { CertificateVerificationCodeGenerationTooManyTrials } from '../../../../shared/domain/errors.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 
-const availableCharacters =
-  `${config.availableCharacterForCode.numbers}${config.availableCharacterForCode.letters}`.split('');
+const availableCharacters = `${config.availableCharacterForCode.numbers}${config.availableCharacterForCode.letters}`
+  .toUpperCase()
+  .split('');
 const NB_CHAR = 8;
 const NB_OF_TRIALS = 1000;
 
 function _generateCode() {
-  return 'P-' + _.times(NB_CHAR, _randomCharacter).join('').toUpperCase();
+  return 'P-' + _.times(NB_CHAR, _randomCharacter).join('');
 }
 
 function _randomCharacter() {

--- a/api/src/certification/results/application/certificate-route.js
+++ b/api/src/certification/results/application/certificate-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
-import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { certificationVerificationCodeType, identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificateController } from './certificate-controller.js';
 
 const { FRENCH_SPOKEN, ENGLISH_SPOKEN } = LOCALE;
@@ -99,7 +99,9 @@ const register = async function (server) {
       config: {
         validate: {
           payload: Joi.object({
-            verificationCode: Joi.string().min(10).max(10),
+            verificationCode: certificationVerificationCodeType
+              .required()
+              .description('Code de vérification du certificat Pix à vérifier'),
           }),
         },
         auth: false,

--- a/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
+++ b/api/src/certification/results/domain/usecases/get-certification-result-for-parcoursup.js
@@ -41,7 +41,10 @@ export const getCertificationResultForParcoursup = async ({
       birthdate,
     });
   } else if (verificationCode) {
-    certifications = await certificationParcoursupRepository.getByVerificationCode({ verificationCode });
+    const upperCasedVerificationCode = verificationCode.toUpperCase();
+    certifications = await certificationParcoursupRepository.getByVerificationCode({
+      verificationCode: upperCasedVerificationCode,
+    });
   }
 
   if (certifications.length !== 1) {

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -206,7 +206,7 @@ async function isVerificationCodeAvailable({ verificationCode }) {
 
   const exist = await knexConn('certification-courses')
     .select('id')
-    .whereRaw('UPPER(??)=?', ['verificationCode', verificationCode.toUpperCase()])
+    .where('verificationCode', verificationCode)
     .first();
 
   return !exist;

--- a/api/tests/certification/evaluation/unit/domain/services/verify-certificate-code-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/verify-certificate-code-service_test.js
@@ -9,7 +9,7 @@ describe('Unit | Service | VerifyCertificateCode', function () {
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     _.times(100, () =>
-      it('should return a certification code containing 8 digits/letters except 0, 1 and vowels', async function () {
+      it('should return a certification code containing 8 digits/uppercase letters except 0, 1 and vowels', async function () {
         // given
         const certificationCourseRepositoryStub = {
           isVerificationCodeAvailable: sinon.stub().resolves(true),

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -745,21 +745,6 @@ describe('Certification | Results | Acceptance | Application | Certification', f
     });
 
     context('when the given verificationCode is incorrect', function () {
-      it('should return 500 HTTP status code when param is missing', async function () {
-        // given
-        options = {
-          method: 'POST',
-          url: '/api/shared-certifications',
-          payload: {},
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(500);
-      });
-
       it('should return notFound 404 HTTP status code when param is incorrect', async function () {
         // given
         const verificationCode = 'P-12345678';

--- a/api/tests/certification/results/unit/application/certificate-route_test.js
+++ b/api/tests/certification/results/unit/application/certificate-route_test.js
@@ -63,4 +63,17 @@ describe('Certification | Results | Unit | Application | Certification Route', f
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('GET /api/shared-certifications', function () {
+    it('return 400 when the verification code is missing', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/shared-certifications');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/certification/results/unit/domain/usecases/get-certification-result-for-parcoursup_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certification-result-for-parcoursup_test.js
@@ -87,17 +87,18 @@ describe('Certification | Results | Unit | Domain | UseCase | getCertificationRe
     context('with a verification code', function () {
       it('returns matching certification', async function () {
         // given
-        const verificationCode = 'P-1234567A';
+        const verificationCode = 'P-123b5c7a';
+        const upperCasedVerificationCode = 'P-123B5C7A';
         const certificationParcoursupRepository = {
           getByVerificationCode: sinon.stub(),
         };
 
         const expectedCertification = domainBuilder.certification.results.parcoursup.buildCertificationResult({
-          verificationCode,
+          verificationCode: upperCasedVerificationCode,
         });
         certificationParcoursupRepository.getByVerificationCode
           .withArgs({
-            verificationCode,
+            verificationCode: upperCasedVerificationCode,
           })
           .resolves([expectedCertification]);
 


### PR DESCRIPTION
## 🌸 Problème

Sur la recherche par code de vérification, l’index contient un UPPER.

Volontaire : il n’y a aucun code de vérification en small case en PROD (regle metier certif)

Nous avons une recherche SQL qui ne fait pas le UPPER sur son where, du coup n’utilise pas l’index, du coup cette recherche est lente et tape la BDD plus que nécessaire.

## 🌳 Proposition

Ne plus utiliser de fonction `UPPER` dans nos requêtes SQL.
Nous avons remplacé par l'utilisation du `ILIKE` pour rendre la recherche `case insensitive`

## 🐝 Remarques

Nous avons aussi supprimé l'index UPPERisé.

Il est toujours possible de tenter d'accéder via une requête cUrl à un certificat avec un code de vérification en minuscule... Comme ce n'est pas l'usage prévu, ça ne nous dérange pas que ça ne fonctionne pas !

## 🤧 Pour tester

- [ ] faire un appel ParcourSup avec un code de vérification en minuscule
- [ ] passer une certification et s'assurer que le code de vérification a été créé en majuscule
- [ ] accéder à la certification avec le vérification code (impossible de saisir en minuscule), ça devrait fonctionner

