### PR TITLE
[FEATURE] Supprimer les stepsLabels et avoir toutes les jauges sur 8 niveaux (PIX-18033)

### DIFF
--- a/orga/app/components/analysis/global-positioning.gjs
+++ b/orga/app/components/analysis/global-positioning.gjs
@@ -7,22 +7,12 @@ import { t } from 'ember-intl';
 export default class GlobalPositioning extends Component {
   @service intl;
 
-  get stepLabels() {
-    return [
-      this.intl.t('pages.statistics.level.novice'),
-      this.intl.t('pages.statistics.level.independent'),
-      this.intl.t('pages.statistics.level.advanced'),
-      this.intl.t('pages.statistics.level.expert'),
-    ];
-  }
-
   <template>
     <PixBlock class="global-positioning" @variant="orga">
       <h2 class="global-positioning__title">{{t "components.global-positioning.title"}}</h2>
       <p class="global-positioning__description">{{t "components.global-positioning.description"}}</p>
       <PixGauge
         @isSmall={{false}}
-        @stepLabels={{this.stepLabels}}
         @maxLevel={{@data.maxReachableLevel}}
         @reachedLevel={{@data.meanReachedLevel}}
         @label={{t

--- a/orga/app/components/statistics/cover-rate-gauge.gjs
+++ b/orga/app/components/statistics/cover-rate-gauge.gjs
@@ -3,7 +3,7 @@ import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-const MAX_REACHABLE_LEVEL = 7;
+const MAX_REACHABLE_LEVEL = 8;
 
 export default class CoverRateGauge extends Component {
   get id() {

--- a/orga/tests/integration/components/analysis/global-positioning_test.gjs
+++ b/orga/tests/integration/components/analysis/global-positioning_test.gjs
@@ -33,21 +33,5 @@ module('Integration | Component | Analysis | global-positioning', function (hook
         }),
       );
     });
-    test('the gauge should have stepLabels', async function (assert) {
-      // given
-      const data = {
-        maxReachableLevel: 4,
-        meanReachedLevel: 2,
-      };
-
-      // when
-      const screen = await render(<template><GlobalPositioning @data={{data}} /></template>);
-
-      // then
-      assert.ok(screen.getByText(t('pages.statistics.level.novice')));
-      assert.ok(screen.getByText(t('pages.statistics.level.independent')));
-      assert.ok(screen.getByText(t('pages.statistics.level.advanced')));
-      assert.ok(screen.getByText(t('pages.statistics.level.expert')));
-    });
   });
 });


### PR DESCRIPTION
## 🌸 Problème
1/ On a une incohérence dans le positionnement et l'indication des niveaux sur la grande jauge de la page analyse de campagne. 
En effet on indique qu'un niveau moyen de 4,6 est avancé alors qu'il devrait être indépendant. 
On ne peut pas modifier les bornes sans rendre l'affichage incohérent pour la team certif. 

2/ On veut avoir des jauges à 8 niveaux partout. 

## 🌳 Proposition

1/ On supprime les stepLabels
2/ On passe le MAX_REACHABLE_LEVEL de la petite jauge à 8

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Faire un tour et vérifier que tout est bien cohérent 🫰 