### PR TITLE
[FEATURE] Détacher les assessments quand on supprime une participation (PIX-18047).

### DIFF
--- a/api/db/database-builder/factory/build-assessment-from-participation.js
+++ b/api/db/database-builder/factory/build-assessment-from-participation.js
@@ -5,7 +5,7 @@ import { buildUser } from './build-user.js';
 
 const buildAssessmentFromParticipation = function (campaignParticipation, organizationLearner, user) {
   const userId = buildUser(user).id;
-  const organizationLearnerId = buildOrganizationLearner(organizationLearner).id;
+  const organizationLearnerId = buildOrganizationLearner({ ...organizationLearner, userId }).id;
   const campaignParticipationId = buildCampaignParticipation({
     ...campaignParticipation,
     userId,

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -7,6 +7,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
   featureToggles,
   badgeAcquisitionRepository,
   campaignParticipationRepository,
+  assessmentRepository,
 }) {
   const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
 
@@ -25,7 +26,11 @@ const deleteCampaignParticipation = withTransaction(async function ({
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       campaignParticipationIds,
     );
-    // on détache les assessment
+    const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
+    for (const assessment of assessments) {
+      assessment.detachCampaignParticipation();
+      await assessmentRepository.updateCampaignParticipationId(assessment);
+    }
   }
 });
 

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -25,6 +25,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       campaignParticipationIds,
     );
+    // on détache les assessment
   }
 });
 

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -8,6 +8,7 @@ const deleteOrganizationLearners = async function ({
   featureToggles,
   campaignParticipationRepositoryfromBC,
   badgeAcquisitionRepository,
+  assessmentRepository,
 }) {
   const organizationLearnersFromOrganization =
     await organizationLearnerRepository.findOrganizationLearnersByOrganizationId({
@@ -45,6 +46,11 @@ const deleteOrganizationLearners = async function ({
       await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
         campaignParticipationIds,
       );
+      const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
+      for (const assessment of assessments) {
+        assessment.detachCampaignParticipation();
+        await assessmentRepository.updateCampaignParticipationId(assessment);
+      }
     }
   }
 };

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -9,6 +9,7 @@ import * as placementProfileService from '../../../../shared/domain/services/pla
 import * as userReconciliationService from '../../../../shared/domain/services/user-reconciliation-service.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
 import { logErrorWithCorrelationIds } from '../../../../shared/infrastructure/monitoring-tools.js';
+import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as libOrganizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
@@ -32,6 +33,7 @@ import * as organizationLearnerRepository from '../../infrastructure/repositorie
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import { importStorage } from '../../infrastructure/storage/import-storage.js';
+
 /**
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} CampaignParticipationRepository
  * @typedef {import ('../../../campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
@@ -60,6 +62,7 @@ import { importStorage } from '../../infrastructure/storage/import-storage.js';
  * @typedef {import ('../../infrastructure/repositories/jobs/validate-organization-learners-import-file-job-repository.js')} ValidateOrganizationImportFileJobRepository
  */
 const dependencies = {
+  assessmentRepository,
   campaignParticipationRepository: repositories.campaignParticipationRepository,
   campaignRepository,
   importCommonOrganizationLearnersJobRepository,

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -219,6 +219,11 @@ class Assessment {
     this.companionLiveAlerts = companionLiveAlerts;
   }
 
+  detachCampaignParticipation() {
+    this.campaignParticipationId = null;
+    this.updatedAt = new Date();
+  }
+
   get hasLastQuestionBeenFocusedOut() {
     return this.lastQuestionState === Assessment.statesOfLastQuestion.FOCUSEDOUT;
   }

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -189,6 +189,14 @@ const setAssessmentsAsStarted = async function ({ assessmentIds }) {
     .update({ state: Assessment.states.STARTED, updatedAt: new Date() });
 };
 
+const getByCampaignParticipationIds = async function (campaignParticipationIds = []) {
+  const knexConn = DomainTransaction.getConnection();
+  const assessments = await knexConn('assessments')
+    .whereIn('campaignParticipationId', campaignParticipationIds)
+    .orderBy('id', 'asc');
+  return assessments.map((assessment) => new Assessment({ ...assessment }));
+};
+
 export {
   _updateStateById,
   abortByAssessmentId,
@@ -198,6 +206,7 @@ export {
   findNotAbortedCampaignAssessmentsByUserId,
   get,
   getByAssessmentIdAndUserId,
+  getByCampaignParticipationIds,
   getByCertificationCandidateId,
   getWithAnswers,
   ownedByUser,

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -197,6 +197,15 @@ const getByCampaignParticipationIds = async function (campaignParticipationIds =
   return assessments.map((assessment) => new Assessment({ ...assessment }));
 };
 
+const updateCampaignParticipationId = async function (assessment) {
+  const knexConn = DomainTransaction.getConnection();
+  const [assessmentUpdated] = await knexConn('assessments')
+    .update({ campaignParticipationId: assessment.campaignParticipationId, updatedAt: assessment.updatedAt })
+    .where('id', assessment.id)
+    .returning('*');
+  if (!assessmentUpdated) return null;
+};
+
 export {
   _updateStateById,
   abortByAssessmentId,
@@ -212,6 +221,7 @@ export {
   ownedByUser,
   save,
   setAssessmentsAsStarted,
+  updateCampaignParticipationId,
   updateLastQuestionDate,
   updateLastQuestionState,
   updateWhenNewChallengeIsAsked,

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -232,7 +232,7 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
     });
   });
 
-  context('when there is assessment linked to campaing participation', function () {
+  context('when there is assessment linked to campaign participation', function () {
     let campaignId;
     let campaignParticipationId;
     let adminUserId;
@@ -272,9 +272,9 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
       });
     });
     context('when feature toggle `isAnonymizationWithDeletionEnabled` is true', function () {
-      it('should detach assesmments', async function () {
+      it('should detach assessments', async function () {
         // given
-        await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
+        await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
         const assessment2 = buildAssessment({
           userId,
           campaignParticipationId,

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -166,6 +166,69 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
+  describe('#getByCampaignParticipationIds', function () {
+    let assessment1, assessment1Improved, assessment2;
+    let participation1, participation2;
+
+    beforeEach(async function () {
+      const campaignId = databaseBuilder.factory.buildCampaign({ code: 'COUCOUYVO' }).id;
+      participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+      participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+
+      assessment1 = databaseBuilder.factory.buildAssessment({
+        id: 1,
+        type: Assessment.types.CAMPAIGN,
+        campaignParticipationId: participation1.id,
+      });
+      assessment1Improved = databaseBuilder.factory.buildAssessment({
+        id: 2,
+        type: Assessment.types.CAMPAIGN,
+        campaignParticipationId: participation1.id,
+        isImproving: true,
+      });
+      assessment2 = databaseBuilder.factory.buildAssessment({
+        id: 3,
+        type: Assessment.types.CAMPAIGN,
+        campaignParticipationId: participation2.id,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should return assessments', async function () {
+      // when
+      const assessments = await assessmentRepository.getByCampaignParticipationIds([
+        participation1.id,
+        participation2.id,
+      ]);
+
+      // then
+      expect(assessments).lengthOf(3);
+      assessments.forEach((assessment) => {
+        expect(assessment).to.be.an.instanceOf(Assessment);
+      });
+      expect(assessments[0].id).deep.equal(assessment1.id);
+      expect(assessments[0].campaignParticipationId).equal(participation1.id);
+      expect(assessments[1].id).equal(assessment1Improved.id);
+      expect(assessments[1].campaignParticipationId).equal(participation1.id);
+      expect(assessments[2].id).equal(assessment2.id);
+      expect(assessments[2].campaignParticipationId).equal(participation2.id);
+    });
+
+    context('when there is no assessment', function () {
+      it('should return an empty array', async function () {
+        // when
+        const assessments = await assessmentRepository.getByCampaignParticipationIds([assessment1.id]);
+
+        // then
+        expect(assessments).lengthOf(0);
+      });
+    });
+  });
+
   describe('#findLastCompletedAssessmentsForEachCompetenceByUser', function () {
     let johnUserId;
     let laylaUserId;

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -1,8 +1,9 @@
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { Campaign } from '../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | Assessment', function () {
   describe('#constructor', function () {
@@ -209,6 +210,37 @@ describe('Unit | Domain | Models | Assessment', function () {
       // then
       expect(assessment.state).to.be.equal('completed');
       expect(assessment.userId).to.be.equal(2);
+    });
+  });
+
+  describe('#detachCampaignParticipation', function () {
+    let clock, now;
+
+    beforeEach(function () {
+      now = new Date(2023, 3, 3);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should return the same object without info on campaign and participation', function () {
+      // given
+      const assessment = new Assessment({
+        state: 'started',
+        userId: 2,
+        campaignParticipationId: 123,
+        campaign: new Campaign({ id: 111 }),
+        updatedAt: new Date('2000-01-12'),
+      });
+
+      // when
+      assessment.detachCampaignParticipation();
+
+      // then
+      expect(assessment.campaignParticipationId).null;
+      expect(assessment.updatedAt).deep.equal(now);
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lorsqu'on supprime une participation et que le flag isAnonymisationWithDeletionEnabled est a true
on souhaite aussi détacher les assessments pour éviter de pouvoir faire le lien entre user et participation.

## :bowl_with_spoon: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
on supprime le campaignParticipationId de la table assessment pour les participations supprimées.

## :milk_glass: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
Une prochaine PR sur la table user-recommended-trainings permettra de complètement couper le lien entre user et participation
lorsqu'on on supprime un participation

## :butter: Pour tester
### Suppression d'une participation sans anonymisation 
- **pix-admin** afficher les participations de l'utilisateur correspondant a learneremail1005_0@example.net
- **pix-orga** supprimer une participation
-  **pix-admin**:  Constater qu'on remonte toujours les infos de la participation

### Suppression d'une participation avec anonymisation
- **pix-admin**  afficher les participations de l'utilisateur correspondant a learneremail1005_0@example.net
- **pix-orga** supprimer une participation
- **pix-admin** Constater qu'on ne remonte plus aucune infos liés à la participation(ormis la date de création de l'assessment

### Suppression d'un participant sans anonymisation 
- **pix-admin** afficher les participations de l'utilisateur correspondant a learneremail1005_0@example.net
- **pix-orga** supprimer une participation
-  **pix-admin**:  Constater qu'on remonte toujours les infos (statuts de participation, externalId) des participations 

### Suppression d'un participation avec anonymisation
- **pix-admin**  afficher les participations de l'utilisateur correspondant a learneremail1005_0@example.net
- **pix-orga** supprimer une participation
- **pix-admin** Constater qu'on ne remonte plus qu'une seule participation (et jeter un oeil à pgsql console pour vérifier qu'on ne remonte plus d'info sur les participations