### PR TITLE
[FEATURE] Empêcher Ember de gérer les erreurs 403 de type HTML dans PixApp (PIX-17835).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -54,7 +54,12 @@ export default class ApplicationRoute extends Route {
   @action
   error(error) {
     this.#stopPolling();
-    const isUnauthorizedError = error?.errors?.some((err) => err.status === '401');
+
+    const has403WithHTMLContentTypeError = () => {
+      return error?.errors?.some((err) => err.status === '403') && error?.error.includes('Payload (text/html;');
+    };
+
+    const isUnauthorizedError = has403WithHTMLContentTypeError() || error?.errors?.some((err) => err.status === '401');
     return !isUnauthorizedError;
   }
 

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -90,4 +90,51 @@ module('Unit | Route | application', function (hooks) {
       assert.ok(true);
     });
   });
+
+  module('error', function () {
+    module('when the error is a 401', function () {
+      test('should return false to prevent ember error handling', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:application');
+
+        const currentError = { errors: [{ status: '401' }] };
+
+        // when
+        const err = await route.error(currentError);
+
+        // then
+        assert.false(err);
+      });
+    });
+
+    module('when the error is a 403 with HTML content-type', function () {
+      test('should return false to prevent ember error handling', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:application');
+
+        const currentError = { error: '...Payload (text/html;...', errors: [{ status: '403' }] };
+
+        // when
+        const err = await route.error(currentError);
+
+        // then
+        assert.false(err);
+      });
+    });
+
+    module('when the error is not a 401 or a a 403 with HTML content-type', function () {
+      test('should return true to keep ember error handling', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:application');
+
+        const currentError = { errors: [{ status: '404' }] };
+
+        // when
+        const err = await route.error(currentError);
+
+        // then
+        assert.true(err);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🌸 Problème

Dans PixApp, lorsqu'une erreur de type HTML était renvoyée par l'API, on voyait une page d'erreur peu évocatrice et possiblement intrigante pour l'utilisateur.

![image](https://github.com/user-attachments/assets/c6fa4bec-bc2c-4f99-9c7d-c3302c184c6c)

## 🌳 Proposition

On souhaite afficher la page d'erreur Baleen en production.
Pour se faire, nous devons annuler la gestion faite par Ember de ces erreurs 403 et de type HTML.

## 🐝 Remarques

On ne pourra voir la page Baleen qu'en prod.

## 🤧 Pour tester

- En local, dans l'API, faire en sorte qu'une route retourne une erreur 403 et de type HTML
`return h.response('erreur').code(403).type('text/html');`

- Aller sur la page PixApp utilisant cette route et constater qu'on ne tombe plus sur la page d'erreur spécifique
