### PR TITLE
[BUGFIX] Corriger l'import des modifiers provenant de PixUI (PIX-17922)

### DIFF
--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.gjs
@@ -1,5 +1,5 @@
-import onEnterAction from '@1024pix/pix-ui/app/modifiers/on-enter-action';
-import onSpaceAction from '@1024pix/pix-ui/app/modifiers/on-space-action';
+import onEnterAction from '@1024pix/pix-ui/addon/modifiers/on-enter-action';
+import onSpaceAction from '@1024pix/pix-ui/addon/modifiers/on-space-action';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';

--- a/admin/tests/integration/components/common/tubes-selection-test.gjs
+++ b/admin/tests/integration/components/common/tubes-selection-test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 import { click, triggerEvent } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import TubesSelection from 'pix-admin/components/common/tubes-selection';
@@ -53,7 +53,7 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
     await clickByName(/Sélection du niveau du sujet suivant : Tube 1/);
-    await click(screen.getAllByText('4').find((item) => item.tabIndex === 0));
+    await click(within(await screen.findByRole('listbox')).getByRole('option', { name: '4' }));
 
     // then
     assert.dom(screen.getByLabelText('@tubeName1 : Tube 1')).isChecked();
@@ -68,7 +68,7 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
     await clickByName(/Sélection du niveau du sujet suivant : Tube 1/);
-    await click(screen.getAllByText('4').find((item) => item.tabIndex === 0));
+    await click(within(await screen.findByRole('listbox')).getByRole('option', { name: '4' }));
     await click(screen.getByLabelText('@tubeName1 : Tube 1'));
 
     // then


### PR DESCRIPTION
## 🌸 Problème

les modifiers sur PixUI on été déporté dans le folder addon et non app, renovate a été un peu vite en besogne et il n'a pas attendu que tout soit vert

## 🌳 Proposition

On corrige

## 🐝 Remarques

RAS

## 🤧 Pour tester

Build et deploy au vert