### PR TITLE
[FEATURE] Pouvoir vérifier depuis Pix Admin si un utilisateur est en capacité de valider une quête (PIX-18008)

### DIFF
--- a/admin/app/components/administration/common/index.gjs
+++ b/admin/app/components/administration/common/index.gjs
@@ -1,9 +1,11 @@
 import AddOrganizationFeaturesInBatch from './add-organization-features-in-batch';
 import LearningContent from './learning-content';
 import UpsertQuestsInBatch from './upsert-quests-in-batch';
+import UserQuestChecker from './user-quest-checker';
 
 <template>
   <LearningContent />
   <AddOrganizationFeaturesInBatch />
   <UpsertQuestsInBatch />
+  <UserQuestChecker />
 </template>

--- a/admin/app/components/administration/common/user-quest-checker.gjs
+++ b/admin/app/components/administration/common/user-quest-checker.gjs
@@ -1,0 +1,80 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class UserQuestChecker extends Component {
+  @tracked userId;
+  @tracked questId;
+  @tracked canBeSuccessful;
+  @service session;
+  @service intl;
+
+  @action
+  onQuestIdChange(event) {
+    this.questId = event.target.value;
+  }
+
+  @action
+  onUserIdChange(event) {
+    this.userId = event.target.value;
+  }
+
+  @action
+  async onSubmit(event) {
+    event.preventDefault();
+
+    const response = await window.fetch(`${ENV.APP.API_HOST}/api/admin/check-user-quest`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.session.data.authenticated.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        data: {
+          attributes: {
+            'user-id': this.userId,
+            'quest-id': this.questId,
+          },
+        },
+      }),
+    });
+
+    const json = await response.json();
+    this.canBeSuccessful =
+      json.data.attributes['is-successful'] === true
+        ? this.intl.t('components.administration.user-quest-checker.messages.success')
+        : this.intl.t('components.administration.user-quest-checker.messages.error');
+    this.tagColor = json.data.attributes['is-successful'] === true ? 'green' : 'primary';
+  }
+
+  <template>
+    <AdministrationBlockLayout
+      @title={{t "components.administration.user-quest-checker.title"}}
+      @description={{t "components.administration.user-quest-checker.description"}}
+    >
+      <form class="user-quest-checker__form" {{on "submit" this.onSubmit}}>
+        <PixInput value={{this.userId}} {{on "change" this.onUserIdChange}}>
+          <:label>{{t "components.administration.user-quest-checker.form.user-id-input-label"}}</:label>
+        </PixInput>
+        <PixInput value={{this.questId}} {{on "change" this.onQuestIdChange}}>
+          <:label>{{t "components.administration.user-quest-checker.form.quest-id-input-label"}}</:label>
+        </PixInput>
+        <PixButton @type="submit">
+          {{t "components.administration.user-quest-checker.form.submit-button"}}
+        </PixButton>
+        {{#if this.canBeSuccessful}}
+          <PixTag @color={{this.tagColor}}>{{this.canBeSuccessful}}</PixTag>
+        {{/if}}
+      </form>
+    </AdministrationBlockLayout>
+  </template>
+}

--- a/admin/app/styles/components/administration/index.scss
+++ b/admin/app/styles/components/administration/index.scss
@@ -3,3 +3,4 @@
 @use 'campaigns-swap-code';
 @use 'block-layout';
 @use 'upsert-quests-in-batch';
+@use 'user-quest-checker';

--- a/admin/app/styles/components/administration/user-quest-checker.scss
+++ b/admin/app/styles/components/administration/user-quest-checker.scss
@@ -1,0 +1,7 @@
+.user-quest-checker__form {
+  display:flex;
+  flex-direction:row;
+  gap: var(--pix-spacing-4x);
+  align-items: flex-end;
+  margin-bottom: var(--pix-spacing-4x);
+}

--- a/admin/tests/integration/components/administration/common/user-quest-checker-test.gjs
+++ b/admin/tests/integration/components/administration/common/user-quest-checker-test.gjs
@@ -1,0 +1,119 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click, fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import UserQuestChecker from 'pix-admin/components/administration/common/user-quest-checker';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  administration/user-quest-checker', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  test('it should display a form', async function (assert) {
+    // when
+    const screen = await render(<template><UserQuestChecker /></template>);
+
+    // then
+    assert.ok(await screen.findByText(t('components.administration.user-quest-checker.title')));
+    assert.ok(await screen.findByText(t('components.administration.user-quest-checker.description')));
+    assert.ok(await screen.findByText(t('components.administration.user-quest-checker.form.user-id-input-label')));
+    assert.ok(await screen.findByText(t('components.administration.user-quest-checker.form.quest-id-input-label')));
+    assert.ok(await screen.findByText(t('components.administration.user-quest-checker.form.submit-button')));
+  });
+
+  test('should display eligibility on quest for given user id and quest id', async function (assert) {
+    // given
+    const accessToken = 'an accesstoken';
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+    sinon
+      .stub(window, 'fetch')
+      .withArgs(`${ENV.APP.API_HOST}/api/admin/check-user-quest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          data: {
+            attributes: {
+              'user-id': '1',
+              'quest-id': '2',
+            },
+          },
+        }),
+      })
+      .resolves(fetchResponse({ body: { data: { attributes: { 'is-successful': true } } }, status: 200 }));
+
+    // when
+    const screen = await render(<template><UserQuestChecker /></template>);
+    await fillIn(screen.getByLabelText(t('components.administration.user-quest-checker.form.user-id-input-label')), 1);
+    await fillIn(screen.getByLabelText(t('components.administration.user-quest-checker.form.quest-id-input-label')), 2);
+    await click(
+      screen.getByRole('button', { name: t('components.administration.user-quest-checker.form.submit-button') }),
+    );
+
+    // then
+    assert.ok(window.fetch.calledOnce);
+    assert.ok(screen.getByText(t('components.administration.user-quest-checker.messages.success')));
+  });
+
+  test('should display ineligibility on quest for given user id and quest id', async function (assert) {
+    // given
+    const accessToken = 'an accesstoken';
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+    sinon
+      .stub(window, 'fetch')
+      .withArgs(`${ENV.APP.API_HOST}/api/admin/check-user-quest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          data: {
+            attributes: {
+              'user-id': '1',
+              'quest-id': '2',
+            },
+          },
+        }),
+      })
+      .resolves(fetchResponse({ body: { data: { attributes: { 'is-successful': false } } }, status: 200 }));
+
+    // when
+    const screen = await render(<template><UserQuestChecker /></template>);
+    await fillIn(screen.getByLabelText(t('components.administration.user-quest-checker.form.user-id-input-label')), 1);
+    await fillIn(screen.getByLabelText(t('components.administration.user-quest-checker.form.quest-id-input-label')), 2);
+    await click(
+      screen.getByRole('button', { name: t('components.administration.user-quest-checker.form.submit-button') }),
+    );
+
+    // then
+    assert.ok(window.fetch.calledOnce);
+    assert.ok(screen.getByText(t('components.administration.user-quest-checker.messages.error')));
+  });
+});
+
+function fetchResponse({ body, status }) {
+  const mockResponse = new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+
+  return mockResponse;
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -242,6 +242,19 @@
         "quest-creator": "Create your quest",
         "title": "Create and update quests",
         "upload-button": "Import CSV file"
+      },
+      "user-quest-checker": {
+        "description": "Check whether a user meets the eligibility and success criteria for a quest",
+        "form": {
+          "quest-id-input-label": "Quest Id",
+          "submit-button": "Check",
+          "user-id-input-label": "user Id"
+        },
+        "messages": {
+          "error": "This user is not yet able to validate this quest.",
+          "success": "This user is already able to validate this quest"
+        },
+        "title": "Checking whether a quest can be completed"
       }
     },
     "autonomous-courses": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -242,6 +242,19 @@
         "quest-creator": "Créer ta Quête",
         "title": "Création et modification de quêtes",
         "upload-button": "Importer un fichier CSV"
+      },
+      "user-quest-checker": {
+        "description": "Vérifier si un utilisateur répond aux critères d'éligibilité et de succès d'une quête",
+        "form": {
+          "quest-id-input-label": "Id de la quête",
+          "submit-button": "Vérifier",
+          "user-id-input-label": "Id de l'utilisateur"
+        },
+        "messages": {
+          "error": "Cet utilisateur n'est pas encore en capacité de valider cette quête",
+          "success": "Cet utilisateur est en capacité de valider cette quête"
+        },
+        "title": "Vérification de possibilité de complétion de quête"
       }
     },
     "autonomous-courses": {

--- a/api/src/quest/application/index.js
+++ b/api/src/quest/application/index.js
@@ -82,6 +82,34 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/check-user-quest',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'user-id': identifiersType.userId,
+                'quest-id': identifiersType.questId,
+              },
+            },
+          }),
+        },
+        handler: questController.checkUserQuest,
+        tags: ['api', 'admin', 'quests'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle permet de vérifier si un utilisateur valide une quête',
+        ],
+      },
+    },
   ]);
 };
 const name = 'quest-api';

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -33,7 +33,17 @@ const createOrUpdateQuestsInBatch = async function (request, h) {
   return h.response().code(204);
 };
 
+const checkUserQuest = async function (request, h) {
+  const result = await usecases.checkUserQuest({
+    questId: request.payload.data.attributes['quest-id'],
+    userId: request.payload.data.attributes['user-id'],
+  });
+
+  return h.response({ data: { attributes: { 'is-successful': result } } }).code(200);
+};
+
 const questController = {
+  checkUserQuest,
   getQuestResults,
   createOrUpdateQuestsInBatch,
   getTemplateForCreateOrUpdateQuestsInBatch,

--- a/api/src/quest/domain/usecases/check-user-quest-success.js
+++ b/api/src/quest/domain/usecases/check-user-quest-success.js
@@ -1,0 +1,41 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { DataForQuest } from '../models/DataForQuest.js';
+
+export const checkUserQuest = async ({
+  userId,
+  questRepository,
+  eligibilityRepository,
+  successRepository,
+  questId,
+}) => {
+  if (!userId) {
+    return;
+  }
+
+  const quest = await questRepository.findById({ questId });
+
+  if (!quest) {
+    throw new NotFoundError(`No quest found for questId ${questId}`);
+  }
+
+  const eligibilities = await eligibilityRepository.find({ userId });
+
+  const dataForQuest = eligibilities
+    .map((eligibility) => new DataForQuest({ eligibility }))
+    .find((dataForQuest) => quest.isEligible(dataForQuest));
+
+  if (!dataForQuest && quest.eligibilityRequirements.length !== 0) {
+    return false;
+  }
+
+  if (!dataForQuest && quest.eligibilityRequirements.length === 0 && quest.successRequirements.length === 0) {
+    return true;
+  }
+
+  const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+  const targetProfileIds = quest.findTargetProfileIdsWithoutCampaignParticipationContributingToQuest(dataForQuest);
+  const success = await successRepository.find({ userId, campaignParticipationIds, targetProfileIds });
+  dataForQuest.success = success;
+
+  return quest.isSuccessful(dataForQuest);
+};

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -13,6 +13,16 @@ const findAll = async () => {
   return toDomain(quests);
 };
 
+const findById = async ({ questId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const quest = await knexConn('quests').where('id', questId).first();
+
+  if (!quest) return null;
+
+  return new Quest(quest);
+};
+
 // envisager de mettre tableau vide en valeur par défaut des requirements si pas renseigné pour pas péter le code
 // ensuite
 const saveInBatch = async ({ quests }) => {
@@ -39,4 +49,4 @@ const deleteByIds = async ({ questIds }) => {
   return knexConn('quests').whereIn('id', questIds).delete();
 };
 
-export { deleteByIds, findAll, saveInBatch };
+export { deleteByIds, findAll, findById, saveInBatch };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -67,6 +67,7 @@ const typesPositiveInteger32bits = [
   'passageId',
   'placeId',
   'profileRewardId',
+  'questId',
   'schoolingRegistrationId',
   'sessionId',
   'stageCollectionId',

--- a/api/tests/quest/integration/domain/usecases/check-user-quest-success_test.js
+++ b/api/tests/quest/integration/domain/usecases/check-user-quest-success_test.js
@@ -1,0 +1,219 @@
+import {
+  CRITERION_COMPARISONS,
+  REQUIREMENT_COMPARISONS,
+  REQUIREMENT_TYPES,
+} from '../../../../../src/quest/domain/models/Quest.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+const { INVALIDATED, VALIDATED } = KnowledgeElement.StatusType;
+import { KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
+
+describe('Integration | Quest | Domain | UseCases | check-user-quest-success', function () {
+  it('should return undefined if userId not defined', async function () {
+    // given
+    const questId = 1;
+
+    // when
+    const result = await usecases.checkUserQuest({ userId: null, questId });
+
+    // then
+    expect(result).to.be.undefined;
+  });
+
+  it('should return not found error if quest does not exist', async function () {
+    // given
+    const nonExistentQuestId = 2;
+    const userId = 1234;
+    databaseBuilder.factory.buildQuest({ id: 1 });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await catchErr(usecases.checkUserQuest)({ userId, questId: nonExistentQuestId });
+
+    // then
+    expect(result).to.be.instanceOf(NotFoundError);
+  });
+
+  it('should return true if quest do not have eligibility requirements or success', async function () {
+    // given
+    const userId = 1234;
+    const questId = 1;
+    databaseBuilder.factory.buildUser({ id: userId });
+    databaseBuilder.factory.buildQuest({
+      id: questId,
+      eligibilityRequirements: [],
+      successRequirements: [],
+    });
+    await databaseBuilder.commit();
+    // when
+    const result = await usecases.checkUserQuest({ userId, questId });
+    // then
+    expect(result).to.be.true;
+  });
+
+  it('should return true if user match the quest eligibility and success requirements', async function () {
+    // given
+    const questId = 1;
+    const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+    const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+    });
+    const firstTargetProfile = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organizationId,
+    });
+    const firstCampaign = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      targetProfileId: firstTargetProfile.id,
+    });
+    databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId,
+      campaignId: firstCampaign.id,
+      userId,
+    });
+    const userKnowledgeElements = [
+      {
+        userId,
+        skillId: 'skillId1',
+        status: VALIDATED,
+      },
+    ];
+    userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+    databaseBuilder.factory.buildQuest({
+      id: questId,
+      eligibilityRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: firstTargetProfile.id,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ],
+      successRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          data: {
+            skillIds: ['skillId1'],
+            threshold: 50,
+          },
+        },
+      ],
+    });
+    await databaseBuilder.commit();
+    // when
+    const result = await usecases.checkUserQuest({ userId, questId });
+    // then
+    expect(result).to.be.true;
+  });
+
+  it('should return false if user does not match the success requirements', async function () {
+    // given
+    const questId = 1;
+    const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+    const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+    });
+    const firstTargetProfile = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organizationId,
+    });
+    const firstCampaign = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      targetProfileId: firstTargetProfile.id,
+    });
+    databaseBuilder.factory.buildCampaignParticipation({
+      organizationLearnerId,
+      campaignId: firstCampaign.id,
+      userId,
+    });
+    const userKnowledgeElements = [
+      {
+        userId,
+        skillId: 'skillId1',
+        status: INVALIDATED,
+      },
+    ];
+    userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+    databaseBuilder.factory.buildQuest({
+      id: questId,
+      eligibilityRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: firstTargetProfile.id,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ],
+      successRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          data: {
+            skillIds: ['skillId1'],
+            threshold: 50,
+          },
+        },
+      ],
+    });
+    await databaseBuilder.commit();
+    // when
+    const result = await usecases.checkUserQuest({ userId, questId });
+    // then
+    expect(result).to.be.false;
+  });
+
+  it('should return false if user does not match the eligibility requirements', async function () {
+    // given
+    const questId = 1;
+    const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+    const { userId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+    });
+    const firstTargetProfile = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organizationId,
+    });
+    const userKnowledgeElements = [
+      {
+        userId,
+        skillId: 'skillId1',
+        status: VALIDATED,
+      },
+    ];
+    userKnowledgeElements.map(databaseBuilder.factory.buildKnowledgeElement);
+    databaseBuilder.factory.buildQuest({
+      id: questId,
+      eligibilityRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          data: {
+            targetProfileId: {
+              data: firstTargetProfile.id,
+              comparison: CRITERION_COMPARISONS.EQUAL,
+            },
+          },
+          comparison: REQUIREMENT_COMPARISONS.ALL,
+        },
+      ],
+      successRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.SKILL_PROFILE,
+          data: {
+            skillIds: ['skillId1'],
+            threshold: 50,
+          },
+        },
+      ],
+    });
+    await databaseBuilder.commit();
+    // when
+    const result = await usecases.checkUserQuest({ userId, questId });
+    // then
+    expect(result).to.be.false;
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -89,6 +89,33 @@ describe('Quest | Integration | Repository | quest', function () {
     });
   });
 
+  describe('#findById', function () {
+    it('should return a quest if quest exist', async function () {
+      // given
+      const questId = 1;
+      databaseBuilder.factory.buildQuest({ id: questId });
+      await databaseBuilder.commit();
+
+      // when
+      const quest = await questRepository.findById({ questId });
+
+      // then
+      expect(quest).to.be.an.instanceof(Quest);
+      expect(quest.id).to.equal(1);
+    });
+
+    it('should return null if quest does not exist', async function () {
+      // given
+      const questId = 1;
+
+      // when
+      const quest = await questRepository.findById({ questId });
+
+      // then
+      expect(quest).to.be.null;
+    });
+  });
+
   describe('#deleteByIds', function () {
     it('should delete quest given ids', async function () {
       // given

--- a/api/tests/quest/unit/application/index_test.js
+++ b/api/tests/quest/unit/application/index_test.js
@@ -22,4 +22,21 @@ describe('Quest | Unit | Router | quest-router', function () {
       expect(securityPreHandlers.checkCampaignParticipationBelongsToUser).to.have.been.called;
     });
   });
+
+  describe('POST /api/admin/check-user-quest', function () {
+    it('should call checkAdminMemberHasRoleSuperAdmin prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(() => true);
+      sinon.stub(questController, 'checkUserQuest').callsFake((request, h) => h.response());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      // when
+      await httpTestServer.request('POST', `/api/admin/check-user-quest`, {
+        data: { attributes: { 'user-id': 1234, 'quest-id': 1 } },
+      });
+      // then
+      sinon.assert.called(questController.checkUserQuest);
+      expect(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin).to.have.been.called;
+    });
+  });
 });

--- a/api/tests/quest/unit/application/quest-controller_test.js
+++ b/api/tests/quest/unit/application/quest-controller_test.js
@@ -1,0 +1,35 @@
+import { questController } from '../../../../src/quest/application/quest-controller.js';
+import { usecases } from '../../../../src/quest/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Application | Controller | Quest', function () {
+  describe('#checkUserQuest', function () {
+    it('should return statusCode 200', async function () {
+      // given
+      const userId = 1234;
+      const questId = 1;
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              'user-id': userId,
+              'quest-id': questId,
+            },
+          },
+        },
+      };
+
+      sinon.stub(usecases, 'checkUserQuest');
+
+      // when
+      const response = await questController.checkUserQuest(request, hFake);
+
+      // then
+      expect(response.statusCode).to.be.equal(200);
+      expect(usecases.checkUserQuest).to.have.been.calledWithExactly({
+        userId,
+        questId,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Il est utile pour le support ou le produit de pouvoir aller vérifier simplement si un utilisateur peut répondre aux critères d'éligibilité et de succès d'une quête.

## 🌳 Proposition

Ajouter un block dans la partie administration de Pix Admin

## 🐝 Remarques

si on veut tester le cas où un utilisateur peut être éligible, il faut attendre de pouvoir rebase une fois que [cette PR](https://github.com/1024pix/pix/pull/12370) soit passée
## 🤧 Pour tester

- Être super admin
- se rendre sur le lien `/administration/common`
- utiliser le user quest checker qui est le dernier block de la page
