### PR TITLE
[TECH] Corrige le lockfile pour qu'il soit cohérent avec le fichier package.json

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -28979,15 +28979,14 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-6.1.0.tgz",
-      "integrity": "sha512-7FBMsr5XlSVs080FEw0ssNgbQEAAzQGc3ZHmgBE40LRcz7g+vMXPwaZ7DGsOoWPXHKAVeeDbr5qiMC13WkVj5w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-6.0.0.tgz",
+      "integrity": "sha512-3aBkhm8bXgwI1ONUgMF8wfKRF8opHrp31T9118B17qg6Fcpe6iiOJUwgyQbDX82cpq8jmbWFu8WPLOHDwqVysA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
-        "@embroider/addon-shim": "^1.9.0",
         "@glimmer/compiler": "0.92.4",
         "@glimmer/destroyable": "0.92.3",
         "@glimmer/env": "^0.1.7",
@@ -29011,7 +29010,7 @@
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "chalk": "^4.0.0",
-        "ember-auto-import": "^2.10.0",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
@@ -29032,7 +29031,7 @@
         "node": ">= 18.*"
       },
       "peerDependencies": {
-        "@glimmer/component": ">= 1.1.2"
+        "@glimmer/component": "^1.1.2"
       }
     },
     "node_modules/ember-source/node_modules/@glimmer/interfaces": {


### PR DESCRIPTION
## 🌸 Problème

Le package.json indique une version 6.0.0 pour la dépendance ember-source. Cependant le lockfile était encore sur une version 5.

## 🌳 Proposition

Mettre à jour le lockfile pour qu'il soit cohérent avec le package.json.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

La CI est verte 🍏
Faire un tour sur l'application 🤗 
