### PR TITLE
[TECH] Ne pas declencher la CI à chaque ajout/suppression de label

### DIFF
--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -2,14 +2,18 @@ name: Trigger CircleCI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    types: [opened, reopened, synchronize, ready_for_review, unlabeled]
   push:
     branches: dev
 
 jobs:
   trigger-ci:
     runs-on: ubuntu-latest
-    if: (!contains(github.event.pull_request.labels.*.name, 'Development in progress')) && ((!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev')
+
+    # Triggered when :
+    # The opened PR is not draft or is on "dev" branch
+    # And doesn't have the label 'Development in progress' or the label 'Development in progress' label is removed
+    if: ((!github.event.pull_request.draft && github.event.pull_request.state == 'open') || github.ref == 'refs/heads/dev') && ((github.event.action == 'unlabeled' && github.event.label.name == 'Development in progress') || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'Development in progress')))
 
     steps:
       - name: Extract branch name

--- a/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -203,19 +203,6 @@ describe('Integration | Repository | Competence Evaluation', function () {
     });
 
     it('should return only one competence evaluation linked to the competence id', async function () {
-      // given
-      const anotherAssessment = databaseBuilder.factory.buildAssessment({
-        userId: user.id,
-        type: Assessment.types.COMPETENCE_EVALUATION,
-      });
-
-      databaseBuilder.factory.buildCompetenceEvaluation({
-        userId: user.id,
-        competenceId: '1',
-        assessmentId: anotherAssessment.id,
-        status: STARTED,
-      });
-
       // when
       const result = await competenceEvaluationRepository.getByCompetenceIdAndUserId({
         competenceId: 1,


### PR DESCRIPTION
## 🌸 Problème

Actuellement, la CI est déclenchée à chaque fois qu'un label est ajouté ou supprimé. Ce qui entraine des déclenchements inutiles de la CI.

## 🌳 Proposition

Déclencher la CI : 
- sur la branche dev
- sur les PR (ré)ouvertes non draft
- uniquement si le label "Development in progress" est retiré


## 🤧 Pour tester

- ✅ mettre la PR en draft => ne déclenche pas la CI
- ✅ enlever le draft => déclenche la CI
- ✅ mettre le label "team accès" => ne déclenche pas la CI
- ✅ enlever le label "team accès" => ne déclenche pas la CI
- ✅ mettre le label "Development in progress" => ne déclenche pas la CI
- ✅ enlever le label "Development in progress" => déclenche la CI
