### PR TITLE
[FEATURE] Supprimer les méthode d'authentifications GAR et nom d'utilisateur lors de la sortie du sco (PIX-17509)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
@@ -1,3 +1,4 @@
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 
@@ -52,11 +53,23 @@ export const updateUserForAccountRecovery = async function ({
 
   const now = new Date();
   const userValuesToUpdate = {
+    // username: null // Uncomment this line when the feature toggle will be deleted
     cgu: true,
     email: newEmail,
     emailConfirmedAt: now,
     lastTermsOfServiceValidatedAt: now,
   };
+
+  // Remove this if when the feature toggle will be activated
+  const toggle = await featureToggles.get('isNewAccountRecoveryEnabled');
+  if (toggle) {
+    userValuesToUpdate.username = null;
+    // move the following line out if
+    await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
+      userId,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    });
+  }
 
   await userRepository.updateWithEmailConfirmed({
     id: userId,

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1714,6 +1714,25 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         expect(updatedUser.updatedAt).to.deep.equal(now);
       });
 
+      context('when username is null', function () {
+        it('still updates the username with the null username', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({
+            username: 'monutilisateur',
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const updatedUser = await userRepository.updateUsername({
+            id: user.id,
+            username: null,
+          });
+
+          // then
+          expect(updatedUser.username).to.equal(null);
+        });
+      });
+
       it('throws UserNotFoundError when user id not found', async function () {
         // given
         const wrongUserId = 0;


### PR DESCRIPTION
## 🌸 Problème

Lorsqu'un utilisateur de type sco souhaite quitter le système scolaire et se dissocier de son établissement, on conservait sa méthode d'authentification GAR, ce qui n'était pas très utile étant donné qu'il perd en général l'accès au GAR. De plus, on conservait son nom d'utilisateur sco, ce qui n'est pas nécessaire non plus.

## 🌳 Proposition

Lors de la sortie du sco, supprimer la méthode d'authentification GAR et mettre le nom d'utilisateur à null.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

Vérifier que le feature toggle isNewAccountRecoveryEnabled est activé et **l’activer si ce n’est pas le cas** :
```shell
scalingo -a pix-api-review-pr12285 run npm run toggles -- --key isNewAccountRecoveryEnabled
```
- Se rendre sur [cette page](https://app-pr12285.review.pix.fr/recuperer-mon-compte),
- Utiliser les informations suivante pour vous connecter:
- - INE: 123456789BL,
- - Prénom: Bob,
- - Nom: Leponge,
- - Date de naissance: 02/02/2012,
- Cocher et confirmer,
- Mettre son adresse email,
- Cliquer sur le lien dans le mail de réinitialisation,
- Mettre un mot de passe,
- Une fois sur la page d'accueil se rendre dans la page Mon compte, onglet Méthodes de connexion,
- Constater que le GAR n'est plus là,
- En base, constater qu'il n'y a plus de username:
```sql
SELECT "user","email" FROM "users" WHERE "email" = 'votre_email";
```