### PR TITLE
[FEATURE] Anonymiser les badges lors de la suppression des participations (PIX-17712)

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-acquisition-repository.js
@@ -24,6 +24,19 @@ const createOrUpdate = async function ({ badgeAcquisitionsToCreate = [] }) {
   }
 };
 
+/**
+ * @param {number[]} campaignParticipationIds
+ */
+const deleteUserIdOnNonCertifiableBadgesForCampaignParticipations = async (campaignParticipationIds) => {
+  const knexConnection = DomainTransaction.getConnection();
+  return knexConnection(BADGE_ACQUISITIONS_TABLE)
+    .update({ userId: null })
+    .updateFrom(BADGE_TABLE)
+    .where(`${BADGE_ACQUISITIONS_TABLE}.badgeId`, knex.raw('??', [`${BADGE_TABLE}.id`]))
+    .where(`${BADGE_TABLE}.isCertifiable`, '=', false)
+    .whereIn(`${BADGE_ACQUISITIONS_TABLE}.campaignParticipationId`, campaignParticipationIds);
+};
+
 const getAcquiredBadgeIds = async function ({ badgeIds, userId }) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn(BADGE_ACQUISITIONS_TABLE).pluck('badgeId').where({ userId }).whereIn('badgeId', badgeIds);
@@ -60,6 +73,7 @@ const getAcquiredBadgesByCampaignParticipations = async function ({ campaignPart
 
 export {
   createOrUpdate,
+  deleteUserIdOnNonCertifiableBadgesForCampaignParticipations,
   getAcquiredBadgeIds,
   getAcquiredBadgesByCampaignParticipations,
   getAcquiredBadgesForCampaignParticipations,

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -5,6 +5,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
   campaignId,
   campaignParticipationId,
   featureToggles,
+  badgeAcquisitionRepository,
   campaignParticipationRepository,
 }) {
   const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
@@ -19,6 +20,11 @@ const deleteCampaignParticipation = withTransaction(async function ({
     campaignParticipation.delete(userId, isAnonymizationWithDeletionEnabled);
     await campaignParticipationRepository.remove(campaignParticipation.dataToUpdateOnDeletion);
   }
+
+  const campaignParticipationIds = campaignParticipations.map(({ id }) => id);
+  await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
+    campaignParticipationIds,
+  );
 });
 
 export { deleteCampaignParticipation };


### PR DESCRIPTION
## 🌸 Problème

Nous souhaitons supprimer le champ _userId_ de la table badge-acquisitions lors de la suppression d'une participation.

## 🌳 Proposition

Ajouter une méthode de repository dans le usecase pour supprimer _userId_ sur les acquisitions.

## 🐝 Remarques

⚠️ ça ne doit s'appliquer que aux badges non certifiants
il y a un autre usecase de suppression de participation que j'ai ignore [car il est en cours de suppression](https://github.com/1024pix/pix/pull/12284)

## 🤧 Pour tester

Supprimer une participation avec des badges
Constater en base qu'on a bien supprime le champ _userId_ sur les badge-acquisition non certifiants lies a cette participation.
