### PR TITLE
[TECH] Vide la table `organizations_cover_rates` après chaque test.

### DIFF
--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -43,7 +43,7 @@ class DatamartBuilder {
   async clean() {
     let rawQuery = '';
 
-    ['certification_results', 'sco_certification_results'].forEach((tableName) => {
+    ['certification_results', 'sco_certification_results', 'organizations_cover_rates'].forEach((tableName) => {
       rawQuery += `DELETE FROM ${tableName};`;
     });
 


### PR DESCRIPTION
## 🌸 Problème

Après chaque test impliquant le datamart, le datamart builder invoque sa fonction `clean` qui s'occupe de vider toutes les tables potentiellement utilisées lors des tests afin de garantir un environnement identique pour chaque test.
Lors de l'ajout de la table `organization_cover_rates`, celle-ci a été oubliée dans la fonction `clean`, ce qui peut entrainé des tests en échec de manière plus ou moins aléatoire.

## 🌳 Proposition

On ajoute la table `organization_cover_rates` à la liste des tables devant être vider dans la fonction `clean` du `datamartBuilder`.

## 🤧 Pour tester

Une CI verte