### PR TITLE
[TECH] Retirer des commentaires de linter pour retirer les erreurs (PIX-18077).

### DIFF
--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -1,9 +1,3 @@
-/* eslint ember/classic-decorator-hooks: 0 */
-/* eslint ember/no-actions-hash: 0 */
-/* eslint ember/no-classic-classes: 0 */
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
 import EmberRouter from '@ember/routing/router';
 
 import config from './config/environment';
@@ -12,7 +6,8 @@ export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 
-  init() {
+  constructor() {
+    super(...arguments);
     this.on('routeDidChange', () => {
       window.scrollTo(0, 0);
     });


### PR DESCRIPTION
## 🌸 Problème

On mettait des commentaires sur la route de PixApp pour éviter des erreur de linter

## 🌳 Proposition

Retirer ces commentaires et effecteur les corrections

## 🤧 Pour tester

Vérifier qu'en changeant de route le scroll remonte bien tout en haut comme avant. Mais c'est beaucoup mieux maintenant. 