### PR TITLE
[FEATURE] Permettre d'anonymiser au grain d'une campagne lors de la suppression de celle-ci (PIX-17847)

### DIFF
--- a/api/src/prescription/campaign/domain/models/Campaign.js
+++ b/api/src/prescription/campaign/domain/models/Campaign.js
@@ -89,7 +89,7 @@ class Campaign {
     return !this.archivedAt && !this.deletedAt;
   }
 
-  delete(userId) {
+  delete(userId, isAnonymizationWithDeletionEnabled = false) {
     if (this.deletedAt) {
       throw new DeletedCampaignError();
     }
@@ -99,6 +99,17 @@ class Campaign {
 
     this.deletedAt = new Date();
     this.deletedBy = userId;
+
+    if (isAnonymizationWithDeletionEnabled) {
+      this.name = '(anonymized)';
+      this.title = null;
+      this.customLandingPageText = null;
+      this.externalIdHelpImageUrl = null;
+      this.alternativeTextToExternalIdHelpImage = null;
+      this.customResultPageText = null;
+      this.customResultPageButtonText = null;
+      this.customResultPageButtonUrl = null;
+    }
   }
 
   archive(archivedAt, archivedBy) {

--- a/api/src/prescription/campaign/domain/models/CampaignsDestructor.js
+++ b/api/src/prescription/campaign/domain/models/CampaignsDestructor.js
@@ -42,9 +42,11 @@ class CampaignsDestructor {
       throw new ObjectValidationError('User does not have right to delete some campaigns.');
   }
 
-  delete() {
-    this.#campaignParticipationsToDelete.forEach((campaignParticipation) => campaignParticipation.delete(this.#userId));
-    this.#campaignsToDelete.forEach((campaign) => campaign.delete(this.#userId));
+  delete(isAnonymizationWithDeletionEnabled = false) {
+    this.#campaignParticipationsToDelete.forEach((campaignParticipation) =>
+      campaignParticipation.delete(this.#userId, isAnonymizationWithDeletionEnabled),
+    );
+    this.#campaignsToDelete.forEach((campaign) => campaign.delete(this.#userId, isAnonymizationWithDeletionEnabled));
   }
 
   get campaignParticipations() {

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -4,6 +4,7 @@ const deleteCampaigns = async ({
   userId,
   organizationId,
   campaignIds,
+  featureToggles,
   organizationMembershipRepository,
   campaignAdministrationRepository,
   campaignParticipationRepository,
@@ -12,6 +13,8 @@ const deleteCampaigns = async ({
   const campaignsToDelete = await campaignAdministrationRepository.getByIds(campaignIds);
   const campaignParticipationsToDelete = await campaignParticipationRepository.getByCampaignIds(campaignIds);
 
+  const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
+
   const campaignDestructor = new CampaignsDestructor({
     campaignsToDelete,
     campaignParticipationsToDelete,
@@ -19,10 +22,10 @@ const deleteCampaigns = async ({
     organizationId,
     membership,
   });
-  campaignDestructor.delete();
+  campaignDestructor.delete(isAnonymizationWithDeletionEnabled);
 
   await campaignParticipationRepository.batchUpdate(campaignParticipationsToDelete);
-  await campaignAdministrationRepository.batchUpdate(campaignsToDelete);
+  await campaignAdministrationRepository.remove(campaignsToDelete);
 };
 
 export { deleteCampaigns };

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -13,6 +13,7 @@ import * as userRepository from '../../../../identity-access-management/infrastr
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
+import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
@@ -86,7 +87,6 @@ const dependencies = {
   campaignAssessmentParticipationResultListRepository,
   campaignCollectiveResultRepository,
   campaignCreatorRepository,
-
   campaignManagementRepository,
   campaignParticipantActivityRepository,
   campaignParticipationInfoRepository,
@@ -100,6 +100,7 @@ const dependencies = {
   codeGenerator,
   competenceRepository,
   divisionRepository,
+  featureToggles,
   groupRepository,
   knowledgeElementRepository,
   knowledgeElementSnapshotRepository,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -94,10 +94,6 @@ const _update = async function (campaign, attributes) {
   return new Campaign(editedCampaign);
 };
 
-const batchUpdate = async function (campaigns) {
-  return Promise.all(campaigns.map((campaign) => update(campaign)));
-};
-
 const save = async function (campaigns, dependencies = { skillRepository }) {
   const trx = await knex.transaction();
   const campaignsToCreate = _.isArray(campaigns) ? campaigns : [campaigns];

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -64,10 +64,31 @@ const get = async function (id) {
 };
 
 const update = async function (campaign) {
+  return _update(campaign, CAMPAIGN_ATTRIBUTES);
+};
+
+const CAMPAIGN_DELETION_ATTRIBUTES = [
+  'name',
+  'title',
+  'customLandingPageText',
+  'externalIdHelpImageUrl',
+  'alternativeTextToExternalIdHelpImage',
+  'customResultPageText',
+  'customResultPageButtonText',
+  'customResultPageButtonUrl',
+  'deletedAt',
+  'deletedBy',
+];
+
+const remove = async function (campaigns) {
+  return Promise.all(campaigns.map((campaign) => _update(campaign, CAMPAIGN_DELETION_ATTRIBUTES)));
+};
+
+const _update = async function (campaign, attributes) {
   const knexConn = DomainTransaction.getConnection();
   const [editedCampaign] = await knexConn('campaigns')
     .where({ id: campaign.id })
-    .update(_.pick(campaign, CAMPAIGN_ATTRIBUTES))
+    .update(_.pick(campaign, attributes))
     .returning('*');
 
   return new Campaign(editedCampaign);
@@ -173,12 +194,12 @@ const archiveCampaigns = function (campaignIds, userId) {
 
 export {
   archiveCampaigns,
-  batchUpdate,
   get,
   getByCode,
   getByIds,
   isCodeAvailable,
   isFromSameOrganization,
+  remove,
   save,
   swapCampaignCodes,
   update,

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | delete-campaign', function () {
@@ -42,20 +43,69 @@ describe('Integration | UseCases | delete-campaign', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
-      const campaignId = databaseBuilder.factory.buildCampaign({ ownerId: userId, organizationId }).id;
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        ownerId: userId,
+        organizationId,
+        name: 'nom de campagne',
+        title: 'titre de campagne',
+      }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        participantExternalId: 'externalId',
+      });
+      await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
 
       await databaseBuilder.commit();
 
+      // when
       await usecases.deleteCampaigns({ userId, organizationId, campaignIds: [campaignId] });
       const updatedCampaign = await campaignAdministrationRepository.get(campaignId);
-      const updatedCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+      const updatedCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId.id);
 
-      // when & then
+      // then
       expect(updatedCampaign.deletedAt).to.deep.equal(now);
       expect(updatedCampaign.deletedBy).to.equal(userId);
+      expect(updatedCampaign.name).to.equal('nom de campagne');
+      expect(updatedCampaign.title).to.equal('titre de campagne');
+      expect(updatedCampaignParticipation.participantExternalId).to.equal('externalId');
+      expect(updatedCampaignParticipation.userId).to.equal(campaignParticipationId.userId);
       expect(updatedCampaignParticipation.deletedAt).to.deep.equal(now);
       expect(updatedCampaignParticipation.deletedBy).to.equal(userId);
+    });
+
+    it('should also anonymize when flag is true', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        ownerId: userId,
+        organizationId,
+        name: 'nom de campagne',
+        title: 'titre de campagne',
+      }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        participantExternalId: 'externalId',
+      });
+      await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
+
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.deleteCampaigns({ userId, organizationId, campaignIds: [campaignId] });
+      const updatedCampaign = await campaignAdministrationRepository.get(campaignId);
+      const updatedCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId.id);
+
+      // then
+      expect(updatedCampaign.deletedAt).to.deep.equal(now);
+      expect(updatedCampaign.deletedBy).to.equal(userId);
+      expect(updatedCampaign.name).to.equal('(anonymized)');
+      expect(updatedCampaign.title).to.be.null;
+      expect(updatedCampaignParticipation.deletedAt).to.deep.equal(now);
+      expect(updatedCampaignParticipation.deletedBy).to.equal(userId);
+      expect(updatedCampaignParticipation.participantExternalId).to.be.null;
+      expect(updatedCampaignParticipation.userId).to.be.null;
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -717,46 +717,6 @@ describe('Integration | Repository | Campaign Administration', function () {
     });
   });
 
-  describe('#batchUpdate', function () {
-    let clock;
-    const frozenTime = new Date('1992-07-07');
-
-    beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
-    it('should update campaigns', async function () {
-      const user = databaseBuilder.factory.buildUser();
-      const firstCampaign = new Campaign(databaseBuilder.factory.buildCampaign());
-      const secondCampaign = new Campaign(databaseBuilder.factory.buildCampaign());
-
-      await databaseBuilder.commit();
-      // given
-      firstCampaign.delete(user.id);
-      secondCampaign.delete(user.id);
-
-      // when
-      await campaignAdministrationRepository.batchUpdate([firstCampaign, secondCampaign]);
-
-      const firstCampaignUpdated = await campaignAdministrationRepository.get(firstCampaign.id);
-      const secondCampaignUpdated = await campaignAdministrationRepository.get(secondCampaign.id);
-
-      // then
-      expect(firstCampaignUpdated).to.deep.include({
-        deletedAt: frozenTime,
-        deletedBy: user.id,
-      });
-      expect(secondCampaignUpdated).to.deep.include({
-        deletedAt: frozenTime,
-        deletedBy: user.id,
-      });
-    });
-  });
-
   describe('#update', function () {
     let campaign;
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -831,6 +831,108 @@ describe('Integration | Repository | Campaign Administration', function () {
     });
   });
 
+  describe('#remove', function () {
+    let campaign, userId;
+    let clock;
+    const frozenTime = new Date('1992-07-07');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
+
+      campaign = new Campaign(
+        databaseBuilder.factory.buildCampaign({
+          name: 'Campaign name',
+          title: 'Campaign title',
+          customLandingPageText: 'customLandingPageText',
+          externalIdHelpImageUrl: 'externalIdHelpImageUrl',
+          alternativeTextToExternalIdHelpImage: 'alternativeTextToExternalIdHelpImage',
+          customResultPageText: 'customResultPageText',
+          customResultPageButtonText: 'customResultPageButtonText',
+          customResultPageButtonUrl: 'customResultPageButtonUrl',
+          multipleSendings: true,
+          isForAbsoluteNovice: false,
+        }),
+      );
+      userId = databaseBuilder.factory.buildUser().id;
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should remove the correct campaign', async function () {
+      // given
+      const isAnonymizationWithDeletionEnabled = true;
+      campaign.delete(userId, isAnonymizationWithDeletionEnabled);
+
+      const anotherCampaign = databaseBuilder.factory.buildCampaign({
+        name: 'Another Campaign',
+        title: 'Another title',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await campaignAdministrationRepository.remove([campaign]);
+
+      // then
+      const removedCampaign = await knex.from('campaigns').where({ id: campaign.id }).first();
+      const notRemovedCampaign = await knex.from('campaigns').where({ id: anotherCampaign.id }).first();
+
+      expect(removedCampaign.name).to.equal('(anonymized)');
+      expect(removedCampaign.deletedAt).to.deep.equal(frozenTime);
+      expect(removedCampaign.deletedBy).to.equal(userId);
+      expect(notRemovedCampaign.name).to.equal('Another Campaign');
+      expect(notRemovedCampaign.title).to.equal('Another title');
+      expect(notRemovedCampaign.deletedBy).to.be.null;
+      expect(notRemovedCampaign.deletedAt).to.be.null;
+    });
+
+    it('should remove campaign deletion attributes fields', async function () {
+      // given
+      const isAnonymizationWithDeletionEnabled = true;
+
+      campaign.delete(userId, isAnonymizationWithDeletionEnabled);
+
+      // when
+      await campaignAdministrationRepository.remove([campaign]);
+      const campaignRemoved = await knex.from('campaigns').where({ id: campaign.id }).first();
+
+      // then
+      expect(campaignRemoved.id).to.equal(campaign.id);
+      expect(campaignRemoved.name).to.equal('(anonymized)');
+      expect(campaignRemoved.title).to.be.null;
+      expect(campaignRemoved.customLandingPageText).to.be.null;
+      expect(campaignRemoved.alternativeTextToExternalIdHelpImage).to.be.null;
+      expect(campaignRemoved.customResultPageText).to.be.null;
+      expect(campaignRemoved.customResultPageButtonText).to.be.null;
+      expect(campaignRemoved.customResultPageButtonUrl).to.be.null;
+      expect(campaignRemoved.deletedBy).to.equal(userId);
+      expect(campaignRemoved.deletedAt).to.deep.equal(frozenTime);
+    });
+
+    it('should not update other fields', async function () {
+      // given
+      const isAnonymizationWithDeletionEnabled = true;
+
+      campaign.updateFields({
+        multipleSendings: false,
+        type: 'PROFILE_COLLECTION',
+      });
+      campaign.delete(userId, isAnonymizationWithDeletionEnabled);
+
+      // when
+      await campaignAdministrationRepository.remove([campaign]);
+      const campaignRemoved = await knex.from('campaigns').where({ id: campaign.id }).first();
+
+      // then
+      expect(campaignRemoved.id).to.equal(campaign.id);
+      expect(campaignRemoved.multipleSendings).to.be.true;
+      expect(campaignRemoved.type).to.equal('ASSESSMENT');
+    });
+  });
+
   describe('#swapCampaignCode', function () {
     it('should swap campaigns codes', async function () {
       const { code: firstCode, id: firstCampaignId } = databaseBuilder.factory.buildCampaign({ code: 'ABCDEFG' });

--- a/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
@@ -52,11 +52,22 @@ describe('Campaign', function () {
 
   describe('#delete', function () {
     it('deletes the campaign', function () {
-      const campaign = new Campaign({ id: 1, code: 'ABC123' });
+      // given
+      const campaign = new Campaign({ id: 1, code: 'ABC123', name: 'Nom de Campagne', title: 'Titre de campagne' });
+      const isAnonymizationWithDeletionEnabled = false;
 
-      campaign.delete(1);
+      // when
+      campaign.delete(777, isAnonymizationWithDeletionEnabled);
 
-      expect(campaign).to.deep.includes({ id: 1, code: 'ABC123', deletedAt: now, deletedBy: 1 });
+      // then
+      expect(campaign).to.deep.includes({
+        id: 1,
+        code: 'ABC123',
+        name: 'Nom de Campagne',
+        title: 'Titre de campagne',
+        deletedAt: now,
+        deletedBy: 777,
+      });
     });
 
     context('when the campaign is already deleted', function () {
@@ -76,6 +87,36 @@ describe('Campaign', function () {
         const error = await catchErr(campaign.delete, campaign)();
 
         expect(error).to.be.an.instanceOf(ObjectValidationError);
+      });
+    });
+
+    context('when anonymization flag is true', function () {
+      it('anonymize datas', async function () {
+        // given
+        const campaign = new Campaign({
+          name: 'Ma campagne',
+          title: 'Title',
+          customLandingPageText: 'customLandingPageText',
+          externalIdHelpImageUrl: 'externalIdHelpImageUrl',
+          alternativeTextToExternalIdHelpImage: 'alternativeTextToExternalIdHelpImage',
+          customResultPageText: 'customResultPageText',
+          customResultPageButtonText: 'customResultPageButtonText',
+          customResultPageButtonUrl: 'customResultPageButtonUrl',
+        });
+        const isAnonymizationWithDeletionEnabled = true;
+
+        // when
+        campaign.delete(1, isAnonymizationWithDeletionEnabled);
+
+        // then
+        expect(campaign.name).to.equal('(anonymized)');
+        expect(campaign.title).to.be.null;
+        expect(campaign.customLandingPageText).to.be.null;
+        expect(campaign.externalIdHelpImageUrl).to.be.null;
+        expect(campaign.alternativeTextToExternalIdHelpImage).to.be.null;
+        expect(campaign.customResultPageText).to.be.null;
+        expect(campaign.customResultPageButtonText).to.be.null;
+        expect(campaign.customResultPageButtonUrl).to.be.null;
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignsDestructor_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignsDestructor_test.js
@@ -64,7 +64,7 @@ describe('CampaignsDestructor', function () {
     it('deletes campaigns and campaign participations', function () {
       const participations = [new CampaignParticipation()];
       const organizationId = 7;
-      const campaigns = [new Campaign({ organizationId })];
+      const campaigns = [new Campaign({ organizationId, name: 'Ma campagne' })];
 
       const destructor = new CampaignsDestructor({
         userId: 1,
@@ -77,7 +77,29 @@ describe('CampaignsDestructor', function () {
       destructor.delete();
 
       expect(destructor.campaigns[0].isDeleted).to.be.true;
+      expect(destructor.campaigns[0].name).to.equal('Ma campagne');
       expect(destructor.campaignParticipations[0].isDeleted).to.be.true;
+    });
+
+    it('should anonymize when flag is true', function () {
+      const participations = [new CampaignParticipation({ participantExternalId: 'externalId', userId: 'userId' })];
+      const organizationId = 7;
+      const campaigns = [new Campaign({ organizationId, name: 'Ma campagne', title: 'Mon titre' })];
+      const isAnonymizationWithDeletionEnabled = true;
+      const destructor = new CampaignsDestructor({
+        userId: 1,
+        organizationId,
+        membership: new OrganizationMembership({ isAdmin: true }),
+        campaignsToDelete: campaigns,
+        campaignParticipationsToDelete: participations,
+      });
+
+      destructor.delete(isAnonymizationWithDeletionEnabled);
+
+      expect(destructor.campaigns[0].name).to.equal('(anonymized)');
+      expect(destructor.campaigns[0].title).to.be.null;
+      expect(destructor.campaignParticipations[0].userId).to.be.null;
+      expect(destructor.campaignParticipations[0].participantExternalId).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## 🌸 Problème
Suite de notre EPIX concernant l'anonymisation. 
On souhaite pouvoir anonymiser les données de la campagne lors de la suppression de celle ci

## 🌳 Proposition
Mettre les colonnes définies dans la documentation a null, et mettre le nom de la campagne à : '(anonymized)'

## 🐝 Remarques


## 🤧 Pour tester
- Supprimer une campagne via PixOrga avec le flag a false pour commencer
- Vérifier en base que seules les colonnes `deletedAt` & `deletedBy` sont mises a jour
- Mettre le flag a true
- `scalingo -a pix-api-review-pr12313 run npm run toggles -- -k isAnonymizationWithDeletionEnabled -v true`
- Supprimer une campagne depuis PixOrga
- Vérifier en base que cette fois, dans la table `campaign` les colonnes `idPixLabel, title, customLandingPage, externalIdHelpImageUrl, alternativeTextToExternalIdHelpImage, customResultPageText, customResultPageButtonText, customResultPageButtonUrl` sont à `null` et que la colonne `name` est à `(anonymized)`
- Vérifier que les autres colonnes n'ont pas bougées
- 🐈‍⬛ 