### PR TITLE
[BUGFIX] Changer le déclencheur de l'action

### DIFF
--- a/.github/workflows/create-jira-version.yaml
+++ b/.github/workflows/create-jira-version.yaml
@@ -1,21 +1,14 @@
 name: Create Jira Version
 
 on:
-  push:
-    tags:
-      - '*' 
+  release:
+    types: [published]
 
 jobs:
   create-jira-version:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get tag name and current date
-        run: |
-          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-
-
       - name: Create version in Jira
         run: |
           AUTH_HEADER=$(echo -n "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" | base64)
@@ -24,8 +17,8 @@ jobs:
             -H "Content-Type: application/json" \
             --url "${{ secrets.JIRA_BASE_URL }}/rest/api/3/version" \
             -d '{
-              "name": "${{ env.TAG_NAME }}",
+              "name": "${{ github.event.release.tag_name }}",
               "project": "${{ secrets.JIRA_PROJECT_KEY }}",
-              "startDate": "${{ env.TODAY }}",
+              "startDate": "$(date +%Y-%m-%d)",
               "released": false
             }'


### PR DESCRIPTION
## 🌸 Problème

Le process de MER a changé pour être automatisé et une release gh est maintenant liée. 
L'action n'a pas été déclenchée via le tag lors de la dernière MER.

## 🌳 Proposition

On pense qu'il faut se baser sur la publication de la release et non sur la création du tag.
On en profite pour simplifier et ne pas créer de variables alors qu'elles ne sont utilisées qu'une fois. 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
