### PR TITLE
[POC] Animer les transitions entre les cartes de la modalité QAB (PIX-18069)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-card.scss
@@ -2,15 +2,19 @@
 @use 'pix-design-tokens/typography';
 
 .qab-card {
+  position: absolute;
   display: flex;
   justify-content: center;
   width: 100%;
   max-width: 240px;
   min-height: 380px;
+  height: 380px;
   padding: var(--pix-spacing-3x);
   background: var(--pix-neutral-0);
   border-radius: var(--pix-spacing-3x);
   box-shadow: 8px 8px 28px 0 rgb(0 0 0 / 25%);
+  transition: translate 400ms ease-in, rotate 400ms ease-in;
+  transition-delay: calc(100ms * var(--reverse-index));
 
   &__container {
     --qab-card-content-border-color: var(--pix-primary-300);
@@ -30,6 +34,11 @@
     &--success {
       --qab-card-content-border-color: var(--pix-success-300);
     }
+  }
+
+  &--answered {
+    translate: -100vw -10vh;
+    rotate: -20deg;
   }
 }
 

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -11,8 +11,8 @@
   }
 
   &__cards {
-    display: flex;
-    justify-content: center;
+    position: relative;
+    height: 380px;
   }
 
   &__proposals {
@@ -20,6 +20,7 @@
     flex-wrap: wrap;
     gap: var(--pix-spacing-3x);
     justify-content: center;
+    height: 75px;
     max-width: 240px;
     margin: auto;
   }

--- a/mon-pix/app/components/module/element/qab/qab-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-card.gjs
@@ -15,7 +15,13 @@ export default class QabCard extends Component {
   }
 
   <template>
-    <div class="qab-card">
+    <div
+      class="qab-card {{if @isAnswered 'qab-card--answered'}}"
+      style="
+      z-index: {{@zIndex}};
+      --reverse-index: {{@zIndex}};
+    "
+    >
       {{#if this.isSuccess}}
         <p role="status" class="sr-only"> {{t "pages.modulix.qab.correct-answer"}} </p>
       {{/if}}

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -7,13 +7,14 @@ import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
 import { htmlUnsafe } from '../../../../helpers/html-unsafe';
 import ModuleElement from '../module-element';
 
-export const NEXT_CARD_DELAY = 2000;
+export const NEXT_CARD_DELAY = 1000;
 
 export default class ModuleQab extends ModuleElement {
   @tracked selectedOption = null;
   @tracked currentStep = 'cards'; // 'cards' | 'score'
   @tracked currentCardStatus = '';
   @tracked currentCardIndex = 0;
+  @tracked answeredCardIndexes = [];
   @tracked score = 0;
 
   get numberOfCards() {
@@ -38,6 +39,10 @@ export default class ModuleQab extends ModuleElement {
     return this.selectedOption !== null;
   }
 
+  markCurrentCardAsAnswered() {
+    this.answeredCardIndexes = [...this.answeredCardIndexes, this.currentCardIndex];
+  }
+
   @action
   goToNextCard() {
     this.currentCardIndex = this.currentCardIndex + 1;
@@ -58,7 +63,9 @@ export default class ModuleQab extends ModuleElement {
       this.score++;
       this.currentCardStatus = 'success';
     }
-    window.setTimeout(() => this.goToNextCard(), NEXT_CARD_DELAY);
+    const nextCardTransitionDelay = NEXT_CARD_DELAY + 100 * this.getCardZIndex(this.currentCardIndex);
+    window.setTimeout(() => this.markCurrentCardAsAnswered(), NEXT_CARD_DELAY);
+    window.setTimeout(() => this.goToNextCard(), nextCardTransitionDelay);
   }
 
   @action
@@ -66,6 +73,7 @@ export default class ModuleQab extends ModuleElement {
     this.currentStep = 'cards';
     this.currentCardIndex = 0;
     this.score = 0;
+    this.answeredCardIndexes = [];
   }
 
   get shouldDisplayCards() {
@@ -76,6 +84,16 @@ export default class ModuleQab extends ModuleElement {
     return this.currentStep === 'score';
   }
 
+  @action
+  getCardZIndex(index) {
+    return this.numberOfCards - index;
+  }
+
+  @action
+  isCardAnswered(cardIndex) {
+    return this.answeredCardIndexes.includes(cardIndex);
+  }
+
   <template>
     <form onSubmit={{this.onSubmit}} class="element-qab" aria-describedby="instruction-{{this.element.id}}">
       <fieldset class="element-qab__container">
@@ -83,15 +101,19 @@ export default class ModuleQab extends ModuleElement {
           {{htmlUnsafe this.element.instruction}}
         </div>
         <div class="element-qab__cards">
-          {{#if this.shouldDisplayCards}}
-            <QabCard @card={{this.currentCard}} @status={{this.currentCardStatus}} />
-          {{/if}}
-          {{#if this.shouldDisplayScore}}
-            <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}} @onRetry={{this.onRetry}} />
-          {{/if}}
+          {{#each this.element.cards as |card index|}}
+            <QabCard
+              @card={{card}}
+              @status={{this.currentCardStatus}}
+              @index={{index}}
+              @zIndex={{this.getCardZIndex index}}
+              @isAnswered={{this.isCardAnswered index}}
+            />
+          {{/each}}
+          <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}} @onRetry={{this.onRetry}} />
         </div>
-        {{#if this.shouldDisplayCards}}
-          <div class="element-qab__proposals">
+        <div class="element-qab__proposals">
+          {{#if this.shouldDisplayCards}}
             <QabProposalButton
               @text={{this.currentCard.proposalA}}
               @option="A"
@@ -106,8 +128,8 @@ export default class ModuleQab extends ModuleElement {
               @isSelected={{this.isProposalSelected "B"}}
               @isDisabled={{this.isAnswered}}
             />
-          </div>
-        {{/if}}
+          {{/if}}
+        </div>
       </fieldset>
     </form>
   </template>


### PR DESCRIPTION
## 🔆 Problème

La transition entre les cartes n'est pas suffisamment cool.

## ⛱️ Proposition


![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmN6M2piMXN0aHViazRiZWI3OXExZXFhcnB6cHlndG8yb3EwNms1cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9r75ILTJtiDACKOKoY/giphy.gif)


## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur le module bac à sable
2. Répondre à une question de la modalité QAB
3. Constater que l'utilisateur·ice est époustouflé·e
