### PR TITLE
[FEATURE] Utiliser le webcomponent `message-conversation` à la place de la vidéo (PIX-17921)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -26,7 +26,7 @@
           "element": {
             "id": "91e6c6bb-4287-4184-8860-086277fd6a31",
             "type": "text",
-            "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.<br>Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>"
+            "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.</p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -39,12 +39,49 @@
         {
           "type": "element",
           "element": {
-            "id": "e959af9d-9963-471b-aedb-c234d465b868",
-            "type": "video",
-            "title": "Le format des adresses mail",
-            "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
-            "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-            "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;?&nbsp;<span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;?&nbsp;<span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;!&nbsp;<span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: Dans une adresse mail, il y a toujours le symbole arobase !</li></ul>"
+            "id": "2ef9874d-e137-40e0-bc64-1210ff66b9c0",
+            "type": "custom",
+            "tagName": "message-conversation",
+            "props": {
+              "title": "Conversation entre Naomi et Mickaël à propos d’une adresse mail",
+              "messages": [
+                {
+                  "userName": "Naomi",
+                  "direction": "outgoing",
+                  "content": "Salut, tu peux me redonner ton adresse mail stp ? 😇"
+                },
+                {
+                  "userName": "Mickaël",
+                  "direction": "incoming",
+                  "content": "Oui, c’est mickael.aubert123#laposte.net"
+                },
+                {
+                  "userName": "Naomi",
+                  "direction": "outgoing",
+                  "content": "T’es sûr ? 😬"
+                },
+                {
+                  "userName": "Naomi",
+                  "direction": "outgoing",
+                  "content": "Tu veux dire mickael.aubert123@laposte.net"
+                },
+                {
+                  "userName": "Mickaël",
+                  "direction": "incoming",
+                  "content": "Ah oui désolé ! 😣"
+                },
+                {
+                  "userName": "Mickaël",
+                  "direction": "incoming",
+                  "content": "comment tu as su ? "
+                },
+                {
+                  "userName": "Naomi",
+                  "direction": "outgoing",
+                  "content": "Dans une adresse mail, il y a toujours le symbole arobase !"
+                }
+              ]
+            }
           }
         }
       ]

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -1,0 +1,5 @@
+@use 'pix-design-tokens/colors';
+
+message-conversation::part(conversation) {
+  background-color: var(--pix-primary-10);
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -83,6 +83,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/passage' as *;
 @use '../components/module/instruction/recap' as *;
 @use '../components/module/component/stepper' as *;
+@use '../components/module/element/custom-element' as *;
 @use '../components/module/element/download' as *;
 @use '../components/module/element/embed' as *;
 @use '../components/module/element/expand' as *;
@@ -198,11 +199,14 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 
 
 .unauthenticated-page {
-  & > .pix-app-layout__main, .pix-app-layout__footer, .pix-app-layout__navigation {
+
+  &>.pix-app-layout__main,
+  .pix-app-layout__footer,
+  .pix-app-layout__navigation {
     padding: 0;
   }
 
-  & > .pix-app-layout__main {
+  &>.pix-app-layout__main {
     max-width: 100%;
   }
 }


### PR DESCRIPTION
## 🌳 Proposition
On souhaite rendre l'expérience plus immersive, en simulant une vraie messagerie.

Utiliser le nouveau webcomponent `message-conversation` de `@1024pix/epreuves-components`.

## 🐝 Remarques
Prévoir de supprimer les 2 fichiers vidéos dans videos.pix.fr.

On met un fond (choix design) côté Pix App pour ne pas nuire à la réutilisation du webcomponent.

## 🤧 Pour tester
Vérifier le bon fonctionnement du module :
https://app-pr12340.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage

OK contenu ✅