### PR TITLE
[BUGFIX] Ajustements graphiques et textuels pour la sortie du sco (PIX-18044)

### DIFF
--- a/mon-pix/app/styles/components/account-recovery/_confirmation-step.scss
+++ b/mon-pix/app/styles/components/account-recovery/_confirmation-step.scss
@@ -1,23 +1,24 @@
 @use 'pix-design-tokens/typography';
 
 .confirmation-step-account-information {
+  margin-bottom: var(--pix-spacing-3x);
   padding: 0;
   list-style: none;
 }
 
 .confirmation-step-account-information__field {
   max-width: 400px;
-  height: 65px;
-  margin-bottom: 8px;
+  height: 80px;
+  margin-bottom: var(--pix-spacing-2x);
   padding: 12px 20px;
   color: var(--pix-neutral-800);
   font-weight: 500;
   background: var(--pix-neutral-20);
-  border-radius: 8px;
+  border-radius: var(--pix-spacing-2x);
 
   & > div:first-of-type {
     @extend %pix-body-m;
 
-    margin-bottom: 6px;
+    margin-bottom: var(--pix-spacing-2x);
   }
 }

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -147,11 +147,13 @@
 
     &--actions {
       display: flex;
+      flex-direction: column;
+      flex-grow:1;
       max-width: 400px;
       margin-top: 18px;
 
       button:first-child {
-        margin-right: 32px;
+        margin-bottom: var(--pix-spacing-3x)
       }
     }
   }

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -83,6 +83,10 @@
 
       &--content {
         max-width: 450px;
+
+        .pix-input {
+          width: 100%;
+        }
       }
     }
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -432,7 +432,7 @@
         },
         "send-email-confirmation": {
           "check-spam": "If you don't see this e-mail, check your spam folder.",
-          "return": "Back",
+          "return": "Back to Pix",
           "send-email": "We have just sent you an email to enable you to choose a password. You can now check your mailbox.",
           "title": "Recovering your Pix account"
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -436,7 +436,7 @@
         },
         "send-email-confirmation": {
           "check-spam": "Si no ves este correo electrónico, comprueba tu carpeta de correo no deseado.",
-          "return": "Volver",
+          "return": "Volver a Pix",
           "send-email": "Acabamos de enviarte un correo electrónico para que puedas elegir una contraseña. Ya puedes consultar tu buzón.",
           "title": "Restablecimiento de tu cuenta Pix"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -432,7 +432,7 @@
         },
         "send-email-confirmation": {
           "check-spam": "Si vous ne voyez pas cet e-mail, vérifiez vos courriers indésirables.",
-          "return": "Retour",
+          "return": "Revenir vers Pix",
           "send-email": "Nous venons de vous adresser un mail qui vous permettra de choisir un mot de passe. Vous pouvez consulter dès maintenant votre messagerie.",
           "title": "Récupération de votre compte Pix"
         },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -436,7 +436,7 @@
         },
         "send-email-confirmation": {
           "check-spam": "Als je deze e-mail niet ziet, controleer dan je spammap.",
-          "return": "Terug",
+          "return": "Terug naar Pix",
           "send-email": "We hebben je zojuist een e-mail gestuurd waarmee je een wachtwoord kunt kiezen. Je kunt nu je mailbox controleren.",
           "title": "Je Pix-account herstellen"
         },


### PR DESCRIPTION
## 🔆 Problème

A la fin du processus de sortie du sco, le champ "email" est trop petit et l'adresse est coupée.
Par ailleurs, sur la page suivante, le bouton "retour" n'est pas clair pour l'utilisateur
![image](https://github.com/user-attachments/assets/1e5238ce-d181-4013-a2e3-98e62b4fa31d)
![image](https://github.com/user-attachments/assets/7ff5e887-acf5-4706-9890-cc372b79512d)


## ⛱️ Proposition

Elargir le champ "email"
Renommer le bouton en "Revenir vers Pix"

## 🌊 Remarques

ras

## 🏄 Pour tester

- Sur Pix app, aller sur la page /recuperer-mon-compte

- Remplir le formulaire avec les données de Bob Leponge : 123456789BL et 02/02/2012 , 
- confirmer les données,
- constater que le camp email est suffisamment large
- choisir un nouveau mail, cliquer sur "c'est parti"
- sur la page suivante constater que le bouton affiche "Revenir vers Pix"

