### PR TITLE
[TECH] :truck: Renomme le cas d'utilisation `findCertificationAttestationForDivision` sans le terme `attestation` (pix-18052)

### DIFF
--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -174,7 +174,7 @@ const downloadDivisionCertificates = async function (
   const { i18n } = request;
   const { division, isFrenchDomainExtension } = request.query;
 
-  const certificates = await usecases.findCertificationAttestationsForDivision({
+  const certificates = await usecases.findCertificatesForDivision({
     organizationId,
     division,
   });

--- a/api/src/certification/results/domain/usecases/find-certificates-for-division.js
+++ b/api/src/certification/results/domain/usecases/find-certificates-for-division.js
@@ -1,0 +1,15 @@
+import { NoCertificateForDivisionError } from '../../../../shared/domain/errors.js';
+
+const findCertificatesForDivision = async function ({ organizationId, division, certificateRepository }) {
+  const certificates = await certificateRepository.findByDivisionForScoIsManagingStudentsOrganization({
+    organizationId,
+    division,
+  });
+
+  if (certificates.length === 0) {
+    throw new NoCertificateForDivisionError(division);
+  }
+  return certificates;
+};
+
+export { findCertificatesForDivision };

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -626,7 +626,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         };
 
         sinon
-          .stub(usecases, 'findCertificationAttestationsForDivision')
+          .stub(usecases, 'findCertificatesForDivision')
           .withArgs({
             division,
             organizationId,
@@ -676,7 +676,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         };
 
         sinon
-          .stub(usecases, 'findCertificationAttestationsForDivision')
+          .stub(usecases, 'findCertificatesForDivision')
           .withArgs({
             division,
             organizationId,

--- a/api/tests/certification/results/unit/domain/usecases/find-certificates-for-division_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/find-certificates-for-division_test.js
@@ -1,4 +1,4 @@
-import { findCertificationAttestationsForDivision } from '../../../../../../src/certification/results/domain/usecases/find-certification-attestations-for-division.js';
+import { findCertificatesForDivision } from '../../../../../../src/certification/results/domain/usecases/find-certificates-for-division.js';
 import { NoCertificateForDivisionError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -32,7 +32,7 @@ describe('Unit | UseCase | find-certification-attestations-for-division', functi
       .resolves([certificationAttestation1, certificationAttestation2]);
 
     // when
-    const actualCertificationAttestations = await findCertificationAttestationsForDivision({
+    const actualCertificationAttestations = await findCertificatesForDivision({
       organizationId: 1234,
       division: '3b',
       certificateRepository,
@@ -65,7 +65,7 @@ describe('Unit | UseCase | find-certification-attestations-for-division', functi
         .resolves([]);
 
       // when
-      const error = await catchErr(findCertificationAttestationsForDivision)({
+      const error = await catchErr(findCertificatesForDivision)({
         organizationId: 1234,
         division: '3b',
         certificateRepository,


### PR DESCRIPTION
## 🌸 Problème

Le cas d'utilisation `findCertificationAttestationForDivision` utilise encore le terme `attestation` 
Ce terme n'est pas approprié au domaine de la certification.

## 🌳 Proposition

Renommer le cas d'utilisation `findCertificationAttestationForDivision` sans le terme `attestation` 

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Récupérer les certificats pour une classe dans pixOrga.

