### PR TITLE
[FEATURE] Anonymiser le prescrit quand on anonymise un utilisateur (PIX-17850).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -26,7 +26,9 @@ const buildCampaignParticipation = function ({
   isCertifiable = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
-  organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
+  organizationLearnerId = _.isUndefined(organizationLearnerId)
+    ? buildOrganizationLearner({ userId }).id
+    : organizationLearnerId;
   campaignId = _.isUndefined(campaignId) ? buildCampaign().id : campaignId;
   const isShared = status === SHARED;
   sharedAt = isShared ? sharedAt : null;

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -100,10 +100,13 @@ class CampaignParticipation {
     this.status = CampaignParticipationStatuses.STARTED;
   }
 
+  detachUser() {
+    this.userId = null;
+  }
+
   anonymize() {
     this.participantExternalId = null;
-    this.userId = null;
-
+    this.detachUser();
     this.#loggerContext = CampaignParticipationLoggerContext.ANONYMIZATION;
   }
 

--- a/api/src/prescription/learner-management/application/api/learners-api.js
+++ b/api/src/prescription/learner-management/application/api/learners-api.js
@@ -47,3 +47,13 @@ export const deleteOrganizationLearnerBeforeImportFeature = withTransaction(asyn
     client: 'PIX_ADMIN',
   });
 });
+
+/**
+ * Anonymize an organizationLearner and their campaignParticipations
+ * @param {object} params
+ * @param {number} params.userId
+ * @returns {Promise<void>}
+ */
+export const anonymizeByUserId = withTransaction(async ({ userId }) => {
+  await usecases.anonymizeUser({ userId });
+});

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
@@ -116,6 +116,10 @@ class OrganizationLearner {
     this.educationalTeam = null;
     this.group = null;
     this.diploma = null;
+    this.detachUser();
+  }
+
+  detachUser() {
     this.userId = null;
     this.updatedAt = new Date();
   }

--- a/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
+++ b/api/src/prescription/learner-management/domain/usecases/anonymize-user.js
@@ -1,0 +1,19 @@
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+export const anonymizeUser = withTransaction(
+  async ({ userId, campaignParticipationRepositoryfromBC, organizationLearnerRepository }) => {
+    const learners = await organizationLearnerRepository.findByUserId({ userId });
+    for (const learner of learners) {
+      learner.detachUser();
+      await organizationLearnerRepository.update(learner);
+      const campaignParticipations =
+        await campaignParticipationRepositoryfromBC.getAllCampaignParticipationsForOrganizationLearner({
+          organizationLearnerId: learner.id,
+        });
+      for (const campaignParticipation of campaignParticipations) {
+        campaignParticipation.detachUser();
+        await campaignParticipationRepositoryfromBC.update(campaignParticipation);
+      }
+    }
+  },
+);

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -8,6 +8,7 @@ import { refreshTokenRepository } from '../../../identity-access-management/infr
 import { resetPasswordDemandRepository } from '../../../identity-access-management/infrastructure/repositories/reset-password-demand.repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as userAcceptanceRepository from '../../../legal-documents/infrastructure/repositories/user-acceptance.repository.js';
+import { featureToggles as featureTogglesService } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as organizationLearnerRepository from '../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -39,11 +40,15 @@ const repositories = {
   userTeamsApiRepository,
 };
 
+const services = {
+  featureTogglesService,
+};
+
 const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
 };
 
-const dependencies = Object.assign({}, repositories);
+const dependencies = Object.assign({}, repositories, services);
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 

--- a/api/src/privacy/infrastructure/repositories/learners-api.repository.js
+++ b/api/src/privacy/infrastructure/repositories/learners-api.repository.js
@@ -13,4 +13,17 @@ const hasBeenLearner = async ({ userId, dependencies = { learnersApi } }) => {
   return dependencies.learnersApi.hasBeenLearner({ userId });
 };
 
-export { hasBeenLearner };
+/**
+ * Anonymize learners and participations by a userId.
+ *
+ * @param {Object} params - The parameters.
+ * @param {number} params.userId - The ID of the user.
+ * @param {Object} [params.dependencies] - The dependencies.
+ * @param {Object} [params.dependencies.learnersApi] - The learners API.
+ * @returns {Promise<void>} - A promise that resolves to a boolean indicating if the user has been a learner.
+ */
+const anonymizeByUserId = async ({ userId, dependencies = { learnersApi } }) => {
+  await dependencies.learnersApi.anonymizeByUserId({ userId });
+};
+
+export { anonymizeByUserId, hasBeenLearner };

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -348,4 +348,16 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       });
     });
   });
+
+  describe('#detachUser', function () {
+    it('should remove userId', function () {
+      const campaignParticipation = new CampaignParticipation({
+        userId: 666,
+      });
+
+      campaignParticipation.detachUser();
+
+      expect(campaignParticipation.userId).to.be.null;
+    });
+  });
 });

--- a/api/tests/prescription/learner-management/integration/domain/usecases/anonymize-user_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/anonymize-user_test.js
@@ -1,0 +1,31 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | anonymize-user', function () {
+  it('should anonymize organization-learners', async function () {
+    const userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildOrganizationLearner({ userId });
+    databaseBuilder.factory.buildOrganizationLearner({ userId });
+    await databaseBuilder.commit();
+    const learnersBefore = await knex('organization-learners').where({ userId });
+    expect(learnersBefore).to.have.lengthOf(2);
+
+    await usecases.anonymizeUser({ userId });
+
+    const learnersAfter = await knex('organization-learners').where({ userId });
+    expect(learnersAfter).to.have.lengthOf(0);
+  });
+
+  it('should anonymize campaign-participations', async function () {
+    const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+    databaseBuilder.factory.buildCampaignParticipation();
+
+    await databaseBuilder.commit();
+
+    await usecases.anonymizeUser({ userId: campaignParticipation.userId });
+
+    const campaignParticipationsFound = await knex('campaign-participations').whereNull('userId');
+    expect(campaignParticipationsFound).lengthOf(1);
+    expect(campaignParticipationsFound[0].id).to.equal(campaignParticipation.id);
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
+++ b/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
@@ -1,4 +1,5 @@
 import {
+  anonymizeByUserId,
   deleteOrganizationLearnerBeforeImportFeature,
   hasBeenLearner,
 } from '../../../../../../src/prescription/learner-management/application/api/learners-api.js';
@@ -91,6 +92,26 @@ describe('Unit | Prescription | learner management | Api | learners', function (
       // then
       expect(findOrganizationLearnersBeforeImportFeatureStub).to.have.been.calledOnce;
       expect(deleteOrganizationLearnersStub).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#anonymizeByUserId', function () {
+    beforeEach(function () {
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
+    });
+
+    it('should call anonymizeUser usecase with correct parameters', async function () {
+      // given
+      const anonymizeUserStub = sinon.stub(usecases, 'anonymizeUser').resolves();
+      const userId = 1;
+
+      // when
+      await anonymizeByUserId({ userId });
+
+      // then
+      expect(anonymizeUserStub).to.have.been.calledOnceWith({ userId });
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
@@ -193,4 +193,27 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
       });
     });
   });
+
+  describe('#detachUser', function () {
+    let clock;
+    let now;
+
+    beforeEach(function () {
+      now = new Date('2025-01-01');
+      clock = sinon.useFakeTimers(now, 'Date');
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should detach userId', function () {
+      const organizationLearner = domainBuilder.buildOrganizationLearner({
+        userId: 456,
+      });
+      organizationLearner.detachUser();
+      expect(organizationLearner.userId).null;
+      expect(organizationLearner.updatedAt).deep.equal(now);
+    });
+  });
 });

--- a/api/tests/privacy/unit/infrastructure/repositories/learners-api.repository.test.js
+++ b/api/tests/privacy/unit/infrastructure/repositories/learners-api.repository.test.js
@@ -1,5 +1,8 @@
-import { hasBeenLearner } from '../../../../../src/privacy/infrastructure/repositories/learners-api.repository.js';
-import { expect } from '../../../../test-helper.js';
+import {
+  anonymizeByUserId,
+  hasBeenLearner,
+} from '../../../../../src/privacy/infrastructure/repositories/learners-api.repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Privacy | Infrastructure | Repositories | learners-api', function () {
   describe('#hasBeenLearner', function () {
@@ -16,6 +19,21 @@ describe('Unit | Privacy | Infrastructure | Repositories | learners-api', functi
 
       // then
       expect(result).to.be.true;
+    });
+  });
+
+  describe('#anonymizeByUserId', function () {
+    it('anonymize learners and theirs participations attached to a userId', async function () {
+      // given
+      const dependencies = {
+        learnersApi: {
+          anonymizeByUserId: sinon.stub(),
+        },
+      };
+      // when
+      await anonymizeByUserId({ userId: 123, dependencies });
+      // then
+      expect(dependencies.learnersApi.anonymizeByUserId).calledOnceWithExactly({ userId: 123 });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Depuis PixAdmin, le support a la possibilité d’anonymiser un utilisateur, mais cela ne supprime pas complètement les données personnelles de l’utilisateur, car celles-ci sont aussi présentes dans la table `organization-learner`. Ces données appartenant à l’orga, nous souhaitons seulement couper le lien avec l’utilisateur.

## :robot: Proposition
On souhaite donc anonymiser les informations de l'organization-learner et ses participations UNIQUEMENT si le feature flag isDeletionAndAnonymisationEnabled est true 

- on met à null le userId de l'organization-learner en créant une nouvelle méthode detachUser
- mettre à null le userId des participations des learners associés au `userId`

## :rainbow: Remarques
ras

## :100: Pour tester
### Avant
```bash
scalingo -a pix-api-review-pr12428 run "npm run toggles -- -k isAnonymizationWithDeletionEnabled -v false"
```
- anonymiser l'utilisateur [firstName0 lastName0 de l'orga PRO](https://admin-pr12428.review.pix.fr/users/100079) dans pixAdmin
```bash
scalingo -a pix-api-review-pr12428 pgsql-console
```
```sql
select count(1) from "organization-learners" where "userId"=100079;
-- retourne 1 
```
### Après
```bash
scalingo -a pix-api-review-pr12428 run "npm run toggles -- -k isAnonymizationWithDeletionEnabled -v true"
```
- anonymiser l'utilisateur [firstName1 lastName1 de l'orga PRO](https://admin-pr12428.review.pix.fr/users/100082) dans pixAdmin
```bash
scalingo -a pix-api-review-pr12428 pgsql-console
``` 
```sql
select count(1) from "organization-learners" where "userId"=100082;
-- retourne 0
```

