### PR TITLE
[FEATURE] Améliorer le design des modules (PIX-17833)

### DIFF
--- a/mon-pix/app/components/module/element/_embed.scss
+++ b/mon-pix/app/components/module/element/_embed.scss
@@ -40,5 +40,6 @@
     width: 100%;
     height: 100%;
     background-color: var(--embed-overlay-color);
+    border-radius: var(--modulix-radius-xs);
   }
 }

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -78,12 +78,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     padding: var(--pix-spacing-6x);
     background: var(--modulix-challenge-card-background);
   }
-
-  &--transition {
-    @extend %pix-title-xs;
-
-    font-weight: var(--pix-font-medium);
-  }
 }
 
 .grain-card-content {

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -62,6 +62,11 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     padding: var(--pix-spacing-2x) 0;
     border-top: 0 solid var(--pix-neutral-100);
     border-radius: 0 0 $grain-card-border-radius $grain-card-border-radius;
+
+    &__with-skip-button {
+      display: flex;
+      justify-content: flex-end;
+    }
   }
 
   &--summary {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -222,7 +222,7 @@ export default class ModuleGrain extends Component {
         </div>
 
         {{#if this.shouldDisplaySkipButton}}
-          <footer class="grain-card__footer">
+          <footer class="grain-card__footer grain-card__footer__with-skip-button">
             <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}}>
               {{t "pages.modulix.buttons.grain.skip"}}
             </PixButton>

--- a/mon-pix/app/components/module/layout/navbar.gjs
+++ b/mon-pix/app/components/module/layout/navbar.gjs
@@ -1,4 +1,4 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixProgressBar from '@1024pix/pix-ui/components/pix-progress-bar';
 import PixSidebar from '@1024pix/pix-ui/components/pix-sidebar';
 import { fn } from '@ember/helper';
@@ -58,14 +58,11 @@ export default class ModulixNavbar extends Component {
       aria-label={{t "pages.modulix.flashcards.navigation.longCurrentStep" current=@currentStep total=@totalSteps}}
     >
       <div class="module-navbar__content">
-        <PixButton
+        <PixIconButton
           @triggerAction={{this.openSidebar}}
-          @iconBefore="book"
-          @variant="secondary"
-          aria-label={{t "pages.modulix.sidebar.button"}}
-        >
-          {{t "pages.modulix.flashcards.navigation.shortCurrentStep" current=@currentStep total=@totalSteps}}
-        </PixButton>
+          @iconName="book"
+          @ariaLabel={{t "pages.modulix.sidebar.button"}}
+        />
         <PixProgressBar @hidePercentage={{true}} @isDecorative={{true}} @value={{this.progressValue}} />
       </div>
     </nav>


### PR DESCRIPTION
## 🌸 Problème

Le design des modules peut être amélioré.

## 🌳 Proposition

L'améliorer.

## 🐝 Remarques

PR garantie 100% micro-commits.

## 🤧 Pour tester

Aller sur un module et constater que :

1. Le bouton "passer" à aligné à droite
2. Le texte des grains transition a le même style que les autres grains
3. Le nombre d'étapes n'apparaît plus dans le bouton de la sidebar
4. Les bordures des embed sont arrondies
5. Rien d'autre n'est cassé