### PR TITLE
[TECH] Créer un script de suppression des méthodes de connexion pour les anciens utilisateurs scolaires (PIX-17515).

### DIFF
--- a/api/src/identity-access-management/scripts/delete-ex-sco-authentication-methods.script.js
+++ b/api/src/identity-access-management/scripts/delete-ex-sco-authentication-methods.script.js
@@ -1,0 +1,66 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../domain/constants/identity-providers.js';
+import * as authenticationMethodRepository from '../infrastructure/repositories/authentication-method.repository.js';
+import * as userRepository from '../infrastructure/repositories/user.repository.js';
+
+export class DeleteExScoAuthenticationMethodsScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Deletes authentication methods for users that are no longer SCO and that have already used the account recovery demand.',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If present, the script will not make any changes to the database',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger, dependencies = { authenticationMethodRepository, userRepository } }) {
+    const { dryRun } = options;
+    const exScoUserIdsWithOldCampaignParticipation = await _getUserList();
+    if (dryRun) {
+      logger.info(
+        `DryRun mode, ${exScoUserIdsWithOldCampaignParticipation.length} user authentication methods to be processed.`,
+      );
+      return;
+    } else {
+      for (const userId of exScoUserIdsWithOldCampaignParticipation) {
+        await dependencies.authenticationMethodRepository.removeByUserIdAndIdentityProvider({
+          userId,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        });
+        await dependencies.userRepository.updateUsername({ id: userId, username: null });
+      }
+      logger.info(
+        `The script has modified ${exScoUserIdsWithOldCampaignParticipation.length} user's authentication methods`,
+      );
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteExScoAuthenticationMethodsScript);
+
+function _getDate12MonthsAgo() {
+  const date = new Date();
+  date.setFullYear(date.getFullYear() - 1);
+  return date;
+}
+
+async function _getUserList() {
+  const exScoUserIdsWithOldCampaignParticipation = await knex('campaign-participations')
+    .join('campaigns', 'campaigns.id', '=', 'campaign-participations.campaignId')
+    .join('organizations', 'organizations.id', '=', 'campaigns.organizationId')
+    .where('organizations.type', 'SCO')
+    .whereIn('campaign-participations.userId', function () {
+      this.select('userId').from('account-recovery-demands').where({ used: true });
+    })
+    .andWhere('campaign-participations.createdAt', '<', _getDate12MonthsAgo())
+    .pluck('userId');
+  return exScoUserIdsWithOldCampaignParticipation;
+}

--- a/api/tests/identity-access-management/integration/scripts/delete-ex-sco-authentication-methods.script.test.js
+++ b/api/tests/identity-access-management/integration/scripts/delete-ex-sco-authentication-methods.script.test.js
@@ -1,0 +1,103 @@
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { DeleteExScoAuthenticationMethodsScript } from '../../../../src/identity-access-management/scripts/delete-ex-sco-authentication-methods.script.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Scripts | delete-ex-sco-authentication-methods', function () {
+  describe('#handle', function () {
+    const now = new Date('2024-12-30');
+    let clock;
+    let userId1;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      userId1 = databaseBuilder.factory.buildUser({ id: 100, username: 'user100' }).id;
+      const userId2 = databaseBuilder.factory.buildUser({ id: 101, username: 'user101' }).id;
+      const userId3 = databaseBuilder.factory.buildUser({ id: 102, username: 'user102' }).id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: userId1,
+        externalIdentifier: null,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: userId2,
+        externalIdentifier: null,
+      });
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: userId3,
+        externalIdentifier: null,
+      });
+      const campaignId = databaseBuilder.factory.buildCampaign({ id: 1234, organizationId }).id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: userId1,
+        campaignId,
+        createdAt: new Date('2020-05-05'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: userId2,
+        campaignId,
+        createdAt: new Date('2024-05-05'),
+      });
+
+      databaseBuilder.factory.buildAccountRecoveryDemand({ userId: userId1, used: true, temporaryKey: 'temporary1' });
+      databaseBuilder.factory.buildAccountRecoveryDemand({ userId: userId2, used: true, temporaryKey: 'temporary2' });
+      databaseBuilder.factory.buildAccountRecoveryDemand({ userId: userId3, used: true, temporaryKey: 'temporary3' });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    context('when dryRun is false', function () {
+      it('removes former students GAR authentication methods when their last campaign participation is older than 12 months agos', async function () {
+        // when
+        const script = new DeleteExScoAuthenticationMethodsScript();
+        await script.handle({ options: { dryRun: false }, logger });
+
+        // then
+        const formerUserGarAuthenticationMethod1 = await knex('authentication-methods').where({
+          userId: userId1,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        });
+        expect(formerUserGarAuthenticationMethod1).to.be.empty;
+      });
+
+      context('when the user has a username', function () {
+        it('removes the username', async function () {
+          // when
+          const script = new DeleteExScoAuthenticationMethodsScript();
+          await script.handle({ options: { dryRun: false }, logger });
+
+          // then
+          const formerUserGarAuthenticationMethod1 = await knex('authentication-methods').where({
+            userId: userId1,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+          });
+          expect(formerUserGarAuthenticationMethod1).to.be.empty;
+          const formerUserWithUsername = await knex('users').select('id', 'username').where({ id: userId1 }).first();
+          expect(formerUserWithUsername.username).to.be.null;
+        });
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('does nothing', async function () {
+        // when
+        const script = new DeleteExScoAuthenticationMethodsScript();
+        await script.handle({ options: { dryRun: true }, logger });
+
+        // then
+        const formerUserGarAuthenticationMethod1 = await knex('authentication-methods').where({
+          userId: userId1,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        });
+        const formerUserWithUsername = await knex('users').select('id', 'username').where({ id: userId1 }).first();
+        expect(formerUserGarAuthenticationMethod1.length).to.equal(1);
+        expect(formerUserWithUsername.username).to.equal('user100');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème
On doit profiter de l’amélioration de sortie du SCO pour traiter les utilisateurs qui ont déjà quitté le SCO via le formulaire.

## 🌳 Proposition
Pour les anciens utilisateurs scolaires ayant déjà fait une demande de récupération de méthode de connexion, on souhaite supprimer les anciennes méthodes de connexion propres au scolaire (GAR et/ou identifiant spécifique).
Créer un script qui supprimera ces méthodes de connexion pour les utilisateurs concernés.

:information_source: Ce script est temporaire car il fait un nettoyage des anciennes demandes de récupérations (`account-recovery-demands.used = true`) qui n’effectuaient pas le nettoyage des méthodes de connexion. Or depuis #12285 les méthodes de connexions sont supprimées. Donc une fois passé, ce script n'aura plus de raison d’être.

## 🤧 Pour tester

⚠️  Des seeds temporaire ont été créé pour tester cette PR, pour chaque orga learners, des campagnes et campagnes participations de plus de douze mois ont été rajoutée (15 au totale)

- Lancer le script `node src/identity-access-management/scripts/delete-ex-sco-authentication-methods.script.js`
- Constater que les méthodes d'authentifications des users ont bien été supprimées
