### PR TITLE
[BUGFIX] Corriger la mention du groupe dans le message slack envoyé par le workflow de release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-            text: "Coucou :wave:\nLa v${{ env.new_release_version }} est en recette @team-po\nMettez vos messages en :thread:"
+            text: "Coucou :wave:\nLa v${{ env.new_release_version }} est en recette <!subteam^S074J8W3Q77>\nMettez vos messages en :thread:"


### PR DESCRIPTION
## 🌸 Problème
Actuellement le workflow de release envoie un message Slack et doit mentionner le groupe team-po. Cependant, la mention ne fonctionne pas.

## 🌳 Proposition
- Utiliser la syntaxe `<!subteam^group_id>` comme mentionné dans la [documentation de slack](https://api.slack.com/reference/surfaces/formatting#mentioning-groups)