### PR TITLE
[FEATURE] Modifier le message de la notification Slack post release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-            text: "Coucou :wave:\nLa v${{ env.new_release_version }} est en recette jusqu’à demain matin @team-po\nMettez vos messages en :thread:"
+            text: "Coucou :wave:\nLa v${{ env.new_release_version }} est en recette @team-po\nMettez vos messages en :thread:"


### PR DESCRIPTION
## 🌸 Problème
Aujourd'hui, la notification Slack informe de la présence de la release en recette "jusqu'à demain" mais cette notion n'est pas vrai le vendredi. Afin d'éviter toute confusion, nos souhaitons retirer cette partie.

## 🌳 Proposition
Modifier le message de la notification Slack post release