### PR TITLE
[FEATURE] Ajouter une colone createdBy à la table certification-centers (PIX-17899)

### DIFF
--- a/api/db/migrations/20250519100538_add-createdBy-column-to-certification-centers-table.js
+++ b/api/db/migrations/20250519100538_add-createdBy-column-to-certification-centers-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'createdBy';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.bigInteger(COLUMN_NAME).references('users.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-for-admin.repository.test.js
@@ -64,7 +64,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
 
       // then
       const updatedCertificationCenter = await knex('certification-centers').select().where({ id: center.id }).first();
-      expect(_.omit(updatedCertificationCenter, 'isV3Pilot')).to.deep.equal({
+      expect(_.omit(updatedCertificationCenter, 'isV3Pilot', 'createdBy')).to.deep.equal({
         ...center,
         name: 'Great Oak Certification Center',
         updatedAt: updatedCertificationCenter.updatedAt,
@@ -105,7 +105,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       const nonArchivedCertificationCenter = await knex('certification-centers')
         .where({ id: otherCertificationCenter.id })
         .first();
-      expect(_.omit(nonArchivedCertificationCenter, 'isV3Pilot')).to.deep.equal(
+      expect(_.omit(nonArchivedCertificationCenter, 'isV3Pilot', 'createdBy')).to.deep.equal(
         _.omit(otherCertificationCenter, 'isV3Pilot'),
       );
     });


### PR DESCRIPTION
## 🌸 Problème

On souhaiterais savoir quel utilisateur a créé un centre de certification.

## 🌳 Proposition

Ajouter à la table certification-centers, une colone createdBy qui stoque l'identifiant du créateur du centre de certification.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Tester la migration et le roolback avec:
```shell
npm run db:migrate
npm run db:rollback:latest
```
