### PR TITLE
[FEATURE] Création d'un endpoint côté API pour démarrer une conversation avec le LLM dans le cadre d'une épreuve avec un embed de prompt LLM (PIX-17903)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -65,4 +65,10 @@ export default {
     defaultValue: false,
     tags: ['team-junior'],
   },
+  isEmbedLLMEnabled: {
+    type: 'boolean',
+    description: 'Allow embeds with LLM prompts to interact with the LLM API and start a conversation',
+    defaultValue: false,
+    tags: ['modulix', 'team-contenu', 'llm', 'embed', 'pix-app'],
+  },
 };

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -29,6 +29,11 @@ async function teamContenuDataBuilder({ databaseBuilder }) {
   await _createProfilesCollectionCampaign(databaseBuilder);
   await _createCertifiableUser(databaseBuilder);
   await _createPerfectProfileUser(databaseBuilder);
+  // data for LLM
+  databaseBuilder.factory.buildPassage({
+    moduleId: 'coucouMaman',
+    userId: PERFECT_PROFILE_USER_ID,
+  });
 }
 
 export { teamContenuDataBuilder };

--- a/api/sample.env
+++ b/api/sample.env
@@ -409,6 +409,27 @@ LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 LCMS_API_URL=https://lcms.minimal.pix.fr/api
 
 # =======
+# LLM CHAT
+# =======
+
+# LLM chats temporary storage expiration delay in seconds
+# Default value is worth 12 hours
+#
+# presence: optional
+# type: Integer
+# default: 43200
+# sample: LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS=
+
+# LLM API URL to get a configuration by id
+#
+# If not present, embed with LLM will not work
+#
+# presence: required
+# type: String
+# default: none
+LLM_API_GET_CONFIGURATIONS_URL=
+
+# =======
 # LOGGING
 # =======
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -412,12 +412,11 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # LLM CHAT
 # =======
 
-# LLM chats temporary storage expiration delay in seconds
-# Default value is worth 12 hours
+# LLM chats temporary storage lifespan
 #
 # presence: optional
-# type: Integer
-# default: 43200
+# type: string
+# default: '12h'
 # sample: LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS=
 
 # LLM API URL to get a configuration by id
@@ -427,7 +426,7 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # presence: required
 # type: String
 # default: none
-LLM_API_GET_CONFIGURATIONS_URL=
+# LLM_API_GET_CONFIGURATIONS_URL=
 
 # =======
 # LOGGING

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -44,6 +44,21 @@ const terminate = async function (request, h, { usecases, passageSerializer }) {
   return passageSerializer.serialize(updatedPassage);
 };
 
-const passageController = { create, verifyAndSaveAnswer, terminate };
+const startEmbedLlmChat = async function (request, h, { usecases }) {
+  const { configId } = request.payload;
+  const userId = request.auth.credentials.userId;
+  const passageId = request.params.passageId;
+  const startedChatDTO = await usecases.startEmbedLlmChat({ configId, userId, passageId });
+
+  return h
+    .response({
+      inputMaxChars: startedChatDTO.inputMaxChars,
+      inputMaxPrompts: startedChatDTO.inputMaxPrompts,
+      chatId: startedChatDTO.id,
+    })
+    .code(201);
+};
+
+const passageController = { create, verifyAndSaveAnswer, terminate, startEmbedLlmChat };
 
 export { passageController };

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { checkLLMChatIsEnabled } from '../../../llm/application/pre-handlers/index.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
 import { passageController } from './controller.js';
@@ -84,9 +84,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) => {
-              return securityPreHandlers.checkFeatureToggleIsEnabled(h, 'isEmbedLLMEnabled');
-            },
+            method: checkLLMChatIsEnabled,
           },
         ],
         validate: {

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -77,6 +77,28 @@ const register = async function (server) {
         tags: ['api', 'passages'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/passages/{passageId}/embed/llm/chats',
+      config: {
+        validate: {
+          params: Joi.object({
+            passageId: identifiersType.passageId.required(),
+          }).required(),
+          payload: Joi.object({
+            configId: Joi.string().required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: handlerWithDependencies(passageController.startEmbedLlmChat),
+        tags: ['api', 'passages', 'embed', 'llm'],
+        notes: [
+          "Cette route permet de démarrer une conversation avec un LLM dans le cadre de la réalisation d'un embed LLM dans un modulix",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
 import { passageController } from './controller.js';
@@ -81,6 +82,13 @@ const register = async function (server) {
       method: 'POST',
       path: '/api/passages/{passageId}/embed/llm/chats',
       config: {
+        pre: [
+          {
+            method: (request, h) => {
+              return securityPreHandlers.checkFeatureToggleIsEnabled(h, 'isEmbedLLMEnabled');
+            },
+          },
+        ],
         validate: {
           params: Joi.object({
             passageId: identifiersType.passageId.required(),

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import * as targetProfileTrainingRepository from '../../../../lib/infrastructure/repositories/target-profile-training-repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
+import * as llmApi from '../../../llm/application/api/llm-api.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
@@ -27,6 +28,7 @@ const dependencies = {
   targetProfileTrainingRepository,
   skillRepository,
   userRepository,
+  llmApi,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/src/devcomp/domain/usecases/start-embed-llm-chat.js
+++ b/api/src/devcomp/domain/usecases/start-embed-llm-chat.js
@@ -1,0 +1,15 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+
+export async function startEmbedLlmChat({ configId, userId, passageId, llmApi, passageRepository }) {
+  await checkIfPassageBelongsToUser(passageId, userId, passageRepository);
+  const newChat = await llmApi.startChat({ configId, prefixIdentifier: `p${passageId}` });
+  if (!newChat) {
+    throw new DomainError('Error when starting chat with LLM');
+  }
+  return newChat;
+}
+
+async function checkIfPassageBelongsToUser(passageId, userId, passageRepository) {
+  const passage = await passageRepository.get({ passageId });
+  if (passage.userId !== userId) throw new DomainError(`This passage does not belong to user`);
+}

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -7,7 +7,7 @@ import { LLMChatDTO } from './models/LLMChatDTO.js';
 export const STORAGE_PREFIX = 'llm-chats';
 const llmChatsTemporaryStorage = temporaryStorage.withPrefix(STORAGE_PREFIX);
 
-const logger = child('llm:api', { event: SCOPES.LEARNING_CONTENT });
+const logger = child('llm:api', { event: SCOPES.LLM });
 
 /**
  * @typedef LLMChatDTO
@@ -58,18 +58,23 @@ function generateId(prefixIdentifier) {
 
 async function getLLMConfiguration(configId) {
   const url = config.llm.getConfigurationUrl + '/' + configId;
-  const response = await fetch(url);
-  const statusCode = parseInt(response.status);
-  const jsonResponse = response.body ? await response.json() : '';
-  if (statusCode === 200) {
-    return jsonResponse;
-  }
-  if (statusCode === 404) {
-    logger.error(`No config found for id ${configId}`);
+  try {
+    const response = await fetch(url);
+    const statusCode = parseInt(response.status);
+    const jsonResponse = response.body ? await response.json() : '';
+    if (statusCode === 200) {
+      return jsonResponse;
+    }
+    if (statusCode === 404) {
+      logger.error(`No config found for id ${configId}`);
+      return null;
+    }
+    logger.error(`code (${statusCode}): ${JSON.stringify(jsonResponse, undefined, 2)}}`);
+    return null;
+  } catch (err) {
+    logger.error(err);
     return null;
   }
-  logger.error(`code (${statusCode}): ${JSON.stringify(jsonResponse, undefined, 2)}}`);
-  return null;
 }
 
 function toApi(llmChat) {

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -1,0 +1,81 @@
+import { config } from '../../../shared/config.js';
+import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
+import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
+import { LLMChat } from '../../domain/models/LLMChat.js';
+import { LLMChatDTO } from './models/LLMChatDTO.js';
+
+export const STORAGE_PREFIX = 'llm-chats';
+const llmChatsTemporaryStorage = temporaryStorage.withPrefix(STORAGE_PREFIX);
+
+const logger = child('llm:api', { event: SCOPES.LEARNING_CONTENT });
+
+/**
+ * @typedef LLMChatDTO
+ * @type {object}
+ * @property {string} id
+ * @property {number} inputMaxPrompts
+ * @property {number} inputMaxChars
+ */
+
+/**
+ * @function
+ * @name startChat
+ *
+ * @param {Object} params
+ * @param {string} params.configId
+ * @param {string} params.prefixIdentifier
+ * @returns {Promise<LLMChatDTO>}
+ */
+export async function startChat({ configId, prefixIdentifier }) {
+  if (!configId) {
+    return null;
+  }
+  const chatId = generateId(prefixIdentifier);
+  const llmConfiguration = await getLLMConfiguration(configId);
+  if (!llmConfiguration) {
+    return null;
+  }
+
+  const newChat = new LLMChat({
+    id: chatId,
+    llmConfigurationId: configId,
+    historySize: llmConfiguration.llm.historySize,
+    inputMaxChars: llmConfiguration.challenge.inputMaxChars,
+    inputMaxPrompts: llmConfiguration.challenge.inputMaxPrompts,
+  });
+  await llmChatsTemporaryStorage.save({
+    key: newChat.id,
+    value: newChat.toDTO(),
+    expirationDelaySeconds: config.llm.temporaryStorage.expirationDelaySeconds,
+  });
+  return toApi(newChat);
+}
+
+function generateId(prefixIdentifier) {
+  const nowMs = new Date().getMilliseconds();
+  return `${prefixIdentifier}-${nowMs}`;
+}
+
+async function getLLMConfiguration(configId) {
+  const url = config.llm.getConfigurationUrl + '/' + configId;
+  const response = await fetch(url);
+  const statusCode = parseInt(response.status);
+  const jsonResponse = response.body ? await response.json() : '';
+  if (statusCode === 200) {
+    return jsonResponse;
+  }
+  if (statusCode === 404) {
+    logger.error(`No config found for id ${configId}`);
+    return null;
+  }
+  logger.error(`code (${statusCode}): ${JSON.stringify(jsonResponse, undefined, 2)}}`);
+  return null;
+}
+
+function toApi(llmChat) {
+  return new LLMChatDTO({
+    id: llmChat.id,
+    inputMaxChars: llmChat.inputMaxChars,
+    inputMaxPrompts: llmChat.inputMaxPrompts,
+  });
+}

--- a/api/src/llm/application/api/models/LLMChatDTO.js
+++ b/api/src/llm/application/api/models/LLMChatDTO.js
@@ -1,0 +1,7 @@
+export class LLMChatDTO {
+  constructor({ id, inputMaxChars, inputMaxPrompts }) {
+    this.id = id;
+    this.inputMaxChars = inputMaxChars;
+    this.inputMaxPrompts = inputMaxPrompts;
+  }
+}

--- a/api/src/llm/application/pre-handlers/index.js
+++ b/api/src/llm/application/pre-handlers/index.js
@@ -1,0 +1,20 @@
+import { HttpErrors } from '../../../shared/application/http-errors.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
+import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/error-serializer.js';
+
+export async function checkLLMChatIsEnabled(request, h) {
+  try {
+    const isEnabled = await featureToggles.get('isEmbedLLMEnabled');
+    if (isEnabled) {
+      return h.response(true);
+    }
+    return replyServiceNotAvailableError(h);
+  } catch {
+    return replyServiceNotAvailableError(h);
+  }
+}
+
+function replyServiceNotAvailableError(h) {
+  const error = new HttpErrors.ServiceUnavailableError();
+  return h.response(errorSerializer.serialize(error)).code(error.status).takeover();
+}

--- a/api/src/llm/domain/models/LLMChat.js
+++ b/api/src/llm/domain/models/LLMChat.js
@@ -1,0 +1,19 @@
+export class LLMChat {
+  constructor({ id, llmConfigurationId, historySize, inputMaxChars, inputMaxPrompts }) {
+    this.id = id;
+    this.llmConfigurationId = llmConfigurationId;
+    this.historySize = historySize;
+    this.inputMaxChars = inputMaxChars;
+    this.inputMaxPrompts = inputMaxPrompts;
+  }
+
+  toDTO() {
+    return {
+      id: this.id,
+      llmConfigurationId: this.llmConfigurationId,
+      historySize: this.historySize,
+      inputMaxChars: this.inputMaxChars,
+      inputMaxPrompts: this.inputMaxPrompts,
+    };
+  }
+}

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -8,11 +8,8 @@ import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescript
 import * as isSchoolSessionActive from '../../school/application/usecases/is-school-session-active.js';
 import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import { Organization } from '../domain/models/index.js';
-import { featureToggles } from '../infrastructure/feature-toggles/index.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
-import * as errorSerializer from '../infrastructure/serializers/jsonapi/error-serializer.js';
 import { PromiseUtils } from '../infrastructure/utils/promise-utils.js';
-import { HttpErrors } from './http-errors.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
 import * as checkAdminMemberHasRoleCertifUseCase from './usecases/checkAdminMemberHasRoleCertif.js';
@@ -61,11 +58,6 @@ function _replyNotFoundError(h) {
   });
 
   return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-}
-
-function replyServiceNotAvailableError(h) {
-  const error = new HttpErrors.ServiceUnavailableError();
-  return h.response(errorSerializer.serialize(error)).code(error.status);
 }
 
 async function checkIfUserIsBlocked(
@@ -783,18 +775,6 @@ async function checkOrganizationHasFeature(request, h, dependencies = { checkOrg
   }
 }
 
-async function checkFeatureToggleIsEnabled(h, featureKey) {
-  try {
-    const isEnabled = await featureToggles.get(featureKey);
-    if (isEnabled) {
-      return h.response(true);
-    }
-    return replyServiceNotAvailableError(h);
-  } catch {
-    return replyServiceNotAvailableError(h);
-  }
-}
-
 function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
 }
@@ -834,7 +814,6 @@ const securityPreHandlers = {
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,
   checkUserOwnsCertificationCourse,
   makeCheckOrganizationHasFeature,
-  checkFeatureToggleIsEnabled,
 };
 
 export { securityPreHandlers };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -138,6 +138,8 @@ const schema = Joi.object({
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
+  LLM_API_GET_CONFIGURATIONS_URL: Joi.string().optional(),
+  LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
   LOG_ENABLED: Joi.string().required().valid('true', 'false'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'),
@@ -330,9 +332,9 @@ const configuration = (function () {
     },
     llm: {
       temporaryStorage: {
-        expirationDelaySeconds: parseInt(process.env.LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS, 10) || 43200,
+        expirationDelaySeconds: ms(process.env.LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS ?? '12h'),
       },
-      getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL || ''),
+      getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL ?? ''),
     },
     logging: {
       enabled: toBoolean(process.env.LOG_ENABLED),

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -501,6 +501,7 @@ const configuration = (function () {
     config.llm.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
     config.llm.temporaryStorage.expirationDelaySeconds = 1;
 
+    config.domain.tldFr = '.fr';
     config.domain.tldOrg = '.org';
     config.domain.pix = 'https://pix';
     config.domain.pixOrga = 'https://orga.pix';

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -328,6 +328,12 @@ const configuration = (function () {
       url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL || ''),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
+    llm: {
+      temporaryStorage: {
+        expirationDelaySeconds: parseInt(process.env.LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS, 10) || 43200,
+      },
+      getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL || ''),
+    },
     logging: {
       enabled: toBoolean(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
@@ -492,7 +498,9 @@ const configuration = (function () {
     config.lcms.apiKey = 'test-api-key';
     config.lcms.url = 'https://lcms-test.pix.fr/api';
 
-    config.domain.tldFr = '.fr';
+    config.llm.getConfigurationUrl = 'https://llm-test.pix.fr/api/configurations';
+    config.llm.temporaryStorage.expirationDelaySeconds = 1;
+
     config.domain.tldOrg = '.org';
     config.domain.pix = 'https://pix';
     config.domain.pixOrga = 'https://orga.pix';

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -49,6 +49,7 @@ export function child(section, bindings, options) {
 export const SCOPES = {
   LEARNING_CONTENT: 'learningcontent',
   IAM: 'iam',
+  LLM: 'llm',
 };
 
 function messageFormatCompact(log, messageKey, _logLevel, { colors }) {

--- a/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
@@ -1,0 +1,91 @@
+import { Passage } from '../../../../../src/devcomp/domain/models/Passage.js';
+import { startEmbedLlmChat } from '../../../../../src/devcomp/domain/usecases/start-embed-llm-chat.js';
+import { LLMChatDTO } from '../../../../../src/llm/application/api/models/LLMChatDTO.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | start-embed-llm-chat', function () {
+  let llmApi, passageRepository;
+  const configId = 'uneConfig';
+  const passageId = 123456;
+  const userId = 456789;
+
+  beforeEach(function () {
+    llmApi = {
+      startChat: sinon.stub(),
+    };
+    passageRepository = {
+      get: sinon.stub(),
+    };
+    llmApi.startChat.throws(new Error('llmapi-startchat: Unexpected call'));
+    passageRepository.get.throws(new Error('passageRepository-get: Unexpected call'));
+  });
+
+  context('when passage does not belong to user', function () {
+    it('should throw a DomainError', async function () {
+      // given
+      passageRepository.get.withArgs({ passageId }).resolves(
+        new Passage({
+          id: passageId,
+          userId: userId + 1,
+        }),
+      );
+
+      // when
+      const err = await catchErr(startEmbedLlmChat)({ configId, passageId, userId, llmApi, passageRepository });
+
+      // then
+      expect(err).to.be.instanceOf(DomainError);
+      expect(err.message).to.equal('This passage does not belong to user');
+    });
+  });
+
+  context('when chat could not be created', function () {
+    it('should throw a DomainError', async function () {
+      // given
+      passageRepository.get.withArgs({ passageId }).resolves(
+        new Passage({
+          id: passageId,
+          userId,
+        }),
+      );
+      llmApi.startChat.withArgs({ configId, prefixIdentifier: 'p123456' }).resolves(null);
+
+      // when
+      const err = await catchErr(startEmbedLlmChat)({ configId, passageId, userId, llmApi, passageRepository });
+
+      // then
+      expect(err).to.be.instanceOf(DomainError);
+      expect(err.message).to.equal('Error when starting chat with LLM');
+    });
+  });
+
+  context('success case', function () {
+    it('should return the newly created chat', async function () {
+      // given
+      passageRepository.get.withArgs({ passageId }).resolves(
+        new Passage({
+          id: passageId,
+          userId,
+        }),
+      );
+      llmApi.startChat.withArgs({ configId, prefixIdentifier: 'p123456' }).resolves(
+        new LLMChatDTO({
+          id: 'someChatId',
+          inputMaxChars: 123,
+          inputMaxPrompts: 456,
+        }),
+      );
+
+      // when
+      const chat = await startEmbedLlmChat({ configId, passageId, userId, llmApi, passageRepository });
+
+      // then
+      expect(chat).to.deep.equal({
+        id: 'someChatId',
+        inputMaxChars: 123,
+        inputMaxPrompts: 456,
+      });
+    });
+  });
+});

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -1,0 +1,87 @@
+import { startChat, STORAGE_PREFIX } from '../../../../../src/llm/application/api/llm-api.js';
+import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { expect, nock, sinon } from '../../../../test-helper.js';
+const llmChatsTemporaryStorage = temporaryStorage.withPrefix(STORAGE_PREFIX);
+
+describe('LLM | Integration | Application | API | llm', function () {
+  let clock, now;
+
+  beforeEach(async function () {
+    now = new Date('2023-10-05T18:02:00Z');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+    await llmChatsTemporaryStorage.flushAll();
+  });
+
+  context('when no config id provided', function () {
+    it('should return null', async function () {
+      // given
+      const configId = null;
+
+      // when
+      const chat = await startChat({ configId, prefixIdentifier: 'someUniquePrefix' });
+
+      // then
+      expect(chat).to.be.null;
+    });
+  });
+
+  context('when config id provided', function () {
+    context('when config does not exist', function () {
+      it('should return null', async function () {
+        // given
+        const configId = 'uneConfigQuiExistePo';
+        const llmApiScope = nock('https://llm-test.pix.fr/api')
+          .get('/configurations/uneConfigQuiExistePo')
+          .reply(404, {});
+
+        // when
+        const chat = await startChat({ configId, prefixIdentifier: 'someUniquePrefix' });
+
+        // then
+        expect(chat).to.be.null;
+        expect(llmApiScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when config exists', function () {
+      let configId, llmApiScope, config;
+      beforeEach(function () {
+        configId = 'uneConfigQuiExist';
+        config = {
+          llm: {
+            historySize: 123,
+          },
+          challenge: {
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+          },
+        };
+        llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
+      });
+
+      it('should return the newly created chat', async function () {
+        // when
+        const chat = await startChat({ configId, prefixIdentifier: 'someUniquePrefix' });
+
+        // then
+        expect(chat).to.deep.equal({
+          id: `someUniquePrefix-${now.getMilliseconds()}`,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+        });
+        expect(llmApiScope.isDone()).to.be.true;
+        expect(await llmChatsTemporaryStorage.get(`someUniquePrefix-${now.getMilliseconds()}`)).to.deep.equal({
+          id: `someUniquePrefix-${now.getMilliseconds()}`,
+          llmConfigurationId: 'uneConfigQuiExist',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/llm/unit/application/pre-handlers/index_test.js
+++ b/api/tests/llm/unit/application/pre-handlers/index_test.js
@@ -1,0 +1,30 @@
+import { checkLLMChatIsEnabled } from '../../../../../src/llm/application/pre-handlers/index.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
+import { expect, hFake } from '../../../../test-helper.js';
+
+describe('LLM | Unit | Application | PreHandlers', function () {
+  describe('#checkLLMChatIsEnabled', function () {
+    context('when feature toggle is enabled', function () {
+      it('should authorize access', async function () {
+        await featureToggles.set('isEmbedLLMEnabled', true);
+
+        const response = await checkLLMChatIsEnabled({}, hFake);
+
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('when feature toggle is disabled', function () {
+      it('should not authorize access', async function () {
+        await featureToggles.set('isEmbedLLMEnabled', false);
+
+        const response = await checkLLMChatIsEnabled({}, hFake);
+
+        expect(response.statusCode).to.equal(503);
+        expect(response.source).to.deep.equal({
+          errors: [{ status: '503', title: 'ServiceUnavailable' }],
+        });
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -2015,12 +2015,12 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
-  describe('#checkFeatureToggleIsEnabled', function () {
+  describe('#checkLLMChatIsEnabled', function () {
     context('when feature toggle is enabled', function () {
       it('should authorize access', async function () {
         await featureToggles.set('isEmbedLLMEnabled', true);
 
-        const response = await securityPreHandlers.checkFeatureToggleIsEnabled(hFake, 'isEmbedLLMEnabled');
+        const response = await securityPreHandlers.checkLLMChatIsEnabled(hFake, 'isEmbedLLMEnabled');
 
         expect(response.source).to.be.true;
       });
@@ -2030,7 +2030,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
       it('should authorize access', async function () {
         await featureToggles.set('isEmbedLLMEnabled', false);
 
-        const response = await securityPreHandlers.checkFeatureToggleIsEnabled(hFake, 'isEmbedLLMEnabled');
+        const response = await securityPreHandlers.checkLLMChatIsEnabled(hFake, 'isEmbedLLMEnabled');
 
         expect(response.statusCode).to.equal(503);
         expect(response.source).to.deep.equal({
@@ -2041,7 +2041,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
 
     context('when feature toggle does not exist', function () {
       it('should authorize access', async function () {
-        const response = await securityPreHandlers.checkFeatureToggleIsEnabled(
+        const response = await securityPreHandlers.checkLLMChatIsEnabled(
           hFake,
           'SiVousAvezAppeléVotreFeatureCommeCa,CaCraintChangezDeNom',
         );

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -1,7 +1,6 @@
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
-import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Shared | Unit | Application | SecurityPreHandlers', function () {
@@ -2011,45 +2010,6 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
 
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
-      });
-    });
-  });
-
-  describe('#checkLLMChatIsEnabled', function () {
-    context('when feature toggle is enabled', function () {
-      it('should authorize access', async function () {
-        await featureToggles.set('isEmbedLLMEnabled', true);
-
-        const response = await securityPreHandlers.checkLLMChatIsEnabled(hFake, 'isEmbedLLMEnabled');
-
-        expect(response.source).to.be.true;
-      });
-    });
-
-    context('when feature toggle is disabled', function () {
-      it('should authorize access', async function () {
-        await featureToggles.set('isEmbedLLMEnabled', false);
-
-        const response = await securityPreHandlers.checkLLMChatIsEnabled(hFake, 'isEmbedLLMEnabled');
-
-        expect(response.statusCode).to.equal(503);
-        expect(response.source).to.deep.equal({
-          errors: [{ status: '503', title: 'ServiceUnavailable' }],
-        });
-      });
-    });
-
-    context('when feature toggle does not exist', function () {
-      it('should authorize access', async function () {
-        const response = await securityPreHandlers.checkLLMChatIsEnabled(
-          hFake,
-          'SiVousAvezAppeléVotreFeatureCommeCa,CaCraintChangezDeNom',
-        );
-
-        expect(response.statusCode).to.equal(503);
-        expect(response.source).to.deep.equal({
-          errors: [{ status: '503', title: 'ServiceUnavailable' }],
-        });
       });
     });
   });


### PR DESCRIPTION
## 🌸 Problème
On développe des embeds qui vont communiquer avec POC llm pour faire des prompts IA.
Il faut mettre en place toute la tuyauterie.

## 🌳 Proposition
Premier endpoint : Démarrer une conversation en fonction d'une configuration LLM, sur un modulix (passage).

## 🐝 Remarques
(https://1024pix.atlassian.net/wiki/spaces/TC/pages/5244256274/Contrat+d+interface)

TODO : feature toggle


## 🤧 Pour tester
Pour tester correctement, voir [cette page.](https://1024pix.atlassian.net/wiki/spaces/TC/pages/5246713859/Tester+en+local+le+LLM)
