### PR TITLE
[BUGFIX] Actualiser les informations d'une invitation à rejoindre un centre de certification lorsqu'on réinvite un utilisateur (PIX-18064)

### DIFF
--- a/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/src/team/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -27,8 +27,13 @@ const createOrUpdateCertificationCenterInvitationForAdmin = async function ({
     certificationCenterInvitation = await certificationCenterInvitationRepository.create(newInvitation);
     isInvitationCreated = true;
   } else {
+    const updatedCertificationCenterInvitation = new CertificationCenterInvitation({
+      ...alreadyExistingPendingInvitationForThisEmail,
+      role,
+      locale,
+    });
     certificationCenterInvitation = await certificationCenterInvitationRepository.update(
-      alreadyExistingPendingInvitationForThisEmail,
+      updatedCertificationCenterInvitation,
     );
     isInvitationCreated = false;
   }

--- a/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
@@ -115,7 +115,10 @@ const create = async function (invitation) {
  */
 const update = async function (certificationCenterInvitation) {
   const [updatedCertificationCenterInvitation] = await knex('certification-center-invitations')
-    .update({ updatedAt: new Date() })
+    .update({
+      ...certificationCenterInvitation,
+      updatedAt: new Date(),
+    })
     .where({ id: certificationCenterInvitation.id })
     .returning(['id', 'email', 'code', 'certificationCenterId', 'updatedAt', 'role', 'locale']);
 

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -85,6 +85,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
       email,
       code: 'AAALLLPPP1',
       certificationCenterId,
+      role: 'MEMBER',
       status: CertificationCenterInvitation.StatusType.PENDING,
       updatedAt: someTimeInThePastDate,
     }).id;
@@ -94,6 +95,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
     // when
     const result = await usecases.createOrUpdateCertificationCenterInvitationForAdmin({
       email,
+      role: 'ADMIN',
       certificationCenterId,
       mailService,
     });
@@ -110,7 +112,7 @@ describe('Integration | Team | UseCase | create-or-update-certification-center-i
       certificationCenterName: 'Centre Pixou',
       updatedAt: now,
       code: 'AAALLLPPP1',
-      role: 'MEMBER',
+      role: 'ADMIN',
       locale: 'fr',
     });
   });


### PR DESCRIPTION
## 🌸 Problème

Lorsqu'on renvoie une invitation en modifiant des données (locale/role) celles-ci ne sont pas prise en compte dans la mise à jour de l'invitation.

## 🌳 Proposition

Corriger le usecase et le repository pour qu'ils prennent en compte ces nouvelles informations.

## 🐝 Remarques

Il faudra faire plus où moins le même travail côté Organisations.

## 🤧 Pour tester

- Se rendre sur PIx admin,
- Aller sur la page des centres de certifications,
- Choisir le centre Accessorium,
- Aller dans la section invitations,
- S'inviter avec son email le role MEMBER et la locale anglais,
- Vérifier qu'on a bien reçu un email en anglais et que le role est MEMBER dans le tableau,
- Renvoyer une invitation à son email en mettant la locale français et le role ADMIN,
- Constater qu'on reçoit un mail en français et que le role est ADMIN dans le tableau.
