### PR TITLE
[FEATURE] Ajoute la colonne "Type de campagne" dans la création de campagnes en masse (PIX-17859)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-adminstration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-adminstration-controller.js
@@ -12,7 +12,7 @@ import * as campaignManagementSerializer from '../infrastructure/serializers/jso
 import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi/campaign-report-serializer.js';
 
 const getTemplateForCreateCampaigns = (request, h) => {
-  const fields = csvSerializer.requiredFieldNamesForCampaignsImport;
+  const fields = csvSerializer.fieldNamesForCampaignsImport;
   const csvTemplateFileContent = generateCSVTemplate(fields);
 
   return h

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -78,10 +78,18 @@ class UserNotAuthorizedToCreateCampaignError extends DomainError {
   }
 }
 
+class CampaignTypeError extends DomainError {
+  constructor(campaignType) {
+    const message = `Le type de campagne ${campaignType} n'est pas supporté.`;
+    super(message);
+  }
+}
+
 export {
   ArchivedCampaignError,
   CampaignCodeFormatError,
   CampaignParticipationDoesNotBelongToUser,
+  CampaignTypeError,
   CampaignUniqueCodeError,
   DeletedCampaignError,
   IsForAbsoluteNoviceUpdateError,

--- a/api/src/prescription/campaign/domain/models/CampaignCreator.js
+++ b/api/src/prescription/campaign/domain/models/CampaignCreator.js
@@ -1,6 +1,7 @@
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { CampaignTypes } from '../../../shared/domain/constants.js';
 import {
+  CampaignTypeError,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
@@ -18,6 +19,10 @@ class CampaignCreator {
 
   createCampaign(campaignAttributes) {
     const { type, targetProfileId, multipleSendings, organizationId } = campaignAttributes;
+
+    if (!Object.values(CampaignTypes).includes(type)) {
+      throw new CampaignTypeError(type);
+    }
 
     if (type === CampaignTypes.ASSESSMENT) {
       this.#checkAssessmentCampaignCreationAllowed(targetProfileId);

--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -1,5 +1,3 @@
-import { CampaignTypes } from '../../../shared/domain/constants.js';
-
 const createCampaigns = async function ({
   campaignsToCreate,
   campaignAdministrationRepository,
@@ -18,7 +16,6 @@ const createCampaigns = async function ({
 
     const campaignToCreate = await campaignCreator.createCampaign({
       ...campaign,
-      type: CampaignTypes.ASSESSMENT,
       code: generatedCampaignCode,
     });
     enrichedCampaignsData.push(campaignToCreate);

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -247,7 +247,7 @@ const requiredFieldNamesForCampaignsImport = {
 const optionalFieldNamesForCampaignsImport = {
   externalIdLabel: "Libellé de l'identifiant externe",
   externalIdType: "Type de l'identifiant externe",
-  type: 'Type de campagne',
+  type: 'Type de campagne (Evaluation, Examen)',
   title: 'Titre du parcours',
   customLandingPageText: 'Descriptif du parcours',
   multipleSendings: 'Envoi multiple',
@@ -293,6 +293,14 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
           'CSV_CONTENT_NOT_VALID',
           `${value === '' ? '"empty"' : value} is not a valid value for "${columnName}"`,
         );
+      }
+      if (columnName === optionalFieldNamesForCampaignsImport.type) {
+        if (value === 'Evaluation') {
+          return CampaignTypes.ASSESSMENT;
+        }
+        if (value === 'Examen') {
+          return CampaignTypes.EXAM;
+        }
       }
       return value;
     },

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -6,6 +6,7 @@ import {
   emptySession,
   headers,
 } from '../../../../certification/shared/infrastructure/utils/csv/sessions-import.js';
+import { CampaignTypes } from '../../../../prescription/shared/domain/constants.js';
 import { FileValidationError } from '../../../domain/errors.js';
 import { csvHelper } from '../../helpers/csv.js';
 import { convertDateValue } from '../../utils/date-utils.js';
@@ -286,6 +287,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     name: data['Nom de la campagne*'],
     targetProfileId: data['Identifiant du profil cible*'],
     externalIdLabel: data["Libellé de l'identifiant externe"],
+    type: data['Type de campagne'] || CampaignTypes.ASSESSMENT,
     externalIdType:
       data["Libellé de l'identifiant externe"]?.trim()?.length > 0
         ? data["Type de l'identifiant externe"] || 'STRING'

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
@@ -1,4 +1,5 @@
 import {
+  CampaignTypeError,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   OrganizationNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateCampaignError,
@@ -49,6 +50,28 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
   });
 
   describe('#createCampaign', function () {
+    describe('when campaign type is not supported', function () {
+      it('throws a CampaignTypeError', async function () {
+        const error = await catchErr(function () {
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: 'WRONG TYPE',
+            creatorId: 1,
+            ownerId: 1,
+            organizationId: 2,
+            targetProfileId: 2,
+            multipleSendings: true,
+          };
+
+          creator.createCampaign(campaignData);
+        })();
+
+        expect(error).to.be.an.instanceOf(CampaignTypeError);
+      });
+    });
+
     describe('when the creator is allowed to create the campaign', function () {
       it('creates the campaign', function () {
         const availableTargetProfileIds = [1, 2];

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -41,6 +41,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     campaignsToCreate = [
       {
         organizationId: organization.id,
+        type: 'ASSESSMENT',
         name: 'My Campaign',
         targetProfileId: 3,
         creatorId: 2,
@@ -48,6 +49,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
       },
       {
         organizationId: otherOrganization.id,
+        type: 'ASSESSMENT',
         name: 'My other Campaign',
         targetProfileId: 3,
         creatorId: 1,

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import { SUBSCRIPTION_TYPES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { emptySession } from '../../../../../../src/certification/shared/infrastructure/utils/csv/sessions-import.js';
+import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { FileValidationError } from '../../../../../../src/shared/domain/errors.js';
 import * as csvSerializer from '../../../../../../src/shared/infrastructure/serializers/csv/csv-serializer.js';
 import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
@@ -1505,11 +1506,11 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
+      "Identifiant de l'organisation*;Type de campagne;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
 
     it('should return parsed campaign data', async function () {
       // given
-      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;77\n3;chausson;1234;;123;titre 3;descriptif 3;Non;88;Bravo !;Cliquez ici;https://hmpg.net/`;
+      const csv = `${headerCsv}1;;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;ASSESSMENT;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;77\n3;EXAM;chausson;1234;;123;titre 3;descriptif 3;Non;88;Bravo !;Cliquez ici;https://hmpg.net/`;
 
       // when
       const parsedData = await csvSerializer.parseForCampaignsImport(csv);
@@ -1518,6 +1519,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       const expectedParsedData = [
         {
           organizationId: 1,
+          type: CampaignTypes.ASSESSMENT,
           name: 'chaussette',
           targetProfileId: 1234,
           externalIdLabel: 'numéro étudiant',
@@ -1533,6 +1535,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         },
         {
           organizationId: 2,
+          type: 'ASSESSMENT',
           name: 'chapeau',
           targetProfileId: 1234,
           externalIdLabel: 'identifiant',
@@ -1548,6 +1551,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         },
         {
           organizationId: 3,
+          type: 'EXAM',
           name: 'chausson',
           targetProfileId: 1234,
           externalIdLabel: '',
@@ -1568,7 +1572,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when organizationId field is not valid', function () {
       it('should throw an error when empty', async function () {
         // given
-        const campaignWithoutOrganizationIdCsv = `${headerCsv};chaussette;1234;numéro étudiant;789`;
+        const campaignWithoutOrganizationIdCsv = `${headerCsv};;chaussette;1234;numéro étudiant;789`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutOrganizationIdCsv);
@@ -1581,7 +1585,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
       it('should throw an error when not a number', async function () {
         // given
-        const campaignWithoutOrganizationIdCsv = `${headerCsv};not valid;chaussette;1234;numéro étudiant;789`;
+        const campaignWithoutOrganizationIdCsv = `${headerCsv};;not valid;chaussette;1234;numéro étudiant;789`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutOrganizationIdCsv);
@@ -1596,7 +1600,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when targetProfileId field is not valid', function () {
       it('should throw an error when empty', async function () {
         // given
-        const campaignWithoutTargetProfileIdCsv = `${headerCsv}1;chaussette;;numéro étudiant;789`;
+        const campaignWithoutTargetProfileIdCsv = `${headerCsv}1;;chaussette;;numéro étudiant;789`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutTargetProfileIdCsv);
@@ -1624,7 +1628,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when creatorId field is not valid', function () {
       it('should throw an error when empty', async function () {
         // given
-        const campaignWithoutCreatorIdCsv = `${headerCsv}1;chaussette;1234;numéro étudiant;;`;
+        const campaignWithoutCreatorIdCsv = `${headerCsv}1;;chaussette;1234;numéro étudiant;;`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutCreatorIdCsv);
@@ -1637,7 +1641,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
       it('should throw an error when not a number', async function () {
         // given
-        const campaignWithoutCreatorIdCsv = `${headerCsv}1;chaussette;1234;not valid;numéro étudiant;not valid`;
+        const campaignWithoutCreatorIdCsv = `${headerCsv}1;;chaussette;1234;not valid;numéro étudiant;not valid`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutCreatorIdCsv);
@@ -1652,7 +1656,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when ownerId field is not valid', function () {
       it('should throw an error when empty', async function () {
         // given
-        const campaignWithoutOwnerIdCsv = `${headerCsv}1;chaussette;1234;numéro étudiant;12;titre;descriptif;false;;`;
+        const campaignWithoutOwnerIdCsv = `${headerCsv}1;;chaussette;1234;numéro étudiant;12;titre;descriptif;false;;`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutOwnerIdCsv);
@@ -1665,7 +1669,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
       it('should throw an error when not a number', async function () {
         // given
-        const campaignWithBadNumberForOwnerIdCsv = `${headerCsv}1;chaussette;1234;idpixlabel;1234;titre;descriptif;false;not a number`;
+        const campaignWithBadNumberForOwnerIdCsv = `${headerCsv}1;;chaussette;1234;idpixlabel;1234;titre;descriptif;false;not a number`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithBadNumberForOwnerIdCsv);
@@ -1680,7 +1684,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when name field is not valid', function () {
       it('should throw an error', async function () {
         // given
-        const campaignWithoutNameCsv = `${headerCsv}1;;1234;numéro étudiant`;
+        const campaignWithoutNameCsv = `${headerCsv}1;;;1234;numéro étudiant`;
 
         // when
         const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutNameCsv);
@@ -1708,6 +1712,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           const expectedParsedData = [
             {
               organizationId: 1,
+              type: CampaignTypes.ASSESSMENT,
               name: 'chaussette',
               targetProfileId: 1234,
               externalIdLabel: 'numéro étudiant',
@@ -1726,10 +1731,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         });
       });
 
-      describe('if externalIdType i not present', function () {
+      describe('if externalIdType is not present', function () {
         it('should default to STRING', async function () {
           // given
-          const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+          const csv = `${headerCsv}1;;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
 
           // when
           const parsedData = await csvSerializer.parseForCampaignsImport(csv);
@@ -1738,6 +1743,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           const expectedParsedData = [
             {
               organizationId: 1,
+              type: CampaignTypes.ASSESSMENT,
               name: 'chaussette',
               targetProfileId: 1234,
               externalIdLabel: 'numéro étudiant',

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1506,7 +1506,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Type de campagne;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
+      "Identifiant de l'organisation*;Type de campagne (Evaluation, Examen);Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
 
     it('should return parsed campaign data', async function () {
       // given
@@ -1693,6 +1693,157 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         expect(error).to.be.instanceOf(FileValidationError);
         expect(error.code).to.equal('CSV_CONTENT_NOT_VALID');
         expect(error.meta).to.equal('"empty" is not a valid value for "Nom de la campagne*"');
+      });
+    });
+
+    describe('when type is provided', function () {
+      describe('if type is present', function () {
+        it('should default handle ASSESSMENT', async function () {
+          // given
+          const csv = `${headerCsv}1;ASSESSMENT;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              type: CampaignTypes.ASSESSMENT,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              externalIdLabel: 'numéro étudiant',
+              externalIdType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
+
+        it('should default handle Evaluation', async function () {
+          // given
+          const csv = `${headerCsv}1;Evaluation;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              type: CampaignTypes.ASSESSMENT,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              externalIdLabel: 'numéro étudiant',
+              externalIdType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
+
+        it('should default handle EXAM', async function () {
+          // given
+          const csv = `${headerCsv}1;EXAM;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              type: CampaignTypes.EXAM,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              externalIdLabel: 'numéro étudiant',
+              externalIdType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
+
+        it('should default handle Examen', async function () {
+          // given
+          const csv = `${headerCsv}1;Examen;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              type: CampaignTypes.EXAM,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              externalIdLabel: 'numéro étudiant',
+              externalIdType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
+      });
+
+      describe('if type is not present', function () {
+        it('should default to ASSESSMENT', async function () {
+          // given
+          const csv = `${headerCsv}1;;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45`;
+
+          // when
+          const parsedData = await csvSerializer.parseForCampaignsImport(csv);
+
+          // then
+          const expectedParsedData = [
+            {
+              organizationId: 1,
+              type: CampaignTypes.ASSESSMENT,
+              name: 'chaussette',
+              targetProfileId: 1234,
+              externalIdLabel: 'numéro étudiant',
+              externalIdType: 'STRING',
+              title: 'titre 1',
+              customLandingPageText: 'descriptif 1',
+              creatorId: 789,
+              multipleSendings: true,
+              ownerId: 45,
+              customResultPageText: null,
+              customResultPageButtonText: null,
+              customResultPageButtonUrl: null,
+            },
+          ];
+          expect(parsedData).to.have.deep.members(expectedParsedData);
+        });
       });
     });
 


### PR DESCRIPTION
## 🌸 Problème

Avec l'introduction des campagnes de type Exam s'est fait ressentir le besoin de les créer en masse pour des organisations. Cependant la typologie de campagne est actuellement mise en dure.

## 🌳 Proposition

Ajouter une colonne "Type de campagne" pour choisir entre EXAM et ASSESSMENT

## 🐝 Remarques

J'ai remarqué que le template de création de campagnes en masse n'est pas bon, il ne liste que les colonnes obligatoire. Il faudrait faire évoluer pour qu'il liste toutes les colonnes.

## 🤧 Pour tester

Essayer de créer des campagnes d'ASSESSMENT et d'EXAM avec la création en masse de campagnes dans l'onglet "Administration" de PixAdmin.
