### PR TITLE
[TECH] Remplacer l'utilisation du slug d'un module par l'id (PIX-17701)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -2,14 +2,14 @@ import { requestResponseUtils } from '../../../shared/infrastructure/utils/reque
 
 const create = async function (request, h, { usecases, passageSerializer }) {
   const {
-    'module-id': moduleSlug,
+    'module-id': moduleId,
     'module-version': moduleVersion,
     'occurred-at': occurredAt,
     'sequence-number': sequenceNumber,
   } = request.payload.data.attributes;
   const userId = requestResponseUtils.extractUserIdFromRequest(request);
   const passage = await usecases.createPassage({
-    moduleSlug,
+    moduleId,
     userId,
   });
 

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -19,7 +19,7 @@ const createPassage = withTransaction(async function ({
 
 async function _getModule({ id, moduleRepository }) {
   try {
-    return await moduleRepository.getById(id);
+    return await moduleRepository.getById({ id });
   } catch (e) {
     if (e instanceof NotFoundError) {
       throw new ModuleDoesNotExistError();

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -3,25 +3,23 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { ModuleDoesNotExistError } from '../errors.js';
 
 const createPassage = withTransaction(async function ({
-  moduleSlug,
+  moduleId,
   userId,
   moduleRepository,
   passageRepository,
   userRepository,
 }) {
-  const module = await _getModule({ slug: moduleSlug, moduleRepository });
+  const module = await _getModule({ id: moduleId, moduleRepository });
   if (userId !== null) {
     await userRepository.get(userId);
   }
 
-  const passage = await passageRepository.save({ moduleId: module.id, userId });
-
-  return passage;
+  return await passageRepository.save({ moduleId: module.id, userId });
 });
 
-async function _getModule({ slug, moduleRepository }) {
+async function _getModule({ id, moduleRepository }) {
   try {
-    return await moduleRepository.getBySlug({ slug });
+    return await moduleRepository.getById(id);
   } catch (e) {
     if (e instanceof NotFoundError) {
       throw new ModuleDoesNotExistError();

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -7,37 +7,19 @@ import { ModuleFactory } from '../factories/module-factory.js';
 const memoizedModuleVersions = new Map();
 
 async function getById({ id, moduleDatasource }) {
-  try {
-    const moduleData = await moduleDatasource.getById(id);
-    const version = _computeModuleVersion(moduleData);
-
-    return ModuleFactory.build({ ...moduleData, version });
-  } catch (e) {
-    if (e instanceof LearningContentResourceNotFound) {
-      throw new NotFoundError();
-    }
-    throw e;
-  }
+  return await _getModule({ ref: 'id', moduleDatasource, query: id });
 }
 
 async function getBySlug({ slug, moduleDatasource }) {
-  try {
-    const moduleData = await moduleDatasource.getBySlug(slug);
-    const version = _computeModuleVersion(moduleData);
-
-    return ModuleFactory.build({ ...moduleData, version });
-  } catch (e) {
-    if (e instanceof LearningContentResourceNotFound) {
-      throw new NotFoundError();
-    }
-    throw e;
-  }
+  return await _getModule({ ref: 'slug', moduleDatasource, query: slug });
 }
 
 async function list({ moduleDatasource }) {
   const modulesData = await moduleDatasource.list();
   return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
 }
+
+export { getById, getBySlug, list };
 
 function _computeModuleVersion(moduleData) {
   if (!memoizedModuleVersions.has(moduleData.slug)) {
@@ -49,4 +31,17 @@ function _computeModuleVersion(moduleData) {
   return memoizedModuleVersions.get(moduleData.slug);
 }
 
-export { getById, getBySlug, list };
+async function _getModule({ ref, moduleDatasource, query }) {
+  try {
+    const method = ref === 'id' ? moduleDatasource.getById : moduleDatasource.getBySlug;
+    const moduleData = await method(query);
+    const version = _computeModuleVersion(moduleData);
+
+    return ModuleFactory.build({ ...moduleData, version });
+  } catch (e) {
+    if (e instanceof LearningContentResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw e;
+  }
+}

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -6,6 +6,20 @@ import { ModuleFactory } from '../factories/module-factory.js';
 
 const memoizedModuleVersions = new Map();
 
+async function getById({ id, moduleDatasource }) {
+  try {
+    const moduleData = await moduleDatasource.getById(id);
+    const version = _computeModuleVersion(moduleData);
+
+    return ModuleFactory.build({ ...moduleData, version });
+  } catch (e) {
+    if (e instanceof LearningContentResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw e;
+  }
+}
+
 async function getBySlug({ slug, moduleDatasource }) {
   try {
     const moduleData = await moduleDatasource.getBySlug(slug);
@@ -35,4 +49,4 @@ function _computeModuleVersion(moduleData) {
   return memoizedModuleVersions.get(moduleData.slug);
 }
 
-export { getBySlug, list };
+export { getById, getBySlug, list };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -6,7 +6,7 @@ function serialize(module) {
   return new Serializer('module', {
     transform(module) {
       return {
-        id: module.slug,
+        id: module.id,
         slug: module.slug,
         title: module.title,
         isBeta: module.isBeta,

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -7,6 +7,7 @@ function serialize(module) {
     transform(module) {
       return {
         id: module.slug,
+        slug: module.slug,
         title: module.title,
         isBeta: module.isBeta,
         version: module.version,
@@ -21,7 +22,7 @@ function serialize(module) {
         }),
       };
     },
-    attributes: ['title', 'isBeta', 'version', 'grains', 'details'],
+    attributes: ['slug', 'title', 'isBeta', 'version', 'grains', 'details'],
     grains: {
       ref: 'id',
       includes: true,

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -32,7 +32,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             data: {
               type: 'passages',
               attributes: {
-                'module-id': 'bien-ecrire-son-adresse-mail',
+                'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
                 'occurred-at': new Date('2025-04-30').getTime(),
                 'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
                 'sequence-number': 1,
@@ -70,7 +70,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             data: {
               type: 'passages',
               attributes: {
-                'module-id': 'bien-ecrire-son-adresse-mail',
+                'module-id': 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
                 'occurred-at': new Date('2025-04-30').getTime(),
                 'module-version': '6c3b1771db81f7419d18d7c8010e9b62266b62b032868e319d195e52742825e5',
                 'sequence-number': 1,

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -7,7 +7,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
     it('should call createPassage and recordPassageEvents use-cases and return serialized passage', async function () {
       // given
       const serializedPassage = Symbol('serialized modules');
-      const moduleSlug = Symbol('module-slug');
+      const moduleId = Symbol('module-id');
       const moduleVersion = Symbol('module-version');
       const occurredAtDate = new Date('2025-04-29');
       const occurredAt = occurredAtDate.getTime();
@@ -30,7 +30,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
         payload: {
           data: {
             attributes: {
-              'module-id': moduleSlug,
+              'module-id': moduleId,
               'module-version': moduleVersion,
               'occurred-at': occurredAt,
               'sequence-number': sequenceNumber,
@@ -54,7 +54,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
         createPassage: sinon.stub(),
         recordPassageEvents: sinon.stub(),
       };
-      usecases.createPassage.withArgs({ moduleSlug, userId }).returns(passage);
+      usecases.createPassage.withArgs({ moduleId, userId }).returns(passage);
 
       // when
       await passageController.create(request, hStub, {

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -15,15 +15,15 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   describe('when module does not exist', function () {
     it('should throw a ModuleDoesNotExist error', async function () {
       // given
-      const moduleSlug = 'module-that-does-not-exist';
+      const moduleId = '4c2161c3-41ee-412d-a0ed-8f8f2082ca82';
 
       const moduleRepositoryStub = {
-        getBySlug: sinon.stub(),
+        getById: sinon.stub(),
       };
-      moduleRepositoryStub.getBySlug.withArgs({ slug: moduleSlug }).throws(new NotFoundError());
+      moduleRepositoryStub.getById.withArgs(moduleId).throws(new NotFoundError());
 
       // when
-      const error = await catchErr(createPassage)({ moduleSlug, moduleRepository: moduleRepositoryStub });
+      const error = await catchErr(createPassage)({ moduleId, moduleRepository: moduleRepositoryStub });
 
       // then
       expect(error).to.be.instanceOf(ModuleDoesNotExistError);
@@ -36,7 +36,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       const userId = Symbol('userId');
 
       const moduleRepositoryStub = {
-        getBySlug: sinon.stub(),
+        getById: sinon.stub(),
       };
       const userRepositoryStub = {
         get: sinon.stub(),
@@ -90,9 +90,9 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     };
     userRepositoryStub.get.withArgs(userId).resolves();
     const moduleRepositoryStub = {
-      getBySlug: sinon.stub(),
+      getById: sinon.stub(),
     };
-    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleSlug }).resolves(module);
+    moduleRepositoryStub.getById.withArgs(module.id).resolves(module);
     const passageRepositoryStub = {
       save: sinon.stub(),
     };
@@ -100,7 +100,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
 
     // when
     const result = await createPassage({
-      moduleSlug,
+      moduleId,
       userId,
       passageRepository: passageRepositoryStub,
       moduleRepository: moduleRepositoryStub,

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -20,7 +20,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       const moduleRepositoryStub = {
         getById: sinon.stub(),
       };
-      moduleRepositoryStub.getById.withArgs(moduleId).throws(new NotFoundError());
+      moduleRepositoryStub.getById.withArgs({ id: moduleId }).throws(new NotFoundError());
 
       // when
       const error = await catchErr(createPassage)({ moduleId, moduleRepository: moduleRepositoryStub });
@@ -92,7 +92,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const moduleRepositoryStub = {
       getById: sinon.stub(),
     };
-    moduleRepositoryStub.getById.withArgs(module.id).resolves(module);
+    moduleRepositoryStub.getById.withArgs({ id: module.id }).resolves(module);
     const passageRepositoryStub = {
       save: sinon.stub(),
     };

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -47,6 +47,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           type: 'modules',
           id: slug,
           attributes: {
+            slug,
             title,
             'is-beta': isBeta,
             details,
@@ -105,6 +106,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const expectedJson = {
         data: {
           attributes: {
+            slug,
             title: 'Bien écrire son adresse mail',
             'is-beta': isBeta,
             version,

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -45,7 +45,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const expectedJson = {
         data: {
           type: 'modules',
-          id: slug,
+          id,
           attributes: {
             slug,
             title,
@@ -112,7 +112,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             version,
             details,
           },
-          id: 'bien-ecrire-son-adresse-mail',
+          id: 'id',
           relationships: {
             grains: {
               data: [

--- a/mon-pix/app/adapters/module.js
+++ b/mon-pix/app/adapters/module.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class Module extends ApplicationAdapter {
+  queryRecord(store, type, query) {
+    if (query.slug) {
+      const url = `${this.host}/${this.namespace}/modules/${query.slug}`;
+      return this.ajax(url, 'GET');
+    }
+
+    return super.queryRecord(...arguments);
+  }
+}

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -27,7 +27,7 @@ export default class ModulixDetails extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Commencer un passage`,
     });
     this.router.transitionTo('module.passage', this.args.module.id);
@@ -38,7 +38,7 @@ export default class ModulixDetails extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
     });
     this.router.transitionTo('module.passage', this.args.module.id);
@@ -49,7 +49,7 @@ export default class ModulixDetails extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Ouvre la modale d'alerte de largeur d'écran`,
     });
     this.isSmallScreenModalOpen = true;
@@ -60,7 +60,7 @@ export default class ModulixDetails extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.id}`,
+      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Ferme la modale d'alerte de largeur d'écran`,
     });
     this.isSmallScreenModalOpen = false;

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -30,7 +30,7 @@ export default class ModulixDetails extends Component {
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Commencer un passage`,
     });
-    this.router.transitionTo('module.passage', this.args.module.id);
+    this.router.transitionTo('module.passage', this.args.module.slug);
   }
 
   @action
@@ -41,7 +41,7 @@ export default class ModulixDetails extends Component {
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
     });
-    this.router.transitionTo('module.passage', this.args.module.id);
+    this.router.transitionTo('module.passage', this.args.module.slug);
   }
 
   @action

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -56,7 +56,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton passer du grain : ${currentGrain.id}`,
     });
   }
@@ -70,7 +70,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton continuer du grain : ${currentGrain.id}`,
     });
   }
@@ -82,7 +82,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
     });
   }
@@ -117,7 +117,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Terminer du grain : ${grainId}`,
     });
     this.passageEvents.record({
@@ -141,7 +141,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.element.id}`,
     });
   }
@@ -151,7 +151,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton '${userAssessment}' de la flashcard : ${cardId}`,
     });
   }
@@ -161,7 +161,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton réessayer de l'élément : ${answerData.element.id}`,
     });
   }
@@ -171,7 +171,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElementId}`,
     });
   }
@@ -181,7 +181,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton transcription : ${videoElementId}`,
     });
   }
@@ -191,7 +191,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Play : ${elementId}`,
     });
   }
@@ -201,7 +201,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`,
     });
   }
@@ -211,7 +211,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le bouton Étape ${this.navbarCurrentPassageStep} sur ${this.displayableGrainsInNavbar.length} de la barre de navigation`,
     });
   }
@@ -224,7 +224,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `Click sur le grain ${grainId} de la barre de navigation`,
     });
   }
@@ -235,7 +235,7 @@ export default class ModulePassage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
       'pix-event-name': `${eventToggle} de l'élément Expand : ${elementId}`,
     });
   }

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -1,6 +1,7 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Module extends Model {
+  @attr('string') slug;
   @attr('string') title;
   @attr('boolean') isBeta;
   @attr() details;

--- a/mon-pix/app/routes/module.js
+++ b/mon-pix/app/routes/module.js
@@ -5,6 +5,6 @@ export default class ModuleRoute extends Route {
   @service store;
 
   model(params) {
-    return this.store.findRecord('module', params.slug);
+    return this.store.queryRecord('module', { slug: params.slug });
   }
 }

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -7,7 +7,7 @@ export default class ModulePassageRoute extends Route {
 
   async model() {
     const module = this.modelFor('module');
-    const passage = await this.store.createRecord('passage', { moduleId: module.slug }).save({
+    const passage = await this.store.createRecord('passage', { moduleId: module.id }).save({
       adapterOptions: {
         occurredAt: new Date().getTime(),
         sequenceNumber: 1,

--- a/mon-pix/app/routes/module/passage.js
+++ b/mon-pix/app/routes/module/passage.js
@@ -7,7 +7,7 @@ export default class ModulePassageRoute extends Route {
 
   async model() {
     const module = this.modelFor('module');
-    const passage = await this.store.createRecord('passage', { moduleId: module.id }).save({
+    const passage = await this.store.createRecord('passage', { moduleId: module.slug }).save({
       adapterOptions: {
         occurredAt: new Date().getTime(),
         sequenceNumber: 1,

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
@@ -17,6 +17,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
       // given
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         grains: [],
         details: {
@@ -43,6 +44,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         grains: [grain],
         details: {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         grains,
       });
@@ -42,6 +43,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
+          slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
           grains,
         });
@@ -69,6 +71,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
+          slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
           grains,
         });
@@ -107,6 +110,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       });
       const module = server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         grains: [grain1],
       });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -116,7 +116,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       });
       server.create('passage', {
         id: '122',
-        moduleId: module.id,
+        moduleId: module.slug,
       });
 
       // when

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -31,6 +31,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         grains: [grain],

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -52,6 +52,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: { tabletSupport: 'comfortable' },
       grains: [grain1, grain2],

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -35,6 +35,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       grains: [grain],
     });
@@ -103,6 +104,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       grains: [grain],

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -53,6 +53,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       grains: [grain1, grain2],
@@ -140,6 +141,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       grains: [grain1, grain2],

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -53,6 +53,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       grains: [grain],
@@ -173,6 +174,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       grains: [grain],

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -50,6 +50,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       grains: [grain],
     });

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -46,6 +46,7 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       grains: [grain],
     });

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -63,6 +63,7 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       grains: [grain],
     });

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -14,6 +14,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     // given
     const module = server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: false,
       details: {
@@ -42,6 +43,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
       // given
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
@@ -69,6 +71,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: {
         image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',

--- a/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       grains: [grain],
     });
@@ -37,6 +38,7 @@ module('Acceptance | Module | Routes | get', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       title: module.title,
       grains: [grain],
     });

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
     // given
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      slug: 'bien-ecrire-son-adresse-mail',
       details: { tabletSupport: 'comfortable' },
     });
 

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -67,7 +67,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
         // then
-        sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.id);
+        sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
         assert.ok(true);
       });
     });
@@ -103,7 +103,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.id);
+          sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
           assert.ok(true);
         });
       });
@@ -192,7 +192,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.id);
+            sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
             assert.ok(true);
           });
         });

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -22,7 +22,7 @@ module('Integration | Component | Module | Details', function (hooks) {
       level: 'Débutant',
       objectives: ['Objectif 1'],
     };
-    const module = store.createRecord('module', { title: 'Module title', details });
+    const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', details });
 
     // when
     const screen = await render(<template><ModulixDetails @module={{module}} /></template>);
@@ -263,7 +263,12 @@ function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
     objectives: ['Objectif 1'],
     tabletSupport,
   };
-  const module = store.createRecord('module', { id: 'module-title', title: 'Module title', details });
+  const module = store.createRecord('module', {
+    id: 'module-title',
+    slug: 'module-slug',
+    title: 'Module title',
+    details,
+  });
   setBreakpoint(breakpoint);
 
   return { router, metrics, store, details, module };

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -52,7 +52,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Détails du module : ${module.id}`,
+          'pix-event-action': `Détails du module : ${module.slug}`,
           'pix-event-name': `Click sur le bouton Commencer un passage`,
         });
         assert.ok(true);
@@ -88,7 +88,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           sinon.assert.calledWithExactly(metrics.add, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
-            'pix-event-action': `Détails du module : ${module.id}`,
+            'pix-event-action': `Détails du module : ${module.slug}`,
             'pix-event-name': `Click sur le bouton Commencer un passage`,
           });
           assert.ok(true);
@@ -123,7 +123,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           sinon.assert.calledWithExactly(metrics.add, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
-            'pix-event-action': `Détails du module : ${module.id}`,
+            'pix-event-action': `Détails du module : ${module.slug}`,
             'pix-event-name': `Ouvre la modale d'alerte de largeur d'écran`,
           });
           assert.ok(true);
@@ -170,7 +170,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             sinon.assert.calledWithExactly(metrics.add, {
               event: 'custom-event',
               'pix-event-category': 'Modulix',
-              'pix-event-action': `Détails du module : ${module.id}`,
+              'pix-event-action': `Détails du module : ${module.slug}`,
               'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
             });
             assert.ok(true);
@@ -217,7 +217,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             sinon.assert.calledWithExactly(metrics.add, {
               event: 'custom-event',
               'pix-event-category': 'Modulix',
-              'pix-event-action': `Détails du module : ${module.id}`,
+              'pix-event-action': `Détails du module : ${module.slug}`,
               'pix-event-name': `Ferme la modale d'alerte de largeur d'écran`,
             });
             assert.ok(true);

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -313,7 +313,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
           });
           const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            grains: [grain1, grain2],
+          });
           const passage = store.createRecord('passage');
 
           const metrics = this.owner.lookup('service:metrics');
@@ -352,7 +356,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            grains: [grain1, grain2],
+          });
           const passage = store.createRecord('passage');
 
           // when
@@ -379,7 +387,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            grains: [grain1, grain2],
+          });
           const passage = store.createRecord('passage');
 
           const metrics = this.owner.lookup('service:metrics');
@@ -416,7 +428,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2],
+      });
       const passage = store.createRecord('passage');
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -443,7 +459,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2],
+      });
       const passage = store.createRecord('passage');
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -479,7 +499,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2],
+      });
       const passage = store.createRecord('passage');
 
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -503,7 +527,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2],
+      });
       const passage = store.createRecord('passage');
 
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -525,7 +553,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
       const grain3 = store.createRecord('grain', { components: [{ type: 'element', element: text3Element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2, grain3],
+      });
       const passage = store.createRecord('passage');
 
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -561,7 +593,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
       const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', {
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1, grain2],
+      });
       const passage = store.createRecord('passage');
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -602,7 +638,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
       };
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
 
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain1] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1],
+      });
       const passage = store.createRecord('passage', { id: 'passage-id' });
 
       const saveStub = sinon.stub();
@@ -639,7 +680,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
       };
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
 
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain1] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1],
+      });
       const passage = store.createRecord('passage');
 
       const createRecordMock = sinon.mock();
@@ -673,7 +719,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
       const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
 
       const correction = store.createRecord('correction-response', { status: 'ko' });
@@ -742,7 +793,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: flashcardsElement }] });
 
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain1] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain1],
+      });
       const passage = store.createRecord('passage');
 
       const createRecordStub = sinon.stub();
@@ -785,7 +841,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
         alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
       };
       const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
 
       // when
@@ -822,7 +883,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
           id: '123',
           components: [{ type: 'stepper', steps: [step] }],
         });
-        const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+        const module = store.createRecord('module', {
+          id: 'module-id',
+          slug: 'module-slug',
+          title: 'Module title',
+          grains: [grain],
+        });
         const passage = store.createRecord('passage');
 
         // when
@@ -858,7 +924,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
         transcription: '<p>transcription</p>',
       };
       const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-      const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
 
       // when
@@ -896,7 +967,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
           id: '123',
           components: [{ type: 'stepper', steps: [step] }],
         });
-        const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+        const module = store.createRecord('module', {
+          id: 'module-id',
+          slug: 'module-slug',
+          title: 'Module title',
+          grains: [grain],
+        });
         const passage = store.createRecord('passage');
 
         // when
@@ -928,7 +1004,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
         components: [{ type: 'stepper', steps: [step1, step2] }],
       });
 
-      const module = store.createRecord('module', { id: '1', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: '1',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
       const onStepperNextStepButtonName = t('pages.modulix.buttons.stepper.next.ariaLabel');
 
@@ -958,7 +1039,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const element = { type: 'text', isAnswerable: false };
       const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
       const passage = store.createRecord('passage');
 
       // when
@@ -983,7 +1064,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1008,7 +1089,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'element', element: qcuElement }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1036,7 +1117,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'stepper', steps: [{ elements: [textElement] }, { elements: [qcuElement] }] }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1058,7 +1139,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
             components: [{ type: 'stepper', steps: [{ elements: [text1Element] }, { elements: [text2Element] }] }],
           });
 
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
           const passage = store.createRecord('passage');
 
           // when
@@ -1092,7 +1173,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
         components: [{ type: 'element', element: videoElement }],
       });
 
-      const module = store.createRecord('module', { id: '1', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: '1',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1133,7 +1219,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
           title: 'Grain title',
           components: [{ type: 'element', element: videoElement }],
         });
-        const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+        const module = store.createRecord('module', {
+          id: 'module-id',
+          slug: 'module-slug',
+          title: 'Module title',
+          grains: [grain],
+        });
         const passage = store.createRecord('passage');
         await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
         const video = find(`#${videoElement.id}`);
@@ -1173,7 +1264,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
         components: [{ type: 'element', element: downloadElement }],
       });
 
-      const module = store.createRecord('module', { id: '1', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', {
+        id: '1',
+        slug: 'module-slug',
+        title: 'Module title',
+        grains: [grain],
+      });
       const passage = store.createRecord('passage');
 
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1215,7 +1311,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
           title: 'Grain title',
           components: [{ type: 'element', element: downloadElement }],
         });
-        const module = store.createRecord('module', { id: 'module-id', title: 'Module title', grains: [grain] });
+        const module = store.createRecord('module', {
+          id: 'module-id',
+          slug: 'module-slug',
+          title: 'Module title',
+          grains: [grain],
+        });
         const passage = store.createRecord('passage');
         const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
@@ -1268,6 +1369,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       const module = store.createRecord('module', {
         id: 'module-title',
+        slug: 'module-slug',
         title: 'Module title',
         grains: [grain],
       });
@@ -1311,6 +1413,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const module = store.createRecord('module', {
         title: 'Didacticiel',
+        slug: 'module-slug',
         grains: [grain1, grain2],
       });
       const passage = store.createRecord('passage');
@@ -1351,6 +1454,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const module = store.createRecord('module', {
         title: 'Didacticiel',
+        slug: 'module-slug',
         grains: [grain1, grain2],
       });
       const passage = store.createRecord('passage');
@@ -1386,6 +1490,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       const module = store.createRecord('module', {
         title: 'Didacticiel',
+        slug: 'module-slug',
         grains: [grain1, grain2],
       });
       const passage = store.createRecord('passage');
@@ -1430,6 +1535,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       const module = store.createRecord('module', {
         title: 'Didacticiel',
+        slug: 'module-slug',
         grains: [grain],
       });
       const passage = store.createRecord('passage');
@@ -1474,6 +1580,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
         const module = store.createRecord('module', {
           title: 'Didacticiel',
+          slug: 'module-slug',
           grains: [grain],
         });
         const passage = store.createRecord('passage');
@@ -1518,6 +1625,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       const module = store.createRecord('module', {
         title: 'Didacticiel',
+        slug: 'module-slug',
         grains: [grain],
       });
       const passage = store.createRecord('passage');

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -331,7 +331,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
           sinon.assert.calledWithExactly(metrics.add, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
-            'pix-event-action': `Passage du module : ${module.id}`,
+            'pix-event-action': `Passage du module : ${module.slug}`,
             'pix-event-name': `Click sur le bouton Étape 0 sur 1 de la barre de navigation`,
           });
           assert.ok(true);
@@ -405,7 +405,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
           sinon.assert.calledWithExactly(metrics.add, {
             event: 'custom-event',
             'pix-event-category': 'Modulix',
-            'pix-event-action': `Passage du module : ${module.id}`,
+            'pix-event-action': `Passage du module : ${module.slug}`,
             'pix-event-name': `Click sur le bouton Étape 1 sur 1 de la barre de navigation`,
           });
           assert.ok(true);
@@ -478,7 +478,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
       });
       assert.ok(true);
@@ -612,7 +612,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
       });
       assert.ok(true);
@@ -702,7 +702,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton vérifier de l'élément : ${qcuElement.id}`,
       });
       assert.ok(true);
@@ -738,7 +738,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton réessayer de l'élément : ${element.id}`,
       });
       assert.ok(true);
@@ -818,7 +818,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledOnceWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton 'no' de la flashcard : ${firstCard.id}`,
       });
       assert.ok(true);
@@ -857,7 +857,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton alternative textuelle : ${element.id}`,
       });
       assert.ok(true);
@@ -899,7 +899,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-action': `Passage du module : ${module.slug}`,
           'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElement.id}`,
         });
         assert.ok(true);
@@ -940,7 +940,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton transcription : ${element.id}`,
       });
       assert.ok(true);
@@ -983,7 +983,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-action': `Passage du module : ${module.slug}`,
           'pix-event-name': `Click sur le bouton transcription : ${videoElement.id}`,
         });
         assert.ok(true);
@@ -1025,7 +1025,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
       });
       assert.ok(true);
@@ -1193,7 +1193,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
       });
       assert.ok(true);
@@ -1238,7 +1238,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-action': `Passage du module : ${module.slug}`,
           'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
         });
         assert.ok(true);
@@ -1287,7 +1287,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
       });
       assert.ok(true);
@@ -1333,7 +1333,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-action': `Passage du module : ${module.slug}`,
           'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
         });
         assert.ok(true);
@@ -1384,7 +1384,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton Terminer du grain : ${grain.id}`,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
@@ -1428,7 +1428,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le bouton Étape 1 sur 2 de la barre de navigation`,
       });
       assert.ok(true);
@@ -1508,7 +1508,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Click sur le grain ${grain1.id} de la barre de navigation`,
       });
       assert.ok(true);
@@ -1552,7 +1552,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Ouverture de l'élément Expand : ${expandElement.id}`,
       });
       assert.ok(true);
@@ -1597,7 +1597,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         sinon.assert.calledWithExactly(metrics.add, {
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-action': `Passage du module : ${module.slug}`,
           'pix-event-name': `Ouverture de l'élément Expand : ${expandElement.id}`,
         });
         assert.ok(true);
@@ -1645,7 +1645,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWithExactly(metrics.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-action': `Passage du module : ${module.slug}`,
         'pix-event-name': `Fermeture de l'élément Expand : ${expandElement.id}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/adapters/module-test.js
+++ b/mon-pix/tests/unit/adapters/module-test.js
@@ -1,0 +1,53 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | Module | Module', function (hooks) {
+  setupTest(hooks);
+
+  module('#queryRecord', function () {
+    module('when query.slug is not defined', function () {
+      test('should trigger an ajax call with the default url and method', async function (assert) {
+        // given
+        const query = {
+          'other-prop': 'bac-a-sable',
+        };
+
+        const store = this.owner.lookup('service:store');
+        const adapter = this.owner.lookup('adapter:module');
+        const type = { modelName: 'module' };
+        sinon.stub(adapter, 'ajax').resolves();
+        const expectedUrl = `http://localhost:3000/api/modules`;
+
+        // when
+        await adapter.queryRecord(store, type, query);
+
+        // then
+        sinon.assert.calledWithExactly(adapter.ajax, expectedUrl, 'GET', { data: { 'other-prop': 'bac-a-sable' } });
+        assert.ok(true);
+      });
+    });
+
+    module('when query.slug is defined', function () {
+      test('should trigger an ajax call with the right url and method', async function (assert) {
+        // given
+        const query = {
+          slug: 'bac-a-sable',
+        };
+
+        const store = this.owner.lookup('service:store');
+        const adapter = this.owner.lookup('adapter:module');
+        const type = { modelName: 'module' };
+        sinon.stub(adapter, 'ajax').resolves();
+        const expectedUrl = `http://localhost:3000/api/modules/${query.slug}`;
+
+        // when
+        await adapter.queryRecord(store, type, query);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'GET');
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/module/module-test.js
+++ b/mon-pix/tests/unit/routes/module/module-test.js
@@ -20,8 +20,8 @@ module('Unit | Route | modules | module', function (hooks) {
 
     const module = Symbol('the-module');
 
-    store.findRecord = sinon.stub();
-    store.findRecord.withArgs('module', 'the-module').resolves(module);
+    store.queryRecord = sinon.stub();
+    store.queryRecord.withArgs('module', { slug: 'the-module' }).resolves(module);
 
     // when
     const model = await route.model({ slug: 'the-module' });

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -49,7 +49,7 @@ module('Unit | Route | modules | passage', function (hooks) {
 
     const route = this.owner.lookup('route:module.passage');
     const store = this.owner.lookup('service:store');
-    const module = { id: 'my-module', slug: 'my-module' };
+    const module = { id: 'module-id', slug: 'module-slug' };
 
     route.modelFor = sinon.stub();
     route.modelFor.withArgs('module').returns(module);
@@ -57,7 +57,7 @@ module('Unit | Route | modules | passage', function (hooks) {
     const save = sinon.stub();
     save.resolves(passage);
 
-    store.createRecord.withArgs('passage', { moduleId: 'my-module' }).returns({ save: save });
+    store.createRecord.withArgs('passage', { moduleId: 'module-id' }).returns({ save: save });
 
     const passageEventService = this.owner.lookup('service:passage-events');
     passageEventService.initialize = sinon.stub();

--- a/mon-pix/tests/unit/routes/module/passage-test.js
+++ b/mon-pix/tests/unit/routes/module/passage-test.js
@@ -49,7 +49,7 @@ module('Unit | Route | modules | passage', function (hooks) {
 
     const route = this.owner.lookup('route:module.passage');
     const store = this.owner.lookup('service:store');
-    const module = { id: 'my-module' };
+    const module = { id: 'my-module', slug: 'my-module' };
 
     route.modelFor = sinon.stub();
     route.modelFor.withArgs('module').returns(module);


### PR DESCRIPTION
## 🌸 Problème

Récemment, nous avons choisi d'utiliser les `id` des modules pour les identifier plutôt que les `slug` (qui peuvent changer au cours du temps). Mais il reste des endroits du code où le `slug` est encore appelé `id`.

## 🌳 Proposition

### Module

1. [API] Lors de l'appel de la route `GET /module/{slug}`, renvoyer une nouvelle propriété `slug`contenant le slug et l' renvoyer l'id dans la propriété `id`.
2. [FRONT] Ajouter la propriété `slug` au modèle `module` et remplacer toutes les utilisations de la propriété `module.id` par `module.slug`

### Passage

3. [FRONT] Lors de la création du passage, envoyer l'id du module plutôt que son slug dans l'attribut `moduleId`
4. [API] Lors de la création du passage, attendre récupérer le module correspondant par son id plutôt que par son slug.

## 🐝 Remarques

Cette PR introduit deux breaking changes dans le contrat Front/API et pourrait provoquer une erreur si une ancienne version de Pix App appelle la nouvelle version de l'API. On a décidé que ce n'était pas un problème vu le faible nombre d'utilisations des modules aujourd'hui.

## 🤧 Pour tester

1. Commencer un module
2. Constater que le passage est créé correctement
3. Constater que les évènements Matomo sont envoyés correctement
