### PR TITLE
[TECH] :truck: Retire l'utilisation du mot `attestation` du cas d'utilisation de récupération d'un certificat (PIX-18024)

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -25,7 +25,7 @@ const getCertificateByVerificationCode = async function (
   const certificationCourse = await usecases.getCertificationCourseByVerificationCode({ verificationCode });
 
   if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
-    certificate = await usecases.getCertificationAttestation({
+    certificate = await usecases.getCertificate({
       certificationCourseId: certificationCourse.getId(),
       locale,
     });
@@ -52,7 +52,7 @@ const getCertificate = async function (
 
   let certificate;
   if (certificationCourse.isV3() && (await featureToggles.get('isV3CertificationPageEnabled'))) {
-    certificate = await usecases.getCertificationAttestation({
+    certificate = await usecases.getCertificate({
       certificationCourseId: certificationCourse.getId(),
       locale,
     });
@@ -91,7 +91,7 @@ const getPDFCertificate = async function (
     throw new UnauthorizedError();
   }
 
-  const certificate = await usecases.getCertificationAttestation({ certificationCourseId });
+  const certificate = await usecases.getCertificate({ certificationCourseId });
 
   if (certificate instanceof Certificate) {
     const fileName = i18n.__('certification-confirmation.file-name', {

--- a/api/src/certification/results/domain/usecases/get-certificate.js
+++ b/api/src/certification/results/domain/usecases/get-certificate.js
@@ -8,6 +8,6 @@
  * @param {CertificateRepository} params.certificateRepository
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
-export const getCertificationAttestation = async function ({ certificationCourseId, locale, certificateRepository }) {
-  return certificateRepository.getCertificationAttestation({ certificationCourseId, locale });
+export const getCertificate = async function ({ certificationCourseId, locale, certificateRepository }) {
+  return certificateRepository.getCertificate({ certificationCourseId, locale });
 };

--- a/api/src/certification/results/domain/usecases/get-certification-attestations-for-session.js
+++ b/api/src/certification/results/domain/usecases/get-certification-attestations-for-session.js
@@ -18,7 +18,7 @@ const getCertificationAttestationsForSession = async function ({
   const certificationAttestations = compact(
     await PromiseUtils.mapSeries(certificationCourses, async (certificationCourse) => {
       try {
-        return await certificateRepository.getCertificationAttestation({
+        return await certificateRepository.getCertificate({
           certificationCourseId: certificationCourse.getId(),
         });
       } catch (error) {

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -17,7 +17,7 @@ import { CertifiedBadge } from '../../domain/read-models/CertifiedBadge.js';
 import * as competenceTreeRepository from './competence-tree-repository.js';
 
 const findByDivisionForScoIsManagingStudentsOrganization = async function ({ organizationId, division }) {
-  const certificationCourseDTOs = await _selectCertificationAttestations()
+  const certificationCourseDTOs = await _selectCertificationCourseDTOs()
     .select({ organizationLearnerId: 'view-active-organization-learners.id' })
     .innerJoin('certification-candidates', function () {
       this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
@@ -55,8 +55,8 @@ const findByDivisionForScoIsManagingStudentsOrganization = async function ({ org
   );
 };
 
-const getCertificationAttestation = async function ({ certificationCourseId, locale }) {
-  const certificationCourseDTO = await _selectCertificationAttestations()
+const getCertificate = async function ({ certificationCourseId, locale }) {
+  const certificationCourseDTO = await _selectCertificationCourseDTOs()
     .where('certification-courses.id', '=', certificationCourseId)
     .groupBy('certification-courses.id', 'sessions.id', 'assessment-results.id')
     .first();
@@ -129,12 +129,12 @@ const getShareableCertificate = async function ({ certificationCourseId, locale 
 export {
   findByDivisionForScoIsManagingStudentsOrganization,
   findPrivateCertificatesByUserId,
-  getCertificationAttestation,
+  getCertificate,
   getPrivateCertificate,
   getShareableCertificate,
 };
 
-function _selectCertificationAttestations() {
+function _selectCertificationCourseDTOs() {
   // isCancelled will be removed
   return _getCertificateQuery()
     .select({

--- a/api/src/certification/results/scripts/generate-certification-attestations-by-session-ids.js
+++ b/api/src/certification/results/scripts/generate-certification-attestations-by-session-ids.js
@@ -54,7 +54,7 @@ async function main() {
     const certificationAttestations = compact(
       await PromiseUtils.mapSeries(certificationCourses, async (certificationCourse) => {
         try {
-          return await certificateRepository.getCertificationAttestation({
+          return await certificateRepository.getCertificate({
             certificationCourseId: certificationCourse.getId(),
           });
         } catch (error) {

--- a/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certificate-repository_test.js
@@ -30,10 +30,10 @@ describe('Integration | Infrastructure | Repository | Certification', function (
     },
   ];
 
-  describe('#getCertificationAttestation', function () {
+  describe('#getCertificate', function () {
     it('should throw a NotFoundError when certification attestation does not exist', async function () {
       // when
-      const error = await catchErr(certificateRepository.getCertificationAttestation)({ certificationCourseId: 123 });
+      const error = await catchErr(certificateRepository.getCertificate)({ certificationCourseId: 123 });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
@@ -69,7 +69,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getCertificationAttestation)({
+      const error = await catchErr(certificateRepository.getCertificate)({
         certificationCourseId: certificationAttestationData.id,
       });
 
@@ -107,7 +107,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getCertificationAttestation)({
+      const error = await catchErr(certificateRepository.getCertificate)({
         certificationCourseId: certificationAttestationData.id,
       });
 
@@ -145,7 +145,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getCertificationAttestation)({
+      const error = await catchErr(certificateRepository.getCertificate)({
         certificationCourseId: certificationAttestationData.id,
       });
 
@@ -183,7 +183,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getCertificationAttestation)({
+      const error = await catchErr(certificateRepository.getCertificate)({
         certificationCourseId: certificationAttestationData.id,
       });
 
@@ -226,7 +226,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
       await databaseBuilder.commit();
 
       // when
-      const certificationAttestation = await certificateRepository.getCertificationAttestation({
+      const certificationAttestation = await certificateRepository.getCertificate({
         certificationCourseId: certificationAttestationData.id,
       });
 
@@ -272,7 +272,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         await databaseBuilder.commit();
 
         // when
-        const certificationAttestation = await certificateRepository.getCertificationAttestation({
+        const certificationAttestation = await certificateRepository.getCertificate({
           certificationCourseId: 123,
         });
 
@@ -363,7 +363,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         await mockLearningContent(learningContentObjects);
 
         // when
-        const certificationAttestation = await certificateRepository.getCertificationAttestation({
+        const certificationAttestation = await certificateRepository.getCertificate({
           certificationCourseId: 123,
         });
 
@@ -481,7 +481,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           await databaseBuilder.commit();
 
           // when
-          const certificationAttestation = await certificateRepository.getCertificationAttestation({
+          const certificationAttestation = await certificateRepository.getCertificate({
             certificationCourseId: 123,
           });
 
@@ -585,7 +585,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
             await mockLearningContent(learningContentObjects);
 
             // when
-            const certificationAttestation = await certificateRepository.getCertificationAttestation({
+            const certificationAttestation = await certificateRepository.getCertificate({
               certificationCourseId: 123,
               locale,
             });
@@ -674,7 +674,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
               await databaseBuilder.commit();
 
               // when
-              const certificationAttestation = await certificateRepository.getCertificationAttestation({
+              const certificationAttestation = await certificateRepository.getCertificate({
                 certificationCourseId: 123,
                 locale,
               });
@@ -723,7 +723,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           await databaseBuilder.commit();
 
           // when
-          const certificationAttestation = await certificateRepository.getCertificationAttestation({
+          const certificationAttestation = await certificateRepository.getCertificate({
             certificationCourseId: 123,
           });
 
@@ -771,7 +771,7 @@ describe('Integration | Infrastructure | Repository | Certification', function (
           await databaseBuilder.commit();
 
           // when
-          const certificationAttestation = await certificateRepository.getCertificationAttestation({
+          const certificationAttestation = await certificateRepository.getCertificate({
             certificationCourseId: 123,
           });
 

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -34,9 +34,9 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           sinon.stub(usecases, 'getCertificationCourseByVerificationCode');
           usecases.getCertificationCourseByVerificationCode.resolves(certificationCourse);
 
-          sinon.stub(usecases, 'getCertificationAttestation');
+          sinon.stub(usecases, 'getCertificate');
           const certificate = Symbol('certificate');
-          usecases.getCertificationAttestation.resolves(certificate);
+          usecases.getCertificate.resolves(certificate);
 
           sinon.stub(usecases, 'getShareableCertificate');
 
@@ -50,7 +50,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           expect(usecases.getCertificationCourseByVerificationCode).calledOnceWithExactly({
             verificationCode: 'P-123456BB',
           });
-          expect(usecases.getCertificationAttestation).calledOnceWithExactly({
+          expect(usecases.getCertificate).calledOnceWithExactly({
             certificationCourseId: certificationCourse.getId(),
             locale,
           });
@@ -70,7 +70,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
           sinon.stub(usecases, 'getShareableCertificate');
           sinon.stub(usecases, 'getCertificationCourseByVerificationCode');
-          sinon.stub(usecases, 'getCertificationAttestation');
+          sinon.stub(usecases, 'getCertificate');
           usecases.getShareableCertificate
             .withArgs({ verificationCode: 'P-123456BB', locale })
             .resolves(Symbol('certificate'));
@@ -92,7 +92,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
             certificationCourseId: certificationCourse.getId(),
             locale,
           });
-          expect(usecases.getCertificationAttestation).to.not.have.been.calledOnce;
+          expect(usecases.getCertificate).to.not.have.been.calledOnce;
         });
       });
     });
@@ -107,7 +107,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const certificateSerializerStub = { serialize: sinon.stub() };
         sinon.stub(usecases, 'getShareableCertificate');
         sinon.stub(usecases, 'getCertificationCourseByVerificationCode');
-        sinon.stub(usecases, 'getCertificationAttestation');
+        sinon.stub(usecases, 'getCertificate');
         usecases.getShareableCertificate
           .withArgs({ verificationCode: 'P-123456BB', locale })
           .resolves(Symbol('certificate'));
@@ -129,7 +129,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           certificationCourseId: certificationCourse.getId(),
           locale,
         });
-        expect(usecases.getCertificationAttestation).to.not.have.been.calledOnce;
+        expect(usecases.getCertificate).to.not.have.been.calledOnce;
       });
     });
   });
@@ -210,8 +210,8 @@ describe('Certification | Results | Unit | Application | certificate-controller'
             .withArgs({ certificationCourseId })
             .resolves(certificationCourse);
 
-          sinon.stub(usecases, 'getCertificationAttestation');
-          usecases.getCertificationAttestation.withArgs({ certificationCourseId, locale }).resolves(certificate);
+          sinon.stub(usecases, 'getCertificate');
+          usecases.getCertificate.withArgs({ certificationCourseId, locale }).resolves(certificate);
 
           const certificateSerializerStub = {
             serialize: sinon.stub(),
@@ -407,7 +407,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
 
         const v3CertificationAttestation = domainBuilder.certification.results.buildCertificate();
         sinon
-          .stub(usecases, 'getCertificationAttestation')
+          .stub(usecases, 'getCertificate')
           .withArgs({ certificationCourseId: request.params.certificationCourseId })
           .resolves(v3CertificationAttestation);
 
@@ -461,7 +461,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const filename = 'certification-pix-20181003.pdf';
 
         sinon
-          .stub(usecases, 'getCertificationAttestation')
+          .stub(usecases, 'getCertificate')
           .withArgs({ certificationCourseId: request.params.certificationCourseId })
           .resolves(certificationAttestation);
 

--- a/api/tests/certification/results/unit/domain/usecases/get-certificate_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certificate_test.js
@@ -1,15 +1,15 @@
-import { getCertificationAttestation } from '../../../../../../src/certification/results/domain/usecases/get-certification-attestation.js';
+import { getCertificate } from '../../../../../../src/certification/results/domain/usecases/get-certificate.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
-describe('Unit | UseCase | get-certification-attestation', function () {
+describe('Unit | UseCase | get-certificate', function () {
   let certificateRepository, certificationCourseRepository;
 
   beforeEach(function () {
-    certificateRepository = { getCertificationAttestation: sinon.stub() };
+    certificateRepository = { getCertificate: sinon.stub() };
     certificationCourseRepository = { get: sinon.stub() };
   });
 
-  it('should return the certification attestation enhanced with result competence tree', async function () {
+  it('should return the certificate enhanced with result competence tree', async function () {
     // given
     const locale = 'fr';
 
@@ -20,12 +20,12 @@ describe('Unit | UseCase | get-certification-attestation', function () {
     });
     const certificationCourse = domainBuilder.buildCertificationCourse({ id: 123 });
     certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-    certificateRepository.getCertificationAttestation
+    certificateRepository.getCertificate
       .withArgs({ certificationCourseId: 123, locale })
       .resolves(certificationAttestation);
 
     // when
-    const actualCertificationAttestation = await getCertificationAttestation({
+    const actualCertificate = await getCertificate({
       certificationCourseId: 123,
       locale,
       certificateRepository,
@@ -33,10 +33,10 @@ describe('Unit | UseCase | get-certification-attestation', function () {
     });
 
     // then
-    const expectedCertificationAttestation = domainBuilder.buildCertificationAttestation({
+    const expectedCertificate = domainBuilder.buildCertificationAttestation({
       id: 123,
       resultCompetenceTree,
     });
-    expect(actualCertificationAttestation).to.deep.equal(expectedCertificationAttestation);
+    expect(actualCertificate).to.deep.equal(expectedCertificate);
   });
 });

--- a/api/tests/certification/results/unit/domain/usecases/get-certificates-for-session_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-certificates-for-session_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-certification-attestation-for-session', function 
 
   beforeEach(function () {
     certificateRepository = {
-      getCertificationAttestation: sinon.stub(),
+      getCertificate: sinon.stub(),
     };
     certificationCourseRepository = {
       findCertificationCoursesBySessionId: sinon.stub(),
@@ -53,12 +53,8 @@ describe('Unit | UseCase | get-certification-attestation-for-session', function 
     certificationCourseRepository.findCertificationCoursesBySessionId
       .withArgs({ sessionId: 11 })
       .resolves([certificationCourse1, certificationCourse2]);
-    certificateRepository.getCertificationAttestation
-      .withArgs({ certificationCourseId: 1 })
-      .resolves(certificationAttestation1);
-    certificateRepository.getCertificationAttestation
-      .withArgs({ certificationCourseId: 2 })
-      .resolves(certificationAttestation2);
+    certificateRepository.getCertificate.withArgs({ certificationCourseId: 1 }).resolves(certificationAttestation1);
+    certificateRepository.getCertificate.withArgs({ certificationCourseId: 2 }).resolves(certificationAttestation2);
 
     // when
     const actualCertificationAttestations = await getCertificationAttestationsForSession({
@@ -127,7 +123,7 @@ describe('Unit | UseCase | get-certification-attestation-for-session', function 
       certificationCourseRepository.findCertificationCoursesBySessionId
         .withArgs({ sessionId: 13 })
         .resolves([certificationCourse]);
-      certificateRepository.getCertificationAttestation.withArgs({ certificationCourseId: 3 }).resolves();
+      certificateRepository.getCertificate.withArgs({ certificationCourseId: 3 }).resolves();
 
       // when
       const error = await catchErr(getCertificationAttestationsForSession)({


### PR DESCRIPTION
## 🌸 Problème

Il y a un cas d'utilisation qui s'appelle `get-certification-attestation`, ça crée une confusion avec les « attestations ». Chez certif, nous appelons ces documents des certificats maintenant...

## 🌳 Proposition

 Retirer l'utilisation du mot `attestation` du cas d'utilisation de récupération d'un certificat 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Consulté une certification (sur pixAdmin ? sur pixApp ?)
