### PR TITLE
[TECH] Alléger le container pix-e2e-api en n’utilisant pas nodemon

### DIFF
--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
     user: node
     image: node:22.14.0
     env_file: ./env-api
-    command: npm run dev
+    command: npm start
     volumes:
       - ../..:/code
     working_dir: /code/api


### PR DESCRIPTION
## 🌸 Problème

Pour le container `pix-e2e-api` c'est la commande `npm run dev` qui est utilisée et qui, à son tour, exécute la commande `nodemon index.js`. Or l’utilisation de _nodemon_ est inutile pour les tests e2e (puisqu’il n’y a aucun besoin de redémarrer Pix Api si le code changeait) et _nodemon_ ouvre de très nombreux descripteurs de fichier de l’arborescence de `api/`, tel que défini dans `nodemon.json`.

## 🌳 Proposition

Pour les tests e2e utiliser la commande `npm start` à la place de la commande `npm run dev`.

## 🐝 Remarques

RAS

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
