### PR TITLE
[BUGFIX] Mauvais wording lors du signalement d'une épreuve avec pièce jointe (PIX-17677)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -998,7 +998,7 @@
                   },
                   "open-failure": {
                     "label": "I cannot open the file on a computer",
-                    "solution": "If you are unable to open a file, consult the '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'help'</a>' located under the “download” button. You'll find recommended software or online tools."
+                    "solution": "If you are unable to open a file, consult the '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'help'</a>' located under the “download” button. This is where you will find the recommended software or online tools to use."
                   },
                   "other": "I have another problem with the file"
                 },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -998,7 +998,7 @@
                   },
                   "open-failure": {
                     "label": "I cannot open the file on a computer",
-                    "solution": "To answer this question, you need to use the LibreOffice suite, which is available free-of-charge for PC and Mac. It contains Libre Office Writer (equivalent to Word) and Libre Office Calc (equivalent to Excel).'<a href=\"https://www.libreoffice.org/download/download\">'Download Libre Office'</a>'"
+                    "solution": "If you are unable to open a file, consult the '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'help'</a>' located under the “download” button. You'll find recommended software or online tools."
                   },
                   "other": "I have another problem with the file"
                 },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -996,7 +996,7 @@
                   },
                   "open-failure": {
                     "label": "No puedo abrir el archivo en un ordenador",
-                    "solution": "Para superar esta prueba, puedes utilizar la suite LibreOffice, gratuita y disponible para PC y Mac. Contiene Libre Office Writer (equivalente a Word) y Libre Office Calc (equivalente a Excel).'<a href=\"https://fr.libreoffice.org/download/telecharger-libreoffice\">'Descargar Libre Office'</a>'"
+                    "solution": "Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas."
                   }
                 },
                 "embed-displayed-on-desktop-with-problems": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -998,7 +998,7 @@
                   },
                   "open-failure": {
                     "label": "Je n’arrive pas à ouvrir le fichier sur un ordinateur",
-                    "solution": "Si vous n’arrivez pas à ouvrir un fichier, consultez'<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'l'aide située sous le bouton « Télécharger »'</a>'. Vous trouverez les logiciels ou outils en ligne recommandés."
+                    "solution": "Si vous n’arrivez pas à ouvrir un fichier, consultez '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'l'aide située sous le bouton « Télécharger »'</a>'. Vous y trouverez les logiciels ou outils en ligne recommandés."
                   },
                   "other": "J’ai un autre problème avec le fichier"
                 },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -998,7 +998,7 @@
                   },
                   "open-failure": {
                     "label": "Je n’arrive pas à ouvrir le fichier sur un ordinateur",
-                    "solution": "Pour réussir cette épreuve, vous pouvez utiliser la suite LibreOffice, gratuite et disponible pour PC et Mac. Elle contient Libre Office Writer (équivalent à Word) et Libre Office Calc (équivalent à Excel).'<a href=\"https://fr.libreoffice.org/download/telecharger-libreoffice\">'Télécharger Libre Office'</a>'"
+                    "solution": "Si vous n’arrivez pas à ouvrir un fichier, consultez'<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'l'aide située sous le bouton « Télécharger »'</a>'. Vous trouverez les logiciels ou outils en ligne recommandés."
                   },
                   "other": "J’ai un autre problème avec le fichier"
                 },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1000,7 +1000,7 @@
                   },
                   "open-failure": {
                     "label": "Ik kan het bestand niet openen op een computer",
-                    "solution": "Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen."
+                    "solution": "Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen."
                   }
                 },
                 "embed-displayed-on-desktop-with-problems": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1000,7 +1000,7 @@
                   },
                   "open-failure": {
                     "label": "Ik kan het bestand niet openen op een computer",
-                    "solution": "Om voor deze test te slagen, kun je de LibreOffice-suite gebruiken, die gratis is en beschikbaar voor pc's en Macs. Het bevat Libre Office Writer (gelijkwaardig aan Word) en Libre Office Calc (gelijkwaardig aan Excel).'<a href=\"https://fr.libreoffice.org/download/telecharger-libreoffice\">'Download Libre Office'</a>'"
+                    "solution": "Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen."
                   }
                 },
                 "embed-displayed-on-desktop-with-problems": {


### PR DESCRIPTION
## 🌸 Problème

Mauvais wording lors du signalement d'une épreuve avec pièce jointe

## 🌳 Proposition

Changer le wording lié à la clé pages.challenge.feedback-panel.form.fields.detail-selection.options.download.open-failure.solution (qui s’affiche si on signale qu’on a un problème sur un fichier à télécharger et qu’on n’arrive pas à l’ouvrir)

afin d’afficher en français : 
Si vous n’arrivez pas à ouvrir un fichier, consultez '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\">'l'aide située sous le bouton « Télécharger »'</a>'. Vous y trouverez les logiciels ou outils en ligne recommandés.

en anglais : 
If you are unable to open a file, consult the '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">'help'</a>' located under the “download” button. This is where you will find the recommended software or online tools to use.


en néerlandais : 
Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen.

en espagnol : 
Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas.


## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Afficher une épreuve, signaler qu’on a un problème sur un fichier à télécharger et qu’on n’arrive pas à l’ouvrir et regarder l'encadré.
Renouveler le test pour chaque langue FR / EN / NL / ES