### PR TITLE
[FEATURE] Ajout du QCU déclaratif côté Front (PIX-17684)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -13,6 +13,71 @@
   },
   "grains": [
     {
+      "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
+      "type": "lesson",
+      "title": "test qcu-declarative",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "6a6944be-a8a3-4138-b5dc-af664cf40b07",
+            "type": "qcu-declarative",
+            "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
+            "proposals": [
+              {
+                "id": "1",
+                "content": "Avant de mettre le dentifrice",
+                "feedback": {
+                  "state": "",
+                  "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
+                }
+              },
+              {
+                "id": "2",
+                "content": "Après avoir mis le dentifrice",
+                "feedback": {
+                  "state":  "",
+                  "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
+                }
+              },
+              {
+                "id": "3",
+                "content": "Pendant que le dentifrice est mis",
+                "feedback": {
+                  "state":  "",
+                  "diagnosis": "<p>Digne des plus grands acrobates !</p>"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
+            "type": "text",
+            "content": "<p>Voici une iframe :</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "f00133f5-0653-425b-a25f-3c9604820529",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/cartes2.html\" height=\"420\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
+            "type": "text",
+            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
+          }
+        }
+      ]
+    },
+    {
       "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
       "type": "discovery",
       "title": "Voici un grain de découverte",
@@ -143,71 +208,6 @@
             "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
             "type": "text",
             "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
-      "type": "lesson",
-      "title": "test qcu-declarative",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6a6944be-a8a3-4138-b5dc-af664cf40b07",
-            "type": "qcu-declarative",
-            "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Avant de mettre le dentifrice",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Après avoir mis le dentifrice",
-                "feedback": {
-                  "state":  "",
-                  "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Pendant que le dentifrice est mis",
-                "feedback": {
-                  "state":  "",
-                  "diagnosis": "<p>Digne des plus grands acrobates !</p>"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
-            "type": "text",
-            "content": "<p>Voici une iframe :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f00133f5-0653-425b-a25f-3c9604820529",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/cartes2.html\" height=\"420\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
-            "type": "text",
-            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
           }
         }
       ]

--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -1,0 +1,35 @@
+.proposal-button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--pix-spacing-3x) var(--pix-spacing-4x);
+  background: var(--pix-neutral-0);
+  border: 1px solid var(--pix-neutral-500);
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:focus-within {
+    border: 1px solid var(--pix-primary-500);
+    outline: 2px solid var(--pix-primary-300);
+  }
+
+  &:hover,
+  &:active {
+    background: var(--pix-primary-10);
+  }
+
+  &[disabled] {
+    cursor: not-allowed;
+
+    &:hover {
+    background: var(--pix-neutral-0);
+    }
+  }
+
+  &[disabled]:not(.proposal-button--selected) {
+    --state-border-color: var(--pix-neutral-100);
+
+    background: rgb(var(--pix-success-100-inline), 0.4);
+    border-color: var(--state-border-color);
+  }
+}

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -9,6 +9,7 @@ import FlashcardsElement from 'mon-pix/components/module/element/flashcards/flas
 import ImageElement from 'mon-pix/components/module/element/image';
 import QcmElement from 'mon-pix/components/module/element/qcm';
 import QcuElement from 'mon-pix/components/module/element/qcu';
+import QcuDeclarativeElement from 'mon-pix/components/module/element/qcu-declarative';
 import QrocmElement from 'mon-pix/components/module/element/qrocm';
 import SeparatorElement from 'mon-pix/components/module/element/separator';
 import TextElement from 'mon-pix/components/module/element/text';
@@ -46,6 +47,8 @@ export default class ModulixElement extends Component {
         @onRetry={{@onElementRetry}}
         @correction={{this.getLastCorrectionForElement @element}}
       />
+    {{else if (eq @element.type "qcu-declarative")}}
+      <QcuDeclarativeElement @element={{@element}} />
     {{else if (eq @element.type "qcm")}}
       <QcmElement
         @element={{@element}}

--- a/mon-pix/app/components/module/component/proposal-button.gjs
+++ b/mon-pix/app/components/module/component/proposal-button.gjs
@@ -1,0 +1,13 @@
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+
+<template>
+  <button
+    class="proposal-button {{if @isSelected 'proposal-button--selected'}}"
+    type="submit"
+    name={{@proposal.content}}
+    value={{@proposal.id}}
+    disabled={{@isDisabled}}
+  >
+    {{htmlUnsafe @proposal.content}}
+  </button>
+</template>

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -1,0 +1,36 @@
+@use 'pix-design-tokens/typography';
+
+.element-qcu-declarative {
+  width: 100%;
+  padding: var(--pix-spacing-6x);
+  padding-bottom: var(--pix-spacing-10x);
+
+  &__instruction {
+    @extend %pix-body-m;
+
+    font-weight: var(--pix-font-bold);
+  }
+
+  &__complementary-instruction {
+    @extend %pix-body-s;
+
+    margin: var(--pix-spacing-3x) 0;
+    color: var(--pix-neutral-500);
+  }
+
+  &__proposals {
+    display:flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+    margin-top: var(--pix-spacing-4x);
+  }
+
+  &__feedback {
+    @extend %pix-body-l;
+
+    padding: var(--pix-spacing-6x);
+    color: var(--pix-neutral-0);
+    background: var(--pix-neutral-800);
+    border-radius: var(--pix-spacing-4x);
+  }
+}

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -1,0 +1,75 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import ProposalButton from 'mon-pix/components/module/component/proposal-button';
+
+import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import ModuleElement from './module-element';
+
+export default class ModuleQcuDeclarative extends ModuleElement {
+  @tracked selectedProposalId = null;
+  @tracked shouldDisplayFeedback = false;
+  @service passageEvents;
+
+  get selectedProposalFeedback() {
+    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
+  }
+
+  get selectedProposalAnswer() {
+    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).content;
+  }
+
+  @action
+  isProposalSelected(proposalId) {
+    return this.selectedProposalId === proposalId;
+  }
+
+  @action
+  async onAnswer(event) {
+    event.preventDefault();
+    this.selectedProposalId = event.submitter.value;
+    this.shouldDisplayFeedback = true;
+    this.passageEvents.record({
+      type: 'QCU_DECLARATIVE_ANSWERED',
+      data: {
+        elementId: this.element.id,
+        answer: this.selectedProposalAnswer,
+      },
+    });
+  }
+
+  get isAnswered() {
+    return this.selectedProposalId !== null;
+  }
+
+  <template>
+    <form class="element-qcu-declarative" onSubmit={{this.onAnswer}} aria-describedby="instruction-{{this.element.id}}">
+      <fieldset>
+        <legend class="screen-reader-only">
+          {{t "pages.modulix.qcuDeclarative.direction"}}
+        </legend>
+        <p class="element-qcu-declarative__instruction" id="instruction-{{this.element.id}}">
+          {{htmlUnsafe this.element.instruction}}
+        </p>
+        <p class="element-qcu-declarative__complementary-instruction">
+          {{t "pages.modulix.qcuDeclarative.complementaryInstruction"}}
+        </p>
+        <div class="element-qcu-declarative__proposals">
+          {{#each this.element.proposals as |proposal|}}
+            <ProposalButton
+              @proposal={{proposal}}
+              @isDisabled={{this.isAnswered}}
+              @isSelected={{this.isProposalSelected proposal.id}}
+            />
+          {{/each}}
+        </div>
+      </fieldset>
+    </form>
+    {{#if this.shouldDisplayFeedback}}
+      <div class="element-qcu-declarative__feedback" role="status" tabindex="-1">
+        {{htmlUnsafe this.selectedProposalFeedback}}
+      </div>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -22,6 +22,7 @@ export default class ModuleGrain extends Component {
     'flashcards',
     'image',
     'qcu',
+    'qcu-declarative',
     'qcm',
     'qrocm',
     'separator',

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -89,6 +89,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/element/flashcards/flashcards' as *;
 @use '../components/module/element/flashcards/flashcards-card' as *;
 @use '../components/module/element/image' as *;
+@use '../components/module/component/proposal-button' as *;
 @use '../components/module/element/qcu' as *;
 @use '../components/module/element/qcm' as *;
 @use '../components/module/element/qrocm' as *;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -91,6 +91,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/element/image' as *;
 @use '../components/module/component/proposal-button' as *;
 @use '../components/module/element/qcu' as *;
+@use '../components/module/element/qcu-declarative' as *;
 @use '../components/module/element/qcm' as *;
 @use '../components/module/element/qrocm' as *;
 @use '../components/module/element/separator' as *;

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -224,6 +224,26 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
   });
 
+  test('should display an element with a qcu declarative element', async function (assert) {
+    // given
+    const element = {
+      id: 'd0690f26-978c-41c3-9a21-da931857739c',
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'prop1' },
+        { id: '2', content: 'prop2' },
+      ],
+      type: 'qcu-declarative',
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.ok(screen.getByText('Il n’y a pas de bonne ou de mauvaise réponse.'));
+    assert.ok(screen.getByRole('button', { name: element.proposals[0].content }));
+  });
+
   test('should display an element with a qcm element', async function (assert) {
     // given
     const element = {

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -164,6 +164,33 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
+    module('when element is a qcu-declarative', function () {
+      test('should display qcu-declarative element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcuDeclarativeElement = {
+          instruction: 'instruction',
+          proposals: ['prop1', 'prop2'],
+          type: 'qcu-declarative',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: qcuDeclarativeElement }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.ok(screen.getByText('Il n’y a pas de bonne ou de mauvaise réponse.'));
+      });
+    });
+
     module('when element is a qrocm', function () {
       test('should display qrocm element', async function (assert) {
         // given

--- a/mon-pix/tests/integration/components/module/proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/proposal-button_test.gjs
@@ -1,0 +1,65 @@
+import { render } from '@1024pix/ember-testing-library';
+import ProposalButton from 'mon-pix/components/module/component/proposal-button';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | ProposalButton', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a button for given proposal', async function (assert) {
+    // given
+    const proposal = {
+      id: '1',
+      content: 'Avant de mettre le dentifrice',
+      feedback: {
+        state: '',
+        diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+      },
+    };
+
+    // when
+    const screen = await render(<template><ProposalButton @proposal={{proposal}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('button', { name: proposal.content }));
+  });
+
+  module('when proposal is disabled', function () {
+    test('should display a disabled button', async function (assert) {
+      const proposal = {
+        id: '1',
+        content: 'Avant de mettre le dentifrice',
+        feedback: {
+          state: '',
+          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+        },
+      };
+
+      // when
+      const screen = await render(<template><ProposalButton @proposal={{proposal}} @isDisabled={{true}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: proposal.content })).isDisabled();
+    });
+  });
+
+  module('when proposal is selected', function () {
+    test('should have a selected class', async function (assert) {
+      const proposal = {
+        id: '1',
+        content: 'Avant de mettre le dentifrice',
+        feedback: {
+          state: '',
+          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+        },
+      };
+
+      // when
+      const screen = await render(<template><ProposalButton @proposal={{proposal}} @isSelected={{true}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: proposal.content })).hasClass('proposal-button--selected');
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1715,6 +1715,10 @@
       "qcu": {
         "direction": "Select a single answer."
       },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Select a single answer.",
+        "direction": "There is no right or wrong answer."
+      },
       "qrocm": {
         "direction": "Fill in the {count, plural, =1 {blank} other {blanks}}."
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1700,6 +1700,10 @@
       "qcu": {
         "direction": "Seleccione una sola respuesta."
       },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Seleccione una sola respuesta.",
+        "direction": "There is no right or wrong answer."
+      },
       "qrocm": {
         "direction": "Rellena {count, plural, =1 {le champ vide} other {les champs vides}}."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1715,6 +1715,10 @@
       "qcu": {
         "direction": "Sélectionnez une seule réponse."
       },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Il n’y a pas de bonne ou de mauvaise réponse.",
+        "direction": "Sélectionnez une seule réponse."
+      },
       "qrocm": {
         "direction": "Remplissez {count, plural, =1 {le champ vide} other {les champs vides}}."
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1704,6 +1704,10 @@
       "qcu": {
         "direction": "Kies één antwoord"
       },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Kies één antwoord",
+        "direction": "There is no right or wrong answer."
+      },
       "qrocm": {
         "direction": "Vul de lege velden in."
       },


### PR DESCRIPTION
## 🌸 Problème

On crée un nouveau type de QCU avec son propre design et un feedback neutre. 
## 🌳 Proposition

- On crée les composants QCUDeclarative et ProposalButton.
- On a enlevé le bouton "Vérifier" pour dynamiser l'interface : on considère que l'utilisateur a répondu dès qu'il a cliqué sur une proposition.
 
## 🐝 Remarques
- Les composants ont des fichiers de style dans /mon-pix.

## 🤧 Pour tester
Aller sur le [module bac-a-sable](https://app-pr12308.review.pix.fr/modules/bac-a-sable/passage)
Tester la première question
* Un événement "QCU_DECLARATIVE_ANSWERED" doit partir dans la requête passage-events, avec le texte de la proposition sur laquelle on a cliqué 
* Les boutons doivent être disabled dès qu'on clique sur la réponse (vérifier la maquette)