### PR TITLE
[FEATURE] Inviter les utilisateurs d'un SSO sup à récupérer leur ancien compte sco  (PIX-17510)

### DIFF
--- a/mon-pix/app/components/authentication/sso-selection-form.gjs
+++ b/mon-pix/app/components/authentication/sso-selection-form.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -23,7 +24,7 @@ export default class SsoSelectionForm extends Component {
   }
 
   get providers() {
-    return this.oidcIdentityProviders.list?.filter((provider) => !EXCLUDED_PROVIDER_CODES.includes(provider.code));
+    return this.oidcIdentityProviders.list.filter((provider) => !EXCLUDED_PROVIDER_CODES.includes(provider.code));
   }
 
   get hasSelectedProvider() {
@@ -35,6 +36,17 @@ export default class SsoSelectionForm extends Component {
     if (!provider) return null;
 
     return provider.organizationName;
+  }
+
+  get shouldDisplayAccountRecoveryBanner() {
+    const provider = this.oidcIdentityProviders.list.find((provider) => provider.id === this.selectedProviderId);
+    if (!provider) return false;
+
+    return this.oidcIdentityProviders.shouldDisplayAccountRecoveryBanner(provider.code);
+  }
+
+  get accountRecoveryUrl() {
+    return this.router.urlFor('account-recovery');
   }
 
   <template>
@@ -50,6 +62,15 @@ export default class SsoSelectionForm extends Component {
       <OidcProviderSelector @providers={{this.providers}} @onProviderChange={{this.onProviderChange}} />
 
       {{#if this.hasSelectedProvider}}
+        {{#if this.shouldDisplayAccountRecoveryBanner}}
+          <PixNotificationAlert class="sso-selection-form__should-display-account-recovery-banner">
+            {{t
+              "components.authentication.sso-selection-form.should-display-account-recovery-banner"
+              url=this.accountRecoveryUrl
+              htmlSafe=true
+            }}
+          </PixNotificationAlert>
+        {{/if}}
         <PixButtonLink
           aria-describedby="signin-message"
           @route="authentication.login-oidc"

--- a/mon-pix/app/components/authentication/sso-selection-form.scss
+++ b/mon-pix/app/components/authentication/sso-selection-form.scss
@@ -16,4 +16,10 @@
 
     color: var(--pix-neutral-500);
   }
+
+  &__should-display-account-recovery-banner {
+    a {
+      text-decoration: underline;
+    }
+  }
 }

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -4,10 +4,13 @@ import Service, { service } from '@ember/service';
 const FR_FEATURED_IDENTITY_PROVIDER_CODE = 'POLE_EMPLOI';
 const ORG_FEATURED_IDENTITY_PROVIDER_CODE = 'FWB';
 const FEATURED_IDENTITY_PROVIDER_CODES = [FR_FEATURED_IDENTITY_PROVIDER_CODE, ORG_FEATURED_IDENTITY_PROVIDER_CODE];
+const FER_IDENTITY_PROVIDER_CODE = 'FER';
+const USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES = [FER_IDENTITY_PROVIDER_CODE];
 
 export default class OidcIdentityProviders extends Service {
   @service store;
   @service currentDomain;
+  @service featureToggles;
 
   get list() {
     return this.store.peekAll('oidc-identity-provider');
@@ -49,5 +52,12 @@ export default class OidcIdentityProviders extends Service {
     oidcIdentityProviders.forEach((oidcIdentityProvider) => {
       this[oidcIdentityProvider.id] = oidcIdentityProvider;
     });
+  }
+
+  shouldDisplayAccountRecoveryBanner(identityProviderCode) {
+    return (
+      this.featureToggles.featureToggles.isNewAccountRecoveryEnabled &&
+      USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES.includes(identityProviderCode)
+    );
   }
 }

--- a/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/sso-selection-form-test.gjs
@@ -12,9 +12,13 @@ class OidcProvidersServiceStub extends Service {
     return [
       { id: 'cem', code: 'CEM', organizationName: 'ConnectEtMoi', isVisible: true },
       { id: 'sc', code: 'SC', organizationName: 'StarConnect', isVisible: true },
+      { id: 'fer', code: 'FER', organizationName: 'FER', isVisible: true },
       { id: 'hidden1', code: 'FWB', organizationName: 'Not displayed provider 1', isVisible: true },
       { id: 'hidden2', code: 'GOOGLE', organizationName: 'Not displayed provider 2', isVisible: true },
     ];
+  }
+  shouldDisplayAccountRecoveryBanner(identityProviderCode) {
+    return identityProviderCode == 'FER';
   }
 }
 
@@ -57,7 +61,7 @@ module('Integration | Component | Authentication | SsoSelectionForm', function (
   });
 
   test('it excludes some providers', async function (assert) {
-    //when
+    // when
     const screen = await render(<template><SsoSelectionForm /></template>);
     await clickByName(t('components.authentication.oidc-provider-selector.label'));
     await screen.findByRole('listbox');
@@ -66,6 +70,17 @@ module('Integration | Component | Authentication | SsoSelectionForm', function (
     const options = await screen.findAllByRole('option');
     const optionsLabels = options.map((option) => option.innerText);
 
-    assert.deepEqual(optionsLabels, ['ConnectEtMoi', 'StarConnect']);
+    assert.deepEqual(optionsLabels, ['ConnectEtMoi', 'FER', 'StarConnect']);
+  });
+
+  test('it displays an account recovery banner if SSO is FER', async function (assert) {
+    // when
+    const screen = await render(<template><SsoSelectionForm /></template>);
+    await clickByName(t('components.authentication.oidc-provider-selector.label'));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'FER' }));
+
+    // then
+    assert.dom(screen.getByText(/récupérer.*compte/i)).exists();
   });
 });

--- a/mon-pix/tests/unit/services/oidc-identity-providers-test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers-test.js
@@ -284,4 +284,40 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       });
     });
   });
+
+  module('shouldDisplayAccountRecoveryBanner', function () {
+    test('returns true if SSO code is in USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isNewAccountRecoveryEnabled: true };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+
+      // when
+      const shouldDisplayAccountRecoveryBanner =
+        await oidcIdentityProvidersService.shouldDisplayAccountRecoveryBanner('FER');
+
+      // then
+      assert.true(shouldDisplayAccountRecoveryBanner);
+    });
+
+    module('when feature toggle is set to false', function () {
+      test('returns false if feature toggle is inactive', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isNewAccountRecoveryEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+
+        // when
+        const shouldDisplayAccountRecoveryBanner =
+          await oidcIdentityProvidersService.shouldDisplayAccountRecoveryBanner('FER');
+
+        // then
+        assert.false(shouldDisplayAccountRecoveryBanner);
+      });
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -253,6 +253,9 @@
           },
           "legend": "Information required for sign up."
         }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "Student? If you have not yet done so, '<'a href=\"{url}\"'>'access the page to recover your Pix account'</a>' and keep your progress."
       }
     },
     "campaigns": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -253,6 +253,9 @@
           },
           "legend": "Información necesaria para la inscripción."
         }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "¿Estudiante? Si aún no lo ha hecho, '<'a href=\"{url}\"'>'acceda a la página para recuperar su cuenta Pix'</a>' y mantenga su progreso."
       }
     },
     "campaigns": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -253,6 +253,9 @@
           },
           "legend": "Information nécessaire pour l'inscription."
         }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "Étudiant ? Si ce n'est pas encore fait, '<'a href=\"{url}\"'>'accédez à la page pour récupérer votre compte Pix'</a>' et conservez votre progression."
       }
     },
     "campaigns": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -253,6 +253,9 @@
           },
           "legend": "Vereiste informatie voor registratie."
         }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "Student? Als je dat nog niet hebt gedaan, '<'a href=\"{url}\"'>'ga naar de pagina om je Pix account te herstellen'</a>' en bewaar je voortgang."
       }
     },
     "campaigns": {


### PR DESCRIPTION
## 🌸 Problème

Les anciens utilisateurs du SCO qui vont utiliser un SSO étudiant pour se connecter peuvent ne pas savoir qu'ils peuvent auparavant récupérer leur compte SCO avec un email.

## 🌳 Proposition

Ajouter un bandeau qui apparaît uniquement si certains SSO sont sélectionnés.

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Se rendre sur PIx app,
- Afficher la fenêtre de connexion SSO,
- Sélectionner la FER,
- Constater que le bandeau n'apparaît pas,
- Activer le feature toggle,
```shell
scalingo -a pix-api-review-pr12291 run npm run togles -- --key isNewAccountRecoveryEnabled --value true
```
- Recharger la page et sélectionner la FER,
- Constater que le bandeau apparaît.