### PR TITLE
[TECH] Corriger une injection de dépendances dans les tests qui était mal réalisée

### DIFF
--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -88,4 +88,4 @@ const usecasesWithoutInjectedDependencies = {
  */
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
-export { repositories, usecases };
+export { usecases };

--- a/api/src/organizational-entities/infrastructure/repositories/index.js
+++ b/api/src/organizational-entities/infrastructure/repositories/index.js
@@ -1,9 +1,11 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationApi from '../../../team/application/api/organization.js';
+import { certificationCenterApiRepository } from './certification-center-api.repository.js';
 import { organizationForAdminRepository } from './organization-for-admin.repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   organizationForAdminRepository,
+  certificationCenterApiRepository,
 };
 
 const dependencies = {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-api.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-api.repository.test.js
@@ -1,4 +1,4 @@
-import { repositories } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { repositories } from '../../../../../src/organizational-entities/infrastructure/repositories/index.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 


### PR DESCRIPTION
## 🌸 Problème

Le test `api/tests/organizational-entities/integration/infrastructure/repositories/certification-center-api.repository.test.js` abuse de l’injection de dépendances des usecases au lieu d’utiliser directement l’injection des dépendances pour les repositories.

## 🌳 Proposition

Utiliser directement l’injection des dépendances pour les repositories.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Vérifier que tous les tests passent dans la CI.
