### PR TITLE
[FEATURE] Mettre à jour et generaliser updatedAt à l'anonymisation (PIX-17867)

### DIFF
--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -147,7 +147,7 @@ class User {
     return new User({
       ...this,
       createdAt: anonymizeGeneralizeDate(this.createdAt),
-      updatedAt: anonymizeGeneralizeDate(this.updatedAt),
+      updatedAt: anonymizeGeneralizeDate(new Date()),
       firstName: '(anonymised)',
       lastName: '(anonymised)',
       email: null,

--- a/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -9,7 +9,7 @@ import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js
 
 describe('Integration | Identity Access Management | Domain | UseCase | anonymize-user', function () {
   let clock;
-  const now = new Date('2003-04-05T03:04:05Z');
+  const now = new Date('2024-04-05T03:04:05Z');
 
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
@@ -107,7 +107,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | anonymiz
 
     const anonymizedUser = await knex('users').where({ id: user.id }).first();
     expect(anonymizedUser.createdAt.toISOString()).to.equal('2012-12-01T00:00:00.000Z');
-    expect(anonymizedUser.updatedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
+    expect(anonymizedUser.updatedAt.toISOString()).to.equal('2024-04-01T00:00:00.000Z');
     expect(anonymizedUser.firstName).to.equal('(anonymised)');
     expect(anonymizedUser.lastName).to.equal('(anonymised)');
     expect(anonymizedUser.email).to.be.null;

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -655,6 +655,17 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
   });
 
   describe('#anonymize', function () {
+    let clock;
+    const now = new Date('2023-09-19T01:02:03Z');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
     it('anonymizes user info', function () {
       // given
       const adminId = 1;
@@ -680,7 +691,7 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
       expect(anonymizedUser.lastPixCertifTermsOfServiceValidatedAt).to.be.null;
       expect(anonymizedUser.lastDataProtectionPolicySeenAt).to.be.null;
       expect(anonymizedUser.createdAt.toISOString()).to.equal('2012-12-01T00:00:00.000Z');
-      expect(anonymizedUser.updatedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
+      expect(anonymizedUser.updatedAt.toISOString()).to.equal('2023-09-01T00:00:00.000Z');
     });
   });
 });

--- a/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
+++ b/api/tests/privacy/integration/domain/usecases/anonymize-user.usecase.test.js
@@ -14,7 +14,7 @@ const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Privacy | Domain | UseCase | anonymize-user', function () {
   let clock;
-  const now = new Date('2003-04-05T03:04:05Z');
+  const now = new Date('2024-04-05T03:04:05Z');
 
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
@@ -144,7 +144,7 @@ describe('Integration | Privacy | Domain | UseCase | anonymize-user', function (
 
     const anonymizedUser = await knex('users').where({ id: user.id }).first();
     expect(anonymizedUser.createdAt.toISOString()).to.equal('2012-12-01T00:00:00.000Z');
-    expect(anonymizedUser.updatedAt.toISOString()).to.equal('2023-03-01T00:00:00.000Z');
+    expect(anonymizedUser.updatedAt.toISOString()).to.equal('2024-04-01T00:00:00.000Z');
     expect(anonymizedUser.firstName).to.equal('(anonymised)');
     expect(anonymizedUser.lastName).to.equal('(anonymised)');
     expect(anonymizedUser.email).to.be.null;


### PR DESCRIPTION
## 🌸 Problème

Lors de l’exécution du script d’anonymisation, le champ users.updatedAt est mis à jour en généralisant sa valeur actuelle. On souhaite mettre à jour ce champs avec la date d'anonymisation généralisée.

## 🌳 Proposition

Quand un user est anonymisé, on doit mettre à jour le updatedAt avec la date du jour, puis le généraliser (on garde l'année + le mois, puis pour le jour, mettre ‘01’ et pour l'heure, mettre à minuit)

ca nous permettra de continuer à faire un suivi par mois, mais sans faire le lien avec un ticket au support et donc nous empechera de remonter au user faisant la demande

## 🤧 Pour tester

Aller sur Pix Admin, et anonymiser un utilisateur.
> Observer que le champ `updatedAt` est généralisé à la date du jour.
