### PR TITLE
[TECH] :truck: Déplace la route et le cas d'utilisation `ScoOrganizationLearnerAccountRecovery`

### DIFF
--- a/api/lib/application/sco-organization-learners/index.js
+++ b/api/lib/application/sco-organization-learners/index.js
@@ -8,8 +8,8 @@ import {
   UnprocessableEntityError,
 } from '../../../src/shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
-import { identifiersType, studentIdentifierType } from '../../../src/shared/domain/types/identifiers-type.js';
-import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
+import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { libScoOrganizationLearnerController } from './sco-organization-learner-controller.js';
 
 const register = async function (server) {
   server.route([
@@ -18,7 +18,7 @@ const register = async function (server) {
       path: '/api/sco-organization-learners/possibilities',
       config: {
         auth: false,
-        handler: scoOrganizationLearnerController.generateUsername,
+        handler: libScoOrganizationLearnerController.generateUsername,
         validate: {
           options: {
             allowUnknown: true,
@@ -54,7 +54,7 @@ const register = async function (server) {
             assign: 'belongsToScoOrganizationAndManageStudents',
           },
         ],
-        handler: scoOrganizationLearnerController.updatePassword,
+        handler: libScoOrganizationLearnerController.updatePassword,
         validate: {
           options: {
             allowUnknown: true,
@@ -91,7 +91,7 @@ const register = async function (server) {
             assign: 'belongsToScoOrganizationAndManageStudents',
           },
         ],
-        handler: scoOrganizationLearnerController.batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
+        handler: libScoOrganizationLearnerController.batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
         validate: {
           options: {
             allowUnknown: true,
@@ -128,7 +128,7 @@ const register = async function (server) {
             assign: 'belongsToScoOrganizationAndManageStudents',
           },
         ],
-        handler: scoOrganizationLearnerController.generateUsernameWithTemporaryPassword,
+        handler: libScoOrganizationLearnerController.generateUsernameWithTemporaryPassword,
         validate: {
           options: {
             allowUnknown: true,
@@ -145,31 +145,6 @@ const register = async function (server) {
         notes: [
           "- Génère un identifiant pour l'élève avec un mot de passe temporaire \n" +
             "- La demande de génération d'identifiant doit être effectuée par un membre de l'organisation à laquelle appartient l'élève.",
-        ],
-        tags: ['api', 'sco-organization-learners'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/sco-organization-learners/account-recovery',
-      config: {
-        auth: false,
-        handler: scoOrganizationLearnerController.checkScoAccountRecovery,
-        validate: {
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                'ine-ina': studentIdentifierType,
-                birthdate: Joi.date().format('YYYY-MM-DD').required(),
-              },
-            },
-          }).options({ allowUnknown: true }),
-        },
-        notes: [
-          "- Recherche d'un ancien élève par son ine/ina, prénom, nom, date de naissance \n" +
-            '- On renvoie les informations permettant de récupérer son compte Pix.',
         ],
         tags: ['api', 'sco-organization-learners'],
       },

--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 
-import * as studentInformationForAccountRecoverySerializer from '../../../src/identity-access-management/infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
 import * as scoOrganizationLearnerSerializer from '../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -62,24 +61,6 @@ const generateUsernameWithTemporaryPassword = async function (
   return h.response(dependencies.scoOrganizationLearnerSerializer.serializeCredentialsForDependent(result)).code(200);
 };
 
-const checkScoAccountRecovery = async function (
-  request,
-  h,
-  dependencies = { studentInformationForAccountRecoverySerializer },
-) {
-  const studentInformation = await dependencies.studentInformationForAccountRecoverySerializer.deserialize(
-    request.payload,
-  );
-
-  const studentInformationForAccountRecovery = await usecases.checkScoAccountRecovery({
-    studentInformation,
-  });
-
-  return h.response(
-    dependencies.studentInformationForAccountRecoverySerializer.serialize(studentInformationForAccountRecovery),
-  );
-};
-
 const batchGenerateOrganizationLearnersUsernameWithTemporaryPassword = async function (request, h) {
   const payload = request.payload.data.attributes;
   const userId = request.auth.credentials.userId;
@@ -106,12 +87,11 @@ const batchGenerateOrganizationLearnersUsernameWithTemporaryPassword = async fun
     .header('Content-Disposition', `attachment; filename=${generatedCsvContentFileName}`);
 };
 
-const scoOrganizationLearnerController = {
+const libScoOrganizationLearnerController = {
   generateUsername,
   updatePassword,
   generateUsernameWithTemporaryPassword,
-  checkScoAccountRecovery,
   batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
 };
 
-export { scoOrganizationLearnerController };
+export { libScoOrganizationLearnerController };

--- a/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
+++ b/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js
@@ -1,0 +1,22 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery.serializer.js';
+
+async function checkScoAccountRecovery(request, h, dependencies = { studentInformationForAccountRecoverySerializer }) {
+  const studentInformation = await dependencies.studentInformationForAccountRecoverySerializer.deserialize(
+    request.payload,
+  );
+
+  const studentInformationForAccountRecovery = await usecases.checkScoAccountRecovery({
+    studentInformation,
+  });
+
+  return h.response(
+    dependencies.studentInformationForAccountRecoverySerializer.serialize(studentInformationForAccountRecovery),
+  );
+}
+
+const scoOrganizationLearnerController = {
+  checkScoAccountRecovery,
+};
+
+export { scoOrganizationLearnerController };

--- a/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.route.js
+++ b/api/src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.route.js
@@ -1,0 +1,34 @@
+import JoiDate from '@joi/date';
+import BaseJoi from 'joi';
+const Joi = BaseJoi.extend(JoiDate);
+
+import { studentIdentifierType } from '../../../shared/domain/types/identifiers-type.js';
+import { scoOrganizationLearnerController } from './organization-learner-account-recovery.controller.js';
+
+export const organizationLearnerAccountRecoveryRoutes = [
+  {
+    method: 'POST',
+    path: '/api/sco-organization-learners/account-recovery',
+    config: {
+      auth: false,
+      handler: scoOrganizationLearnerController.checkScoAccountRecovery,
+      validate: {
+        payload: Joi.object({
+          data: {
+            attributes: {
+              'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+              'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+              'ine-ina': studentIdentifierType,
+              birthdate: Joi.date().format('YYYY-MM-DD').required(),
+            },
+          },
+        }).options({ allowUnknown: true }),
+      },
+      notes: [
+        "- Recherche d'un ancien élève par son ine/ina, prénom, nom, date de naissance \n" +
+          '- On renvoie les informations permettant de récupérer son compte Pix.',
+      ],
+      tags: ['api', 'sco-organization-learners'],
+    },
+  },
+];

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -3,6 +3,7 @@ import { anonymizationAdminRoutes } from './anonymization/anonymization.admin.ro
 import { ltiRoutes } from './lti/lti.route.js';
 import { oidcProviderAdminRoutes } from './oidc-provider/oidc-provider.admin.route.js';
 import { oidcProviderRoutes } from './oidc-provider/oidc-provider.route.js';
+import { organizationLearnerAccountRecoveryRoutes } from './organization-learner-account-recovery/organization-learner-account-recovery.route.js';
 import { passwordRoutes } from './password/password.route.js';
 import { samlRoutes } from './saml/saml.route.js';
 import { tokenRoutes } from './token/token.route.js';
@@ -15,6 +16,7 @@ const allRoutes = [
   ...ltiRoutes,
   ...oidcProviderAdminRoutes,
   ...oidcProviderRoutes,
+  ...organizationLearnerAccountRecoveryRoutes,
   ...passwordRoutes,
   ...samlRoutes,
   ...tokenRoutes,

--- a/api/src/identity-access-management/domain/usecases/check-sco-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/check-sco-account-recovery.usecase.js
@@ -1,4 +1,4 @@
-import { StudentInformationForAccountRecovery } from '../../../src/shared/domain/read-models/StudentInformationForAccountRecovery.js';
+import { StudentInformationForAccountRecovery } from '../../../shared/domain/read-models/StudentInformationForAccountRecovery.js';
 
 const checkScoAccountRecovery = async function ({
   studentInformation,

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -21,6 +21,7 @@ import * as userValidator from '../../../shared/domain/validators/user-validator
 import { httpAgent } from '../../../shared/infrastructure/http-agent.js';
 import { adminMemberRepository } from '../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationLearnerRepository from '../../../shared/infrastructure/repositories/organization-learner-repository.js';
+import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import * as codeUtils from '../../../shared/infrastructure/utils/code-utils.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -76,6 +77,7 @@ const repositories = {
   membershipRepository,
   oidcProviderRepository,
   organizationLearnerRepository,
+  organizationRepository,
   prescriptionOrganizationLearnerRepository,
   privacyUsersApiRepository,
   refreshTokenRepository,

--- a/api/tests/identity-access-management/unit/domain/usecases/check-sco-account-recovery_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/check-sco-account-recovery_test.js
@@ -1,6 +1,6 @@
-import { checkScoAccountRecovery } from '../../../../lib/domain/usecases/check-sco-account-recovery.js';
-import { StudentInformationForAccountRecovery } from '../../../../src/shared/domain/read-models/StudentInformationForAccountRecovery.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { checkScoAccountRecovery } from '../../../../../src/identity-access-management/domain/usecases/check-sco-account-recovery.usecase.js';
+import { StudentInformationForAccountRecovery } from '../../../../../src/shared/domain/read-models/StudentInformationForAccountRecovery.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | check-sco-account-recovery', function () {
   let organizationLearnerRepository;

--- a/api/tests/integration/application/sco-organization-learners/index_test.js
+++ b/api/tests/integration/application/sco-organization-learners/index_test.js
@@ -1,5 +1,5 @@
 import * as moduleUnderTest from '../../../../lib/application/sco-organization-learners/index.js';
-import { scoOrganizationLearnerController } from '../../../../lib/application/sco-organization-learners/sco-organization-learner-controller.js';
+import { libScoOrganizationLearnerController } from '../../../../lib/application/sco-organization-learners/sco-organization-learner-controller.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
@@ -8,16 +8,16 @@ describe('Integration | Application | Route | sco-organization-learners', functi
 
   beforeEach(async function () {
     sinon
-      .stub(scoOrganizationLearnerController, 'generateUsername')
+      .stub(libScoOrganizationLearnerController, 'generateUsername')
       .callsFake((request, h) => h.response('ok').code(200));
     sinon
       .stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents')
       .callsFake((request, h) => h.response(true));
     sinon
-      .stub(scoOrganizationLearnerController, 'updatePassword')
+      .stub(libScoOrganizationLearnerController, 'updatePassword')
       .callsFake((request, h) => h.response('ok').code(200));
     sinon
-      .stub(scoOrganizationLearnerController, 'generateUsernameWithTemporaryPassword')
+      .stub(libScoOrganizationLearnerController, 'generateUsernameWithTemporaryPassword')
       .callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer();

--- a/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -1,5 +1,5 @@
-import { scoOrganizationLearnerController } from '../../../../lib/application/sco-organization-learners/sco-organization-learner-controller.js';
-import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { scoOrganizationLearnerController } from '../../../../src/identity-access-management/application/organization-learner-account-recovery/organization-learner-account-recovery.controller.js';
+import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Controller | sco-organization-learner', function () {


### PR DESCRIPTION
## 🌸 Problème

La route et le cas d'utilisation `ScoOrganizationLearnerAccountRecovery` sont dans `lib/`

## 🌳 Proposition

Déplacer la route et le cas d'utilisation `ScoOrganizationLearnerAccountRecovery` vers `/src/identity-access-management/`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

_Je ne sais pas comment tester cette route_
