### PR TITLE
[FEATURE] Module pour atelier recrutement graphiste

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -406,7 +406,7 @@
           "element": {
             "id": "9bc8b95e-c9ca-4836-9f59-2624aa4c37f8",
             "type": "image",
-            "url": "",
+            "url": "https://i.imgur.com/kaxRQeu.png",
             "alt": "Infographie décrite dans l'alternative textuelle",
             "alternativeText": "<p>Infographie<strong> Où trouver des options contrôle parental ?</strong> </p><ul><li>Sur les appareils&nbsp;:<ul><li>les appareils personnels (smarthpones, tablettes, ordinateurs, montres connectées, télévisions connectées)</li><li>les consoles de jeux (nintendo switch, xbox, playstation et d’autres)</li><li>les box internet</li></ul></li><li>En ligne&nbsp;:&nbsp;<ul><li>les réseaux sociaux (instagram, facebook, snapchat, tiktok, discord et d’autres)</li><li>les plateformes de jeux vidéo (electronic art, steam, roblox et d’autres)</li><li>les plateformes de vidéo à la demande (netflix, amazon prime, disney+ et d’autres)</li></ul></li><li>Pour l’activer, rendez-vous sur <strong>paramètres </strong>ou <strong>compte</strong>, puis cherchez, selon les appareils et les plateformes&nbsp;: supervision parentale, contrôle parental, temps d’écran, bien être numérique, connexion famille, famille et contrôle parental, centre familial ou d’autres</li></ul>"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -406,7 +406,7 @@
           "element": {
             "id": "9bc8b95e-c9ca-4836-9f59-2624aa4c37f8",
             "type": "image",
-            "url": "https://images.pix.fr/modulix/ppn2_infographie.png",
+            "url": "",
             "alt": "Infographie décrite dans l'alternative textuelle",
             "alternativeText": "<p>Infographie<strong> Où trouver des options contrôle parental ?</strong> </p><ul><li>Sur les appareils&nbsp;:<ul><li>les appareils personnels (smarthpones, tablettes, ordinateurs, montres connectées, télévisions connectées)</li><li>les consoles de jeux (nintendo switch, xbox, playstation et d’autres)</li><li>les box internet</li></ul></li><li>En ligne&nbsp;:&nbsp;<ul><li>les réseaux sociaux (instagram, facebook, snapchat, tiktok, discord et d’autres)</li><li>les plateformes de jeux vidéo (electronic art, steam, roblox et d’autres)</li><li>les plateformes de vidéo à la demande (netflix, amazon prime, disney+ et d’autres)</li></ul></li><li>Pour l’activer, rendez-vous sur <strong>paramètres </strong>ou <strong>compte</strong>, puis cherchez, selon les appareils et les plateformes&nbsp;: supervision parentale, contrôle parental, temps d’écran, bien être numérique, connexion famille, famille et contrôle parental, centre familial ou d’autres</li></ul>"
           }


### PR DESCRIPTION
## 🌸 Problème

L'équipe comm' veut faire travailler des candidats graphistes sur la base d'un module, sans leur montrer l'infographie existante mais en leur donnant tout le contexte

## 🌳 Proposition

Garde tout le module, en supprimant l'infographie

## 🐝 Remarques

Durée indicative donnée par la comm : besoin que lien de PR review fonctionne jusqu'à fin juillet

## 🤧 Pour tester

Suivre le lien : https://app-pr12306.review.pix.fr/modules/controle-parental