### PR TITLE
[FEATURE] Utilise le composant CoverRateGauge dans la table d'analyse des resultats par sujets / compétences (PIX-17857)

### DIFF
--- a/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
+++ b/orga/app/components/analysis/analysis-per-tubes-and-competences.gjs
@@ -1,7 +1,7 @@
-import PixGauge from '@1024pix/pix-ui/components/pix-gauge';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { t } from 'ember-intl';
+import CoverRateGauge from 'pix-orga/components/statistics/cover-rate-gauge';
 
 import TagLevel from '../statistics/tag-level';
 
@@ -46,16 +46,7 @@ import TagLevel from '../statistics/tag-level';
             {{t "components.analysis-per-tubes-and-competences.table.column.positioning"}}
           </:header>
           <:cell>
-            <PixGauge
-              @isSmall={{true}}
-              @maxLevel={{tubeLevel.maxLevel}}
-              @reachedLevel={{tubeLevel.meanLevel}}
-              @label={{t
-                "components.analysis-per-tubes-and-competences.gauge.label"
-                maxLevel=tubeLevel.maxLevel
-                reachedLevel=tubeLevel.meanLevel
-              }}
-            />
+            <CoverRateGauge @hideMaxMin={{true}} @userLevel={{tubeLevel.meanLevel}} @tubeLevel={{tubeLevel.maxLevel}} />
           </:cell>
         </PixTableColumn>
 

--- a/orga/app/components/statistics/cover-rate-gauge.gjs
+++ b/orga/app/components/statistics/cover-rate-gauge.gjs
@@ -18,6 +18,10 @@ export default class CoverRateGauge extends Component {
     return this.formatNumber(this.args.tubeLevel);
   }
 
+  get translation() {
+    return this.args.label || 'pages.statistics.gauge.label';
+  }
+
   formatNumber = (str) => {
     const num = Number(str);
     const oneDigitNum = num.toFixed(1);
@@ -36,18 +40,20 @@ export default class CoverRateGauge extends Component {
     <div class="cover-rate-gauge">
       <div class="cover-rate-gauge__container">
         <div
+          aria-hidden="true"
           class="cover-rate-gauge__level cover-rate-gauge__level--tube-level"
           style={{this.getGaugeSizeStyle this.tubeLevel withExtraPercentage=true}}
         >
           {{this.tubeLevel}}
         </div>
-        <div class="cover-rate-gauge__background">
+        <div class="cover-rate-gauge__background {{if @hideMaxMin ' cover-rate-gauge__background--hide-max-min'}}">
           <label for={{this.id}} class="screen-reader-only">{{t
-              "pages.statistics.gauge.label"
+              this.translation
               userLevel=this.userLevel
               tubeLevel=this.tubeLevel
             }}</label>
           <progress
+            aria-hidden="true"
             class="cover-rate-gauge__progress"
             id={{this.id}}
             max={{this.tubeLevel}}
@@ -58,6 +64,7 @@ export default class CoverRateGauge extends Component {
           </progress>
         </div>
         <div
+          aria-hidden="true"
           class="cover-rate-gauge__level cover-rate-gauge__level--user-level"
           style={{this.getGaugeSizeStyle this.userLevel withExtraPercentage=true}}
         >

--- a/orga/app/styles/components/statistics/cover-rate-gauge.scss
+++ b/orga/app/styles/components/statistics/cover-rate-gauge.scss
@@ -1,7 +1,6 @@
 .cover-rate-gauge {
   display: grid;
   align-items: center;
-  justify-content: center;
   width: 100%;
   height: 3.5rem;
 }
@@ -28,13 +27,13 @@
 
   --level-text-spacing-from-gauge: -12px;
 
-  &:before {
+  &:not(.cover-rate-gauge__background--hide-max-min):before {
     position: absolute;
     left: var(--level-text-spacing-from-gauge);
     content: '0';
   }
 
-  &:after {
+  &:not(.cover-rate-gauge__background--hide-max-min):after {
     position: absolute;
     right: var(--level-text-spacing-from-gauge);
     content: '7';

--- a/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
+++ b/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
@@ -80,7 +80,7 @@ module('Integration | Component | analysis-per-tubes-and-competences', function 
       assert.ok(filledTable.getByRole('cell', { name: 'tube 1 cp 1 desc tube 1 cp 1' }));
       assert.ok(
         filledTable.getByRole('cell', {
-          name: t('components.analysis-per-tubes-and-competences.gauge.label', { reachedLevel: 2, maxLevel: 8 }),
+          name: t('pages.statistics.gauge.label', { userLevel: 2, tubeLevel: 8 }),
         }),
       );
       assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.novice') }));
@@ -88,7 +88,7 @@ module('Integration | Component | analysis-per-tubes-and-competences', function 
       assert.ok(filledTable.getByRole('cell', { name: 'tube 2 cp 1 desc tube 2 cp 1' }));
       assert.ok(
         filledTable.getByRole('cell', {
-          name: t('components.analysis-per-tubes-and-competences.gauge.label', { reachedLevel: 3.45, maxLevel: 4 }),
+          name: t('pages.statistics.gauge.label', { userLevel: 3.5, tubeLevel: 4 }),
         }),
       );
       assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.advanced') }));


### PR DESCRIPTION
## 🌸 Problème

c'était pas fifou la grosse gauge dans le tableau

## 🌳 Proposition

On utilise celle existante dans PixOrga sur la page statistics

## 🐝 Remarques

les key d'entrée pour la trad sont pas fifou. mais ça peut être fait dans un second temps. 

## 🤧 Pour tester

Aller sur la page de résultats d'une campagne et vérifier qu'on a bien la gauge de la page statistics quand on active la page

de mémoire : 

```
npm run toggle -- -k shouldDisplayNewAnalysisPage -v true
```