### PR TITLE
[TECH] Correction de deprecation SCSS dans Pix Orga

### DIFF
--- a/orga/app/styles/components/campaign/charts/campaign-badge-acquisitions.scss
+++ b/orga/app/styles/components/campaign/charts/campaign-badge-acquisitions.scss
@@ -2,32 +2,32 @@
 @use 'pix-design-tokens/breakpoints';
 
 .badge-acquisitions {
+  width: 100%;
+
   @include breakpoints.device-is('desktop') {
     width: calc(53% - var(--pix-spacing-6x));
   }
 
-  width: 100%;
-
   &__list {
-  display: grid;
-  grid-row-gap: var(--pix-spacing-1x);
-  grid-column-gap: var(--pix-spacing-4x);
-  grid-template-rows: repeat(1, 1fr);
-  grid-template-columns: repeat(2, 1fr);
-  width: fit-content;
+    display: grid;
+    grid-row-gap: var(--pix-spacing-1x);
+    grid-column-gap: var(--pix-spacing-4x);
+    grid-template-rows: repeat(1, 1fr);
+    grid-template-columns: repeat(2, 1fr);
+    width: fit-content;
 
-  li:nth-child(4n) {
-    flex-basis: 100%;
-}
-}
+    li:nth-child(4n) {
+      flex-basis: 100%;
+    }
+  }
 
-&__count{
-  @extend %pix-title-xs;
-}
+  &__count{
+    @extend %pix-title-xs;
+  }
 
-&__percentage {
-  @extend %pix-body-xs;
-}
+  &__percentage {
+    @extend %pix-body-xs;
+  }
 
   &__list-item {
     display: flex;
@@ -41,5 +41,5 @@
       height: 36px;
     }
 
-    }
+  }
 }

--- a/orga/app/styles/components/campaign/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-stage.scss
@@ -35,11 +35,11 @@
   }
 
   &__container {
+    flex-grow: 1;
+
     @include breakpoints.device-is('mobile') {
       display: none;
     }
-
-    flex-grow: 1;
 
     .pix-tooltip__content {
       left: 0;

--- a/orga/app/styles/components/campaign/charts/results-distribution.scss
+++ b/orga/app/styles/components/campaign/charts/results-distribution.scss
@@ -1,15 +1,15 @@
 @use 'pix-design-tokens/breakpoints';
 
 .stats {
-  @include breakpoints.device-is('desktop') {
-    flex-direction: row;
-  }
-
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-6x);
   align-items: stretch;
   margin-bottom: var(--pix-spacing-6x);
+
+  @include breakpoints.device-is('desktop') {
+    flex-direction: row;
+  }
 }
 
 .participants {


### PR DESCRIPTION
## 🌸 Problème

A build de Pix Orga, il y a des warning de dépréciation SCSS

> Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.
> More info: https://sass-lang.com/d/mixed-decls

## 🌳 Proposition

Appliquer la modification de base qui consiste à définir les propriétés de la classe avant les propriétés nestée. (voir https://sass-lang.com/d/mixed-decls) 

## 🤧 Pour tester

Lancer `npm run dev`, il n'y a plus les warning scss 👍

![image](https://github.com/user-attachments/assets/8d0f3469-a05c-43c6-b854-26e82b4cc8bf)

J'ai du mal à identifier s'il y a un impact sur l'UI (@1024pix/team-prescription vous pouvez m'aider?)
