### PR TITLE
[FEATURE] Afficher les POIC dans Modulix (PIX-17941)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -70,6 +70,22 @@
         {
           "type": "element",
           "element": {
+            "id": "32e9196a-d854-4553-bb93-5a341213f6e2",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/videoCaroline.html\" height=\"800\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "a5e32f35-889c-45aa-8151-2da532de4eeb",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/objectif.html\" height=\"600\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
             "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
             "type": "text",
             "content": "<p>Elles ne sont autorisées qu'en béta.</p>"

--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -77,6 +77,7 @@
 
   iframe {
     width: 100%;
+    border: none;
   }
 
   .modulix-two-columns {


### PR DESCRIPTION
## 🌸 Problème

On veut tester l'affichage des POIC dans un module

## 🌳 Proposition

Ajouter 2 POIC dans le bac-a-sable

## 🐝 Remarques

- Le CSS pour les éléments iframe d'un module a été enrichi pour enlever la bordure.
- On ne peut pas cacher la scrollbar d'un POIC sans mettre une exception dans le validateur HTML. Il y a une [issue](https://gitlab.com/html-validate/html-validate/-/issues/302) pour ça. On recommande de plutôt corriger cela côté POIC.

## 🤧 Pour tester

- Aller sur le module bac-a-sable 
- Vérifier que les 2 POIC s'affichent bien sans bordure 😄 
