### PR TITLE
[TECH] Augmenter le timeout sur des tests de generation PDF

### DIFF
--- a/api/tests/certification/results/integration/infrastructure/utils/pdf/get-certificates-pdf-buffer_test.js
+++ b/api/tests/certification/results/integration/infrastructure/utils/pdf/get-certificates-pdf-buffer_test.js
@@ -14,6 +14,8 @@ import { isSameBinary } from '../../../../../../tooling/binary-comparator.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Integration | Infrastructure | Utils | Pdf | getCertificatesPdfBuffer', function () {
+  this.timeout(10000); // Some pdf-lib operations can be slow, especially on CI
+
   beforeEach(async function () {
     _makePdfLibPredictable();
 


### PR DESCRIPTION
## 🌸 Problème

Les opération sur la generation de PDF peuvent être longue, en particulier dans la CI. Ce qui peut entrainer de la flakiness dans ces tests ([exemple](https://app.circleci.com/pipelines/github/1024pix/pix/123500/workflows/999e23d6-b26b-46a2-bd91-21c652821699/jobs/1374771/tests))

Certains de ces tests peuvent prendre entre 500ms et 1s sur un Mac M3, donc ils peuvent facilement dépasser les 2s dans la CI.

## 🌳 Proposition

Augmenter le timeout de ces tests de generation PDF.
