### PR TITLE
[FEATURE] Modifier les valeurs pour l'affichage des niveaux dans les tags (PIX-17967)

### DIFF
--- a/orga/app/components/statistics/tag-level.gjs
+++ b/orga/app/components/statistics/tag-level.gjs
@@ -4,8 +4,8 @@ import { t } from 'ember-intl';
 
 const MAX_LEVEL = {
   novice: 3,
-  independent: 4,
-  advanced: 6,
+  independent: 5,
+  advanced: 7,
 };
 
 export default class TagLevel extends Component {

--- a/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
+++ b/orga/tests/integration/components/analysis/analysis-per-tubes-and-competences_test.gjs
@@ -91,7 +91,7 @@ module('Integration | Component | analysis-per-tubes-and-competences', function 
           name: t('pages.statistics.gauge.label', { userLevel: 3.5, tubeLevel: 4 }),
         }),
       );
-      assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.advanced') }));
+      assert.ok(filledTable.getByRole('cell', { name: t('pages.statistics.level.independent') }));
 
       assert.ok(
         filledTable.getByRole('columnheader', {

--- a/orga/tests/integration/components/statistics/tag-level-test.gjs
+++ b/orga/tests/integration/components/statistics/tag-level-test.gjs
@@ -19,9 +19,9 @@ module('Integration | Component | Statistics | TagLevel', function (hooks) {
       //then
       assert.ok(screen.getByText(t('pages.statistics.level.novice')));
     });
-    test('when level is lower than 4 it should return independent', async function (assert) {
+    test('when level is lower than 5 it should return independent', async function (assert) {
       //given
-      const level = 3;
+      const level = 4;
 
       //when
       const screen = await render(<template><TagLevel @level={{level}} /></template>);
@@ -29,9 +29,9 @@ module('Integration | Component | Statistics | TagLevel', function (hooks) {
       //then
       assert.ok(screen.getByText(t('pages.statistics.level.independent')));
     });
-    test('when level is lower than 6 it should return advanced', async function (assert) {
+    test('when level is lower than 7 it should return advanced', async function (assert) {
       //given
-      const level = 5;
+      const level = 6;
 
       //when
       const screen = await render(<template><TagLevel @level={{level}} /></template>);
@@ -39,7 +39,7 @@ module('Integration | Component | Statistics | TagLevel', function (hooks) {
       //then
       assert.ok(screen.getByText(t('pages.statistics.level.advanced')));
     });
-    test('when level is upper than 6 it should return expert', async function (assert) {
+    test('when level is upper or equal 7 it should return expert', async function (assert) {
       //given
       const level = 7;
 


### PR DESCRIPTION
## 🌸 Problème
On a un souci avec les bornes au niveau des jauges 
Ex : Un niveau 4,6 ne devrait pas être positionné en avancé 

## 🌳 Proposition
Changer les bornes : 
[0-]3 novice
[3-]5 indépendant
[5-]7 avancé
[7-8 expert

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

- Aller sur la page Statistiques et la nouvelle page d'analyse, et vérifier que les tags affichés sont ceux prévus dans la proposition ci dessus
- Pour tester tous les tags si besoin passer par l'inspector ember et modifier directement les valeurs dans le store 
- 🐈‍⬛ 