### PR TITLE
[FEATURE] Modulix - QROCM : corriger choix input pour autoriser Number (PIX-17424)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -723,14 +723,14 @@
               {
                 "input": "pix-birth",
                 "type": "input",
-                "inputType": "text",
+                "inputType": "number",
                 "size": 10,
                 "display": "inline",
                 "placeholder": "",
                 "ariaLabel": "Année à trouver",
                 "defaultValue": "",
                 "tolerances": [],
-                "solutions": ["2016"]
+                "solutions": [2016]
               }
             ],
             "feedbacks": {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm-schema.js
@@ -16,7 +16,9 @@ const blockInputSchema = Joi.object({
     .unique()
     .items(Joi.string().valid('t1', 't2', 't3'))
     .required(),
-  solutions: Joi.array().items(Joi.string().min(1).required()).required(),
+  solutions: Joi.array()
+    .items(Joi.alternatives(Joi.string().min(1).required(), Joi.number().min(1).required()))
+    .required(),
 }).required();
 
 const blockSelectSchema = Joi.object({

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -107,8 +107,8 @@ export default class ModuleQrocm extends ModuleElement {
               {{htmlUnsafe block.content}}
             {{/if}}
             {{#if (eq block.type "input")}}
-              {{#if (eq block.inputType "text")}}
-                <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
+              <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
+                {{#if (eq block.inputType "text")}}
                   <PixInput
                     @type="text"
                     @value={{get this.selectedValues block.input}}
@@ -121,8 +121,21 @@ export default class ModuleQrocm extends ModuleElement {
                   >
                     <:label>{{block.ariaLabel}}</:label>
                   </PixInput>
-                </div>
-              {{/if}}
+                {{else if (eq block.inputType "number")}}
+                  <PixInput
+                    type="number"
+                    @value={{get this.selectedValues block.input}}
+                    @id={{block.input}}
+                    placeholder={{block.placeholder}}
+                    @screenReaderOnly={{true}}
+                    {{on "change" (fn this.onInputChanged block)}}
+                    size={{block.size}}
+                    readonly={{this.disableInput}}
+                  >
+                    <:label>{{block.ariaLabel}}</:label>
+                  </PixInput>
+                {{/if}}
+              </div>
             {{else if (eq block.type "select")}}
               <div class="element-qrocm-proposals__input element-qrocm-proposals__input--{{block.display}}">
                 <PixSelect

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -127,7 +127,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
         { content: '<span>Ma première proposition</span>', type: 'text' },
         {
           input: 'symbole',
-          inputType: 'text',
+          inputType: 'number',
           display: 'inline',
           size: 1,
           placeholder: '',
@@ -169,7 +169,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       }),
     );
     assert.dom(screen.getByText('Ma première proposition')).exists({ count: 1 });
-    assert.ok(screen.queryByRole('textbox', { name: 'input-aria' }));
+    assert.ok(screen.queryByRole('spinbutton', { name: 'input-aria' }));
     assert.ok(screen.queryByText("l'identifiant"));
     assert.dom('.element-qrocm-proposals__input--inline').exists({ count: 2 });
   });


### PR DESCRIPTION
## 🌸 Problème

Actuellement, si le QROCM a un input avec `inputType == number`, le input ne s’affichera pas à l'écran (j’ai testé avec le bac-a-sable dans cette branche)

## 🌳 Proposition

Permettre l'affichage d'un input de type number, avec les flèches pour diminuer/augmenter la valeur du nombre.

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Aller sur le [bac-a-sable](https://app-pr12312.review.pix.fr/modules/bac-a-sable/passage)
- Parcourir le module jusqu'au grain contenant l'instruction "Compléter le texte suivant :"
- Dans le second input, essayer de saisir des chaînes de caractère : cela ne doit pas être possible
- Vérifier qu'on peut répondre à la question
