### PR TITLE
[BUGFIX] Corrections graphiques sur le formulaire d'inscription / connexion d'une campagne SCO (PIX-17926)

### DIFF
--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -156,7 +156,7 @@ export default class RegisterForm extends Component {
       <hr />
 
       <label class="register-form__login-options">{{t "pages.login-or-register.register-form.options.text"}}</label>
-      <div id="login-mode-container">
+      <div id="login-mode-container" class="register-form__login-mode-container">
         <PixToggleDeprecated
           @valueFirstLabel={{t "pages.login-or-register.register-form.options.username"}}
           @valueSecondLabel={{t "pages.login-or-register.register-form.options.email"}}

--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -164,7 +164,7 @@ export default class RegisterForm extends Component {
         />
       </div>
 
-      <form {{on "submit" this.register}} autocomplete="off">
+      <form {{on "submit" this.register}} autocomplete="off" class="register-form">
         {{#if this.loginWithUsername}}
           <div id="register-username-container" class="register-form-username-container">
             <label class="register-form-username-container__label">

--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -209,21 +209,14 @@ export default class RegisterForm extends Component {
           </div>
         {{/if}}
 
-        <div class="register-button-container">
+        <div class="register-form__action-form-buttons">
           <PixButton id="submit-registration" @type="submit" @isLoading={{this.isLoading}}>
             {{t "pages.login-or-register.register-form.button-form"}}
           </PixButton>
+          <PixButton @triggerAction={{this.resetForm}} @variant="secondary" @iconBefore="arrowLeft">
+            {{t "pages.login-or-register.register-form.not-me"}}
+          </PixButton>
         </div>
-
-        <PixButton
-          @triggerAction={{this.resetForm}}
-          @variant="secondary"
-          @iconBefore="arrowLeft"
-          class="register-form__reset-form-button"
-        >
-          {{t "pages.login-or-register.register-form.not-me"}}
-        </PixButton>
-
         <p class="legal-notice">
           {{t "pages.login-or-register.register-form.rgpd-legal-notice"}}
           <a

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -21,6 +21,10 @@
     font-family: fonts.$font-roboto;
   }
 
+  &__login-mode-container {
+    margin-bottom: var(--pix-spacing-3x);
+  }
+
   &__required-inputs {
     color: var(--pix-neutral-500);
     font-weight: var(--pix-font-normal);
@@ -67,7 +71,6 @@
   &-username-container {
     display: flex;
     flex-direction: column;
-    margin-top: 20px;
 
     &__label {
       color: var(--pix-neutral-800);

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -45,11 +45,12 @@
     border: none;
   }
 
-  &__reset-form-button {
+  &__action-form-buttons {
     display: flex;
-    gap: 6px;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
     width: 100%;
-    margin-top: 10px;
+    margin-top: var(--pix-spacing-3x);
   }
 
   &__error {


### PR DESCRIPTION
## 🌸 Problème

Dans le cadre de l'amélioration de la sortie du sco, quelques corrections graphiques doivent être faites sur le formulaire d'inscription / connexion d'une campagne sco

## 🌳 Proposition

Problème 1

→ Le bouton “Je m’inscris” est mal positionné 

→ Il doit être iso à “Ce n’est pas moi” en termes de taille + ajouter un petit espacement entre le champ “mot de passe” et le bouton “je m'inscris”
![image-20250520-134211](https://github.com/user-attachments/assets/afb78c11-afda-4de4-bef3-d25449ce0ae6)

Problème 2
→ Le champ e-mail doit faire la même taille que le champ mot de passe
![Capture d’écran 2025-05-27 à 13 42 33](https://github.com/user-attachments/assets/0f64e451-6262-4f1d-8348-f9b4b7921d44)


## 🐝 Remarques

j'ai également augmenté l'espace entre le toggle "mon identifiant / mon adresse email" et "Adresse email" (même espace qu'entre le toggle et "Mon identifiant" quand ce dernier est sélectionné)

## 🤧 Pour tester

- Sur Pix App, aller sur la page pour rejoindre une campagne /campagnes/SCOBADGE1/rejoindre/identification
- Dans la partie "Je m'inscris sur Pix", s'identifier avec Harry Potter, 12/12/2012
- Dans le deuxième formulaire qui est maintenant visible sur la même page :
_ Constater que le bouton "Je m'inscris" est bien positionné et qu'il est iso à "Ce n'est pas moi"
_ Constater l'espacement entre le champ "mot de passe" et le bouton "Je m'inscris"
_ Constater que le champ "email" fait la même taille que le champ "mot de passe"
_ Constater que l'espacement entre "Mon adresse e-mail" et "Adresse e-mail" est le même que celui qui existe entre "Mon identifiant" du toggle et "Mon identifiant" de l'input


