### PR TITLE
[BUGFIX] Pix Junior - Bouton hors du cadre des cartes de mission (PIX-17854)

### DIFF
--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -89,6 +89,7 @@
 
       .mission-name {
         @extend %pix-title-xs;
+
         min-height: 62px;
         margin-bottom: var(--pix-spacing-3x);
         text-align: center;

--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -1,4 +1,5 @@
 @use '../../globals/fonts';
+@use 'pix-design-tokens/typography';
 
 .mission-card {
   &__container {
@@ -87,11 +88,9 @@
       margin-top: var(--pix-spacing-2x);
 
       .mission-name {
+        @extend %pix-title-xs;
         min-height: 62px;
         margin-bottom: var(--pix-spacing-3x);
-        font-weight: 800;
-        font-size: 22.38px;
-        line-height: normal;
         text-align: center;
 
         p {


### PR DESCRIPTION
## 🌸 Problème

Le bouton "Commencer" sort du cadre des cartes de mission si le titre est trop long.
<img width="267" alt="Capture d’écran 2025-05-19 à 11 07 03" src="https://github.com/user-attachments/assets/a161a4e4-c856-47bd-b356-6b7c23f3d2f6" />


## 🌳 Proposition

Réduire la taille de la police pour permettre d'afficher des titres de mission longs sans repousser le bouton hors du cadre.

## 🤧 Pour tester

Accéder à la page d'accueil d'une école.
Le bouton de la mission "Organiser des fichiers et des dossier" est bien dans le cadre.
