### PR TITLE
[FEATURE] Communication entre Pix App et l’embed pix-llm (PIX-17788)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/test-iframe-llm.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/test-iframe-llm.json
@@ -1,0 +1,51 @@
+{
+  "id": "8f148ad1-fc14-4de8-a776-5224c1db1d70",
+  "slug": "test-iframe-llm",
+  "title": "Iframe LLM",
+  "isBeta": true,
+  "details": {
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
+    "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+    "duration": 5,
+    "level": "Débutant",
+    "tabletSupport": "inconvenient",
+    "objectives": ["Non régression fonctionnelle"]
+  },
+  "grains": [
+    {
+      "id": "a39ce6eb-f3db-447f-808f-aa6a06432012",
+      "type": "lesson",
+      "title": "test qcu-declarative",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "52af6cab-07df-4962-abc5-20cf95d5a5ba",
+            "type": "text",
+            "content": "<p>Voici une iframe :</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "9c8a0dc3-4e8e-4cf9-ab37-3280931c7aba",
+            "type": "embed",
+            "isCompletionRequired": false,
+            "title": "LLM",
+            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?lang=fr&mode=cma2ihhoa000bwg011i86qb30",
+            "instruction": "<p>LLM</p>",
+            "height": 600
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c52d04",
+            "type": "text",
+            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -31,7 +31,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "download")}}
       <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}
-      <EmbedElement @embed={{@element}} @onAnswer={{@onElementAnswer}} />
+      <EmbedElement @embed={{@element}} @passageId={{@passageId}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "custom")}}
       <CustomElement @component={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "expand")}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -190,6 +190,7 @@ export default class ModuleGrain extends Component {
               <div class="grain-card-content__element">
                 <Element
                   @element={{component.element}}
+                  @passageId={{@passage.id}}
                   @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onElementAnswer={{@onElementAnswer}}

--- a/mon-pix/app/services/embed-api-proxy.js
+++ b/mon-pix/app/services/embed-api-proxy.js
@@ -1,0 +1,54 @@
+import { registerDestructor } from '@ember/destroyable';
+import { getOwner } from '@ember/owner';
+import Service from '@ember/service';
+
+export default class EmbedApiProxyService extends Service {
+  forward(context, requestsPort, urlPrefix) {
+    requestsPort.addEventListener('message', (event) => this.handleMessageEvent(event, { urlPrefix }));
+
+    requestsPort.start();
+
+    registerDestructor(context, () => {
+      requestsPort.close();
+    });
+  }
+
+  async handleMessageEvent(event, { fetch = window.fetch, urlPrefix }) {
+    let { url } = event.data;
+    if (url.startsWith('/')) url = url.slice(1);
+    url = urlPrefix + url;
+
+    const { init } = event.data;
+
+    const [responsePort] = event.ports;
+
+    try {
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          ...init.headers,
+          ...this.headers,
+        },
+      });
+
+      responsePort.postMessage(
+        {
+          body: response.body,
+          init: {
+            headers: Object.fromEntries(response.headers),
+            status: response.status,
+          },
+        },
+        [response.body],
+      );
+    } catch (error) {
+      responsePort.postMessage({
+        error: error.message,
+      });
+    }
+  }
+
+  get headers() {
+    return getOwner(this).lookup('adapter:application').headers;
+  }
+}

--- a/mon-pix/tests/unit/services/embed-api-proxy-test.js
+++ b/mon-pix/tests/unit/services/embed-api-proxy-test.js
@@ -1,0 +1,154 @@
+import { destroy, registerDestructor } from '@ember/destroyable';
+import EmberObject from '@ember/object';
+import Adapter from '@ember-data/adapter';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Services | embed api proxy', function (hooks) {
+  setupTest(hooks);
+
+  let embedApiProxy;
+
+  hooks.beforeEach(function () {
+    this.owner.register(
+      'adapter:application',
+      class ApplicationAdapter extends Adapter {
+        get headers() {
+          return {
+            Authorization: 'Bearer oursier 🐻',
+          };
+        }
+      },
+    );
+
+    embedApiProxy = this.owner.lookup('service:embed-api-proxy');
+  });
+
+  module('#forward', function () {
+    test('it should add event listener and start port', function (assert) {
+      // given
+      const requestsPort = {
+        start: sinon.stub(),
+        close: sinon.stub(),
+        addEventListener: sinon.stub(),
+      };
+
+      // when
+      embedApiProxy.forward({}, requestsPort, '/api');
+
+      // then
+      sinon.assert.calledWith(requestsPort.addEventListener, 'message', sinon.match.func);
+      sinon.assert.calledOnce(requestsPort.start);
+      assert.ok(true);
+    });
+
+    test('it closes the port when the context is destroyed', async function (assert) {
+      // given
+      const requestsPort = {
+        addEventListener: sinon.stub(),
+        start: sinon.stub(),
+        close: sinon.stub(),
+      };
+      const context = EmberObject.create();
+      const contextDestroyed = new Promise((resolve) => {
+        registerDestructor(context, () => resolve());
+      });
+
+      // when
+      embedApiProxy.forward(context, requestsPort, '/api/');
+      destroy(context);
+      await contextDestroyed;
+
+      // then
+      sinon.assert.calledOnceWithExactly(requestsPort.close);
+      assert.ok(true);
+    });
+  });
+
+  module('#handleMessageEvent', function () {
+    test('it should proxy request and postMessage the response', async function (assert) {
+      // given
+      const postMessageStub = sinon.stub();
+      const request = {
+        url: '/test',
+        init: {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{ "prompt": "salut!" }',
+        },
+      };
+      const event = {
+        data: request,
+        ports: [{ postMessage: postMessageStub }],
+      };
+      const headers = {
+        'content-type': 'text/event-stream',
+      };
+      const response = new Response('mon body', {
+        headers: new Headers(headers),
+        status: 200,
+      });
+      const fetchStub = sinon.stub().resolves(response);
+
+      // when
+      await embedApiProxy.handleMessageEvent(event, {
+        fetch: fetchStub,
+        urlPrefix: '/api/',
+      });
+
+      // then
+      sinon.assert.calledWith(fetchStub, '/api/test', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer oursier 🐻',
+          'content-type': 'application/json',
+        },
+        body: '{ "prompt": "salut!" }',
+      });
+
+      sinon.assert.calledWith(
+        postMessageStub,
+        {
+          body: response.body,
+          init: {
+            headers,
+            status: response.status,
+          },
+        },
+        [response.body],
+      );
+      assert.ok(true);
+    });
+
+    module('when fetch throws an error', function () {
+      test('it should postMessage the error', async function (assert) {
+        // given
+        const postMessageStub = sinon.stub();
+        const request = {
+          url: '/test',
+          init: {
+            method: 'POST',
+          },
+        };
+        const event = {
+          data: request,
+          ports: [{ postMessage: postMessageStub }],
+        };
+        const fetchStub = sinon.stub().rejects(new Error('connection reset by pear 🍐'));
+
+        // when
+        await embedApiProxy.handleMessageEvent(event, {
+          fetch: fetchStub,
+          urlPrefix: '/api/',
+        });
+
+        // then
+        sinon.assert.calledWith(postMessageStub, {
+          error: 'connection reset by pear 🍐',
+        });
+        assert.ok(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Pour que l’embed pix-llm puisse fonctionner, il doit pouvoir ouvrir un canal de communication avec Pix App lui permettant de faire des fetch vers l’API.

## 🌳 Proposition

Implémenter un service assurant l’ouverture du canal de commumication et intégration de se service dans l’élément embed de modulix.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Uniquement les tests autos pour le moment.

Valider qu’il n’y a pas de régressions sur les embeds modulix.