### PR TITLE
[FEATURE] Edition du fond pour le QCU déclaratif (PIX-17906)

### DIFF
--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -29,7 +29,7 @@
   &[disabled]:not(.proposal-button--selected) {
     --state-border-color: var(--pix-neutral-100);
 
-    background: rgb(var(--pix-success-100-inline), 0.4);
+    background: var(--pix-primary-100);
     border-color: var(--state-border-color);
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -4,6 +4,8 @@
   width: 100%;
   padding: var(--pix-spacing-6x);
   padding-bottom: var(--pix-spacing-10x);
+  background-color: rgb(var(--pix-primary-100-inline), 0.6);
+  border-radius: var(--pix-spacing-4x) var(--pix-spacing-4x) 0 0;
 
   &__instruction {
     @extend %pix-body-m;
@@ -15,7 +17,7 @@
     @extend %pix-body-s;
 
     margin: var(--pix-spacing-3x) 0;
-    color: var(--pix-neutral-500);
+    color: var(--pix-neutral-800);
   }
 
   &__proposals {
@@ -31,6 +33,6 @@
     padding: var(--pix-spacing-6x);
     color: var(--pix-neutral-0);
     background: var(--pix-neutral-800);
-    border-radius: var(--pix-spacing-4x);
+    border-radius: 0 0 var(--pix-spacing-4x) var(--pix-spacing-4x);
   }
 }


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le qcu déclaratif n'a pas de fond, et les propositions non sélectionnées s'affichent en vert.

## ⛱️ Proposition

Ajouter un fond et changer les propositions non sélectionnées en utilisant pix-primary

## 🌊 Remarques

Maquette [ici](https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R-D-DevComp?node-id=8590-1169&m=dev) 

## 🏄 Pour tester

- Ouvrir le [module bac-a-sable](https://app-pr12429.review.pix.fr/modules/bac-a-sable/details)
- Commencer, et Continuer jusqu'au grain contenant un QCU déclaratif. 
- Constater changement de couleur, et répondre pour voir le comportement de l'élément
