### PR TITLE
[FEATURE] Anonymiser les données d'un participant à la suppression de celui-ci (PIX-17488).

### DIFF
--- a/api/db/database-builder/factory/build-organization-learner.js
+++ b/api/db/database-builder/factory/build-organization-learner.js
@@ -56,6 +56,7 @@ const buildOrganizationLearner = function ({
   MEFCode = '10010012110',
   status = 'ST',
   nationalStudentId = null,
+  nationalApprenticeId = null,
   division = '6eme',
   studentNumber = null,
   email = 'supermail@example.net',
@@ -72,6 +73,7 @@ const buildOrganizationLearner = function ({
   deletedAt = null,
   isCertifiable = null,
   certifiableAt = null,
+  attributes = null,
 } = {}) {
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -92,6 +94,7 @@ const buildOrganizationLearner = function ({
     MEFCode,
     status,
     nationalStudentId,
+    nationalApprenticeId,
     division,
     studentNumber,
     email,
@@ -108,6 +111,7 @@ const buildOrganizationLearner = function ({
     deletedAt,
     isCertifiable,
     certifiableAt,
+    attributes,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
@@ -21,11 +21,22 @@ class OrganizationLearner {
     nationalStudentId,
     division,
     isDisabled,
+    createdAt,
     updatedAt,
     userId,
     organizationId,
     isCertifiable,
     certifiableAt,
+    email,
+    studentNumber,
+    department,
+    educationalTeam,
+    group,
+    diploma,
+    nationalApprenticeId,
+    deletedAt,
+    deletedBy,
+    attributes,
   } = {}) {
     this.id = id;
     this.lastName = lastName;
@@ -44,11 +55,22 @@ class OrganizationLearner {
     this.nationalStudentId = nationalStudentId;
     this.division = division;
     this.isDisabled = isDisabled;
+    this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.userId = userId;
     this.organizationId = organizationId;
     this.isCertifiable = isCertifiable;
     this.certifiableAt = certifiableAt;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
+    this.email = email;
+    this.studentNumber = studentNumber;
+    this.department = department;
+    this.educationalTeam = educationalTeam;
+    this.group = group;
+    this.diploma = diploma;
+    this.nationalApprenticeId = nationalApprenticeId;
+    this.attributes = attributes;
   }
 
   updateCertificability(placementProfile) {
@@ -58,6 +80,7 @@ class OrganizationLearner {
 
   delete(userId) {
     this.deletedAt = new Date();
+    this.updatedAt = this.deletedAt;
     this.deletedBy = userId;
   }
 }

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
@@ -1,8 +1,12 @@
+import dayjs from 'dayjs';
+
 const STATUS = {
   STUDENT: 'ST',
   APPRENTICE: 'AP',
 };
 class OrganizationLearner {
+  #loggerContext;
+
   constructor({
     id,
     lastName,
@@ -73,15 +77,88 @@ class OrganizationLearner {
     this.attributes = attributes;
   }
 
+  get loggerContext() {
+    return this.#loggerContext;
+  }
+
   updateCertificability(placementProfile) {
     this.certifiableAt = placementProfile.profileDate;
     this.isCertifiable = placementProfile.isCertifiable();
   }
 
-  delete(userId) {
+  anonymize() {
+    this.#loggerContext = 'ORGANIZATION_LEARNER_ANONYMIZATION';
+    this.firstName = '(anonymized)';
+    this.lastName = '(anonymized)';
+    this.preferredLastName = null;
+    this.middleName = null;
+    this.thirdName = null;
+
+    if (this.birthdate) {
+      const birthdate = dayjs(this.birthdate).set('date', 1).set('month', 0).format('YYYY-MM-DD');
+      this.birthdate = birthdate;
+    }
+
+    this.birthCity = null;
+    this.birthCityCode = null;
+    this.birthProvinceCode = null;
+    this.birthCountryCode = null;
+    this.status = null;
+    this.nationalStudentId = null;
+    this.nationalApprenticeId = null;
+    this.division = null;
+    this.sex = null;
+    this.email = null;
+    this.studentNumber = null;
+    this.department = null;
+    this.educationalTeam = null;
+    this.group = null;
+    this.diploma = null;
+    this.userId = null;
+    this.updatedAt = new Date();
+  }
+
+  delete(userId, isAnonymizedWithDeletionEnabled) {
+    if (isAnonymizedWithDeletionEnabled) {
+      this.anonymize();
+      this.#loggerContext = 'ORGANIZATION_LEARNER_DELETION';
+    }
+
     this.deletedAt = new Date();
     this.updatedAt = this.deletedAt;
     this.deletedBy = userId;
+  }
+
+  get dataToUpdateOnDeletion() {
+    return {
+      id: this.id,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      preferredLastName: this.preferredLastName,
+      middleName: this.middleName,
+      thirdName: this.thirdName,
+      birthdate: this.birthdate,
+      birthCity: this.birthCity,
+      birthCityCode: this.birthCityCode,
+      birthProvinceCode: this.birthProvinceCode,
+      birthCountryCode: this.birthCountryCode,
+      status: this.status,
+      nationalStudentId: this.nationalStudentId,
+      nationalApprenticeId: this.nationalApprenticeId,
+      division: this.division,
+      sex: this.sex,
+      email: this.email,
+      studentNumber: this.studentNumber,
+      department: this.department,
+      educationalTeam: this.educationalTeam,
+      group: this.group,
+      diploma: this.diploma,
+      userId: this.userId,
+      isDisabled: this.isDisabled,
+      updatedAt: this.updatedAt,
+      deletedAt: this.deletedAt,
+      deletedBy: this.deletedBy,
+    };
   }
 }
 

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -24,11 +24,11 @@ const deleteOrganizationLearners = async function ({
     userId,
   );
 
-  for (const organizationLearner of organizationLearnersToDelete) {
-    organizationLearner.delete(userId);
-    await organizationLearnerRepository.remove(organizationLearner);
+  const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
 
-    const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
+  for (const organizationLearner of organizationLearnersToDelete) {
+    organizationLearner.delete(userId, isAnonymizationWithDeletionEnabled);
+    await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
 
     const campaignParticipations =
       await campaignParticipationRepositoryfromBC.getAllCampaignParticipationsForOrganizationLearner({

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -331,14 +331,44 @@ async function getLearnerInfo(organizationLearnerId) {
   return new OrganizationLearner(organizationLearner);
 }
 
-const remove = async ({ id, deletedBy, deletedAt }) => {
+const remove = async (organizationLearner) => {
   const knexConn = DomainTransaction.getConnection();
 
-  return knexConn('organization-learners').where('id', id).update({ deletedAt, deletedBy, updatedAt: deletedAt });
+  return knexConn('organization-learners').where('id', organizationLearner.id).update(_toInfra(organizationLearner));
 };
 
 function _toDomain(result) {
   return new OrganizationLearner(result);
+}
+
+function _toInfra(organizationLearner) {
+  return {
+    lastName: organizationLearner.lastName,
+    preferredLastName: organizationLearner.preferredLastName,
+    firstName: organizationLearner.firstName,
+    middleName: organizationLearner.middleName,
+    thirdName: organizationLearner.thirdName,
+    sex: organizationLearner.sex,
+    birthdate: organizationLearner.birthdate,
+    birthCity: organizationLearner.birthCity,
+    birthCityCode: organizationLearner.birthCityCode,
+    birthProvinceCode: organizationLearner.birthProvinceCode,
+    birthCountryCode: organizationLearner.birthCountryCode,
+    status: organizationLearner.status,
+    nationalStudentId: organizationLearner.nationalStudentId,
+    division: organizationLearner.division,
+    updatedAt: organizationLearner.updatedAt,
+    userId: organizationLearner.userId,
+    email: organizationLearner.email,
+    studentNumber: organizationLearner.studentNumber,
+    department: organizationLearner.department,
+    educationalTeam: organizationLearner.educationalTeam,
+    group: organizationLearner.group,
+    diploma: organizationLearner.diploma,
+    nationalApprenticeId: organizationLearner.nationalApprenticeId,
+    deletedAt: organizationLearner.deletedAt,
+    deletedBy: organizationLearner.deletedBy,
+  };
 }
 
 /**

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -16,8 +16,16 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
     adminUserId = databaseBuilder.factory.buildUser().id;
     organizationId = databaseBuilder.factory.buildOrganization().id;
     campaign = databaseBuilder.factory.buildCampaign({ organizationId, type: CampaignTypes.ASSESSMENT });
-    organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
-    organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+    organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      firstName: 'POUET',
+      birthdate: '2020-05-12',
+    });
+    organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      firstName: 'TEUOP',
+      birthdate: '2020-12-12',
+    });
     campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
       organizationLearnerId: organizationLearner1.id,
       participantExternalId,
@@ -96,7 +104,31 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
       ]);
       expect(deletedLearners).lengthOf(2);
       deletedLearners.forEach((learner) => {
-        expect(learner.deletedAt).to.deep.equal(now);
+        expect(learner.firstName).to.equal('(anonymized)');
+        expect(learner.lastName).to.equal('(anonymized)');
+        expect(learner.preferredLastName).null;
+        expect(learner.middleName).null;
+        expect(learner.thirdName).null;
+        expect(learner.birthdate).equal('2020-01-01');
+        expect(learner.birthCity).null;
+        expect(learner.birthCityCode).null;
+        expect(learner.birthProvinceCode).null;
+        expect(learner.birthCountryCode).null;
+        expect(learner.status).null;
+        expect(learner.nationalStudentId).null;
+        expect(learner.nationalApprenticeId).null;
+        expect(learner.division).null;
+        expect(learner.sex).null;
+        expect(learner.email).null;
+        expect(learner.studentNumber).null;
+        expect(learner.department).null;
+        expect(learner.educationalTeam).null;
+        expect(learner.group).null;
+        expect(learner.diploma).null;
+        expect(learner.userId).null;
+        expect(learner.isDisabled).equal(false);
+        expect(learner.updatedAt).deep.equal(now);
+        expect(learner.deletedAt).deep.equal(now);
         expect(learner.deletedBy).to.deep.equal(adminUserId);
       });
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -164,31 +164,88 @@ describe('Integration | Repository | Organization Learner Management | Organizat
   });
 
   describe('#remove', function () {
+    let clock;
+    const now = new Date('2023-02-02');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
     it('update given organization learner', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const deletedAt = new Date('2023-01-01');
+      const adminUserId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
-        firstName: 'firstName',
+      const organizationLearnerFromDB = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
+        lastName: 'Richard',
+        preferredLastName: 'Maurice',
+        firstName: 'jean',
+        middleName: 'paul',
+        thirdName: 'pierre',
+        sex: 'M',
+        MEFCode: '12',
+        birthdate: '2001-05-06',
+        birthCity: 'Mans',
+        birthCityCode: '12345',
+        birthProvinceCode: '45',
+        birthCountryCode: '18',
+        status: 'AP',
+        nationalStudentId: '12314543',
+        division: '6eme ROUGE',
+        updatedAt: new Date('1999-01-01'),
+        email: 'littlepeas@vegatable.org',
+        studentNumber: '9876543',
+        department: '51',
+        educationalTeam: 'Core',
+        group: 'B',
+        diploma: 'pujze, peozaeza; pzaezae',
+        nationalApprenticeId: '123456432',
+        deletedBy: null,
+        deletedAt: null,
       });
 
       await databaseBuilder.commit();
 
       // when
-      organizationLearner.deletedBy = userId;
-      organizationLearner.deletedAt = deletedAt;
+      const organizationLearner = domainBuilder.buildOrganizationLearner(organizationLearnerFromDB);
+      organizationLearner.delete(adminUserId, true);
 
-      await remove(organizationLearner);
+      await remove(organizationLearner.dataToUpdateOnDeletion);
 
       // then
       const organizationLearnerResult = await knex('organization-learners')
         .where({ id: organizationLearner.id })
         .first();
 
-      expect(organizationLearnerResult.deletedBy).to.equal(userId);
-      expect(organizationLearnerResult.deletedAt).to.deep.equal(deletedAt);
+      expect(organizationLearnerResult.MEFCode).equal('12');
+      expect(organizationLearnerResult.lastName).equal('(anonymized)');
+      expect(organizationLearnerResult.firstName).equal('(anonymized)');
+      expect(organizationLearnerResult.preferredLastName).null;
+      expect(organizationLearnerResult.middleName).null;
+      expect(organizationLearnerResult.thirdName).null;
+      expect(organizationLearnerResult.sex).null;
+      expect(organizationLearnerResult.birthdate).deep.equal('2001-01-01');
+      expect(organizationLearnerResult.birthCity).null;
+      expect(organizationLearnerResult.birthCityCode).null;
+      expect(organizationLearnerResult.birthProvinceCode).null;
+      expect(organizationLearnerResult.birthCountryCode).null;
+      expect(organizationLearnerResult.status).null;
+      expect(organizationLearnerResult.nationalStudentId).null;
+      expect(organizationLearnerResult.division).null;
+      expect(organizationLearnerResult.updatedAt).deep.equal(now);
+      expect(organizationLearnerResult.email).null;
+      expect(organizationLearnerResult.studentNumber).null;
+      expect(organizationLearnerResult.department).null;
+      expect(organizationLearnerResult.educationalTeam).null;
+      expect(organizationLearnerResult.group).null;
+      expect(organizationLearnerResult.diploma).null;
+      expect(organizationLearnerResult.nationalApprenticeId).null;
+      expect(organizationLearnerResult.deletedBy).equal(adminUserId);
+      expect(organizationLearnerResult.deletedAt).deep.equal(now);
     });
   });
 
@@ -429,9 +486,45 @@ describe('Integration | Repository | Organization Learner Management | Organizat
           organizationId,
         });
         expect(actualOrganizationLearners).to.have.lengthOf(1);
-        expect(
-          _.omit(actualOrganizationLearners[0], ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']),
-        ).to.deep.equal(_.omit(firstOrganizationLearner, ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']));
+        expect({
+          lastName: firstOrganizationLearner.lastName,
+          preferredLastName: firstOrganizationLearner.preferredLastName,
+          firstName: firstOrganizationLearner.firstName,
+          middleName: firstOrganizationLearner.middleName,
+          thirdName: firstOrganizationLearner.thirdName,
+          sex: firstOrganizationLearner.sex,
+          birthdate: firstOrganizationLearner.birthdate,
+          birthCity: firstOrganizationLearner.birthCity,
+          birthCityCode: firstOrganizationLearner.birthCityCode,
+          birthProvinceCode: firstOrganizationLearner.birthProvinceCode,
+          birthCountryCode: firstOrganizationLearner.birthCountryCode,
+          MEFCode: firstOrganizationLearner.MEFCode,
+          status: firstOrganizationLearner.status,
+          nationalStudentId: firstOrganizationLearner.nationalStudentId,
+          division: firstOrganizationLearner.division,
+          userId: firstOrganizationLearner.userId,
+          isDisabled: firstOrganizationLearner.isDisabled,
+          organizationId: firstOrganizationLearner.organizationId,
+        }).deep.equal({
+          lastName: actualOrganizationLearners[0].lastName,
+          preferredLastName: actualOrganizationLearners[0].preferredLastName,
+          firstName: actualOrganizationLearners[0].firstName,
+          middleName: actualOrganizationLearners[0].middleName,
+          thirdName: actualOrganizationLearners[0].thirdName,
+          sex: actualOrganizationLearners[0].sex,
+          birthdate: actualOrganizationLearners[0].birthdate,
+          birthCity: actualOrganizationLearners[0].birthCity,
+          birthCityCode: actualOrganizationLearners[0].birthCityCode,
+          birthProvinceCode: actualOrganizationLearners[0].birthProvinceCode,
+          birthCountryCode: actualOrganizationLearners[0].birthCountryCode,
+          MEFCode: actualOrganizationLearners[0].MEFCode,
+          status: actualOrganizationLearners[0].status,
+          nationalStudentId: actualOrganizationLearners[0].nationalStudentId,
+          division: actualOrganizationLearners[0].division,
+          userId: actualOrganizationLearners[0].userId,
+          isDisabled: actualOrganizationLearners[0].isDisabled,
+          organizationId: actualOrganizationLearners[0].organizationId,
+        });
       });
     });
 

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
@@ -60,17 +60,47 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
       clock.restore();
     });
 
-    it('should update deteledAt, deletedBy', function () {
-      // given
-      const userId = 123;
-      const organizationLearner = new OrganizationLearner();
+    context('when withAnonymisation is false', function () {
+      it('should update deteledAt, deletedBy', function () {
+        // given
+        const adminUserId = 123;
+        const organizationLearner = domainBuilder.buildOrganizationLearner({
+          birthdate: new Date('2005-10-03'),
+          userId: 456,
+          deletedAt: null,
+          deletedBy: null,
+        });
 
-      // when
-      organizationLearner.delete(userId);
+        // when
+        organizationLearner.delete(adminUserId, false);
 
-      // then
-      expect(organizationLearner.deletedAt).to.deep.equal(now);
-      expect(organizationLearner.deletedBy).to.equal(userId);
+        // then
+        expect(organizationLearner.updatedAt).to.deep.equal(now);
+        expect(organizationLearner.deletedAt).to.deep.equal(now);
+        expect(organizationLearner.deletedBy).to.equal(adminUserId);
+        expect(organizationLearner.userId).to.equal(organizationLearner.userId);
+        expect(organizationLearner.firstName).to.equal(organizationLearner.firstName);
+        expect(organizationLearner.lastName).to.equal(organizationLearner.lastName);
+        expect(organizationLearner.birthDate).to.equal(organizationLearner.birthDate);
+        expect(organizationLearner.preferredLastName).to.equal(organizationLearner.preferredLastName);
+        expect(organizationLearner.middleName).to.equal(organizationLearner.middleName);
+        expect(organizationLearner.thirdName).to.equal(organizationLearner.thirdName);
+        expect(organizationLearner.birthCity).to.equal(organizationLearner.birthCity);
+        expect(organizationLearner.birthCityCode).to.equal(organizationLearner.birthCityCode);
+        expect(organizationLearner.birthProvinceCode).to.equal(organizationLearner.birthProvinceCode);
+        expect(organizationLearner.birthCountryCode).to.equal(organizationLearner.birthCountryCode);
+        expect(organizationLearner.status).to.equal(organizationLearner.status);
+        expect(organizationLearner.nationalStudentId).to.equal(organizationLearner.nationalStudentId);
+        expect(organizationLearner.division).to.equal(organizationLearner.division);
+        expect(organizationLearner.sex).to.equal(organizationLearner.sex);
+        expect(organizationLearner.email).to.equal(organizationLearner.email);
+        expect(organizationLearner.studentNumber).to.equal(organizationLearner.studentNumber);
+        expect(organizationLearner.department).to.equal(organizationLearner.department);
+        expect(organizationLearner.educationalTeam).to.equal(organizationLearner.educationalTeam);
+        expect(organizationLearner.group).to.equal(organizationLearner.group);
+        expect(organizationLearner.diploma).to.equal(organizationLearner.diploma);
+        expect(organizationLearner.nationalApprenticeId).to.equal(organizationLearner.nationalApprenticeId);
+      });
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
@@ -61,11 +61,11 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
     });
 
     context('when withAnonymisation is false', function () {
-      it('should update deteledAt, deletedBy', function () {
+      it('should only update updatedAt, deteledAt, deletedBy', function () {
         // given
         const adminUserId = 123;
         const organizationLearner = domainBuilder.buildOrganizationLearner({
-          birthdate: new Date('2005-10-03'),
+          birthdate: '2005-10-03',
           userId: 456,
           deletedAt: null,
           deletedBy: null,
@@ -81,7 +81,7 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
         expect(organizationLearner.userId).to.equal(organizationLearner.userId);
         expect(organizationLearner.firstName).to.equal(organizationLearner.firstName);
         expect(organizationLearner.lastName).to.equal(organizationLearner.lastName);
-        expect(organizationLearner.birthDate).to.equal(organizationLearner.birthDate);
+        expect(organizationLearner.birthdate).to.equal(organizationLearner.birthdate);
         expect(organizationLearner.preferredLastName).to.equal(organizationLearner.preferredLastName);
         expect(organizationLearner.middleName).to.equal(organizationLearner.middleName);
         expect(organizationLearner.thirdName).to.equal(organizationLearner.thirdName);
@@ -90,6 +90,7 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
         expect(organizationLearner.birthProvinceCode).to.equal(organizationLearner.birthProvinceCode);
         expect(organizationLearner.birthCountryCode).to.equal(organizationLearner.birthCountryCode);
         expect(organizationLearner.status).to.equal(organizationLearner.status);
+        expect(organizationLearner.MEFCode).to.equal(organizationLearner.MEFCode);
         expect(organizationLearner.nationalStudentId).to.equal(organizationLearner.nationalStudentId);
         expect(organizationLearner.division).to.equal(organizationLearner.division);
         expect(organizationLearner.sex).to.equal(organizationLearner.sex);
@@ -100,6 +101,95 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
         expect(organizationLearner.group).to.equal(organizationLearner.group);
         expect(organizationLearner.diploma).to.equal(organizationLearner.diploma);
         expect(organizationLearner.nationalApprenticeId).to.equal(organizationLearner.nationalApprenticeId);
+      });
+    });
+
+    context('when withAnonymisation is true', function () {
+      it('should update updatedAt, deteledAt, deletedBy and anonymised fields', function () {
+        // given
+        const adminUserId = 123;
+        const organizationLearner = domainBuilder.buildOrganizationLearner({
+          birthdate: '2005-10-03',
+          userId: 456,
+          deletedAt: null,
+          deletedBy: null,
+        });
+
+        // when
+        organizationLearner.delete(adminUserId, true);
+
+        // then
+        expect(organizationLearner.MEFCode).to.equal(organizationLearner.MEFCode);
+        expect(organizationLearner.createdAt).to.deep.equal(organizationLearner.createdAt);
+        expect(organizationLearner.isDisabled).to.be.equal(organizationLearner.isDisabled);
+        expect(organizationLearner.firstName).to.equal('(anonymized)');
+        expect(organizationLearner.lastName).to.equal('(anonymized)');
+        expect(organizationLearner.birthdate).to.equal('2005-01-01');
+        expect(organizationLearner.deletedAt).to.deep.equal(now);
+        expect(organizationLearner.deletedBy).to.equal(adminUserId);
+        expect(organizationLearner.updatedAt).to.deep.equal(now);
+        expect(organizationLearner.userId).to.be.null;
+        expect(organizationLearner.preferredLastName).to.be.null;
+        expect(organizationLearner.middleName).to.be.null;
+        expect(organizationLearner.thirdName).to.be.null;
+        expect(organizationLearner.birthCity).to.be.null;
+        expect(organizationLearner.birthCityCode).to.be.null;
+        expect(organizationLearner.birthProvinceCode).to.be.null;
+        expect(organizationLearner.birthCountryCode).to.be.null;
+        expect(organizationLearner.status).to.be.null;
+        expect(organizationLearner.nationalStudentId).to.be.null;
+        expect(organizationLearner.nationalApprenticeId).to.be.null;
+        expect(organizationLearner.division).to.be.null;
+        expect(organizationLearner.sex).to.be.null;
+        expect(organizationLearner.email).to.be.null;
+        expect(organizationLearner.studentNumber).to.be.null;
+        expect(organizationLearner.department).to.be.null;
+        expect(organizationLearner.educationalTeam).to.be.null;
+        expect(organizationLearner.group).to.be.null;
+        expect(organizationLearner.diploma).to.be.null;
+      });
+    });
+  });
+
+  describe('#dataToUpdateOnDeletion', function () {
+    it('should return only data to update on deletion', function () {
+      // given
+      const organizationLearner = domainBuilder.buildOrganizationLearner({
+        birthdate: '2005-10-03',
+        userId: 456,
+        deletedAt: null,
+        deletedBy: null,
+      });
+
+      //when && then
+      expect(organizationLearner.dataToUpdateOnDeletion).deep.equal({
+        id: organizationLearner.id,
+        firstName: organizationLearner.firstName,
+        lastName: organizationLearner.lastName,
+        preferredLastName: organizationLearner.preferredLastName,
+        middleName: organizationLearner.middleName,
+        thirdName: organizationLearner.thirdName,
+        birthdate: organizationLearner.birthdate,
+        birthCity: organizationLearner.birthCity,
+        birthCityCode: organizationLearner.birthCityCode,
+        birthProvinceCode: organizationLearner.birthProvinceCode,
+        birthCountryCode: organizationLearner.birthCountryCode,
+        status: organizationLearner.status,
+        nationalStudentId: organizationLearner.nationalStudentId,
+        nationalApprenticeId: organizationLearner.nationalApprenticeId,
+        division: organizationLearner.division,
+        sex: organizationLearner.sex,
+        email: organizationLearner.email,
+        studentNumber: organizationLearner.studentNumber,
+        department: organizationLearner.department,
+        educationalTeam: organizationLearner.educationalTeam,
+        group: organizationLearner.group,
+        diploma: organizationLearner.diploma,
+        userId: organizationLearner.userId,
+        isDisabled: organizationLearner.isDisabled,
+        updatedAt: organizationLearner.updatedAt,
+        deletedAt: organizationLearner.deletedAt,
+        deletedBy: organizationLearner.deletedBy,
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-organization-learner.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-learner.js
@@ -28,12 +28,12 @@ function buildOrganizationLearner({
   deletedBy = null,
   createdAt = new Date('2020-01-01'),
   email = 'pix@example.net',
-  studentNumber = '12356',
+  studentNumber,
   department = 'faculté',
   educationalTeam = '2ieme année Licence éco',
   group = 'L1',
   diploma = 'Non reconnu',
-  nationalApprenticeId = '123456781',
+  nationalApprenticeId = null,
   attributes = {},
 } = {}) {
   return new OrganizationLearner({

--- a/api/tests/tooling/domain-builder/factory/build-organization-learner.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-learner.js
@@ -24,6 +24,17 @@ function buildOrganizationLearner({
   updatedAt = new Date('2020-01-01'),
   certifiableAt = null,
   isCertifiable = null,
+  deletedAt = null,
+  deletedBy = null,
+  createdAt = new Date('2020-01-01'),
+  email = 'pix@example.net',
+  studentNumber = '12356',
+  department = 'faculté',
+  educationalTeam = '2ieme année Licence éco',
+  group = 'L1',
+  diploma = 'Non reconnu',
+  nationalApprenticeId = '123456781',
+  attributes = {},
 } = {}) {
   return new OrganizationLearner({
     id,
@@ -48,6 +59,17 @@ function buildOrganizationLearner({
     organizationId: organization.id,
     certifiableAt,
     isCertifiable,
+    deletedAt,
+    deletedBy,
+    createdAt,
+    email,
+    studentNumber,
+    department,
+    educationalTeam,
+    group,
+    diploma,
+    nationalApprenticeId,
+    attributes,
   });
 }
 


### PR DESCRIPTION
## :egg: Problème
On anonymise psa en même temps que la suppression d'un organizationLearner

## :bowl_with_spoon: Proposition
On anonymise en même temps que l'on supprime

## :milk_glass: Remarques
Feature sous toggles en attendant que le chantier soit entièrement termné

## :butter: Pour tester
- Supprimer un organizationLearner via PixOrga 
- Vérifier que les learners est bien a deletedAt / deletedBy ( Sur PixAdmin )
- activer la feature
```
npm run toggles -- -k isAnonymizationWithDelationEnabled -v true
```

- Suprimer à nouveau un learner sur PixOrga 
- Vérifier que les learners est bien a deletedAt / deletedBy avec ses données anonymisé (pas de participantExternalId) ( Sur PixAdmin )
- verifier en se connectant la console pg que les autres données sont bien anonymisées