### PR TITLE
[FEATURE] Créer la table des référentiels cadres (PIX-17884).

### DIFF
--- a/api/db/migrations/20250519151410_create-certification-frameworks-challenges-table.js
+++ b/api/db/migrations/20250519151410_create-certification-frameworks-challenges-table.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.bigIncrements('id').primary();
+    table.float('alpha').notNullable().comment('Challenge discriminant');
+    table.float('delta').notNullable().comment('Challenge difficulty');
+
+    table.integer('complementaryCertificationId').unsigned();
+    table.foreign('complementaryCertificationId').references('complementary-certifications.id');
+
+    table.string('challengeId').notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Pour les certifications complémentaires, nous avons besoin que les épreuves des référentiels Pix+ aient des épreuves calibrés spécifiquement pour la complémentaire.

## 🌳 Proposition

Ajouter une table `certification-frameworks-challenges` permettant d'avoir une calibration (discriminant / difficulté) d'épreuve par complémentaire.

## 🤧 Pour tester

Tests verts
