### PR TITLE
[TECH] Récupérer la configuration de l'algo v3 dans la BDD (PIX-17937).

### DIFF
--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -1,13 +1,12 @@
-import { config } from '../../../src/shared/config.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const buildFlashAlgorithmConfiguration = function ({
-  maximumAssessmentLength = config.v3Certification.numberOfChallengesPerCourse,
+  maximumAssessmentLength = 20,
   challengesBetweenSameCompetence = null,
   limitToOneQuestionPerTube = null,
   enablePassageByAllCompetences = false,
   variationPercent = null,
-  createdAt = new Date(),
+  createdAt = new Date('2018-01-01'),
 } = {}) {
   const values = {
     maximumAssessmentLength,

--- a/api/sample.env
+++ b/api/sample.env
@@ -660,23 +660,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
 
 # ========
-# V3 CERTIFICATION
-# ========
-# Number of challenges the candidate has to go through during a V3 certification
-#
-# presence: optional
-# type: Integer
-# default: 20
-V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE=
-
-# Probability to pick a challenge amongst others
-#
-# presence: optional
-# type: Integer
-# default: 51
-DEFAULT_PROBABILITY_TO_PICK_CHALLENGE=
-
-# ========
 # EVALUATION
 # ========
 

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { config } from '../../../../shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/index.js';
@@ -82,8 +81,7 @@ async function get({ id }) {
       knexConn,
     );
 
-    certificationCourseDTO.numberOfChallenges =
-      configuration?.maximumAssessmentLength ?? config.v3Certification.numberOfChallengesPerCourse;
+    certificationCourseDTO.numberOfChallenges = configuration.maximumAssessmentLength;
 
     ({ accessibilityAdjustmentNeeded } = await knexConn('certification-candidates')
       .select('accessibilityAdjustmentNeeded')
@@ -172,8 +170,7 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
       knexConn,
     );
 
-    certificationCourseDTO.numberOfChallenges =
-      configuration?.maximumAssessmentLength ?? config.v3Certification.numberOfChallengesPerCourse;
+    certificationCourseDTO.numberOfChallenges = configuration.maximumAssessmentLength;
   }
 
   return _toDomain({

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -450,8 +450,8 @@ const configuration = (function () {
       expirationDelaySeconds: ms(process.env.EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN || '3d') / 1000,
     },
     v3Certification: {
-      numberOfChallengesPerCourse: parseInt(process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE, 10) || 20,
-      defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
+      numberOfChallengesPerCourse: 32,
+      defaultProbabilityToPickChallenge: 51,
       defaultCandidateCapacity: -3,
       challengesBetweenSameCompetence: 2,
       scoring: {

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -1,6 +1,5 @@
 import { CertificationIssueReportCategory } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 import { SESSIONS_VERSIONS } from '../../../../../../src/certification/shared/domain/models/SessionVersion.js';
-import { config } from '../../../../../../src/shared/config.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
@@ -348,7 +347,7 @@ describe('Acceptance | API | Certification Course', function () {
           it('should have created a v3 certification course without any challenges', async function () {
             // given
             const { options, userId, sessionId } = _createRequestOptions({ version: SESSIONS_VERSIONS.V3 });
-            _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
+            const { flashConfiguration } = _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
             await databaseBuilder.commit();
 
             // when
@@ -358,7 +357,7 @@ describe('Acceptance | API | Certification Course', function () {
             const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
             expect(certificationCourse.version).to.equal(SESSIONS_VERSIONS.V3);
             expect(response.result.data.attributes).to.include({
-              'nb-challenges': config.v3Certification.numberOfChallengesPerCourse,
+              'nb-challenges': flashConfiguration.maximumAssessmentLength,
             });
           });
         });
@@ -504,6 +503,7 @@ function _createRequestOptions(
 function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userId }) {
   const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
   databaseBuilder.factory.learningContent.build(learningContentObjects);
+  const flashConfiguration = databaseBuilder.factory.buildFlashAlgorithmConfiguration();
   const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
     sessionId,
     userId,
@@ -529,6 +529,7 @@ function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userI
 
   return {
     certificationCandidate,
+    flashConfiguration,
   };
 }
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -92,6 +92,8 @@ describe('Integration | Repository | Certification Course', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         const sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
 
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration();
+
         databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
         certificationCourse = domainBuilder.buildCertificationCourse.unpersisted({
           userId,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -203,6 +203,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
         it('should return the last challenge the user has seen before leaving the session', async function () {
           const user = databaseBuilder.factory.buildUser({ id: userId });
           const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration();
           const sessionId = databaseBuilder.factory.buildSession({
             certificationCenterId,
             version: SESSIONS_VERSIONS.V3,


### PR DESCRIPTION
## 🌸 Problème

Aujourd’hui, on a plein de variables d’env qui servent pour le nombre d'épreuves de la certif v3.
Il est difficile de savoir quelle est la vraie source de vérité.

## 🌳 Proposition

La table `flash-algorithm-configuration` a une colonne `maximumAssessmentLength` qui paramètre bien le nombre d'épreuves que l’on souhaite avoir.

- Utiliser cette valeur de la DB comme source de vérité du nombre d'épreuves partout dans le code de l’API.
- Supprimer les variables d'env de configuration.

## 🤧 Pour tester

Tests verts
