### PR TITLE
[TECH] E2E flakies: s'assurer que le serveur X11 est démarré sur la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,6 +814,17 @@ jobs:
     working_directory: ~/pix/high-level-tests/e2e
     steps:
       - browser-tools/install-chrome
+      - run:
+          name: Manual safety start of X11 server
+          command: |
+            set +e
+            Xvfb :99 -screen 0 1280x1024x24 2>/dev/null
+            if [ $? -eq 0 ]; then
+              echo "Xvfb started successfully"
+            else
+              echo "Xvfb is already running"
+            fi
+          background: true
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -884,6 +895,17 @@ jobs:
     working_directory: ~/pix/high-level-tests/e2e
     steps:
       - browser-tools/install-chrome
+      - run:
+          name: Manual safety start of X11 server
+          command: |
+            set +e
+            Xvfb :99 -screen 0 1280x1024x24 2>/dev/null
+            if [ $? -eq 0 ]; then
+              echo "Xvfb started successfully"
+            else
+              echo "Xvfb is already running"
+            fi
+          background: true
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey


### PR DESCRIPTION
## 🌸 Problème

Des flakies apparaissent sur les tests e2e exécuté par CircleCI ([exemple](https://app.circleci.com/pipelines/github/1024pix/pix/122932/workflows/236b7bff-6ae6-4ebb-8119-9b710418e698/jobs/1369083?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)) avec cette erreur:

```
[1711:0526/133318.889133:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[1711:0526/133319.522571:ERROR:ozone_platform_x11.cc(240)] Missing X server or $DISPLAY
[1711:0526/133319.522584:ERROR:env.cc(255)] The platform failed to initialize.  Exiting.
```

## 🌳 Proposition

Ces flakies semblent être lié à l'infrastructure de CircleCI, quand le serveur X11 ne démarre pas ou n'a pas encore démarré.

**Le problème est connu côté Cypress (voir [ticket](https://github.com/cypress-io/cypress/issues/31484)) et côté CircleCI (voir [ticket](https://discuss.circleci.com/t/xvfb-frequently-fails-to-start-with-browsers-convenience-image/53164/4))**

Pour le moment, pour éviter cette erreur, il est recommandé de s'assurer que le serveur X11 est bien démarré en ajoutant la configuration CircleCI suivante:

```
          command: |
            set +e
            Xvfb :99 -screen 0 1280x1024x24
            if [ $? -eq 0 ]; then
              echo "Xvfb started successfully"
            else
              echo "Xvfb is already running"
            fi
          background: true
```


## 🤧 Pour tester

Les tests e2e de la CI doivent s'exécuter correctement.
