### PR TITLE
[TECH] Modifier le token github utilisé par le workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           changelogTitle: "# Pix Changelog"
         env:
-          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_RELEASE_ACTION_TOKEN }}
       - name: Notify to a slack channel
         if: env.new_release_published == 'true'
         uses: slackapi/slack-github-action@v2.0.0


### PR DESCRIPTION
## 🌸 Problème
Le token github utilisé par le workflow de release était celui de pix automerge. Afin de lui permettre de push sur la branche dev, sans avoir besoin d'un PR ou que les checks passent, j'avais donner les droits admin à ce bot. Cependant, cela fait qu'il n'attends plus le passage des check pour le merge des PR :facepalm:.  

## 🌳 Proposition
- Utiliser un autre token, celui de pix service github.

## 🐝 Remarques
J'ai rajouté un nouveau PAT sur le compte de service mais je ne lui ai pas donné de scope, je ne sais pas si cela est nécessaire.