### PR TITLE
[TECH] Séparer 2 commandes dans la github action de création de version jira

### DIFF
--- a/.github/workflows/create-jira-version.yaml
+++ b/.github/workflows/create-jira-version.yaml
@@ -11,8 +11,9 @@ jobs:
 
     steps:
       - name: Get tag name and current date
-        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-             echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+        run: |
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
 
 
       - name: Create version in Jira


### PR DESCRIPTION
## 🌸 Problème
Il manque une séparation de 2 commandes donc on a 
`TAG_NAME=v5.112.0 echo TODAY=2025-05-16` 

au lieu d'avoir 
```
TAG_NAME=v5.112.0
TODAY=2025-05-16
```

## 🌳 Proposition

Ajouter une | après run: 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
