### PR TITLE
[BUGFIX] Corriger le champ "Adresse email" du formulaire de sortie du sco (PIX-17516)

### DIFF
--- a/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
@@ -101,12 +101,9 @@ export default class UpdateScoRecordFormComponent extends Component {
     </form>
 
     {{#if this.isNewAccountRecoveryEnabled}}
-
-      <div class="account-recovery__content--form-quit-button-container">
-        <PixButtonLink @route="logout" class="account-recovery__content--actions update-sco-record-form__buttons">
-          {{t "common.actions.quit"}}
-        </PixButtonLink>
-      </div>
+      <PixButtonLink @route="logout" class="account-recovery__content--actions update-sco-record-form__buttons">
+        {{t "common.actions.quit"}}
+      </PixButtonLink>
     {{/if}}
   </template>
   @service intl;

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -54,10 +54,6 @@
       }
     }
 
-    &-quit-button-container{
-      max-width: 400px;
-    }
-
     &--image {
       display: none;
 
@@ -147,7 +143,8 @@
 
     &--actions {
       display: flex;
-      margin-top: 24px;
+      max-width: 400px;
+      margin-top: 18px;
 
       button:first-child {
         margin-right: 32px;

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -43,14 +43,18 @@
       position: relative;
 
       &-fields {
-        position: relative;
-        max-width: 400px;
-      }
+        display: flex;
+        flex-direction: column;
+        width: 100%;
 
-      &-quit-button-container{
-        max-width: 400px;
+        @include breakpoints.device-is('desktop') {
+          max-width: 400px;
+        }
       }
+    }
 
+    &-quit-button-container{
+      max-width: 400px;
     }
 
     &--image {

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -45,6 +45,7 @@
       &-fields {
         display: flex;
         flex-direction: column;
+        gap: var(--pix-spacing-2x);
         width: 100%;
 
         @include breakpoints.device-is('desktop') {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -490,7 +490,7 @@
             "username": "votre identifiant scolaire Pix"
           }
         },
-        "welcome-message": "Bon retour parmi nous { firstName } !"
+        "welcome-message": "Bon retour parmi nous { firstName } !"
       }
     },
     "assessment-banner": {


### PR DESCRIPTION
## 🌸 Problème

Le champ email du formulaire de récupération de compte est trop petit

![champ_email](https://github.com/user-attachments/assets/86087414-1b5c-4bec-83b7-21e901cf8f79)

## 🌳 Proposition

Correction du champ “Adresse e-mail” à agrandir afin que l’adresse e-mail soit visible complètement, et harmonisation avec la page de login (les champs "email" et "mot de passe" prennent toute la largeur du formulaire)

## 🐝 Remarques

trois commits supplémentaires proposent des améliorations sur cette page :
- un ajout d'espace insécable pour éviter un point d'exclamation isolé dans le message de bienvenue en version mobile (fr uniquement)
- un ajout d'espace entre les éléments du formulaire pour aérer la page
- [TECH] la suppression d'une classe css inutile 

## 🤧 Pour tester

- vérifier que la CI passe

Pour le test fonctionnel, reprendre le scénario de test et les seeds de https://github.com/1024pix/pix/pull/12218 , et :
- constater que la page `/recuperer-mon-compte/{temporary-key}` s'affiche correctement **avec et sans feature toggle** (non régression), en **desktop et mobile**
- constater que le champ "email" permet de voir complètement l'adresse
