### PR TITLE
[TECH] Supprimer la version de session dans le usecase retrieve-last-or-create-certification-course (PIX-18075).

### DIFF
--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -324,41 +324,20 @@ describe('Acceptance | API | Certification Course', function () {
           expect(response.statusCode).to.equal(201);
         });
 
-        it('should have created a V2 certification course', async function () {
+        it('should have created a v3 certification course without any challenges', async function () {
           // given
-          const { options, userId, sessionId } = _createRequestOptions();
-          _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
-
+          const { options, userId, sessionId } = _createRequestOptions({ version: SESSIONS_VERSIONS.V3 });
+          const { flashConfiguration } = _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
           await databaseBuilder.commit();
 
           // when
           response = await server.inject(options);
 
           // then
-          const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
-          expect(certificationCourses).to.have.lengthOf(1);
-          expect(certificationCourses[0].version).to.equal(SESSIONS_VERSIONS.V2);
+          const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
+          expect(certificationCourse.version).to.equal(SESSIONS_VERSIONS.V3);
           expect(response.result.data.attributes).to.include({
-            'nb-challenges': 2,
-          });
-        });
-
-        context('when the session is v3', function () {
-          it('should have created a v3 certification course without any challenges', async function () {
-            // given
-            const { options, userId, sessionId } = _createRequestOptions({ version: SESSIONS_VERSIONS.V3 });
-            const { flashConfiguration } = _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
-            await databaseBuilder.commit();
-
-            // when
-            response = await server.inject(options);
-
-            // then
-            const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
-            expect(certificationCourse.version).to.equal(SESSIONS_VERSIONS.V3);
-            expect(response.result.data.attributes).to.include({
-              'nb-challenges': flashConfiguration.maximumAssessmentLength,
-            });
+            'nb-challenges': flashConfiguration.maximumAssessmentLength,
           });
         });
 
@@ -382,40 +361,6 @@ describe('Acceptance | API | Certification Course', function () {
           expect(certificationCourses[0].birthdate).to.equal(certificationCandidate.birthdate);
           expect(certificationCourses[0].birthplace).to.equal(certificationCandidate.birthCity);
           expect(certificationCourses[0].externalId).to.equal(certificationCandidate.externalId);
-        });
-
-        it('should have only fr-fr challenges associated with certification-course', async function () {
-          // given
-          const { options, userId, sessionId } = _createRequestOptions();
-          _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
-          await databaseBuilder.commit();
-
-          // when
-          await server.inject(options);
-
-          // then
-          const certificationChallenges = await knex('certification-challenges');
-          expect(certificationChallenges).to.have.lengthOf(2);
-          expect(certificationChallenges[0].challengeId).to.equal('recChallenge5_1_1');
-          expect(certificationChallenges[1].challengeId).to.equal('recChallenge5_0_0');
-        });
-      });
-
-      context('when locale is en', function () {
-        it('should have only en challenges associated with certification-course', async function () {
-          // given
-          const { options, userId, sessionId } = _createRequestOptions({ locale: 'en' });
-          _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
-          await databaseBuilder.commit();
-
-          // when
-          response = await server.inject(options);
-
-          // then
-          const certificationChallenges = await knex('certification-challenges');
-          expect(certificationChallenges).to.have.lengthOf(2);
-          expect(certificationChallenges[0].challengeId).to.equal('recChallenge6_1_0');
-          expect(certificationChallenges[1].challengeId).to.equal('recChallenge6_0_0');
         });
       });
     });

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
@@ -254,9 +254,11 @@ describe('Acceptance | Route | Certification Courses', function () {
         const certificationCourse = await knex('certification-courses').select().where({ userId: 1 });
         expect(certificationCourse).to.exist;
       });
+
       it('should return CREATED (201) and a certification course', async function () {
         // given
         databaseBuilder.factory.buildUser({ id: 1 });
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration();
         databaseBuilder.factory.buildSession({ id: 2, accessCode: 'FMKP39' });
         const candidate = databaseBuilder.factory.buildCertificationCandidate({
           sessionId: 2,


### PR DESCRIPTION
## 🌸 Problème

L'utilisateur de la version de session n'est plus souhaitée.

Au besoin, nous voulons maintenant utiliser la version de l'algo, qui vient du certification-course.

## 🌳 Proposition

Puisque tous les nouveaux certification-courses sont forcément en V3, nous pouvons éviter tout le code en lien avec la version de session (y compris pour les complémentaires).

Ici, nous n'avons plus besoin de récupérer les challenges de la certification avant la création.

## 🤧 Pour tester

✅ Tests verts
