### PR TITLE
[FEATURE] Afficher CLEA dans le certificat V3 sur Pix App (PIX-17892).

### DIFF
--- a/api/src/certification/results/domain/models/v3/Certificate.js
+++ b/api/src/certification/results/domain/models/v3/Certificate.js
@@ -1,3 +1,6 @@
+/**
+ * @typedef {import ('../../read-models/CertifiedBadge.js').CertifiedBadge} CertifiedBadge
+ */
 import { MAX_REACHABLE_SCORE } from '../../../../../shared/domain/constants.js';
 import { CERTIFICATE_LEVELS } from './CertificateLevels.js';
 import { GlobalCertificationLevel } from './GlobalCertificationLevel.js';
@@ -17,6 +20,7 @@ export class Certificate {
    * @param {Array<ResultCompetenceTree>} props.resultCompetenceTree
    * @param {AlgorithmEngineVersion} props.algorithmEngineVersion
    * @param {Date} props.certificationDate - date of certification
+   * @param {CertifiedBadge} props.acquiredComplementaryCertification
    */
   constructor({
     id,
@@ -31,6 +35,7 @@ export class Certificate {
     resultCompetenceTree,
     algorithmEngineVersion,
     certificationDate,
+    acquiredComplementaryCertification,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -46,6 +51,7 @@ export class Certificate {
     this.resultCompetenceTree = this.globalLevel ? resultCompetenceTree : null;
     this.algorithmEngineVersion = algorithmEngineVersion;
     this.certificationDate = certificationDate;
+    this.acquiredComplementaryCertification = acquiredComplementaryCertification;
   }
 
   #findLevel() {

--- a/api/src/certification/results/infrastructure/repositories/certificate-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certificate-repository.js
@@ -276,6 +276,7 @@ async function _toDomainForCertificationAttestation({ certificationCourseDTO, co
       ...certificationCourseDTO,
       certificationDate: certificationCourseDTO.date,
       resultCompetenceTree: (await featureToggles.get('isV3CertificationPageEnabled')) ? resultCompetenceTree : [],
+      acquiredComplementaryCertification: certifiedBadges.length ? certifiedBadges[0] : null,
     });
   }
 

--- a/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/certificate-serializer.js
@@ -51,6 +51,7 @@ const attributes = [
   'level',
   'certificationDate',
   'verificationCode',
+  'acquiredComplementaryCertification',
 ];
 
 const serialize = function ({ certificate, translate }) {
@@ -69,6 +70,7 @@ const serialize = function ({ certificate, translate }) {
       return {
         ...certificate,
         ...globalLevel,
+        acquiredComplementaryCertification: certificate.acquiredComplementaryCertification?.imageUrl,
       };
     },
     typeForAttribute,

--- a/api/tests/certification/results/acceptance/application/certificate-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certificate-route_test.js
@@ -649,6 +649,7 @@ describe('Certification | Results | Acceptance | Application | Certification', f
               ],
               'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
               version: session.version,
+              'acquired-complementary-certification': undefined,
             },
             id: `${certificationCourse.id}`,
             relationships: {

--- a/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/certificate-serializer_test.js
@@ -74,6 +74,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
             'certified-badge-images': ['/img/1', '/img/2'],
             'max-reachable-level-on-certification-date': 6,
             version: SESSIONS_VERSIONS.V3,
+            'acquired-complementary-certification': undefined,
           },
           relationships: {
             'result-competence-tree': {
@@ -182,6 +183,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
         const shareableCertificate = domainBuilder.certification.results.buildCertificate({
           id: 123,
           resultCompetenceTree,
+          acquiredComplementaryCertification: { imageUrl: 'http://example.com/' },
         });
         const translate = getI18n().__;
 
@@ -207,6 +209,7 @@ describe('Unit | Serializer | JSONAPI | certificate-serializer', function () {
             'global-description-label': shareableCertificate.globalLevel.getDescriptionLabel(translate),
             level: '1',
             'certification-date': new Date('2015-10-03T01:02:03Z'),
+            'acquired-complementary-certification': 'http://example.com/',
           },
           relationships: {
             'result-competence-tree': {

--- a/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/certification/results/build-v3-certification-attestation.js
@@ -14,6 +14,7 @@ const buildCertificate = function ({
   resultCompetenceTree = null,
   algorithmEngineVersion = AlgorithmEngineVersion.V3,
   certificationDate = new Date('2015-10-03T01:02:03Z'),
+  acquiredComplementaryCertification = null,
 } = {}) {
   return new Certificate({
     id,
@@ -28,6 +29,7 @@ const buildCertificate = function ({
     resultCompetenceTree,
     algorithmEngineVersion,
     certificationDate,
+    acquiredComplementaryCertification,
   });
 };
 

--- a/mon-pix/app/components/certifications/candidate-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/candidate-certificate/v3-certificate.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 
 import CandidateGlobalLevel from '../certificate-information/candidate-global-level';
 import CandidateInformation from '../certificate-information/candidate-information';
+import CleaCertification from '../certificate-information/clea-certification';
 import CompetencesDetails from '../certificate-information/competences-details';
 import DownloadPdf from '../certificate-information/download-pdf';
 
@@ -54,9 +55,15 @@ export default class v3Certificate extends Component {
 
       <CandidateGlobalLevel @certificate={{@certificate}} />
 
-      {{#if @certificate.resultCompetenceTree}}
-        <CompetencesDetails @certificate={{@certificate}} />
-      {{/if}}
+      <section class="v3-candidate-certificate__complementary">
+        {{#if @certificate.resultCompetenceTree}}
+          <CompetencesDetails @certificate={{@certificate}} />
+        {{/if}}
+
+        {{#if @certificate.acquiredComplementaryCertification}}
+          <CleaCertification @certificate={{@certificate}} />
+        {{/if}}
+      </section>
     </section>
   </template>
 }

--- a/mon-pix/app/components/certifications/certificate-information/clea-certification.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/clea-certification.gjs
@@ -1,0 +1,17 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import { t } from 'ember-intl';
+
+<template>
+  <section>
+    <h2 class="v3-candidate-certificate-complementary__title">{{t "pages.certificate.complementary.title"}}</h2>
+    <p class="v3-candidate-certificate-complementary__description">{{t "pages.certificate.complementary.clea"}}</p>
+    <PixBlock class="v3-candidate-certificate-complementary__information">
+      <div class="v3-complementary-certification-details-image">
+        <img
+          src={{@certificate.acquiredComplementaryCertification}}
+          alt="{{t 'pages.certificate.complementary.alternative'}}"
+        />
+      </div>
+    </PixBlock>
+  </section>
+</template>

--- a/mon-pix/app/components/certifications/certificate-information/competences-details.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/competences-details.gjs
@@ -7,7 +7,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { eq } from 'ember-truth-helpers';
+import { eq, gte } from 'ember-truth-helpers';
 
 export default class CertificateCompetencesDetails extends Component {
   @service url;
@@ -114,7 +114,11 @@ export default class CertificateCompetencesDetails extends Component {
                 {{#each area.resultCompetences as |resultCompetence|}}
                   <li data-competence-index={{resultCompetence.index}}>
                     <span>{{resultCompetence.name}}</span>
-                    <span><small class="sr-only">{{t "common.level"}}</small>{{resultCompetence.level}}</span>
+                    {{#if (gte resultCompetence.level 0)}}
+                      <span><small class="sr-only">{{t "common.level"}}</small>{{resultCompetence.level}}</span>
+                    {{else}}
+                      <span>-<small class="sr-only">{{t "common.no-level"}}</small></span>
+                    {{/if}}
                   </li>
                 {{/each}}
               </ol>

--- a/mon-pix/app/components/certifications/list/item.gjs
+++ b/mon-pix/app/components/certifications/list/item.gjs
@@ -52,8 +52,8 @@ export default class Item extends Component {
     return { color: 'green', content: this.intl.t('pages.certifications-list.statuses.validated') };
   }
 
-  get shouldDisplayComment() {
-    return (this.isRejected || this.isCancelled) && this.args.certification.commentForCandidate;
+  get notObtainedCertificationWithComment() {
+    return (this.isRejected || this.isCancelled) && this.args.certification.commentForCandidate && this.isPublished;
   }
 
   get pixScore() {
@@ -103,40 +103,40 @@ export default class Item extends Component {
       </div>
     </div>
     <div>
-      {{#if this.isPublished}}
-        {{#if this.shouldDisplayComment}}
-          <p class="certification-item-comment">{{t "pages.certifications-list.comment"}}
-            {{@certification.commentForCandidate}}</p>
-        {{else}}
-          {{#if this.errorMessage}}
-            <PixNotificationAlert @type="error" @withIcon={{true}} class="certification-item-error">
-              <p>{{this.errorMessage}}</p>
-            </PixNotificationAlert>
-          {{/if}}
+      {{#if this.notObtainedCertificationWithComment}}
+        <p class="certification-item-comment">{{t "pages.certifications-list.comment"}}
+          {{@certification.commentForCandidate}}</p>
 
-          <ul class="certification-item-buttons">
-            <li>
-              <PixButtonLink
-                @variant="secondary"
-                @route="authenticated.user-certifications.get"
-                @model={{@certification.id}}
-                @iconBefore="eye"
-              >
-                {{t "pages.certifications-list.buttons.details"}}
-              </PixButtonLink>
-            </li>
-            <li>
-              <PixButton
-                @triggerAction={{this.downloadAttestation}}
-                @loadingColor="grey"
-                @iconBefore="download"
-                @variant="tertiary"
-              >
-                {{this.downloadLabel}}
-              </PixButton>
-            </li>
-          </ul>
+      {{/if}}
+      {{#if this.isValidated}}
+        {{#if this.errorMessage}}
+          <PixNotificationAlert @type="error" @withIcon={{true}} class="certification-item-error">
+            <p>{{this.errorMessage}}</p>
+          </PixNotificationAlert>
         {{/if}}
+
+        <ul class="certification-item-buttons">
+          <li>
+            <PixButtonLink
+              @variant="secondary"
+              @route="authenticated.user-certifications.get"
+              @model={{@certification.id}}
+              @iconBefore="eye"
+            >
+              {{t "pages.certifications-list.buttons.details"}}
+            </PixButtonLink>
+          </li>
+          <li>
+            <PixButton
+              @triggerAction={{this.downloadAttestation}}
+              @loadingColor="grey"
+              @iconBefore="download"
+              @variant="tertiary"
+            >
+              {{this.downloadLabel}}
+            </PixButton>
+          </li>
+        </ul>
       {{/if}}
     </div>
   </template>

--- a/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
+++ b/mon-pix/app/components/certifications/shareable-certificate/v3-certificate.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 
 import CandidateGlobalLevel from '../certificate-information/candidate-global-level';
 import CandidateInformation from '../certificate-information/candidate-information';
+import CleaCertification from '../certificate-information/clea-certification';
 import CompetencesDetails from '../certificate-information/competences-details';
 
 export default class v3Certificate extends Component {
@@ -36,9 +37,15 @@ export default class v3Certificate extends Component {
 
       <CandidateGlobalLevel @certificate={{@certificate}} />
 
-      {{#if @certificate.resultCompetenceTree}}
-        <CompetencesDetails @certificate={{@certificate}} />
-      {{/if}}
+      <section class="v3-candidate-certificate__complementary">
+        {{#if @certificate.resultCompetenceTree}}
+          <CompetencesDetails @certificate={{@certificate}} />
+        {{/if}}
+
+        {{#if @certificate.acquiredComplementaryCertification}}
+          <CleaCertification @certificate={{@certificate}} />
+        {{/if}}
+      </section>
     </section>
   </template>
 }

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -37,6 +37,7 @@ export default class Certification extends Model {
   @attr('string') globalDescriptionLabel;
   @attr('date') certificationDate;
   @attr('string') level;
+  @attr('string') acquiredComplementaryCertification;
 
   // includes
   @belongsTo('result-competence-tree', { async: true, inverse: null }) resultCompetenceTree;

--- a/mon-pix/app/styles/components/certifications/candidate-certificate/_v3-certificate.scss
+++ b/mon-pix/app/styles/components/certifications/candidate-certificate/_v3-certificate.scss
@@ -18,6 +18,22 @@
       gap: var(--pix-spacing-8x);
     }
   }
+
+  &__complementary {
+    @extend %pix-body-l;
+
+    display: flex;
+    flex-direction: column-reverse;
+    gap: var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('desktop') {
+      flex-direction: row;
+
+      .certificate-competences-details {
+        flex: 2;
+      }
+    }
+  }
 }
 
 .v3-candidate-certificate-information {
@@ -29,5 +45,35 @@
     @extend %pix-title-xs;
 
     margin-bottom: var(--pix-spacing-4x);
+  }
+}
+
+.v3-candidate-certificate-complementary{
+  &__title {
+    @extend %pix-title-xs;
+  }
+
+  &__description {
+    @extend %pix-body-m;
+
+    padding: var(--pix-spacing-2x) 0;
+    color: var(--pix-neutral-900);
+  }
+
+  &__information {
+    margin-top: var(--pix-spacing-4x);
+  }
+}
+
+.v3-complementary-certification-details-image {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  img {
+    width: 130px;
+    height: 130px;
   }
 }

--- a/mon-pix/app/styles/components/certifications/certificate-information/_complementary-information-details.scss
+++ b/mon-pix/app/styles/components/certifications/certificate-information/_complementary-information-details.scss
@@ -1,6 +1,11 @@
 @use 'pix-design-tokens/typography';
 
 .v2-complementary-certification-details-image {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+  justify-content: center;
   text-align: center;
 
   img {

--- a/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/candidate-certificate/v3-certificate-test.gjs
@@ -96,4 +96,35 @@ module('Integration | Component | Certifications | Candidate certificate | v3-ce
       assert.strictEqual(globalLevelLabels.length, 2);
     });
   });
+
+  module('when the candidate acquired a complementary certification (clea only)', function () {
+    test('it displays complementary certification information', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 31,
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+        acquiredComplementaryCertification: 'http://example.com/clea.svg',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+        <Certifications::CandidateCertificate::v3Certificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { level: 2, name: t('pages.certificate.complementary.title') })).exists();
+      assert.dom(screen.getByText(t('pages.certificate.complementary.clea'))).exists();
+      assert
+        .dom(screen.getByRole('img', { name: t('pages.certificate.complementary.alternative') }))
+        .hasAttribute('src', 'http://example.com/clea.svg');
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
@@ -173,6 +173,42 @@ module('Integration | Component | Certifications | Certificate | Competences det
     });
   });
 
+  module('when a level is -1', function () {
+    test('should not display the level', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const area2 = store.createRecord('area', {
+        code: 2,
+        id: 'recs7Gpf90ln8NCv7',
+        name: '2. Deuxième domaine',
+        title: 'Domaine 2',
+        resultCompetences: [
+          store.createRecord('result-competence', {
+            index: '1.1',
+            name: 'Competence 1 du domaine 2',
+            level: -1,
+          }),
+        ],
+      });
+
+      const resultCompetenceTree = store.createRecord('result-competence-tree', {
+        areas: [area2],
+      });
+      const certification = store.createRecord('certification', {
+        resultCompetenceTree,
+      });
+      // when
+      const screen = await render(<template><CompetencesDetails @certificate={{certification}} /></template>);
+
+      // then
+      const tabpanel = screen.getByRole('tabpanel', { name: 'Domaine 2' });
+      const displayedCompetences = within(tabpanel).getAllByRole('listitem');
+      assert.dom(within(displayedCompetences[0]).getByText('Competence 1 du domaine 2')).exists();
+      assert.dom(within(displayedCompetences[0]).getByText('-')).exists();
+      assert.dom(within(displayedCompetences[0]).queryByText('-1')).doesNotExist();
+    });
+  });
+
   test('should update tabpanel on tab click', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/mon-pix/tests/integration/components/certifications/list/item-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/list/item-test.gjs
@@ -156,6 +156,33 @@ module('Integration | Component | item', function (hooks) {
           .doesNotExist();
       });
     });
+
+    module('when the certification is rejected or cancelled without comment', function () {
+      test('should not display the details and download button', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          date: new Date('2018-02-15T15:15:52Z'),
+          deliveredAt: new Date('2018-02-17T15:15:52Z'),
+          certificationCenter: 'Université de Lyon',
+          isPublished: true,
+          pixScore: 34,
+          status: 'rejected',
+          commentForCandidate: null,
+        });
+
+        // when
+        const screen = await render(<template><Item @certification={{certification}} /></template>);
+
+        // then
+        assert.ok(screen.getByText(t('pages.certifications-list.statuses.rejected')));
+        assert.dom(screen.queryByText(t('pages.certifications-list.comment'))).doesNotExist();
+        assert.dom(screen.queryByText(t('pages.certifications-list.buttons.details'))).doesNotExist();
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.certifications-list.buttons.download-attestation') }))
+          .doesNotExist();
+      });
+    });
   });
 
   module('when algorithm engine version is v2', function () {

--- a/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/shareable-certificate/v3-certificate-test.gjs
@@ -83,4 +83,35 @@ module('Integration | Component | Certifications | Shareable certificate | v3-ce
       assert.strictEqual(globalLevelLabels.length, 2);
     });
   });
+
+  module('when the candidate acquired a complementary certification (clea only)', function () {
+    test('it displays complementary certification information', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'Jean',
+        lastName: 'Bon',
+        certificationDate: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        pixScore: 31,
+        maxReachableLevelOnCertificationDate: new Date('2018-02-15T15:15:52Z'),
+        acquiredComplementaryCertification: 'http://example.com/clea.svg',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await render(hbs`
+        <Certifications::ShareableCertificate::v3Certificate @certificate={{this.certification}} />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { level: 2, name: t('pages.certificate.complementary.title') })).exists();
+      assert.dom(screen.getByText(t('pages.certificate.complementary.clea'))).exists();
+      assert
+        .dom(screen.getByRole('img', { name: t('pages.certificate.complementary.alternative') }))
+        .hasAttribute('src', 'http://example.com/clea.svg');
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -116,6 +116,7 @@
     "new-information-banner": {
       "close-label": "Close banner"
     },
+    "no-level": "No level",
     "or": "or",
     "pagination": {
       "action": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -647,6 +647,7 @@
       },
       "complementary": {
         "alternative": "Additional certification",
+        "clea": "Certification CléA Numérique by Pix",
         "title": "Other certification awarded"
       },
       "congratulations": "Congratulations!",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -108,6 +108,7 @@
       "nl": "Holandés"
     },
     "level": "nivel",
+    "no-level": "No nivel",
     "loading": {
       "default": "Cargando",
       "results": "Preparación de tus resultados",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -660,7 +660,8 @@
       },
       "complementary": {
         "alternative": "Certificación complementaria",
-        "title": "No hay ninguna certificación obtenida"
+        "title": "No hay ninguna certificación obtenida",
+        "clea": "Certificación CléA Numérique by Pix"
       },
       "exam-date": "Fecha de presentación:",
       "hexagon-score": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -116,6 +116,7 @@
     "new-information-banner": {
       "close-label": "Fermer la bannière"
     },
+    "no-level": "Aucun niveau",
     "or": "ou",
     "pagination": {
       "action": {
@@ -903,7 +904,7 @@
     },
     "certifications-list": {
       "buttons": {
-        "details": "Voir le détails",
+        "details": "Voir le détail",
         "download-attestation": "Télécharger l'attestation",
         "download-certificate": "Télécharger le certificat"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -647,6 +647,7 @@
       },
       "complementary": {
         "alternative": "Certification complémentaire",
+        "clea": "Certification CléA Numérique by Pix",
         "title": "Autre certification obtenue"
       },
       "congratulations": "Félicitations !",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -664,7 +664,8 @@
       },
       "complementary": {
         "alternative": "Aanvullende certificering",
-        "title": "Andere behaalde certificering"
+        "title": "Andere behaalde certificering",
+        "clea": "Certificering CléA Numérique by Pix"
       },
       "exam-date": "Datum bezoek :",
       "hexagon-score": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -108,6 +108,7 @@
       "nl": "Nederlands"
     },
     "level": "niveau",
+    "no-level": "Geen niveau",
     "loading": {
       "default": "Bezig met laden",
       "results": "Je resultaten voorbereiden",


### PR DESCRIPTION
## 🌸 Problème
le certificat V3 est presque fini ! Il ne manque que le cléa à afficher en cas de double certification 

## 🌳 Proposition

Afficher cléa

## 🐝 Remarques
Plusieurs fix sont compris dans cette PR

1er commit, fix de plusieurs soucis vu dans le certificat : 
- coquille sur le bouton "voir le détail"
- Alignement de la complémentaire avec le message
- Le tableau de compétence affiche un -1 quand le candidat n'a pas obtenu l'acquis

2nd commit, fix de l'affichage des boutons dans la liste des certifications : 
- Lorsqu'une certif est annulée ou non obtenu (sans commentaire) on affichait les boutons pour y accéder => on ne le veut pas

## 🤧 Pour tester

V3 only : 

Se connecter avec certif-success@example.net

https://app-pr12384.review.pix.fr/mes-certifications/3
=> avec complémentaire

<img width="1301" alt="Capture d’écran 2025-05-27 à 14 19 36" src="https://github.com/user-attachments/assets/a4a35051-5d6f-4f22-9046-c9bed157fb7f" />

- il y a le tiret pour un -1

https://app-pr12384.review.pix.fr/mes-certifications/2
=> sans complémentaire 


V2 : 
https://app-pr12384.review.pix.fr/mes-certifications/4
=> avec complémentaire (le message sous la complémentaire est en dessous, centré)

<img width="1266" alt="Capture d’écran 2025-05-27 à 14 20 32" src="https://github.com/user-attachments/assets/b7d52e13-2040-406a-8fc7-0e57fb1856f7" />
