### PR TITLE
[FEATURE] Vocaliser le changement d'étape sur un module (PIX-17934) (PIX-17910)

### DIFF
--- a/mon-pix/app/components/module/layout/navbar.gjs
+++ b/mon-pix/app/components/module/layout/navbar.gjs
@@ -22,6 +22,9 @@ export default class ModulixNavbar extends Component {
       <div class="module-navbar__content">
         <PixProgressBar @hidePercentage={{true}} @isDecorative={{true}} @value={{this.progressValue}} />
       </div>
+      <p class="sr-only" aria-atomic="true" aria-live="polite">
+        {{t "pages.modulix.flashcards.navigation.longCurrentStep" current=@currentStep total=@totalSteps}}
+      </p>
     </nav>
   </template>
 }


### PR DESCRIPTION
## 🌸 Problème

Avec la suppression de la sidebar, on voudrait améliorer l'accessibilité sur la page des modules pour décrire le passage à une étape suivante.

## 🌳 Proposition
Ajouter un texte en sr-only qui se met à jour à chaque changement d'étape.

## 🐝 Remarques

RAS 

## 🤧 Pour tester

- Aller sur un module
- Lancer un logiciel de lecteur d'écran (ex: voiceover)
- Vérifier que le changement d'étape est bien vocalisé
