### PR TITLE
[TECH] Modifier la table certification-frameworks-challenges (PIX-18054).

### DIFF
--- a/api/db/migrations/20250528130408_remove-calibrated-framework-alpha-delta-constraints.js
+++ b/api/db/migrations/20250528130408_remove-calibrated-framework-alpha-delta-constraints.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.float('alpha').nullable().alter();
+    table.float('delta').nullable().alter();
+
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.float('alpha').notNullable().alter();
+    table.float('delta').notNullable().alter();
+
+    table.dropColumn('createdAt');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🌸 Problème

Lors de la création de la table, nous avons déterminé que les colonnes `alpha` et `delta` ont forcément une valeur.

Alors qu'au remplissage de la table, nous n'avons pas forcément ces valeurs.

## 🌳 Proposition

Dans la table `certification-frameworks-challenges`, nous souhaitons que les colonnes `alpha` et `delta` puissent être `null`.

Aussi, nous ajoutons une colonne `createdAt` pour avoir un historique des créations.

## 🐝 Remarques

Plus tard, nous aurons sûrement une colonne `calibratedAt` pour savoir quand `alpha` et `delta` ont été remplies.

## 🤧 Pour tester

- Lancer la migration en RA, vérifier la structure de la table `certification-frameworks-challenges`
- Puis lancer `npm run db:rollback:latest` et vérifier qu'on est bien revenu à l'état initial
