### PR TITLE
[TECH] Exposer la doc de l’API MaDDo sur /documentation/maddo

### DIFF
--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -17,7 +17,7 @@ import { config } from './src/shared/config.js';
 import { installHapiHook } from './src/shared/infrastructure/async-local-storage.js';
 import { plugins } from './src/shared/infrastructure/plugins/index.js';
 import { deserializer } from './src/shared/infrastructure/serializers/jsonapi/deserializer.js';
-import { swaggers } from './src/shared/swaggers.js';
+import { maddoSwaggers } from './src/shared/swaggers.js';
 import { handleFailAction } from './src/shared/validate.js';
 
 installHapiHook();
@@ -194,7 +194,7 @@ const setupRoutesAndPlugins = async function (server) {
 };
 
 const setupOpenApiSpecification = async function (server) {
-  for (const swaggerRegisterArgs of swaggers) {
+  for (const swaggerRegisterArgs of maddoSwaggers) {
     await server.register(...swaggerRegisterArgs);
   }
 };

--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -107,12 +107,12 @@ class ApiManagerAccess extends PixOpenApiBaseDefinition {
     }
 
     // Api Manager documentation are all grouped under same endpoint
-    super({ endpoint: '/documentation' });
+    super({ endpoint: `/documentation/${appIdentifier}` });
 
     // Group Swagger static assets under our app endpoint
-    this.swaggerConfiguration.documentationPath = `/${appIdentifier}`;
-    this.swaggerConfiguration.swaggerUIPath = `/${appIdentifier}/`;
-    this.swaggerConfiguration.jsonPath = `/${appIdentifier}/openapi.json`;
+    this.swaggerConfiguration.documentationPath = '/';
+    this.swaggerConfiguration.swaggerUIPath = '/';
+    this.swaggerConfiguration.jsonPath = '/openapi.json';
     this.swaggerConfiguration.uiOptions.url = `${this.endpoint}${this.swaggerConfiguration.jsonPath}`;
 
     // UI won't display the internal api base path externally
@@ -154,6 +154,15 @@ class Parcoursup extends ApiManagerAccess {
   }
 }
 
+class Maddo extends ApiManagerAccess {
+  constructor() {
+    super({ appIdentifier: 'maddo' });
+    this.swaggerConfiguration.info.title = 'Api de mise à disposition de données Pix';
+    this.swaggerConfiguration.grouping = 'tags';
+    this.swaggerConfiguration.tagsGroupingFilter = (tag) => !['api', 'maddo'].includes(tag);
+  }
+}
+
 const buildHapiPlugin = (clazz) => {
   const apiDefinition = new clazz();
 
@@ -168,4 +177,6 @@ const buildHapiPlugin = (clazz) => {
   ];
 };
 
-export const swaggers = [PixAPI, AuthorizationServer, LivretScolaire, PoleEmploi, Parcoursup].map(buildHapiPlugin);
+export const swaggers = [PixAPI, AuthorizationServer, LivretScolaire, PoleEmploi].map(buildHapiPlugin);
+
+export const maddoSwaggers = [Maddo, Parcoursup].map(buildHapiPlugin);

--- a/api/tests/shared/acceptance/application/swaggers_test.js
+++ b/api/tests/shared/acceptance/application/swaggers_test.js
@@ -1,5 +1,5 @@
 import { config } from '../../../../src/shared/config.js';
-import { createServer, expect } from '../../../test-helper.js';
+import { createMaddoServer, createServer, expect } from '../../../test-helper.js';
 
 describe('Acceptance | Controller | Open Api', function () {
   // Increase the test timeout because swagger.json endpoints can be long to generate/respond.
@@ -7,11 +7,11 @@ describe('Acceptance | Controller | Open Api', function () {
 
   let server;
 
-  beforeEach(async function () {
-    server = await createServer();
-  });
-
   context('Internal API definitons', function () {
+    beforeEach(async function () {
+      server = await createServer();
+    });
+
     context('Pix API', function () {
       describe('GET /api/swagger.json', function () {
         it('should respond with a 200', async function () {
@@ -183,6 +183,10 @@ describe('Acceptance | Controller | Open Api', function () {
   });
 
   context('API Manager definitions', function () {
+    beforeEach(async function () {
+      server = await createMaddoServer();
+    });
+
     context('Parcoursup', function () {
       describe('GET /documentation/parcoursup/openapi.json', function () {
         it('should respond with a 200', async function () {
@@ -221,6 +225,49 @@ describe('Acceptance | Controller | Open Api', function () {
             // then
             expect(response.statusCode).to.equal(200);
             expect(response.result).to.contain('Pix Parcoursup Open Api');
+          });
+        });
+      });
+    });
+
+    context('Maddo', function () {
+      describe('GET /documentation/maddo/openapi.json', function () {
+        it('should respond with a 200', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: '/documentation/maddo/openapi.json',
+            headers: {},
+          };
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.info.title).to.deep.equal('Api de mise à disposition de données Pix');
+          expect(response.result.servers[0].url).to.equal(config.apiManager.url);
+        });
+      });
+
+      context('Documentation page', function () {
+        beforeEach(async function () {
+          await server.start();
+        });
+
+        describe('GET /documentation/maddo', function () {
+          it('should respond with a 200', async function () {
+            // given
+            const options = {
+              method: 'GET',
+              url: '/documentation/maddo',
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.contain('Api de mise à disposition de données Pix');
           });
         });
       });


### PR DESCRIPTION
## 🌸 Problème

On souhaite exposer la doc de l’API MaDDo sur la gateway.

## 🌳 Proposition

Ajouter une route permettant de l’exposer.

## 🐝 Remarques

N/A

## 🤧 Pour tester

 - Vérifier que la doc MaDDo est dispo sur la RA MaDDo : https://pix-api-maddo-review-pr12377.osc-fr1.scalingo.io/documentation/maddo
 - Vérifier que la doc parcoursup est toujours dispo sur la RA MaDDo : https://pix-api-maddo-review-pr12377.osc-fr1.scalingo.io/documentation/parcoursup