### PR TITLE
[TECH] Rendre le processus de connexion depuis un mediacentre agnostique des campagnes (PIX-18087)

### DIFF
--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -14,13 +14,17 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   h,
   dependencies = { scoOrganizationLearnerSerializer },
 ) {
-  const { birthdate, 'campaign-code': campaignCode, 'external-user-token': token } = request.payload.data.attributes;
+  const {
+    birthdate,
+    'organization-id': organizationId,
+    'external-user-token': token,
+  } = request.payload.data.attributes;
 
   const origin = getForwardedOrigin(request.headers);
   const requestedApplication = RequestedApplication.fromOrigin(origin);
   const accessToken = await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
     birthdate,
-    campaignCode,
+    organizationId,
     token,
     audience: origin,
     requestedApplication,

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -27,7 +27,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'campaign-code': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'organization-id': Joi.number().empty(null).required(),
                 'external-user-token': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 birthdate: Joi.date().format('YYYY-MM-DD').raw().required(),
                 'access-token': Joi.string().allow(null).optional(),

--- a/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -3,7 +3,7 @@ import { AuthenticationMethod } from '../../../../identity-access-management/dom
 import { User } from '../../../../identity-access-management/domain/models/User.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CampaignCodeError, ObjectValidationError } from '../../../../shared/domain/errors.js';
+import { ObjectValidationError } from '../../../../shared/domain/errors.js';
 
 const existingUserReconciliationErrors = [
   STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION.samlId.code,
@@ -12,7 +12,7 @@ const existingUserReconciliationErrors = [
 
 const createUserAndReconcileToOrganizationLearnerFromExternalUser = async function ({
   birthdate,
-  campaignCode,
+  organizationId,
   token,
   obfuscationService,
   tokenService,
@@ -21,7 +21,6 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   userReconciliationService,
   userService,
   authenticationMethodRepository,
-  campaignRepository,
   userRepository,
   userLoginRepository,
   userToCreateRepository,
@@ -30,11 +29,6 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   lastUserApplicationConnectionsRepository,
   studentRepository,
 }) {
-  const campaign = await campaignRepository.getByCode(campaignCode);
-  if (!campaign) {
-    throw new CampaignCodeError();
-  }
-
   const externalUser = await tokenService.extractExternalUserFromIdToken(token);
   const firstName = externalUser.firstName;
   const lastName = externalUser.lastName;
@@ -57,7 +51,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   try {
     matchedOrganizationLearner =
       await userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
-        organizationId: campaign.organizationId,
+        organizationId,
         reconciliationInfo,
         organizationLearnerRepository: libOrganizationLearnerRepository,
       });

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
@@ -17,13 +17,11 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
   describe('POST /api/sco-organization-learners/external', function () {
     let organization;
-    let campaign;
     let options;
     let organizationLearner;
 
     beforeEach(async function () {
       // given
-
       options = {
         method: 'POST',
         url: '/api/sco-organization-learners/external',
@@ -40,7 +38,6 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
         organizationId: organization.id,
         userId: null,
       });
-      campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
       await databaseBuilder.commit();
     });
 
@@ -56,7 +53,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
         options.payload.data = {
           attributes: {
-            'campaign-code': campaign.code,
+            'organization-id': organization.id,
             'external-user-token': idTokenForExternalUser,
             birthdate: organizationLearner.birthdate,
             'access-token': null,
@@ -103,7 +100,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
           options.payload.data = {
             attributes: {
-              'campaign-code': campaign.code,
+              'organization-id': organization.id,
               'external-user-token': idTokenForExternalUser,
               birthdate: organizationLearner.birthdate,
               'access-token': null,
@@ -150,7 +147,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
           options.payload.data = {
             attributes: {
-              'campaign-code': campaign.code,
+              'organization-id': organization.id,
               'external-user-token': idTokenForExternalUser,
               birthdate: organizationLearner.birthdate,
               'access-token': null,
@@ -179,7 +176,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
           options.payload.data = {
             attributes: {
-              'campaign-code': campaign.code,
+              'organization-id': organization.id,
               'external-user-token': invalidIdToken,
               birthdate: organizationLearner.birthdate,
               'access-token': null,

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
@@ -34,7 +34,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
       payload = {
         data: {
           attributes: {
-            'campaign-code': 'RESTRICTD',
+            'organization-id': 123,
             'external-user-token': 'external-user-token',
             birthdate: '1948-12-21',
             'access-token': null,
@@ -44,18 +44,16 @@ describe('Integration | Application | Route | sco-organization-learners', functi
       };
     });
 
-    it('should return a 400 Bad Request when campaignCode is missing', async function () {
+    it('should return a 400 Bad Request when organizationId is missing', async function () {
       // given
-      payload.data.attributes['campaign-code'] = '';
+      payload.data.attributes['organization-id'] = undefined;
 
       // when
       response = await httpTestServer.request(method, url, payload);
 
       // then
       expect(response.statusCode).to.equal(400);
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-        '"data.attributes.campaign-code" is not allowed to be empty',
-      );
+      expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.organization-id" is required');
     });
 
     it('should return 400 Bad Request when external-user-token is missing', async function () {
@@ -101,7 +99,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
         payload = {
           data: {
             attributes: {
-              'campaign-code': 'RESTRICTD',
+              'organization-id': 123,
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: '2012-12-12',
@@ -146,9 +144,9 @@ describe('Integration | Application | Route | sco-organization-learners', functi
         expect(response.statusCode).to.equal(400);
       });
 
-      it('should return 400 when campaignCode is empty', async function () {
+      it('should return 400 when organizationId is empty', async function () {
         // given
-        payload.data.attributes['campaign-code'] = '';
+        payload.data.attributes['organization-id'] = undefined;
 
         // when
         response = await httpTestServer.request(method, url, payload);

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -2,7 +2,6 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-acce
 import { RequestedApplication } from '../../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import {
-  CampaignCodeError,
   NotFoundError,
   ObjectValidationError,
   OrganizationLearnerAlreadyLinkedToUserError,
@@ -18,23 +17,11 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     requestedApplication = new RequestedApplication('app');
   });
 
-  context('When there is no campaign with the given code', function () {
-    it('should throw a campaign code error', async function () {
-      // when
-      const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
-        campaignCode: 'NOTEXIST',
-      });
-
-      // then
-      expect(error).to.be.instanceof(CampaignCodeError);
-    });
-  });
-
   context('When the token is invalid', function () {
-    let campaignCode;
+    let organizationId;
 
     beforeEach(async function () {
-      campaignCode = databaseBuilder.factory.buildCampaign().code;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
     });
 
@@ -49,7 +36,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
-          campaignCode,
+          organizationId,
           token,
           tokenService,
         });
@@ -71,7 +58,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
-          campaignCode,
+          organizationId,
           token,
           tokenService,
         });
@@ -93,7 +80,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
-          campaignCode,
+          organizationId,
           token,
         });
 
@@ -104,12 +91,12 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     });
   });
 
-  context('When no organizationLearner is found', function () {
-    let campaignCode;
+  context('When no organizationLearners are found', function () {
+    let organizationId;
     let token;
 
     beforeEach(async function () {
-      campaignCode = databaseBuilder.factory.buildCampaign().code;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
       const externalUser = {
         firstName: 'Saml',
@@ -126,7 +113,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       // when
       const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
         birthdate,
-        campaignCode,
+        organizationId,
         token,
       });
 
@@ -141,13 +128,11 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     const lastName = 'Dumoulin-Lemarchand';
     const samlId = 'SamlId';
 
-    let campaignCode;
     let organizationId;
     let token;
 
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
-      campaignCode = databaseBuilder.factory.buildCampaign({ organizationId }).code;
       await databaseBuilder.commit();
 
       const externalUser = { firstName, lastName, samlId };
@@ -169,7 +154,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       // when
       await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
         birthdate: organizationLearner.birthdate,
-        campaignCode,
+        organizationId,
         token,
         tokenService,
         audience,
@@ -208,7 +193,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
           // when
           const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
             birthdate: organizationLearner.birthdate,
-            campaignCode,
+            organizationId,
             token,
           });
 
@@ -253,7 +238,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
             // when
             await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
-              campaignCode,
+              organizationId,
               token,
               birthdate: organizationLearner.birthdate,
               audience,
@@ -307,7 +292,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
             // when
             await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
-              campaignCode,
+              organizationId,
               token,
               birthdate: organizationLearner.birthdate,
               audience,
@@ -360,7 +345,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
         // when
         await usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser({
           birthdate: organizationLearner.birthdate,
-          campaignCode,
+          organizationId,
           token,
           audience,
           requestedApplication,

--- a/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
@@ -28,7 +28,7 @@ describe('Prescription | Unit | Application | Controller | sco-organization-lear
           data: {
             attributes: {
               birthdate: '01-01-2000',
-              'campaign-code': 'BADGES123',
+              'organization-id': 123,
               'external-user-token': '123SamlId',
             },
           },
@@ -62,7 +62,7 @@ describe('Prescription | Unit | Application | Controller | sco-organization-lear
         'first-name': 'Robert',
         'last-name': 'Smith',
         birthdate: '2012-12-12',
-        'campaign-code': 'RESTRICTD',
+        'organization-id': 123,
         password: 'P@ssw0rd',
         username: 'robert.smith1212',
         'with-username': true,

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -4,12 +4,12 @@ import { createUserAndReconcileToOrganizationLearnerFromExternalUser } from '../
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-from-external-user', function () {
+  const organizationId = 1;
   let obfuscationService;
   let tokenService;
   let userReconciliationService;
   let userService;
   let authenticationMethodRepository;
-  let campaignRepository;
   let userRepository;
   let userLoginRepository;
   let organizationLearnerRepository;
@@ -19,9 +19,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   const requestedApplication = new RequestedApplication('app');
 
   beforeEach(function () {
-    campaignRepository = {
-      getByCode: sinon.stub(),
-    };
     tokenService = {
       extractExternalUserFromIdToken: sinon.stub(),
       createAccessTokenForSaml: sinon.stub(),
@@ -56,7 +53,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const organizationLearner = domainBuilder.buildOrganizationLearner(user);
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
 
-      campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
@@ -66,14 +62,13 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       // when
       await createUserAndReconcileToOrganizationLearnerFromExternalUser({
         birthdate: user.birthdate,
-        campaignCode: 'ABCDE',
+        organizationId,
         token: 'a token',
         obfuscationService,
         tokenService,
         userReconciliationService,
         userService,
         authenticationMethodRepository,
-        campaignRepository,
         userRepository,
         userLoginRepository,
         organizationLearnerRepository,
@@ -102,7 +97,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
       const token = Symbol('token');
 
-      campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
@@ -113,7 +107,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({
         birthdate: user.birthdate,
-        campaignCode: 'ABCDE',
+        organizationId,
         token: 'a token',
         obfuscationService,
         tokenService,
@@ -121,7 +115,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         userReconciliationService,
         userService,
         authenticationMethodRepository,
-        campaignRepository,
         userRepository,
         userLoginRepository,
         organizationLearnerRepository,
@@ -142,7 +135,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const organizationLearner = domainBuilder.buildOrganizationLearner(user);
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
 
-      campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
@@ -153,14 +145,13 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       // when
       await createUserAndReconcileToOrganizationLearnerFromExternalUser({
         birthdate: user.birthdate,
-        campaignCode: 'ABCDE',
+        organizationId,
         token: 'a token',
         obfuscationService,
         tokenService,
         userReconciliationService,
         userService,
         authenticationMethodRepository,
-        campaignRepository,
         userRepository,
         userLoginRepository,
         organizationLearnerRepository,
@@ -180,7 +171,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
       const token = Symbol('token');
 
-      campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
@@ -192,7 +182,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       // when
       const result = await createUserAndReconcileToOrganizationLearnerFromExternalUser({
         birthdate: user.birthdate,
-        campaignCode: 'ABCDE',
+        organizationId,
         token: 'a token',
         obfuscationService,
         tokenService,
@@ -200,7 +190,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         userReconciliationService,
         userService,
         authenticationMethodRepository,
-        campaignRepository,
         userRepository,
         userLoginRepository,
         organizationLearnerRepository,

--- a/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.gjs
+++ b/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.gjs
@@ -78,7 +78,7 @@ export default class AssociateScoStudentWithMediacentreForm extends Component {
     const externalUserToken = this.session.externalUserTokenFromGar;
     return this.store.createRecord('external-user', {
       birthdate: this.attributes.birthdate,
-      campaignCode: this.args.campaignCode,
+      organizationId: this.args.organizationId,
       externalUserToken,
     });
   }

--- a/mon-pix/app/models/external-user.js
+++ b/mon-pix/app/models/external-user.js
@@ -3,7 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class ExternalUser extends Model {
   // attributes
   @attr('date-only') birthdate;
-  @attr('string') campaignCode;
+  @attr('number') organizationId;
   @attr('string') externalUserToken;
   @attr('string') accessToken;
 }

--- a/mon-pix/app/templates/campaigns/join/sco-mediacentre.gjs
+++ b/mon-pix/app/templates/campaigns/join/sco-mediacentre.gjs
@@ -13,6 +13,7 @@ import AssociateScoStudentWithMediacentreForm from 'mon-pix/components/routes/ca
       <div class="join-restricted-campaign">
         <AssociateScoStudentWithMediacentreForm
           @organizationName={{@model.organizationName}}
+          @organizationId={{@model.organizationId}}
           @campaignCode={{@model.code}}
           @onSubmit={{@controller.createAndReconcile}}
         />

--- a/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form-test.js
@@ -23,7 +23,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
     onSubmitStub = sinon.stub();
     component = createComponent('routes/campaigns/join/associate-sco-student-with-mediacentre-form', {
       onSubmit: onSubmitStub,
-      campaignCode: 123,
+      organizationId: 123,
     });
     component.store = storeStub;
     component.session = sessionStub;
@@ -54,7 +54,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
       // then
       sinon.assert.calledWith(storeStub.createRecord, 'external-user', {
         birthdate: attributes.birthdate,
-        campaignCode: component.args.campaignCode,
+        organizationId: component.args.organizationId,
         externalUserToken,
       });
       assert.ok(true);


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre des développements Combinix, on a besoin de pouvoir connecter / réconcilier les élèves qui viennent du GAR sans campaignCode.

## ⛱️ Proposition
On remplace campaignCode par organizationId sur la route api/sco-organization-learners/external.

## 🏄 Pour tester
ADMIN
Aller dans admin et créer une nouvelle organisation, lui rattacher un profil cible, remplir son identifiant externe, choisir "Etablissement scolaire" dans la liste déroulante, et lui ajouter un membre (admin-orga@example.net).
Cocher la case "Gestion élèves étudiants".

ORGA
Télécharger le template sco-ok du drive pour l'import, lui changer la ligne 4 pour avoir un identifiant externe qui correspond à celui de l'organisation qu'on a créée. Importer la liste d'élèves sur l'organisation nouvellement créée.
Créer une campagne d'évaluation, relever son code.

APP
Suivre le processus pour simuler le GAR : https://1024pix.atlassian.net/wiki/spaces/DA/pages/1743323153/Simuler+le+GAR+protocole+SAML+appel+faux+GAR

Remplir le formulaire avec un nom et un prénom qui correspondent à un élève présent dans l'organisation nouvellement créée. Vérifier que les informations sont bien pré-remplies.

Passer la campagne nouvellement créée. 