### PR TITLE
[FEATURE] Streamer/Batch les lignes CSV du script d'anonymisation (PIX-17830)

### DIFF
--- a/api/scripts/certification/fix-doubled-answers.js
+++ b/api/scripts/certification/fix-doubled-answers.js
@@ -8,7 +8,7 @@ import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 import { Assessment } from '../../src/shared/domain/models/index.js';
 
-const columnsSchemas = [
+const columnSchemas = [
   { name: 'certificationChallengeId', schema: Joi.number() },
   { name: 'answerId', schema: Joi.number() },
   { name: 'completionDate', schema: Joi.string() },
@@ -25,7 +25,7 @@ export class FixDoubledAnswers extends Script {
           describe:
             'CSV File with three columns with certificationChallengeIds (integer), answerIds (integer) and completion date (string) to process',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
         assessmentId: {
           type: 'integer',

--- a/api/scripts/certification/rescore-certifications.js
+++ b/api/scripts/certification/rescore-certifications.js
@@ -8,7 +8,7 @@ import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
 import { handlersAsServices } from '../../src/shared/domain/events/index.js';
 
-const columnsSchemas = [{ name: 'certificationCourseId', schema: Joi.number() }];
+const columnSchemas = [{ name: 'certificationCourseId', schema: Joi.number() }];
 
 export class RescoreCertificationScript extends Script {
   constructor(services = handlersAsServices) {
@@ -21,7 +21,7 @@ export class RescoreCertificationScript extends Script {
           describe:
             'CSV File with only one column with certification-courses.id (integer) to process. Need `certificationCourseId`',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
       },
     });

--- a/api/src/evaluation/scripts/add-multiple-level-stages.js
+++ b/api/src/evaluation/scripts/add-multiple-level-stages.js
@@ -7,7 +7,8 @@ import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { DomainTransaction } from '../../shared/domain/DomainTransaction.js';
 import { evaluationUsecases } from '../domain/usecases/index.js';
-const columnsSchemas = [
+
+const columnSchemas = [
   { name: 'targetProfileId', schema: Joi.number().integer().positive().required() },
   { name: 'level', schema: Joi.number().integer().min(0).required() },
   { name: 'title', schema: Joi.string().max(255).required() },
@@ -24,7 +25,7 @@ class AddMultipleLevelStagesScript extends Script {
           type: 'string',
           describe: 'CSV File containing multiple stages to add',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
       },
     });

--- a/api/src/identity-access-management/scripts/anonymize-users-in-batch.script.js
+++ b/api/src/identity-access-management/scripts/anonymize-users-in-batch.script.js
@@ -1,11 +1,14 @@
 import joi from 'joi';
 
-import { csvFileParser } from '../../shared/application/scripts/parsers.js';
+import { csvFileStreamer } from '../../shared/application/scripts/parsers.js';
 import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const columnsSchema = [{ name: 'userId', schema: joi.number().required() }];
+const CHUNK_SIZE = 1000;
+const DELAY = 1000;
+
+const columnSchemas = [{ name: 'userId', schema: joi.number().required() }];
 
 export class AnonymizeUsersInBatchScript extends Script {
   constructor() {
@@ -17,7 +20,7 @@ export class AnonymizeUsersInBatchScript extends Script {
           type: 'string',
           describe: 'The file path',
           demandOption: true,
-          coerce: csvFileParser(columnsSchema),
+          coerce: csvFileStreamer(columnSchemas),
         },
         dryRun: {
           type: 'boolean',
@@ -29,35 +32,53 @@ export class AnonymizeUsersInBatchScript extends Script {
           describe: 'The user id of the anonymizer',
           demandOption: true,
         },
+        chunkSize: {
+          type: 'number',
+          describe: 'Chunk size to process the file',
+          default: CHUNK_SIZE,
+        },
+        delayInMilliseconds: {
+          type: 'number',
+          describe: 'Delay between each chunk in milliseconds',
+          default: DELAY,
+        },
       },
     });
 
     this.successLines = 0;
     this.failedLines = 0;
-    this.totalLines = 0;
+    this.currentLineNumber = 0;
+    this.currentChunkNumber = 0;
     this.errorOccured = false;
   }
 
   async handle({ options, logger, anonymizeUser = usecases.anonymizeUser }) {
-    const { file, dryRun, anonymizerId } = options;
-    if (dryRun) {
-      logger.info(`DryRun mode, ${file.length} user accounts to be processed.`);
-      return;
-    }
+    const { file: streamFile, dryRun, anonymizerId, chunkSize, delayInMilliseconds } = options;
 
-    this.totalLines = file.length;
-    for (const [index, { userId }] of file.entries()) {
-      try {
-        await anonymizeUser({
-          userId,
-          updatedByUserId: anonymizerId,
-        });
-        this.successLines++;
-      } catch (error) {
-        this.errorOccured = true;
-        this.failedLines++;
-        logger.error(`Error on line ${index + 1}. ${error}`);
+    await streamFile(async (chunk) => {
+      logger.info(`Processing chunk ${this.currentChunkNumber + 1} (${chunk.length} rows)...`);
+      this.currentChunkNumber++;
+
+      await new Promise((resolve) => setTimeout(resolve, delayInMilliseconds)); // delay between chunks to avoid overloading the database
+
+      for (const { userId } of chunk) {
+        this.currentLineNumber += 1;
+        if (dryRun) continue;
+
+        try {
+          await anonymizeUser({ userId, updatedByUserId: anonymizerId });
+          this.successLines++;
+        } catch (error) {
+          this.errorOccured = true;
+          this.failedLines++;
+          logger.error(`Error on line ${this.currentLineNumber}. ${error}`);
+        }
       }
+    }, chunkSize);
+
+    if (dryRun) {
+      logger.info(`DryRun mode, ${this.currentLineNumber} user accounts to be processed.`);
+      return;
     }
 
     logger.info(`${this.successLines} user accounts processed successfully.`);

--- a/api/src/organizational-entities/scripts/add-or-update-certification-centers-dpo-info.js
+++ b/api/src/organizational-entities/scripts/add-or-update-certification-centers-dpo-info.js
@@ -5,7 +5,7 @@ import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const columnsSchemas = [
+const columnSchemas = [
   { name: 'certificationCenterId', schema: Joi.number() },
   { name: 'firstName', schema: Joi.string().trim().optional() },
   { name: 'lastName', schema: Joi.string().trim().optional() },
@@ -22,7 +22,7 @@ export class AddOrUpdateCertificationCentersDpoInfoScript extends Script {
           type: 'string',
           describe: 'CSV File to process',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
       },
     });

--- a/api/src/organizational-entities/scripts/archive-certification-centers-script.js
+++ b/api/src/organizational-entities/scripts/archive-certification-centers-script.js
@@ -5,7 +5,7 @@ import { Script } from '../../shared/application/scripts/script.js';
 import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
 import { usecases } from '../domain/usecases/index.js';
 
-const columnsSchemas = [
+const columnSchemas = [
   { name: 'certificationCenterId', schema: Joi.number().required() },
   { name: 'archivedBy', schema: Joi.number().required() },
 ];
@@ -20,7 +20,7 @@ export class ArchiveCertificationCentersScript extends Script {
           type: 'string',
           describe: 'The file path',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
         dryRun: {
           type: 'boolean',

--- a/api/src/shared/application/scripts/parsers.js
+++ b/api/src/shared/application/scripts/parsers.js
@@ -6,12 +6,12 @@ import { checkCsvHeader, parseCsvWithHeader, streamCsv } from '../../infrastruct
 
 /**
  * Create a parser for a CSV file with the given column schema
- * @param {Record<string, Joi.Schema>} columnSchema
+ * @param {Record<string, Joi.Schema>} columnSchemas
  * @returns {Promise<Array<Record<string, any>>>} parsed data
  */
-export function csvFileParser(columnSchema = []) {
+export function csvFileParser(columnSchemas = []) {
   return async (filePath) => {
-    const columnNames = columnSchema.map((column) => column.name);
+    const columnNames = columnSchemas.map((column) => column.name);
 
     await checkCsvHeader({ filePath, requiredFieldNames: columnNames });
 
@@ -19,7 +19,7 @@ export function csvFileParser(columnSchema = []) {
       header: true,
       skipEmptyLines: true,
       transform: (value, columnName) => {
-        const column = columnSchema.find((column) => column.name === columnName);
+        const column = columnSchemas.find((column) => column.name === columnName);
 
         if (!column) return value;
 
@@ -31,10 +31,10 @@ export function csvFileParser(columnSchema = []) {
 
 /**
  * Stream CSV file by chunk with the given column schema
- * @param {Record<string, Joi.Schema>} columnSchema
+ * @param {Record<string, Joi.Schema>} columnSchemas
  * @returns {Promise<Function>} function to process each chunk
  */
-export function csvFileStreamer(columnSchema = []) {
+export function csvFileStreamer(columnSchemas = []) {
   return async (filePath) => {
     return async (onChunk, chunkSize = 1) => {
       const dataStream = fs.createReadStream(filePath);
@@ -50,7 +50,7 @@ export function csvFileStreamer(columnSchema = []) {
             const validatedRow = Joi.attempt(
               row,
               Joi.object().keys(
-                columnSchema.reduce((acc, column) => {
+                columnSchemas.reduce((acc, column) => {
                   acc[column.name] = column.schema;
                   return acc;
                 }, {}),

--- a/api/src/shared/infrastructure/helpers/csv.js
+++ b/api/src/shared/infrastructure/helpers/csv.js
@@ -87,6 +87,10 @@ async function parseCsvData(cleanedData, options) {
   return data;
 }
 
+async function streamCsv(options) {
+  return papa.parse(papa.NODE_STREAM_INPUT, options);
+}
+
 const csvHelper = { checkCsvHeader, parseCsvWithHeader, parseCsvData, readCsvFile };
 
-export { checkCsvHeader, csvHelper, parseCsvData, parseCsvWithHeader };
+export { checkCsvHeader, csvHelper, parseCsvData, parseCsvWithHeader, streamCsv };

--- a/api/src/team/scripts/send-organization-invitations.script.js
+++ b/api/src/team/scripts/send-organization-invitations.script.js
@@ -12,7 +12,7 @@ import { usecases } from '../domain/usecases/index.js';
 const DEFAULT_BATCH_SIZE = 200;
 const DEFAULT_THROTTE_DELAY = 1000;
 
-const columnsSchemas = [
+const columnSchemas = [
   { name: 'Organization ID', schema: Joi.number() },
   { name: 'email', schema: Joi.string().trim().replace(' ', '').lowercase().email() },
   { name: 'locale', schema: Joi.string().trim().lowercase() },
@@ -41,7 +41,7 @@ export class SendOrganizationInvitationsScript extends Script {
           type: 'string',
           describe: 'The file path',
           demandOption: true,
-          coerce: csvFileParser(columnsSchemas),
+          coerce: csvFileParser(columnSchemas),
         },
         batchSize: {
           type: 'number',

--- a/api/tests/identity-access-management/unit/scripts/anonymize-users-in-batch.script.test.js
+++ b/api/tests/identity-access-management/unit/scripts/anonymize-users-in-batch.script.test.js
@@ -24,12 +24,15 @@ describe('Unit | Identities Access Management | Scripts | Anonymize users in bat
         // when
         await script.handle({
           options: {
-            file,
+            file: async (callback) => {
+              await callback(file);
+            },
             dryRun: true,
             anonymizerId: 1234,
           },
           logger,
           anonymizeUser,
+          delay: 0,
         });
 
         // then
@@ -45,12 +48,15 @@ describe('Unit | Identities Access Management | Scripts | Anonymize users in bat
         // when
         await script.handle({
           options: {
-            file,
+            file: async (callback) => {
+              await callback(file);
+            },
             dryRun: false,
             anonymizerId: 1234,
           },
           logger,
           anonymizeUser,
+          delay: 0,
         });
 
         // then
@@ -69,12 +75,15 @@ describe('Unit | Identities Access Management | Scripts | Anonymize users in bat
           await expect(
             script.handle({
               options: {
-                file,
+                file: async (callback) => {
+                  await callback(file);
+                },
                 dryRun: false,
                 anonymizerId: 1234,
               },
               logger,
               anonymizeUser,
+              delay: 0,
             }),
           ).to.be.rejectedWith('There was some errors during the process.');
 

--- a/api/tests/shared/unit/application/scripts/files/invalid.csv
+++ b/api/tests/shared/unit/application/scripts/files/invalid.csv
@@ -1,3 +1,5 @@
 foo,bar
 hello,world@email.com
 baz,BOOMEMAIL
+hello2,world2@email.com
+baz2,BOOMEMAIL2

--- a/api/tests/shared/unit/application/scripts/files/valid.csv
+++ b/api/tests/shared/unit/application/scripts/files/valid.csv
@@ -1,3 +1,4 @@
 foo,bar
 hello,world@email.com
 baz,someone@example.net
+bob,john@example.net

--- a/api/tests/shared/unit/application/scripts/parsers_test.js
+++ b/api/tests/shared/unit/application/scripts/parsers_test.js
@@ -18,13 +18,13 @@ describe('Shared | Unit | Application | Parsers', function () {
     it('parses a CSV with the given schema', async function () {
       // given
       const validFilePath = `${__dirname}files/valid.csv`;
-      const columnsSchema = [
+      const columnSchemas = [
         { name: 'foo', schema: Joi.string() },
         { name: 'bar', schema: Joi.string().email() },
       ];
 
       // when
-      const parser = csvFileParser(columnsSchema);
+      const parser = csvFileParser(columnSchemas);
       const result = await parser(validFilePath);
 
       // then
@@ -38,13 +38,13 @@ describe('Shared | Unit | Application | Parsers', function () {
     it('throws an error when CSV is invalid', async function () {
       // given
       const invalidFilePath = `${__dirname}files/invalid.csv`;
-      const columnsSchema = [
+      const columnSchemas = [
         { name: 'foo', schema: Joi.string() },
         { name: 'bar', schema: Joi.string().email() },
       ];
 
       // when
-      const parser = csvFileParser(columnsSchema);
+      const parser = csvFileParser(columnSchemas);
       const error = await catchErr(parser)(invalidFilePath);
 
       // then
@@ -57,13 +57,13 @@ describe('Shared | Unit | Application | Parsers', function () {
     it('streams a CSV by row with the given schema', async function () {
       // given
       const validFilePath = `${__dirname}files/valid.csv`;
-      const columnsSchema = [
+      const columnSchemas = [
         { name: 'foo', schema: Joi.string() },
         { name: 'bar', schema: Joi.string().email() },
       ];
 
       // when
-      const streamer = await csvFileStreamer(columnsSchema);
+      const streamer = await csvFileStreamer(columnSchemas);
       const fileStream = await streamer(validFilePath);
 
       const chunks = [];
@@ -82,14 +82,14 @@ describe('Shared | Unit | Application | Parsers', function () {
     it('streams a CSV by chunk with the given schema', async function () {
       // given
       const validFilePath = `${__dirname}files/valid.csv`;
-      const columnsSchema = [
+      const columnSchemas = [
         { name: 'foo', schema: Joi.string() },
         { name: 'bar', schema: Joi.string().email() },
       ];
 
       // when
       const chunkSize = 2;
-      const streamer = await csvFileStreamer(columnsSchema);
+      const streamer = await csvFileStreamer(columnSchemas);
       const fileStream = await streamer(validFilePath);
 
       const chunks = [];
@@ -110,13 +110,13 @@ describe('Shared | Unit | Application | Parsers', function () {
     it('throws an error when CSV is invalid', async function () {
       // given
       const invalidFilePath = `${__dirname}files/invalid.csv`;
-      const columnsSchema = [
+      const columnSchemas = [
         { name: 'foo', schema: Joi.string() },
         { name: 'bar', schema: Joi.string().email() },
       ];
 
       // when
-      const streamer = await csvFileStreamer(columnsSchema);
+      const streamer = await csvFileStreamer(columnSchemas);
       const fileStream = await streamer(invalidFilePath);
 
       const chunks = [];


### PR DESCRIPTION
## 🌸 Problème

Le script `anonymize-users-in-batch.script.js` doit traiter un fichier CSV de plus de 400000 lignes sur un traitement coûteux (l'anonymisation) pour chaque ligne.

Actuellement, en production, ce script traite 4000 lignes en 6 minutes.

## 🌳 Proposition

Pour s'assurer que le script ne monte pas en mémoire et ne surcharge pas la base de données, nous avons mise en place plusieurs mesures : 
1. Streamer la lecture du fichier CSV (et éviter de le monter en mémoire).
2. Partitioner la lecture fichier en chunk pour lancer le traitement sur un lot de lignes (1000 par défaut).
3. Ajouter un délai entre chaque chunk pour décharger la base de données (1000ms par défaut)

Le `chunkSize` et `delay` sont modifiables via le CLI.

## 🐝 Remarques

Le streaming et chunking d'un fichier CSV a été isolé dans une fonction utilitaire `csvFileStreamer` pour être réutilisé dans tous les scripts.

```js
// Initialiser le CSV streamer avec un schema de colonnes
const streamer = await csvFileStreamer(columnsSchema);

// Créer le stream pour le fichier CSV
const chunkSize = 100;
const fileStream = await streamer(validFilePath, chunkSize);

// Exécuter le stream par chunk
await fileStream((chunk) => { console.log(chunk) });
```

## 🤧 Pour tester

1. Créer un fichier `test.csv` dans le dossier `api`

```
userId
187885
187996
188084
188113
188119
188269
```

2. Dans le dossier `api`, exécuter le script en `dryRun`

```
node src/identity-access-management/scripts/anonymize-users-in-batch.script.js --file=./test.csv --anonymizerId=123 --dryRun
```

**Résultat :**
> INFO: Processing chunk 1 (6 rows)... 
> INFO: DryRun mode, 6 user accounts to be processed. 

2. Dans le dossier `api`, exécuter le script en `dryRun` avec une taille de batch 2

```
node src/identity-access-management/scripts/anonymize-users-in-batch.script.js --file=./test.csv --anonymizerId=123 --batchSize=2 --dryRun
```

**Résultat :**
> INFO: Processing chunk 1 (2 rows)... 
> INFO: Processing chunk 2 (2 rows)... 
> INFO: Processing chunk 3 (2 rows)... 
> INFO: DryRun mode, 6 user accounts to be processed. 