### PR TITLE
[TECH] Automatiser la création de version Jira à la création d’un nouveau tag 

### DIFF
--- a/.github/workflows/create-jira-version.yaml
+++ b/.github/workflows/create-jira-version.yaml
@@ -1,0 +1,30 @@
+name: Create Jira Version
+
+on:
+  push:
+    tags:
+      - '*' 
+
+jobs:
+  create-jira-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get tag name and current date
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+             echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
+
+      - name: Create version in Jira
+        run: |
+          AUTH_HEADER=$(echo -n "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" | base64)
+          curl -X POST \
+            -H "Authorization: Basic $AUTH_HEADER" \
+            -H "Content-Type: application/json" \
+            --url "${{ secrets.JIRA_BASE_URL }}/rest/api/3/version" \
+            -d '{
+              "name": "${{ env.TAG_NAME }}",
+              "project": "${{ secrets.JIRA_PROJECT_KEY }}",
+              "startDate": "${{ env.TODAY }}",
+              "released": false
+            }'


### PR DESCRIPTION
## 🌸 Problème
Les MER/MEP vont bientôt être automatisées. 
Pour alléger les manips faites par le produit, on cherche à automatiser le maximum d’étapes côté JIRA.
Il y a plein d’automatisation possibles dans JIRA mais on a besoin d’un déclencheur : créer une nouvelle version lorsqu’il y a une nouvelle release. 

## 🌳 Proposition
Ajouter un nouveau workflow qui va créer une nouvelle version JIRA via l'api JIRA lorsqu’un nouveau tag est créé côté GitHub. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
