### PR TITLE
[TECH] Enlever les sources junior du container RA front

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -3,6 +3,7 @@ admin
 api
 certif
 high-level-tests
+junior
 mon-pix
 node_modules
 orga


### PR DESCRIPTION
## 🔆 Problème

Les containers RA front incluent les sources du front junior.

## ⛱️ Proposition

Ajouter le répertoire au slugignore.

## 🌊 Remarques

Le container redescend à ~70MB au lieu de ~450MB.

## 🏄 Pour tester

- Vérifier que le front (y compris junior) fonctionne tjrs.
- Vérifier qu les sources junior sont bien supprimées du container.