### PR TITLE
[FEATURE] Sur le domaine pix.org mettre "en" comme fallback de locale sur tous les frontaux (PIX-17758)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,6 +547,7 @@ jobs:
           command: npm run build
           environment:
             BUILD_ENVIRONMENT: development
+            DEFAULT_LOCALE: fr
             JOBS: 2
       - save_cache:
           key: v7-mon-pix-npm-{{ checksum "cachekey" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,6 +607,7 @@ jobs:
           command: npm run build
           environment:
             BUILD_ENVIRONMENT: development
+            DEFAULT_LOCALE: fr
             JOBS: 2
       - save_cache:
           key: v7-orga-npm-{{ checksum "cachekey" }}

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -1,17 +1,25 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-const defaultLocale = 'fr';
+export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
+export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 
 export default class ApplicationRoute extends Route {
   @service session;
   @service intl;
+  @service currentDomain;
   @service currentUser;
   @service featureToggles;
 
   async beforeModel() {
     await this.session.setup();
-    this.intl.setLocale([defaultLocale]);
+
+    if (this.currentDomain.isFranceDomain) {
+      this.intl.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+    } else {
+      this.intl.setLocale(DEFAULT_LOCALE);
+    }
 
     await this.featureToggles.load();
 

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -1,8 +1,8 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import ENV from 'pix-admin/config/environment';
 
-export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
-export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+export const { DEFAULT_LOCALE } = ENV.APP;
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 
 export default class ApplicationRoute extends Route {

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -36,6 +36,7 @@ module.exports = function (environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {
           CODE: '400',
@@ -137,6 +138,8 @@ module.exports = function (environment) {
     // Testem prefers this...
     ENV.locationType = 'none';
     ENV.APP.API_HOST = 'http://localhost:3000';
+
+    ENV.APP.DEFAULT_LOCALE = 'fr';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -1,14 +1,14 @@
 import Service, { service } from '@ember/service';
-import config from 'pix-certif/config/environment';
+import ENV from 'pix-certif/config/environment';
 import languages from 'pix-certif/languages';
 
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
+export const DEFAULT_LOCALE = ENV.APP.DEFAULT_LOCALE;
 export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
-const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
 
 export default class LocaleService extends Service {
   @service cookies;

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -5,7 +5,7 @@ import languages from 'pix-certif/languages';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
 export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 import { runTask } from 'ember-lifeline';
 import SessionService from 'ember-simple-auth/services/session';
 import {
-  ENGLISH_INTERNATIONAL_LOCALE,
+  DEFAULT_LOCALE,
   FRENCH_FRANCE_LOCALE,
   FRENCH_INTERNATIONAL_LOCALE,
   SUPPORTED_LANGUAGES,
@@ -49,12 +49,12 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (!userLocale) {
-      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      this.locale.setLocale(DEFAULT_LOCALE);
       return;
     }
 
     const localeNotSupported = !SUPPORTED_LANGUAGES.includes(userLocale);
-    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale;
+    const locale = localeNotSupported ? DEFAULT_LOCALE : userLocale;
 
     this.data.localeNotSupported = localeNotSupported;
     this.locale.setLocale(locale);

--- a/certif/config/ember-intl.js
+++ b/certif/config/ember-intl.js
@@ -14,7 +14,7 @@ module.exports = function (/* environment */) {
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: null,
+    fallbackLocale: 'en',
 
     /**
      * Path where translations are stored.  This is relative to the project root.

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -37,6 +37,7 @@ module.exports = function (environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-certif-local',
+      DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
       BANNER: {
         CONTENT: process.env.BANNER_CONTENT || '',
         TYPE: process.env.BANNER_TYPE || '',
@@ -119,6 +120,8 @@ module.exports = function (environment) {
     ENV.locationType = 'none';
 
     ENV.APP.API_HOST = 'http://localhost:3000';
+
+    ENV.APP.DEFAULT_LOCALE = 'fr';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/certif/tests/unit/services/session-test.js
+++ b/certif/tests/unit/services/session-test.js
@@ -218,7 +218,7 @@ module('Unit | Service | session', function (hooks) {
 
         module('when user is loaded', function () {
           module('when user language is not available', function () {
-            test('sets the locale to English international', function (assert) {
+            test('sets the locale to the default locale', function (assert) {
               // given
               const userLocale = 'my-new-language-code-here';
 
@@ -226,7 +226,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
               assert.true(service.data.localeNotSupported);
               assert.strictEqual(service.data.localeNotSupportedBannerClosed, undefined);
             });
@@ -277,7 +277,7 @@ module('Unit | Service | session', function (hooks) {
             });
 
             module('when user profile language is not supported', function () {
-              test(`sets the locale to english`, function (assert) {
+              test('sets the locale to the default locale', function (assert) {
                 // given
                 const localeFromQueryParam = 'an invalid locale';
                 const userLocale = 'not supported locale';
@@ -286,7 +286,7 @@ module('Unit | Service | session', function (hooks) {
                 service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
                 // then
-                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+                assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
               });
             });
           });

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
     container_name: pix-e2e-monpix
     user: node
     image: node:22.14.0
+    environment:
+      DEFAULT_LOCALE: fr
     command: npx ember serve --proxy http://api:3000
     volumes:
       - ../..:/code

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
     user: node
     # renovate datasource=node-version depName=node
     image: node:22.14.0
+    environment:
+      DEFAULT_LOCALE: fr
     command: npx ember serve --proxy http://api:3000
     volumes:
       - ../..:/code

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -1,12 +1,12 @@
 import Service, { service } from '@ember/service';
-import config from 'mon-pix/config/environment';
+import ENV from 'mon-pix/config/environment';
 import languages from 'mon-pix/languages';
 
-const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
+export const { DEFAULT_LOCALE } = ENV.APP;
 
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
 

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -6,7 +6,7 @@ const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
 
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
 

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
-import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
+import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry.js';
 
 const FRANCE_TLD = 'fr';
@@ -134,7 +134,7 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+    this.locale.setLocale(DEFAULT_LOCALE);
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/config/ember-intl.js
+++ b/mon-pix/config/ember-intl.js
@@ -12,7 +12,7 @@ module.exports = function (/* environment */) {
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: 'fr',
+    fallbackLocale: 'en',
 
     /**
      * Path where translations are kept.  This is relative to the project root.

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -37,6 +37,7 @@ module.exports = function (environment) {
       // when it is created
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-app-local',
+      DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
@@ -170,6 +171,8 @@ module.exports = function (environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
+
+    ENV.APP.DEFAULT_LOCALE = 'fr';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -5,7 +5,7 @@ import languages from 'pix-orga/languages';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
 export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -1,15 +1,15 @@
 import Service, { service } from '@ember/service';
-import config from 'pix-orga/config/environment';
+import ENV from 'pix-orga/config/environment';
 import languages from 'pix-orga/languages';
 
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
-export const DEFAULT_LOCALE = ENGLISH_INTERNATIONAL_LOCALE;
+export const { DEFAULT_LOCALE } = ENV.APP;
 export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
-const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
 
 export default class LocaleService extends Service {
   @service cookies;

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import {
-  ENGLISH_INTERNATIONAL_LOCALE,
+  DEFAULT_LOCALE,
   FRENCH_FRANCE_LOCALE,
   FRENCH_INTERNATIONAL_LOCALE,
   SUPPORTED_LANGUAGES,
@@ -49,12 +49,12 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (!userLocale) {
-      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      this.locale.setLocale(DEFAULT_LOCALE);
       return;
     }
 
     const localeNotSupported = !SUPPORTED_LANGUAGES.includes(userLocale);
-    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale;
+    const locale = localeNotSupported ? DEFAULT_LOCALE : userLocale;
 
     this.data.localeNotSupported = localeNotSupported;
     this.locale.setLocale(locale);

--- a/orga/config/ember-intl.js
+++ b/orga/config/ember-intl.js
@@ -14,7 +14,7 @@ module.exports = function (/* environment */) {
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: null,
+    fallbackLocale: 'en',
 
     /**
      * Path where translations are stored.  This is relative to the project root.

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function (environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-orga-local',
+      DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       CERTIFICATION_BANNER_DISPLAY_DATES: process.env.CERTIFICATION_BANNER_DISPLAY_DATES || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
@@ -139,12 +140,15 @@ module.exports = function (environment) {
   }
 
   if (environment === 'test') {
-    ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
-    ENV.APP.API_HOST = 'http://localhost:3000';
-    ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
-
     // Testem prefers this...
     ENV.locationType = 'none';
+
+    ENV.APP.API_HOST = 'http://localhost:3000';
+
+    ENV.APP.DEFAULT_LOCALE = 'fr';
+
+    ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
+    ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/orga/tests/unit/services/session-test.js
+++ b/orga/tests/unit/services/session-test.js
@@ -240,7 +240,7 @@ module('Unit | Service | session', function (hooks) {
 
         module('when user is loaded', function () {
           module('when user language is not available', function () {
-            test('sets the locale to English international', function (assert) {
+            test('sets the default locale', function (assert) {
               // given
               const userLocale = 'my-new-language-code-here';
 
@@ -248,7 +248,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
               assert.true(service.data.localeNotSupported);
               assert.strictEqual(service.data.localeNotSupportedBannerClosed, undefined);
             });
@@ -299,7 +299,7 @@ module('Unit | Service | session', function (hooks) {
             });
 
             module('when user profile language is not supported', function () {
-              test(`sets the locale to english`, function (assert) {
+              test('sets the default locale', function (assert) {
                 // given
                 const localeFromQueryParam = 'an invalid locale';
                 const userLocale = 'not supported locale';
@@ -308,7 +308,7 @@ module('Unit | Service | session', function (hooks) {
                 service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
                 // then
-                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+                assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
               });
             });
           });


### PR DESCRIPTION
## 🌸 Problème

Sur le domaine `pix.org` c’est un public international qui est attendu et qui vient. Un utilisateur « international », indépendamment de sa langue maternelle, est majoritairement plus à l’aise avec l’anglais qu’avec le français. Or 
sur le domaine `pix.org` les frontaux sont par défaut affichés en français et il est nécessaire pour l’utilisateur de faire un changement de langue pour trouver une langue qui lui correspond ou à défaut l’anglais.

## 🌳 Proposition

Sur le domaine `pix.org`, et pas sur `pix.fr`, sur tous les frontaux (Pix App, Pix Orga, Pix Certif, Pix Admin), mettre la locale `en` comme fallback de locale, c’est à dire si aucune locale n’est spécifiée (soit dans les queryParam, soit dans comme locale de l’utilisateur).

Les commits de cette PR sont en 2 phases : 
1. Pour tous les frontaux définition et centralisation de la notion de `DEFAULT_LOCALE`,
2. Pour tous les frontaux ajout de la possibilité de surcharger la `DEFAULT_LOCALE` à partir d’une nouvelle variable d’environnement `DEFAULT_LOCALE`, de manière à ce que les tests, dont de grandes parties sont écrites pour le français au lieu d’être génériques ou plus génériques, continuent de fonctionner.

## 🐝 Remarques

Avec cette PR l’objectif n’est pas de rendre identique et factoriser en partie la gestion des locales entre les différents frontaux. Ce sujet fait l’objet d’une Epix dédiée. Dans cette PR on essaye néanmoins que le code des différents frontaux soit quand même le plus proche possible pour justement se pas s’éloigner de l’Epix en question.

## 🤧 Pour tester

1. Vérifier que les tests de la CI passent,
2. Sans être connecté, se rendre sur les frontaux Pix App, Pix Orga, Pix Certif et Pix Admin sur le domaine `pix.fr`,
3. Constater que ces frontaux présentent tous par défaut une interface utilisateur en français,
4. Sans être connecté, se rendre sur les frontaux Pix App, Pix Orga, Pix Certif et Pix Admin sur le domaine `pix.org`,
5. Constater que ces frontaux présentent tous par défaut une interface utilisateur en anglais. À noter que pour Pix Admin lorsqu’une traduction en anglais est absente, alors elle est remplacée par la traduction française.
