### PR TITLE
[TECH] Correction des flakies causés par Chrome Headless

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -10,10 +10,12 @@ const config = {
       // --no-sandbox is needed when running Chrome inside a container
       process.env.CI ? '--no-sandbox' : null,
       '--headless',
+      '--disable-gpu',
       '--disable-dev-shm-usage',
       '--disable-software-rasterizer',
+      '--disable-accelerated-2d-canvas',
       '--mute-audio',
-      '--remote-debugging-port=0',
+      '--remote-debugging-port=9222',
       '--window-size=1440,900',
     ].filter(Boolean),
   },
@@ -24,9 +26,9 @@ const config = {
 module.exports = process.env.CI
   ? {
       ...config,
-      reporter: "xunit",
+      reporter: 'xunit',
       report_file: `${
-        process.env.RESULTS_PATH ?? "./test-results/"
+        process.env.RESULTS_PATH ?? './test-results/'
       }/report.xml`,
     }
   : config;


### PR DESCRIPTION
## 🌸 Problème

Depuis quelques temps, on observe des flakies liés à la connexion à Chrome Headless par `testem.js` pour les tests frontends.
- https://app.circleci.com/pipelines/github/1024pix/pix/121141/workflows/7214f200-83ab-4855-ad99-f43e247607db/jobs/1350188/tests
- https://app.circleci.com/pipelines/github/1024pix/pix/121141/workflows/f02c752b-139f-40c7-8ec3-f685d42e24c0/jobs/1350264/tests
- https://app.circleci.com/pipelines/github/1024pix/pix/121044/workflows/6abc8494-ee4f-4727-809b-d0b0151bc098/jobs/1349306/tests
- https://app.circleci.com/pipelines/github/1024pix/pix/121186/workflows/8792422b-bd42-4743-8165-db5fe8efe7af/jobs/1350636/tests

## 🌳 Proposition

Modifier la configuration de Chrome Headless pour ne pas utiliser les fonctionnalités GPU qui ne sont pas disponibles ou émulé dans les environnements virtualisés (ex: Docker, CI).
- `--disable-gpu`: Disables GPU hardware acceleration.
- `--disable-accelerated-2d-canvas`: Disables GPU acceleration for canvas rendering.
- `--remote-debugging-port=9222`: Utiliser un port fixe plutôt qu'un port random sur la CI

## 🤧 Pour tester

J'ai exécuté plusieurs fois la CI pour vérifier si ce flaky réapparaissait