### PR TITLE
[FEATURE] Ajouter la possibilité de désactiver l'authentification par mot de passe sur Pix admin (PIX-17820)

### DIFF
--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -63,6 +63,7 @@ export default class LoginForm extends Component {
   _handleApiError(responseError) {
     const errors = get(responseError, 'responseJSON.errors');
     const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+    console.log(error);
     switch (error?.code) {
       case 'USER_IS_TEMPORARY_BLOCKED':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
@@ -75,6 +76,9 @@ export default class LoginForm extends Component {
           url: 'https://support.pix.org/support/tickets/new',
           htmlSafe: true,
         });
+        break;
+      case 'PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED.I18N_KEY);
         break;
       default:
         this.errorMessage = this.intl.t(this._getI18nKeyByStatus(responseError.status));

--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -63,7 +63,6 @@ export default class LoginForm extends Component {
   _handleApiError(responseError) {
     const errors = get(responseError, 'responseJSON.errors');
     const error = Array.isArray(errors) && errors.length > 0 && errors[0];
-    console.log(error);
     switch (error?.code) {
       case 'USER_IS_TEMPORARY_BLOCKED':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -45,6 +45,10 @@ module.exports = function (environment) {
           CODE: '401',
           I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
         },
+        PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED: {
+          CODE: '401',
+          I18N_KEY: 'common.api-error-messages.pix-admin-login-from-password-disabled-error',
+        },
         USER_IS_TEMPORARY_BLOCKED: {
           CODE: '403',
           I18N_KEY: 'common.api-error-messages.login-user-temporary-blocked-error',

--- a/admin/tests/integration/components/login-form-test.gjs
+++ b/admin/tests/integration/components/login-form-test.gjs
@@ -172,6 +172,33 @@ module('Integration | Component | login-form', function (hooks) {
       assert.dom(screen.getByText(t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
     });
 
+    test('should display good error message when login with username and password is disabled', async function (assert) {
+      // given
+      const errorResponse = {
+        status: Number(ApiErrorMessages.PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED.CODE),
+        responseJSON: {
+          errors: [
+            {
+              status: ApiErrorMessages.PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED.CODE,
+              code: 'PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED',
+              detail: ApiErrorMessages.PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED.I18N_KEY,
+            },
+          ],
+        },
+      };
+      sessionStub.authenticate = () => reject(errorResponse);
+
+      const screen = await render(<template><LoginForm /></template>);
+
+      // when
+      await fillByLabel('Adresse e-mail', 'pix@example.net');
+      await fillByLabel('Mot de passe', 'JeMeLoggue1024');
+      await clickByName('Je me connecte');
+
+      // then
+      assert.dom(screen.getByText(t(ApiErrorMessages.PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED.I18N_KEY))).exists();
+    });
+
     test('should display good error message when an error 400 occurred', async function (assert) {
       // given
       const errorResponse = {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -19,7 +19,8 @@
       "login-unauthorized-error": "There was an error in the email address or username/password entered.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'.",
-      "organization-not-found-error": "The organization \"{organizationId}\" does not exist."
+      "organization-not-found-error": "The organization \"{organizationId}\" does not exist.",
+      "pix-admin-login-from-password-disabled-error": "Email and password login is disabled. Please use SSO to log in."
     },
     "fields": {
       "createdAt": "creation date",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -19,7 +19,8 @@
       "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, '<'a href=\"{url}\"'>'contactez-nous'</a>'.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser.",
-      "organization-not-found-error": "L’organisation \"{organizationId}\" n’existe pas."
+      "organization-not-found-error": "L’organisation \"{organizationId}\" n’existe pas.",
+      "pix-admin-login-from-password-disabled-error": "La connexion par email et mot de passe est désactivée. Utilisez un SSO pour vous connecter."
     },
     "fields": {
       "createdAt": "date de création",

--- a/api/sample.env
+++ b/api/sample.env
@@ -524,6 +524,12 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # sample: SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES=10
 # SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES=
 
+# Enable or disable password login for Pix Admin
+# presence: optional
+# type: boolean
+# default: false
+# PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED = false
+
 # ===================
 # SAML CONFIGURATION
 # ===================

--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -8,6 +8,7 @@ import {
   MissingUserAccountError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
+  PixAdminLoginFromPasswordDisabledError,
   UserCantBeCreatedError,
   UserShouldChangePasswordError,
 } from '../domain/errors.js';
@@ -40,6 +41,10 @@ const authenticationDomainErrorMappingConfiguration = [
   {
     name: PasswordResetDemandNotFoundError.name,
     httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message),
+  },
+  {
+    name: PixAdminLoginFromPasswordDisabledError.name,
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
   },
   {
     name: UserCantBeCreatedError.name,

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -70,6 +70,12 @@ class PasswordResetDemandNotFoundError extends DomainError {
   }
 }
 
+class PixAdminLoginFromPasswordDisabledError extends DomainError {
+  constructor() {
+    super('PixAdminLoginFromPassword disabled. Use SSO authentication.', 'PIX_ADMIN_LOGIN_FROM_PASSWORD_DISABLED');
+  }
+}
+
 class UserCantBeCreatedError extends DomainError {
   constructor(message = "L'utilisateur ne peut pas être créé") {
     super(message);
@@ -114,6 +120,7 @@ export {
   OrganizationLearnerNotBelongToOrganizationIdentityError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
+  PixAdminLoginFromPasswordDisabledError,
   RevokeUntilMustBeAnInstanceOfDate,
   UserCantBeCreatedError,
   UserIdIsRequiredError,

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -1,8 +1,14 @@
 import { PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
+import { config } from '../../../shared/config.js';
 import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { createWarningConnectionEmail } from '../emails/create-warning-connection.email.js';
-import { MissingOrInvalidCredentialsError, PasswordNotMatching, UserShouldChangePasswordError } from '../errors.js';
+import {
+  MissingOrInvalidCredentialsError,
+  PasswordNotMatching,
+  PixAdminLoginFromPasswordDisabledError,
+  UserShouldChangePasswordError,
+} from '../errors.js';
 import { RefreshToken } from '../models/RefreshToken.js';
 
 /**
@@ -45,6 +51,9 @@ const authenticateUser = async function ({
   requestedApplication,
   audience,
 }) {
+  if (!config.authentication.permitPixAdminLoginFromPassword && requestedApplication.isPixAdmin) {
+    throw new PixAdminLoginFromPasswordDisabledError();
+  }
   try {
     const user = await pixAuthenticationService.getUserByUsernameAndPassword({
       username,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -205,6 +205,7 @@ const configuration = (function () {
       revokedUserAccessLifespanMs: ms(process.env.REVOKED_USER_ACCESS_LIFESPAN || '7d'),
       tokenForStudentReconciliationLifespan: '1h',
       passwordResetTokenLifespan: '1h',
+      permitPixAdminLoginFromPassword: toBoolean(process.env.PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED),
     },
     authenticationSession: {
       temporaryStorage: {
@@ -556,6 +557,7 @@ const configuration = (function () {
     config.temporaryKey.secret = 'the-password-must-be-at-least-32-characters-long';
 
     config.temporaryStorage.redisUrl = process.env.TEST_REDIS_URL;
+    config.authentication.permitPixAdminLoginFromPassword = false;
 
     config.saml.accessTokenLifespanMs = 1000;
 

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -5,6 +5,7 @@ import { decodeIfValid } from '../../../../src/shared/domain/services/token-serv
 import { createServer, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
+import { config } from '../../../../src/shared/config.js';
 
 describe('Acceptance | Identity Access Management | Route | Token', function () {
   let server;
@@ -21,6 +22,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     let userId;
 
     beforeEach(async function () {
+      config.authentication.permitPixAdminLoginFromPassword = true;
       userId = databaseBuilder.factory.buildUser.withRawPassword({
         email: userEmailAddress,
         rawPassword: userPassword,


### PR DESCRIPTION
## 🌸 Problème

Même si le front affiche l'interface SSO pour se connecter à Pix admin, on peut toujours passer par l'endpoint api/token avec username et password pour récupérer un token.

## 🌳 Proposition

Autoriser ou non la connexion via username et password en fonction d'une variable d'environnement `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` ayant la valeur `false` par défaut.

Et répondre l’erreur suivante en cas de tentative de connexion par mot de passe si la variable d’environnement ne l’autorise pas : 
```
401 Unauthorized: "PixAdminLoginFromPassword disabled. Use SSO authentication."
```

Compte tenu, actuellement, de l’absence d’un endpoint adapté pour remonter la valeur de la variable d’environnement `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED`, on ne conditionnera pas l’affichage du formulaire de connexion par mot de passe vs le bouton de connexion par SSO dans cette PR. Cela sera fait plus tard quand un endpoint adapté sera disponible.

## 🐝 Remarques

Mettre la variable sur les environnement de recette et intégration. 

## 🤧 Pour tester

- Aller sur Pix Admin,
- Tenter de se connecter par mot de passe,
- Constater qu'on ne peut pas et qu'un message indique pourquoi (passer par un SSO),
- Mettre la valeur de `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` à `true`,
- Redémarrer Pix API,
- Constater qu'on peut de nouveau se connecter normalement avec nom d'utilisateur et mot de passe.
