### PR TITLE
[FEATURE] Modifier les wordings de la page d'analyse de résultats de campagne (PIX-17836).

### DIFF
--- a/orga/app/components/analysis/global-positioning.scss
+++ b/orga/app/components/analysis/global-positioning.scss
@@ -1,7 +1,6 @@
 @use 'pix-design-tokens/typography';
 
 .global-positioning {
-  margin-bottom: var(--pix-spacing-10x);
 
   &__title {
     @extend %pix-title-xs;

--- a/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
@@ -1,14 +1,44 @@
 @use 'pix-design-tokens/typography';
 
+
+.result-analysis {
+  &__title {
+    @extend %pix-title-s;
+
+    margin-bottom: var(--pix-spacing-1x);
+  }
+
+  &__global-information {
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-1x);
+    margin-bottom: var(--pix-spacing-10x);
+
+  }
+
+  &__global-positioning-explanation {
+    @extend %pix-body-s;
+
+    white-space: nowrap;
+
+    ul {
+      padding-left:var(--pix-spacing-6x);
+      list-style-type: circle;
+    }
+  }
+}
+
 .analysis-description {
   @extend %pix-body-s;
 
   margin-bottom: var(--pix-spacing-8x);
 
+
   &__resume {
     font-weight: var(--pix-font-bold);
   }
 }
+
 
 
 .analysis-per-tube-or-competence {
@@ -67,7 +97,3 @@
   }
 
 }
-
-
-
-

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
@@ -1,3 +1,4 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AnalysisPerTubeOrCompetence from 'pix-orga/components/analysis/analysis-per-tube-or-competence';
@@ -6,16 +7,42 @@ import Competences from 'pix-orga/components/campaign/analysis/competences';
 import Recommendations from 'pix-orga/components/campaign/analysis/recommendations';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
 
+const levels = [
+  'pages.campaign-analysis.levels-correspondence.levels.beginner',
+  'pages.campaign-analysis.levels-correspondence.levels.independent',
+  'pages.campaign-analysis.levels-correspondence.levels.advanced',
+  'pages.campaign-analysis.levels-correspondence.levels.expert',
+];
+
 <template>
   {{pageTitle (t "pages.campaign-analysis.title")}}
   {{#if @model.campaign.hasSharedParticipations}}
     {{#if @model.isNewPage}}
+      <h2 class="result-analysis__title">{{t "pages.campaign-analysis.second-title"}}</h2>
       <div class="analysis-description">
         <b class="analysis-description__resume">{{t "pages.campaign-analysis.description.resume"}}</b>
         <p>{{t "pages.campaign-analysis.description.explanation"}}</p>
         <p>{{t "pages.campaign-analysis.description.nota-bene"}}</p>
       </div>
-      <GlobalPositioning @data={{@model.analysisData}} />
+      <div class="result-analysis__global-information">
+        <GlobalPositioning @data={{@model.analysisData}} />
+        <PixBlock class="result-analysis__global-positioning-explanation" @variant="orga">
+          <h2 class="global-positioning__title">{{t "pages.campaign-analysis.levels-correspondence.title"}}</h2>
+          <ul>
+            {{#each levels as |levelKey|}}
+              <li>{{t levelKey}}</li>
+            {{/each}}
+          </ul>
+          <br />
+          <a
+            href={{t "pages.campaign-analysis.levels-correspondence.infos.link"}}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="link link--banner link--underlined"
+          >
+            {{t "pages.campaign-analysis.levels-correspondence.infos.text"}}</a>
+        </PixBlock>
+      </div>
       <AnalysisPerTubeOrCompetence @data={{@model.analysisData}} />
     {{else}}
       <h2 class="screen-reader-only">{{t "pages.campaign-review.title"}}</h2>

--- a/orga/tests/integration/templates/analysis_test.gjs
+++ b/orga/tests/integration/templates/analysis_test.gjs
@@ -23,6 +23,11 @@ module('Integration | Template | analysis', function (hooks) {
       assert.ok(screen.getByText(t('pages.campaign-analysis.description.resume')));
       assert.ok(screen.getByText(t('pages.campaign-analysis.description.explanation')));
       assert.ok(screen.getByText(t('pages.campaign-analysis.description.nota-bene')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.beginner')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.independent')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.advanced')));
+      assert.ok(screen.getByText(t('pages.campaign-analysis.levels-correspondence.levels.expert')));
+      assert.ok(screen.getByRole('link', { name: t('pages.campaign-analysis.levels-correspondence.infos.text') }));
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -275,7 +275,7 @@
   "components": {
     "analysis-per-competence": {
       "cover-rate-gauge-label": "Your participants have achieved a level of {reachedLevel} out of a maximum attainable level of {maxLevel}.",
-      "description": "Average level achieved by participants per competence out of the maximum level attainable in this campaign.",
+      "description": "Below are the campaign competences and their descriptions, as well as the positioning of the participants.",
       "table": {
         "caption": "Competences",
         "column": {
@@ -287,7 +287,7 @@
     },
     "analysis-per-tube": {
       "cover-rate-gauge-label": "On the subject your participants have obtained a level of {reachedLevel} out of a maximum attainable level of {maxLevel}.",
-      "description": "Average level achieved by participants per subject out of the maximum level attainable in this campaign.",
+      "description": "Below are the campaign topics and their descriptions, as well as the positioning of the participants.",
       "table": {
         "caption": "{index} - {name}",
         "column": {
@@ -335,7 +335,7 @@
       "no-date": "No date yet"
     },
     "global-positioning": {
-      "description": "Average level achieved by participants out of the maximum level achievable in this campaign.",
+      "description": "Overall positioning is the average level achieved by participants (purple bar) compared with the maximum they could have achieved in this campaign (white bar).",
       "gauge-label": "On this test, your participants achieved an average level of {reachedLevel} out of a maximum reachable level of {maxLevel}.",
       "title": "Global positioning"
     },
@@ -570,8 +570,22 @@
       "description": {
         "explanation": "Each test assesses a selection of digital skills from the Pix reference framework. Positioning reflects the average level achieved by participants in relation to the maximum level achievable on the test.",
         "nota-bene": "All the data presented comes from shared and undeleted participation in assessment campaigns, and is updated in real time.",
-        "resume": "Analyse, overall and by topic, the positioning of your participants."
+        "resume": "Analyse, overall and by topic, the positioning of your participants in this campaign, which covers a selection of subjects from the Pix reference framework."
       },
+      "levels-correspondence": {
+        "infos": {
+          "link": "https://pix.org/en/understand-certification-results",
+          "text": "Find out more about levels."
+        },
+        "levels": {
+          "advanced": "5 or 6: Advanced level",
+          "beginner": "1 or 2: Novice level",
+          "expert": "7 or 8: Expert level",
+          "independent": "3 or 4: Independent level"
+        },
+        "title": "levels correspondence"
+      },
+      "second-title": "Results Analysis",
       "title": "Analysis"
     },
     "campaign-creation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -275,7 +275,7 @@
   "components": {
     "analysis-per-competence": {
       "cover-rate-gauge-label": "Sur la compétence vos participants ont obtenu un niveau de {reachedLevel} sur un niveau maximum atteignable de {maxLevel}.",
-      "description": "Niveau moyen atteint par les participants par compétence sur le niveau maximal accessible dans cette campagne.",
+      "description": "Ci-dessous, retrouvez les compétences de la campagne et leurs descriptifs ainsi que le positionnement des participants.",
       "table": {
         "caption": "Compétences",
         "column": {
@@ -287,7 +287,7 @@
     },
     "analysis-per-tube": {
       "cover-rate-gauge-label": "Sur le sujet vos participants ont obtenu un niveau de {reachedLevel} sur un niveau maximum atteignable de {maxLevel}.",
-      "description": "Niveau moyen atteint par les participants par sujet sur le niveau maximal accessible dans cette campagne.",
+      "description": "Ci-dessous, retrouvez les sujets de la campagne et leurs descriptifs ainsi que le positionnement des participants.",
       "table": {
         "caption": "{index} - {name}",
         "column": {
@@ -300,7 +300,7 @@
     "analysis-per-tube-or-competence": {
       "title": "Positionnement détaillé",
       "toggle": {
-        "label": "Vue par:",
+        "label": "Vue par :",
         "label-competences": "Compétences",
         "label-tubes": "Sujets"
       }
@@ -335,7 +335,7 @@
       "no-date": "Pas encore de date"
     },
     "global-positioning": {
-      "description": "Niveau moyen atteint par les participants sur le niveau maximal accessible dans cette campagne.",
+      "description": "Le positionnement global est le niveau moyen atteint par les participants (barre violette) par rapport au maximum qu’ils auraient pu atteindre dans cette campagne (barre blanche).",
       "gauge-label": "Lors de cette campagne, vos participants ont obtenu en moyenne un niveau de {reachedLevel} sur un niveau maximum atteignable de {maxLevel}.",
       "title": "Positionnement global"
     },
@@ -568,10 +568,24 @@
     },
     "campaign-analysis": {
       "description": {
-        "explanation": "Chaque parcours évalue sur une sélection de compétences numériques du référentiel Pix. Le positionnement reflète le niveau moyen atteint par les participants par rapport au niveau maximal accessible dans le cadre du parcours.",
-        "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation, et sont actualisées en temps réel.",
-        "resume": "Analysez, globalement et par sujet, le positionnement de vos participants dans la campagne."
+        "explanation": "Le positionnement reflète le niveau moyen atteint par les participants, par rapport au niveau maximal accessible dans cette campagne.",
+        "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation et sont actualisées à chaque visite.",
+        "resume": "Analysez, globalement, par compétence ou par sujet, le positionnement de vos participants dans cette campagne qui porte sur une sélection de sujets du référentiel Pix."
       },
+      "levels-correspondence": {
+        "infos": {
+          "link": "https://pix.fr/score-et-niveaux",
+          "text": "En savoir plus sur les niveaux."
+        },
+        "levels": {
+          "advanced": "5 ou 6 : Avancé",
+          "beginner": "1 ou 2 : Novice",
+          "expert": "7 ou 8 : Expert",
+          "independent": "3 ou 4 : Indépendant"
+        },
+        "title": "Correspondance des niveaux"
+      },
+      "second-title": "Analyse de résultats",
       "title": "Analyse"
     },
     "campaign-creation": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -282,7 +282,7 @@
       }
     },
     "analysis-per-tube": {
-      "description": "Gemiddeld niveau behaald door deelnemers per onderwerp van het maximaal haalbare niveau in deze campagne.",
+      "description": "Hieronder vind je de campagneonderwerpen en hun beschrijvingen, evenals de standpunten van de deelnemers.",
       "cover-rate-gauge-label": "Over het onderwerp hebben je deelnemers een niveau van {reachedLevel} gehaald uit een maximaal haalbaar niveau van {maxLevel}.",
       "table": {
         "caption": "{index} - {name}",
@@ -294,7 +294,7 @@
       }
     },
     "analysis-per-competence": {
-      "description": "Gemiddeld niveau behaald door deelnemers per competentie van het maximaal haalbare niveau in deze campagne.",
+      "description": "Hieronder staan de campagnevaardigheden en hun beschrijvingen, evenals de positionering van de deelnemers.",
       "cover-rate-gauge-label": "Je deelnemers hebben een niveau bereikt van {reachedLevel} uit een maximaal haalbaar niveau van {maxLevel}.",
       "table": {
         "caption": "Competenties",
@@ -336,7 +336,7 @@
     },
     "global-positioning":{
       "title":"Wereldwijde positionering",
-      "description":"Gemiddeld niveau bereikt door deelnemers van het maximaal haalbare niveau in deze campagne.",
+      "description":"De algehele positionering is het gemiddelde niveau dat deelnemers hebben bereikt (paarse balk) vergeleken met het maximum dat ze in deze campagne hadden kunnen bereiken (witte balk).",
       "gauge-label":"Bij deze test behaalden je deelnemers een gemiddeld niveau van {reachedLevel} uit een maximaal haalbaar niveau van {maxLevel}."
     },
     "group": {
@@ -531,12 +531,26 @@
       "title": "Activiteit"
     },
     "campaign-analysis": {
-      "title": "Uitleg",
+      "second-title":"Analyse van resultaten",
       "description": {
-        "resume": "Analyseer, globaal en per onderwerp, de positionering van je deelnemers.",
-        "explanation": "Elke toets beoordeelt een selectie van digitale vaardigheden uit het Pix referentiekader. De positionering weerspiegelt het gemiddelde niveau dat deelnemers hebben bereikt ten opzichte van het maximaal haalbare niveau op de toets.",
-        "nota-bene": "Alle gepresenteerde gegevens zijn afkomstig van gedeelde en niet-verwijderde deelname aan beoordelingscampagnes en worden in realtime bijgewerkt."
-      }
+        "explanation": "Elke toets beoordeelt een selectie van digitale vaardigheden uit het Pix referentiekader. De positionering geeft het gemiddelde niveau weer dat deelnemers hebben bereikt ten opzichte van het maximaal haalbare niveau op de toets.",
+        "nota-bene": "Alle gepresenteerde gegevens zijn afkomstig van gedeelde en niet verwijderde deelname aan beoordelingscampagnes en worden in realtime bijgewerkt.",
+        "resume": "Analyseer, globaal en per onderwerp, de positionering van je deelnemers aan deze campagne, die een selectie van onderwerpen uit het Pix-referentiekader omvat."
+      },
+      "levels-correspondence": {
+        "title": "Correspondentie tussen niveaus",
+        "infos": {
+          "text": "Meer weten over niveaus.",
+          "link":"https://pix.org/nl-be/scores-en-niveaus"
+        },
+        "levels":{
+          "advanced": "5 of 6: Advanced level",
+          "beginner": "1 of 2: Beginnersniveau",
+          "expert": "7 of 8: Expert level",
+          "independent": "3 of 4: Independent level"
+        }
+      },
+      "title": "Uitleg"
     },
     "campaign-creation": {
       "actions": {


### PR DESCRIPTION
## 🔆 Problème
Ajustements de wordings à faire suite aux retours du métier. 


## ⛱️ Proposition
-> DESCRIPTION DE LA PAGE 
Analysez, globalement, par compétence ou par sujet, le positionnement de vos participants dans cette campagne qui porte sur une sélection de sujets du référentiel Pix.
Le positionnement reflète le niveau moyen atteint par les participants, par rapport au niveau maximal accessible dans cette campagne.
Voici la correspondance des niveaux :
- 1 ou 2 correspond à un niveau Novice
- 3 ou 4 correspond à un niveau Indépendant
- 5 ou 6 correspond à un niveau Avancé
- 7 ou 8 correspond à un niveau Expert
[En savoir plus sur les niveaux.](https://pix.fr/score-et-niveaux)
Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation et sont actualisées à chaque visite.


-> GRANDE JAUGE
Le positionnement global est le niveau moyen atteint par les participants (barre violette) par rapport au maximum qu’ils auraient pu atteindre dans cette campagne (barre blanche).


-> TABLEAUX / SUJET
Ci-dessous, retrouvez les sujets de la campagne et leurs descriptifs ainsi que le positionnement des participants.


-> TABLEAUX / COMPETENCE
Ci-dessous, retrouvez les compétences de la campagne et leurs descriptifs ainsi que le positionnement des participants.


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Vérifier :
- que les descriptifs sont cohérents
- que la liste à puces s'affiche correctement
- les versions EN et NL 
- 🫰