### PR TITLE
[TECH] Supprimer la seed SSO OIDC PixAdmin

### DIFF
--- a/api/db/seeds/data/team-acces/build-oidc-providers.js
+++ b/api/db/seeds/data/team-acces/build-oidc-providers.js
@@ -17,17 +17,9 @@ const defaultNotVisibleOidcProviderProperties = Object.assign(
   defaultVisibleOidcProviderProperties,
 );
 
-const defaultOidcProviderForPixAdminProperties = Object.assign(
-  {
-    enabledForPixAdmin: true,
-  },
-  defaultVisibleOidcProviderProperties,
-);
-
 export async function buildOidcProviders(databaseBuilder) {
   await _buildVisibleOidcProviders(databaseBuilder);
   await _buildNotVisibleOidcProviders(databaseBuilder);
-  await _buildOidcProvidersForPixAdmin(databaseBuilder);
   await _buildOidcProvidersFromEnv(databaseBuilder);
 }
 
@@ -95,24 +87,6 @@ async function _buildNotVisibleOidcProviders(databaseBuilder) {
         redirectUri: 'https://app.dev.pix.org/connexion/seeds-not-visible-2-oidc-example-net',
       },
       defaultNotVisibleOidcProviderProperties,
-    ),
-  );
-}
-
-async function _buildOidcProvidersForPixAdmin(databaseBuilder) {
-  await databaseBuilder.factory.buildOidcProvider(
-    Object.assign(
-      {
-        identityProvider: 'OIDC_EXAMPLE_NET_FOR_PIX_ADMIN_FROM_SEEDS',
-        organizationName: 'OIDC Example for Pix Admin from seeds',
-        slug: 'seeds-for-pix-admin-oidc-example-net',
-        source: 'seeds-for-pix-admin-oidc-example-net',
-        clientId: 'for-pix-admin-XXX',
-        clientSecret: 'for-pix-admin-YYY',
-        openidConfigurationUrl: 'https://seeds-for-pix-admin.oidc.example.net/.well-known/openid-configuration',
-        redirectUri: 'https://app.dev.pix.org/connexion/seeds-for-pix-admin-oidc-example-net',
-      },
-      defaultOidcProviderForPixAdminProperties,
     ),
   );
 }


### PR DESCRIPTION
## 🌸 Problème

Depuis la PR https://github.com/1024pix/pix/pull/12232 (SSO générique sur PixAdmin), les seeds d'OIDC empêche la connexion en local ou RA via login et mot de passe.

## 🌳 Proposition

Supprimer la seed dans un premier temps, avant d'avoir une solution plus pereine en local et RA (dans l'idéal utiliser le SSO OIDC).

## 🤧 Pour tester

1. Aller sur Pix Admin
2. Se connecter via login et mot de passe.
