### PR TITLE
[TECH] :truck: Utilise le terme `certificat` plutôt que `attestation` dans une erreur (PIX-18051)

### DIFF
--- a/api/src/certification/results/domain/usecases/find-certification-attestations-for-division.js
+++ b/api/src/certification/results/domain/usecases/find-certification-attestations-for-division.js
@@ -1,4 +1,4 @@
-import { NoCertificationAttestationForDivisionError } from '../../../../shared/domain/errors.js';
+import { NoCertificateForDivisionError } from '../../../../shared/domain/errors.js';
 
 const findCertificationAttestationsForDivision = async function ({ organizationId, division, certificateRepository }) {
   const certificationAttestations = await certificateRepository.findByDivisionForScoIsManagingStudentsOrganization({
@@ -7,7 +7,7 @@ const findCertificationAttestationsForDivision = async function ({ organizationI
   });
 
   if (certificationAttestations.length === 0) {
-    throw new NoCertificationAttestationForDivisionError(division);
+    throw new NoCertificateForDivisionError(division);
   }
   return certificationAttestations;
 };

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -167,7 +167,7 @@ function _mapToHttpError(error) {
   if (error instanceof AdminMemberError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }
-  if (error instanceof SharedDomainErrors.NoCertificationAttestationForDivisionError) {
+  if (error instanceof SharedDomainErrors.NoCertificateForDivisionError) {
     return new HttpErrors.BadRequestError(error.message);
   }
   if (error instanceof OrganizationCantGetPlacesStatisticsError) {

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -471,9 +471,9 @@ class MissingBadgeCriterionError extends DomainError {
   }
 }
 
-class NoCertificationAttestationForDivisionError extends DomainError {
+class NoCertificateForDivisionError extends DomainError {
   constructor(division) {
-    const message = `Aucune attestation de certification pour la classe ${division}.`;
+    const message = `Aucun certificat pour la classe ${division}.`;
     super(message);
   }
 }
@@ -1098,7 +1098,7 @@ export {
   ModelValidationError,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   NoCampaignParticipationForUserAndCampaign,
-  NoCertificationAttestationForDivisionError,
+  NoCertificateForDivisionError,
   NoOrganizationToAttach,
   NoSkillsInCampaignError,
   NoStagesForCampaign,

--- a/api/tests/certification/results/unit/domain/usecases/find-certificates-for-division_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/find-certificates-for-division_test.js
@@ -1,5 +1,5 @@
 import { findCertificationAttestationsForDivision } from '../../../../../../src/certification/results/domain/usecases/find-certification-attestations-for-division.js';
-import { NoCertificationAttestationForDivisionError } from '../../../../../../src/shared/domain/errors.js';
+import { NoCertificateForDivisionError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | find-certification-attestations-for-division', function () {
@@ -58,7 +58,7 @@ describe('Unit | UseCase | find-certification-attestations-for-division', functi
   });
 
   describe('when there is no attestation', function () {
-    it('should throw a NoCertificationAttestationForDivisionError', async function () {
+    it('should throw a NoCertificateForDivisionError', async function () {
       // given
       certificateRepository.findByDivisionForScoIsManagingStudentsOrganization
         .withArgs({ organizationId: 1234, division: '3b' })
@@ -72,7 +72,7 @@ describe('Unit | UseCase | find-certification-attestations-for-division', functi
       });
 
       // then
-      expect(error).to.be.an.instanceOf(NoCertificationAttestationForDivisionError);
+      expect(error).to.be.an.instanceOf(NoCertificateForDivisionError);
     });
   });
 });

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -27,7 +27,7 @@ import {
   LocaleFormatError,
   LocaleNotSupportedError,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
-  NoCertificationAttestationForDivisionError,
+  NoCertificateForDivisionError,
   NotEnoughDaysPassedBeforeResetCampaignParticipationError,
   NotFoundError,
   OidcError,
@@ -327,9 +327,9 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
-    it('should instantiate BadRequestError when NoCertificationAttestationForDivisionError', async function () {
+    it('should instantiate BadRequestError when NoCertificateForDivisionError', async function () {
       // given
-      const error = new NoCertificationAttestationForDivisionError(1);
+      const error = new NoCertificateForDivisionError(1);
       sinon.stub(HttpErrors, 'BadRequestError');
       const params = { request: {}, h: hFake, error };
 
@@ -337,9 +337,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       await handle(params.request, params.h, params.error);
 
       // then
-      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
-        'Aucune attestation de certification pour la classe 1.',
-      );
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly('Aucun certificat pour la classe 1.');
     });
 
     it('should instantiate BaseHttpError when UnauthorizedError', async function () {

--- a/api/tests/shared/unit/domain/errors_test.js
+++ b/api/tests/shared/unit/domain/errors_test.js
@@ -15,8 +15,8 @@ describe('Unit | Shared | Domain | Errors', function () {
     expect(errors.UserNotAuthorizedToUpdatePasswordError).to.exist;
   });
 
-  it('should export NoCertificationAttestationForDivisionError', function () {
-    expect(errors.NoCertificationAttestationForDivisionError).to.exist;
+  it('should export NoCertificateForDivisionError', function () {
+    expect(errors.NoCertificateForDivisionError).to.exist;
   });
 
   it('should export an EmailModificationDemandNotFoundOrExpiredError', function () {


### PR DESCRIPTION
## 🌸 Problème

Le terme `attestation` est utilisé dans le nom de l'erreur `NoCertificationAttestationForDivisionError`
Ce terme n'est pas le bon dans le contexte de la certification.

## 🌳 Proposition

Utiliser le terme `certificat` plutôt que `attestation` dans l'erreur `NoCertificationAttestationForDivisionError`

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
