### PR TITLE
[FEATURE] Exécution du simulateur de déroulé sur des certifications complémentaires (PIX-17936).

### DIFF
--- a/api/db/database-builder/factory/build-certification-frameworks-challenge.js
+++ b/api/db/database-builder/factory/build-certification-frameworks-challenge.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+import { databaseBuffer } from '../database-buffer.js';
+import { buildComplementaryCertification } from './build-complementary-certification.js';
+import { buildChallenge } from './learning-content/build-challenge.js';
+
+const buildCertificationFrameworksChallenge = function ({
+  id = databaseBuffer.getNextId(),
+  alpha = 2.2,
+  delta = 3.5,
+  complementaryCertificationId,
+  challengeId,
+} = {}) {
+  complementaryCertificationId = _.isUndefined(complementaryCertificationId)
+    ? buildComplementaryCertification().id
+    : complementaryCertificationId;
+
+  challengeId = _.isUndefined(challengeId) ? buildChallenge().id : challengeId;
+
+  const values = {
+    id,
+    alpha,
+    delta,
+    complementaryCertificationId,
+    challengeId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-frameworks-challenges',
+    values,
+  });
+};
+
+export { buildCertificationFrameworksChallenge };

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
+ */
+
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
@@ -24,6 +28,20 @@ const getByLabel = async function ({ label }) {
   return _toDomain(complementaryCertification);
 };
 
+/**
+ * @param {ComplementaryCertificationKey} key
+ * @returns {Promise<ComplementaryCertification>}
+ */
+const getByKey = async function (key) {
+  const complementaryCertification = await knex.from('complementary-certifications').where({ key }).first();
+
+  if (!complementaryCertification) {
+    throw new NotFoundError('Complementary certification does not exist');
+  }
+
+  return _toDomain(complementaryCertification);
+};
+
 const getById = async function ({ id }) {
   const complementaryCertification = await knex.from('complementary-certifications').where({ id }).first();
 
@@ -34,4 +52,4 @@ const getById = async function ({ id }) {
   return _toDomain(complementaryCertification);
 };
 
-export { findAll, getById, getByLabel };
+export { findAll, getById, getByKey, getByLabel };

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -26,6 +26,7 @@ async function simulateFlashAssessmentScenario(
     capacity,
     accessibilityAdjustmentNeeded,
     locale,
+    complementaryCertificationKey,
   } = request.payload;
 
   const pickAnswerStatus = dependencies.pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
@@ -44,6 +45,7 @@ async function simulateFlashAssessmentScenario(
           initialCapacity,
           variationPercent,
           accessibilityAdjustmentNeeded,
+          complementaryCertificationKey,
         },
         _.isUndefined,
       );

--- a/api/src/certification/flash-certification/application/scenario-simulator-route.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-route.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
+import { ComplementaryCertificationKeys } from '../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { scenarioSimulatorController } from './scenario-simulator-controller.js';
 
 const register = async (server) => {
@@ -32,6 +33,7 @@ const register = async (server) => {
                 .valid(...Object.values(LOCALE))
                 .lowercase()
                 .required(),
+              complementaryCertificationKey: Joi.string().valid(...Object.values(ComplementaryCertificationKeys)),
             })
             .required(),
         },

--- a/api/src/certification/flash-certification/domain/usecases/index.js
+++ b/api/src/certification/flash-certification/domain/usecases/index.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { complementaryCertificationRepository } from '../../../shared/infrastructure/repositories/complementary-certification-repository.js';
 import * as sharedFlashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as flashAlgorithmService from '../services/algorithm-methods/flash.js';
@@ -21,6 +22,7 @@ const dependencies = {
   challengeRepository,
   flashAlgorithmConfigurationRepository,
   sharedFlashAlgorithmConfigurationRepository,
+  complementaryCertificationRepository,
   flashAlgorithmService,
 };
 

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js
@@ -1,8 +1,16 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
+ */
+
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { AssessmentSimulator } from '../models/AssessmentSimulator.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../models/AssessmentSimulatorSingleMeasureStrategy.js';
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
 
+/**
+ * @param {Object} params
+ * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
+ */
 export async function simulateFlashAssessmentScenario({
   locale,
   pickChallenge,
@@ -12,9 +20,19 @@ export async function simulateFlashAssessmentScenario({
   challengeRepository,
   flashAlgorithmService,
   sharedFlashAlgorithmConfigurationRepository,
+  complementaryCertificationRepository,
   accessibilityAdjustmentNeeded,
+  complementaryCertificationKey,
 }) {
-  const challenges = await challengeRepository.findActiveFlashCompatible({ locale, accessibilityAdjustmentNeeded });
+  const complementaryCertification = complementaryCertificationKey
+    ? await complementaryCertificationRepository.getByKey(complementaryCertificationKey)
+    : null;
+
+  const challenges = await challengeRepository.findActiveFlashCompatible({
+    locale,
+    accessibilityAdjustmentNeeded,
+    complementaryCertificationId: complementaryCertification?.id,
+  });
 
   const configurationUsedInProduction = await sharedFlashAlgorithmConfigurationRepository.getMostRecent();
 

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-repository.js
@@ -1,0 +1,3 @@
+import * as complementaryCertificationRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
+
+export { complementaryCertificationRepository };

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,3 +1,4 @@
+import { knex } from '../../../../db/knex-database-connection.js';
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { config } from '../../config.js';
@@ -117,30 +118,62 @@ export async function findActiveFlashCompatible({
   locale,
   successProbabilityThreshold = config.features.successProbabilityThreshold,
   accessibilityAdjustmentNeeded = false,
+  complementaryCertificationId,
 } = {}) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
   let findCallback;
-  if (accessibilityAdjustmentNeeded) {
-    findCallback = (knex) =>
-      knex
-        .whereRaw('?=ANY(??)', [locale, 'locales'])
-        .where('status', VALIDATED_STATUS)
-        .whereNotNull('alpha')
-        .whereNotNull('delta')
-        .whereIn('accessibility1', ACCESSIBLE_STATUSES)
-        .whereIn('accessibility2', ACCESSIBLE_STATUSES)
-        .orderBy('id');
+  let challengeDtos;
+
+  if (complementaryCertificationId) {
+    const complementaryCertificationChallenges = await knex
+      .from('certification-frameworks-challenges')
+      .select('*')
+      .where({ complementaryCertificationId });
+
+    const complementaryCertificationChallengesIds = complementaryCertificationChallenges.map(
+      ({ challengeId }) => challengeId,
+    );
+
+    findCallback = async (knex) => {
+      return knex.whereIn('id', complementaryCertificationChallengesIds).orderBy('id');
+    };
+
+    challengeDtos = await getInstance().find(cacheKey, findCallback);
+
+    challengeDtos = challengeDtos.map((challenge) => {
+      const currentComplementaryCertificationChallenge = complementaryCertificationChallenges.find(
+        ({ challengeId }) => challengeId === challenge.id,
+      );
+
+      return {
+        ...challenge,
+        alpha: currentComplementaryCertificationChallenge.alpha,
+        delta: currentComplementaryCertificationChallenge.delta,
+      };
+    });
   } else {
-    findCallback = (knex) =>
-      knex
-        .whereRaw('?=ANY(??)', [locale, 'locales'])
-        .where('status', VALIDATED_STATUS)
-        .whereNotNull('alpha')
-        .whereNotNull('delta')
-        .orderBy('id');
+    if (accessibilityAdjustmentNeeded) {
+      findCallback = (knex) =>
+        knex
+          .whereRaw('?=ANY(??)', [locale, 'locales'])
+          .where('status', VALIDATED_STATUS)
+          .whereNotNull('alpha')
+          .whereNotNull('delta')
+          .whereIn('accessibility1', ACCESSIBLE_STATUSES)
+          .whereIn('accessibility2', ACCESSIBLE_STATUSES)
+          .orderBy('id');
+    } else {
+      findCallback = (knex) =>
+        knex
+          .whereRaw('?=ANY(??)', [locale, 'locales'])
+          .where('status', VALIDATED_STATUS)
+          .whereNotNull('alpha')
+          .whereNotNull('delta')
+          .orderBy('id');
+    }
+    challengeDtos = await getInstance().find(cacheKey, findCallback);
   }
-  const challengeDtos = await getInstance().find(cacheKey, findCallback);
   const challengesDtosWithSkills = await loadChallengeDtosSkills(challengeDtos);
   return challengesDtosWithSkills.map(([challengeDto, skill]) =>
     toDomain({ challengeDto, skill, successProbabilityThreshold }),

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
@@ -119,6 +119,47 @@ describe('Integration | Certification | Repository | complementary-certification
     });
   });
 
+  describe('#getByKey', function () {
+    context('when the complementary certification does not exist', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        const unknownComplementaryCertificationKey = 'UNKNOWN_KEY';
+
+        // when
+        const error = await catchErr(complementaryCertificationRepository.getByKey)(
+          unknownComplementaryCertificationKey,
+        );
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal('Complementary certification does not exist');
+      });
+    });
+
+    it('should return the complementary certification by its key', async function () {
+      // given
+      const keyToSearch = 'EDU_1ER_DEGRE';
+      const expectedComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        id: 1,
+        key: keyToSearch,
+      });
+      databaseBuilder.factory.buildComplementaryCertification(expectedComplementaryCertification);
+
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 3,
+        key: 'EDU_2ND_DEGRE',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const complementaryCertification = await complementaryCertificationRepository.getByKey(keyToSearch);
+
+      // then
+      expect(complementaryCertification).to.deep.equal(expectedComplementaryCertification);
+    });
+  });
+
   describe('#getById', function () {
     context('when the complementary certification does not exist', function () {
       it('should throw a NotFoundError', async function () {

--- a/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -1,0 +1,67 @@
+import { simulateFlashAssessmentScenario } from '../../../../../../src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('#simulateFlashAssessmentScenario', function () {
+  describe('when a complementary certification scenario is required', function () {
+    it('should fetch the complementary framework challenges', async function () {
+      // given
+      const locale = LOCALE.FRENCH_FRANCE;
+      const accessibilityAdjustmentNeeded = false;
+      const complementaryCertification = domainBuilder.buildComplementaryCertification();
+      const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+      const complementaryCertificationRepositoryStub = {
+        getByKey: sinon.stub().resolves(complementaryCertification),
+      };
+
+      // when
+      await catchErr(simulateFlashAssessmentScenario)({
+        locale,
+        accessibilityAdjustmentNeeded,
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeRepository: challengeRepositoryStub,
+        complementaryCertificationRepository: complementaryCertificationRepositoryStub,
+      });
+
+      // then
+      expect(complementaryCertificationRepositoryStub.getByKey).to.have.been.calledOnceWithExactly(
+        complementaryCertification.key,
+      );
+
+      expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+        locale,
+        accessibilityAdjustmentNeeded,
+        complementaryCertificationId: complementaryCertification.id,
+      });
+    });
+  });
+
+  describe('when a complementary certification scenario is not required', function () {
+    it('should fetch the core referential challenges', async function () {
+      // given
+      const locale = LOCALE.FRENCH_FRANCE;
+      const accessibilityAdjustmentNeeded = false;
+      const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+      const complementaryCertificationRepositoryStub = {
+        getByKey: sinon.stub(),
+      };
+
+      // when
+      await catchErr(simulateFlashAssessmentScenario)({
+        locale,
+        accessibilityAdjustmentNeeded,
+        complementaryCertificationKey: undefined,
+        challengeRepository: challengeRepositoryStub,
+      });
+
+      // then
+      expect(complementaryCertificationRepositoryStub.getByKey).not.to.have.been.called;
+
+      expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+        locale,
+        accessibilityAdjustmentNeeded,
+        complementaryCertificationId: undefined,
+      });
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -29,9 +29,9 @@ describe('#simulateFlashAssessmentScenario', function () {
       );
 
       expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-        locale,
-        accessibilityAdjustmentNeeded,
         complementaryCertificationId: complementaryCertification.id,
+        locale,
+        accessibilityAdjustmentNeeded: undefined,
       });
     });
   });

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1829,6 +1829,31 @@ describe('Integration | Repository | challenge-repository', function () {
       challengesLC.push(challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson);
     });
 
+    context('when complementary certification given', function () {
+      it('returns flash compatible challenge that link to complementary', async function () {
+        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification.droit({});
+
+        databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
+
+        const certificationFrameworksChallenge = databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationId: complementaryCertification.id,
+          challengeId: challengesLC[0].id,
+        });
+
+        await databaseBuilder.commit();
+
+        const flashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({
+          complementaryCertificationId: complementaryCertification.id,
+          locale: 'fr',
+        });
+
+        expect(flashCompatibleChallenges).to.have.lengthOf(1);
+        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[0].id);
+        expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.alpha);
+        expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.delta);
+      });
+    });
+
     context('when locale is not defined', function () {
       it('should throw an Error', async function () {
         // given
@@ -1842,6 +1867,7 @@ describe('Integration | Repository | challenge-repository', function () {
         expect(err.message).to.equal('Locale shall be defined');
       });
     });
+
     context('when locale is defined', function () {
       context('when no active flash compatible challenges found', function () {
         it('should return an empty array', async function () {
@@ -1858,6 +1884,7 @@ describe('Integration | Repository | challenge-repository', function () {
           expect(challenges).to.deep.equal([]);
         });
       });
+
       context('when active flash compatible challenges found', function () {
         it('should return the challenges', async function () {
           // given


### PR DESCRIPTION
## 🌸 Problème

Lors de la récupération des challenges pour la certif v3, on se base uniquement sur le référentiel coeur.

## 🌳 Proposition

Pour les complémentaires, nous souhaitons avoir de nouveaux référentiels, avec des challenges calibrés spécifiquement.

Nous avons besoin de récupérer les challenges pour un référentiel cadre donné.

## 🐝 Remarques

Note technique : pas de clé étrangère sur le challengeId pour garantir l'intégrité du ref cadre, car il faut voir comme un cache le schema learningcontent + le learningcontent garantit en principe aucune suppression de challenge

## 🤧 Pour tester

NB: La configuration de l'algorithme de choix de question a été modifiée en BDD afin de n'avoir à retrouver qu'un seul challenge dans le simulateur.

- Se connecter sur pix-app avec le compte de votre choix
- Répondre à une question dans n'importe quelle compétence
- Récuper le `challengeId` dans l'answer créée et insérer en BDD
- Choisir une clé de certification complémentaire (ex: `DROIT`) et son `id`

```sql
insert into "certification-frameworks-challenges" (alpha, delta, "complementaryCertificationId", "challengeId") values (<alpha:float>, <delta:float>, <complementaryCertificationId:integer>,<challengeId:string>');

# Exemple

insert into "certification-frameworks-challenges" (alpha, delta, "complementaryCertificationId", "challengeId") values (3.1, 2.0, 53, 'challengeRck46zdEyUFQ4');
```

Exécuter la requête suivante : 

```bash
TOKEN=$(curl --insecure 'https://admin-pr12352.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr12352.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "complementaryCertificationKey": "DROIT", "locale": "fr-fr" }' | jq '.'
```

Vérifier que l'on obtient bien un rapport de simulation

Si vous souhaitez tester avec plus de challenges, réitérer les opérations listées ci-dessus en veillant à modifier la valeur de `maximumAssessmentLength` dans `flash-algorithm-configurations`.