### PR TITLE
[TECH] Utiliser une variable d'environnement classique pour la route du bouton magique

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -802,13 +802,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # FEATURE TOGGLES
 # ===================
 
-# Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=false
-
 # Control the scope of certification result tokens
 #
 # presence: optional
@@ -1099,3 +1092,12 @@ EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN=3d
 # type: Integer
 # default: 4
 DAY_BEFORE_RETRYING=
+
+# ====
+# Routes for specific usages
+# Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint
+#
+# presence: optional
+# type: boolean
+# default: false
+# ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT_ENABLED=false

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -6,7 +6,7 @@ import { config } from '../../config.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import { assessmentController } from './assessment-controller.js';
 
-const { featureToggles } = config;
+const { endpoints } = config;
 
 const register = async function (server) {
   const routes = [
@@ -146,7 +146,7 @@ const register = async function (server) {
     },
   ];
 
-  if (featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled) {
+  if (endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled) {
     routes.push({
       method: 'POST',
       path: '/api/admin/assessments/{id}/always-ok-validate-next-challenge',

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -295,9 +295,6 @@ const configuration = (function () {
     },
     featureToggles: {
       deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
-      isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
-        process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
-      ),
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
@@ -465,6 +462,11 @@ const configuration = (function () {
     autonomousCourse: {
       autonomousCoursesOrganizationId: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
     },
+    endpoints: {
+      isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
+        process.env.ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT_ENABLED,
+      ),
+    },
   };
 
   if (process.env.NODE_ENV === 'test') {
@@ -519,7 +521,6 @@ const configuration = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
-    config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isDirectMetricsEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
@@ -626,6 +627,7 @@ const configuration = (function () {
     config.apiManager.url = 'http://external-partners-access/';
 
     config.infra.engineeringUserId = 800;
+    config.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
   }
 
   return config;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -51,16 +51,12 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
   let assessmentId;
 
   beforeEach(async function () {
-    originalEnvValue = settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled;
-    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
+    originalEnvValue = settings.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled;
+    settings.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
 
     server = await createServer();
     const learningContentObjects = learningContentBuilder(learningContent);
     await mockLearningContent(learningContentObjects);
-  });
-
-  afterEach(function () {
-    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
   });
 
   describe('POST /api/admin/assessments/:id/always-ok-validate-next-challenge', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-route-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-route-auto-validate-next-challenge_test.js
@@ -46,12 +46,10 @@ const learningContent = [
 ];
 
 describe('Acceptance | API | assessment-controller-auto-validate-next-challenge', function () {
-  let originalEnvValue;
   let server;
   let assessmentId;
 
   beforeEach(async function () {
-    originalEnvValue = settings.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled;
     settings.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
 
     server = await createServer();

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'deprecate-pole-emploi-push-notification': false,
             'dynamic-feature-toggle-system': false,
-            'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-direct-metrics-enabled': false,
             'is-new-account-recovery-enabled': false,

--- a/api/tests/shared/unit/application/assessements/index_test.js
+++ b/api/tests/shared/unit/application/assessements/index_test.js
@@ -135,6 +135,7 @@ describe('Unit | Application | Router | assessment-router', function () {
 
     it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {
       // given
+      settings.endpoints.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
       sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
         h
           .response({ errors: new Error('Unauthorized') })


### PR DESCRIPTION
## 🌸 Problème

Il a été décidé de ne plus utiliser un feature toggle pour le bouton magique. En effet la migration vers le nouveau système ne permet pas d'avoir une route montable de manière optimale et une bonne utilisation de ce système de feature toggle.

## 🌳 Proposition

Déplacer cette variable en variable d'environnement classique, nécessitant un redémarrage après modification.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

Modifier la valeur de la variable ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT_ENABLED et constater (après redémarrage), que le bouton fonctionne ou non en fonction de la valeur de la variable.
