### PR TITLE
[FEATURE] Vider le champ mot de passe de la mire de connexion Pix App en cas d'erreur (PIX-17928)

### DIFF
--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -27,7 +27,7 @@ const authenticationDomainErrorMappingConfiguration = [
   },
   {
     name: MissingOrInvalidCredentialsError.name,
-    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message),
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
   },
   {
     name: MissingUserAccountError.name,

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -39,8 +39,8 @@ class OrganizationLearnerIdentityNotFoundError extends DomainError {
 }
 
 class MissingOrInvalidCredentialsError extends DomainError {
-  constructor(message = 'Missing or invalid credentials') {
-    super(message);
+  constructor() {
+    super('Missing or invalid credentials', 'MISSING_OR_INVALID_CREDENTIALS');
   }
 }
 

--- a/mon-pix/app/components/authentication/login-form.gjs
+++ b/mon-pix/app/components/authentication/login-form.gjs
@@ -122,6 +122,12 @@ export default class LoginForm extends Component {
           },
         };
         break;
+      case 'MISSING_OR_INVALID_CREDENTIALS':
+        this.password = null;
+        this.globalError = {
+          key: ENV.APP.API_ERROR_MESSAGES.MISSING_OR_INVALID_CREDENTIALS.I18N_KEY,
+        };
+        break;
       default: {
         const properties = HTTP_ERROR_MESSAGES[responseError.status] || HTTP_ERROR_MESSAGES['default'];
         if (!HTTP_ERROR_MESSAGES[responseError.status]) {
@@ -171,6 +177,7 @@ export default class LoginForm extends Component {
             @id="password"
             name="password"
             {{on "input" this.updatePassword}}
+            @value={{this.password}}
             @validationStatus={{this.validation.password.status}}
             @errorMessage={{t this.validation.password.error}}
             autocomplete="current-password"

--- a/mon-pix/app/services/error-messages.js
+++ b/mon-pix/app/services/error-messages.js
@@ -35,6 +35,9 @@ const ERROR_CODE_MAPPING = {
       return { localeNotSupported: error.meta.locale };
     },
   },
+  MISSING_OR_INVALID_CREDENTIALS: {
+    i18nKey: 'common.api-error-messages.login-unauthorized-error',
+  },
 };
 
 const HTTP_STATUS_MAPPING = {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -93,6 +93,10 @@ module.exports = function (environment) {
           CODE: '504',
           I18N_KEY: 'common.api-error-messages.gateway-timeout-error',
         },
+        MISSING_OR_INVALID_CREDENTIALS: {
+          CODE: '401',
+          I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
+        },
       },
       AUTHENTICATED_SOURCE_FROM_GAR: 'external',
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds

--- a/mon-pix/tests/integration/components/authentication/login-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/login-form-test.gjs
@@ -170,6 +170,22 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
       const errorMessageLink = screen.getByRole('link', { name: 'contactez-nous' });
       assert.dom(errorMessageLink).hasAttribute('href', 'https://support.pix.org/support/tickets/new');
     });
+
+    module('when the given password is incorrect', function () {
+      test('it erases the password field', async function (assert) {
+        // given
+        sessionService.authenticateUser.rejects(
+          _buildApiReponseError({ status: 401, errorCode: 'MISSING_OR_INVALID_CREDENTIALS' }),
+        );
+        await fillByLabel(t(I18N_KEYS.passwordInput), 'JeMeLoggue1024');
+
+        // when
+        await clickByName(t(I18N_KEYS.submitButton));
+
+        // then
+        assert.dom(screen.getByLabelText(t(I18N_KEYS.passwordInput))).hasValue('');
+      });
+    });
   });
 
   module('When a http error occurred', function (hooks) {


### PR DESCRIPTION
## 🌸 Problème

On souhaite avoir plus de friction autour du champ du mot de passe pour éviter qu’un utilisateur bloque trop rapidement son compte en cliquant à de multiples reprises sur _« Je me connecte »_.

## 🌳 Proposition

Vider le champ mot de passe si et seulement si il y a une erreur liée à l’authentification, en ajoutant et en réagissant sur un nouveau `code` d’erreur `MISSING_OR_INVALID_CREDENTIALS`.

## 🐝 Remarques

RAS.

## 🤧 Pour tester

- Se rendre sur PIx app,
- Dans le champ mail: superadmin@example.net,
- Mettre un mot de passe erroné,
- Constater que lorsqu'on clique sur "Je me connecte", constater que le champ se vide si le mot de passe est incorrecte.
