### PR TITLE
[TECH] Correction du flaky sur la route Saml POST (PIX-18045)

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -558,8 +558,6 @@ const configuration = (function () {
     config.temporaryStorage.redisUrl = process.env.TEST_REDIS_URL;
     config.authentication.permitPixAdminLoginFromPassword = false;
 
-    config.saml.accessTokenLifespanMs = 1000;
-
     config.cpf.storage = {
       cpfExports: {
         client: {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -1,5 +1,3 @@
-import { env } from 'node:process';
-
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../../src/shared/config.js';
@@ -134,13 +132,7 @@ function decodeIfValid(token) {
 function getDecodedToken(token, secret = config.authentication.secret) {
   try {
     return jsonwebtoken.verify(token, secret);
-  } catch (error) {
-    // TODO: Remove this debug used to investigate a flaky test when the cause is found
-    if (env.DEBUG == 'pix:token-service:invalid-token') {
-      // eslint-disable-next-line no-console
-      console.error(`token: "${token}"`, error);
-    }
-
+  } catch {
     return false;
   }
 }

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -1,5 +1,3 @@
-import { env } from 'node:process';
-
 import _ from 'lodash';
 import samlify from 'samlify';
 
@@ -262,8 +260,6 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
     describe('when user has a reconciled Pix account and successfully authenticate to Pix from GAR (saml)', function () {
       it('returns a 200 with accessToken', async function () {
         // given
-        env.DEBUG = 'pix:token-service:invalid-token';
-
         const password = 'Pix123';
         const userAttributes = {
           firstName: 'saml',

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -132,7 +132,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const source = 'external';
 
       sinon.stub(settings.authentication, 'secret').value(secret);
-      sinon.stub(settings.authentication, 'accessTokenLifespanMs').value(1000);
+      sinon.stub(settings.saml, 'accessTokenLifespanMs').value(1000);
       const accessToken = 'valid access token';
       const audience = 'https://app.pix.fr';
       const payload = { user_id: userId, source, aud: audience };


### PR DESCRIPTION
## 🌸 Problème

Correction de [ce flaky](https://app.circleci.com/pipelines/github/1024pix/pix/122932/workflows/236b7bff-6ae6-4ebb-8119-9b710418e698/jobs/1369080/steps) suite à l'investigation faite dans la PR [#12191](https://github.com/1024pix/pix/pull/12191)

L'erreur retournée est la suivante:
```
token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxMDA1NDgsInNvdXJjZSI6ImV4dGVybmFsIiwiYXVkIjoiaHR0cHM6Ly9hcHAucGl4LmZyIiwiaWF0IjoxNzQ4MjY2MzI5LCJleHAiOjE3NDgyNjYzMzB9.v2BKmA1AaSENCt4i1NxbUAERUMKCdKf1TcGgsMRNLao" TokenExpiredError: jwt expired
    at /home/circleci/pix/api/node_modules/jsonwebtoken/verify.js:190:21
    at getSecret (/home/circleci/pix/api/node_modules/jsonwebtoken/verify.js:97:14)
    at module.exports [as verify] (/home/circleci/pix/api/node_modules/jsonwebtoken/verify.js:101:10)
    at getDecodedToken (file:///home/circleci/pix/api/src/shared/domain/services/token-service.js:136:25)
    at file:///home/circleci/pix/api/src/shared/domain/services/token-service.js:129:21
    at new Promise (<anonymous>)
    at decodeIfValid (file:///home/circleci/pix/api/src/shared/domain/services/token-service.js:128:10)
    at Context.<anonymous> (file:///home/circleci/pix/api/tests/identity-access-management/acceptance/application/saml.route.test.js:308:42)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  expiredAt: 2025-05-26T13:32:10.000Z
}
```

## 🌳 Proposition

Probablement causé par la propriété `config.saml.accessTokenLifespanMs` qui une valeur à 1000ms dans les tests. À priori si le test est un peu long ou ralenti, le jwt de l'access token peut être expiré.

La correction consiste à supprimer la surcharge de cette propriété dans les test et conserver la valeur par défaut qui est `7d` (7 jours)

## 🐝 Remarques

La log de debug ajoutée pour l'investigation a également été supprimée

