### PR TITLE
[TECH] Remplacer inject par service de l'import @ember/service

### DIFF
--- a/admin/app/components/certification-centers/information-edit.gjs
+++ b/admin/app/components/certification-centers/information-edit.gjs
@@ -5,7 +5,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import pick from 'ember-composable-helpers/helpers/pick';

--- a/admin/app/services/current-user.js
+++ b/admin/app/services/current-user.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CurrentUserService extends Service {

--- a/admin/app/services/feature-toggles.js
+++ b/admin/app/services/feature-toggles.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
   @service store;

--- a/admin/app/services/oidc-identity-providers.js
+++ b/admin/app/services/oidc-identity-providers.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class OidcIdentityProviders extends Service {
   @service store;

--- a/admin/app/services/request-manager-handlers/auth-handler.js
+++ b/admin/app/services/request-manager-handlers/auth-handler.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Request manager handler adding authentication credentials in the request.

--- a/admin/app/services/request-manager-handlers/locale-handler.js
+++ b/admin/app/services/request-manager-handlers/locale-handler.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const FRENCH_FRANCE_LOCALE = 'fr-fr';
 

--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import ENV from 'pix-admin/config/environment';
 
 export default class Url extends Service {

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CurrentUserService extends Service {

--- a/certif/app/services/feature-toggles.js
+++ b/certif/app/services/feature-toggles.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
   @service store;

--- a/certif/app/services/features.js
+++ b/certif/app/services/features.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class FeaturesService extends Service {
   @service store;

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import config from 'pix-certif/config/environment';
 import languages from 'pix-certif/languages';
 

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import ENV from 'pix-certif/config/environment';
 
 export default class Url extends Service {

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -1,6 +1,6 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -4,7 +4,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import PixStars from '@1024pix/pix-ui/components/pix-stars';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -4,7 +4,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -1,5 +1,5 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -1,7 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';

--- a/mon-pix/app/components/global/app-layout.gjs
+++ b/mon-pix/app/components/global/app-layout.gjs
@@ -1,5 +1,5 @@
 import PixAppLayout from '@1024pix/pix-ui/components/pix-app-layout';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/components/global/app-main-header.gjs
+++ b/mon-pix/app/components/global/app-main-header.gjs
@@ -1,6 +1,6 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { LinkTo } from '@ember/routing';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/components/global/app-navigation.gjs
+++ b/mon-pix/app/components/global/app-navigation.gjs
@@ -2,7 +2,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNavigation from '@1024pix/pix-ui/components/pix-navigation';
 import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
 import PixNavigationSeparator from '@1024pix/pix-ui/components/pix-navigation-separator';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 

--- a/mon-pix/app/services/authentication.js
+++ b/mon-pix/app/services/authentication.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import get from 'lodash/get';
 
 const ALLOWED_ROUTES_FOR_ANONYMOUS_ACCESS = [

--- a/mon-pix/app/services/competence-evaluation.js
+++ b/mon-pix/app/services/competence-evaluation.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class CompetenceEvaluationService extends Service {
   @service store;

--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class CurrentUserService extends Service {
   @service session;

--- a/mon-pix/app/services/error-messages.js
+++ b/mon-pix/app/services/error-messages.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import get from 'lodash/get';
 
 const ERROR_CODE_MAPPING = {

--- a/mon-pix/app/services/feature-toggles.js
+++ b/mon-pix/app/services/feature-toggles.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
   @service store;

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import config from 'mon-pix/config/environment';
 import languages from 'mon-pix/languages';
 

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 // TODO: Manage this through the API
 const FR_FEATURED_IDENTITY_PROVIDER_CODE = 'POLE_EMPLOI';

--- a/mon-pix/app/services/request-manager-handlers/auth-handler.js
+++ b/mon-pix/app/services/request-manager-handlers/auth-handler.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Request manager handler adding authentication credentials in the request.

--- a/mon-pix/app/services/request-manager-handlers/locale-handler.js
+++ b/mon-pix/app/services/request-manager-handlers/locale-handler.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const FRENCH_FRANCE_LOCALE = 'fr-fr';
 

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';

--- a/mon-pix/app/templates/application.gjs
+++ b/mon-pix/app/templates/application.gjs
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';


### PR DESCRIPTION
## 🌸 Problème

Depuis Ember 4.1, l'import de `inject` depuis `@ember/service` est déprécié:
https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

## 🌳 Proposition

Remplacer l'import depuis `@ember/service` de `inject` par `service` dans les projets fronts qui ont toujours cette depreciation:
- certif
- admin
- mon-pix

orga et junior ont déjà cette depréciation de résolue.

## 🤧 Pour tester

L'exécution de la CI devrait suffire pour ce type de modification.
