### PR TITLE
[FEATURE] Couper le lien entre user-recommended-training et la participation lors de la suppression de celle-ci (PIX-18049)

### DIFF
--- a/api/db/database-builder/factory/build-user-recommended-training.js
+++ b/api/db/database-builder/factory/build-user-recommended-training.js
@@ -1,3 +1,4 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../migrations/20221017085933_create-user-recommended-trainings.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const buildUserRecommendedTraining = function ({
@@ -9,7 +10,7 @@ const buildUserRecommendedTraining = function ({
   updatedAt = new Date(),
 } = {}) {
   return databaseBuffer.pushInsertable({
-    tableName: 'user-recommended-trainings',
+    tableName: USER_RECOMMENDED_TRAININGS_TABLE_NAME,
     values: { id, userId, trainingId, campaignParticipationId, createdAt, updatedAt },
   });
 };

--- a/api/db/database-builder/factory/build-user-recommended-training.js
+++ b/api/db/database-builder/factory/build-user-recommended-training.js
@@ -1,5 +1,6 @@
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../migrations/20221017085933_create-user-recommended-trainings.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildTraining } from './build-training.js';
 
 const buildUserRecommendedTraining = function ({
   id = databaseBuffer.getNextId(),
@@ -9,6 +10,9 @@ const buildUserRecommendedTraining = function ({
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
+  if (!trainingId) {
+    trainingId = buildTraining().id;
+  }
   return databaseBuffer.pushInsertable({
     tableName: USER_RECOMMENDED_TRAININGS_TABLE_NAME,
     values: { id, userId, trainingId, campaignParticipationId, createdAt, updatedAt },

--- a/api/db/migrations/20221017085933_create-user-recommended-trainings.js
+++ b/api/db/migrations/20221017085933_create-user-recommended-trainings.js
@@ -1,7 +1,7 @@
-const TABLE_NAME = 'user-recommended-trainings';
+export const USER_RECOMMENDED_TRAININGS_TABLE_NAME = 'user-recommended-trainings';
 
 const up = function (knex) {
-  return knex.schema.createTable(TABLE_NAME, (t) => {
+  return knex.schema.createTable(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (t) => {
     t.increments().primary();
     t.integer('userId').references('users.id').notNullable();
     t.integer('trainingId').references('trainings.id').notNullable();
@@ -13,7 +13,7 @@ const up = function (knex) {
 };
 
 const down = function (knex) {
-  return knex.schema.dropTable(TABLE_NAME);
+  return knex.schema.dropTable(USER_RECOMMENDED_TRAININGS_TABLE_NAME);
 };
 
 export { down, up };

--- a/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
+++ b/api/db/migrations/20241119103307_devcomp-user-recommended-trainings-remove-nullable-constraint-on-campaign-participation-id.js
@@ -1,23 +1,14 @@
-// Make sure you properly test your migration, especially DDL (Data Definition Language)
-// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
-
-// You can design and test your migration to avoid this by following this guide
-// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
-
-// If your migrations target `answers` or `knowledge-elements`
-// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
-// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
-const TABLE_NAME = 'user-recommended-trainings';
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from './20221017085933_create-user-recommended-trainings.js';
 const COLUMN_NAME = 'campaignParticipationId';
 
 const up = async (knex) => {
-  await knex.schema.alterTable(TABLE_NAME, (table) => {
+  await knex.schema.alterTable(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).nullable().alter();
   });
 };
 
 const down = async (knex) => {
-  await knex.schema.table(TABLE_NAME, (table) => {
+  await knex.schema.table(USER_RECOMMENDED_TRAININGS_TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).notNullable().alter();
   });
 };

--- a/api/scripts/prod/delete-and-anonymise-organization-learners.js
+++ b/api/scripts/prod/delete-and-anonymise-organization-learners.js
@@ -1,3 +1,4 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { removeByOrganizationLearnerIds } from '../../src/prescription/learner-management/infrastructure/repositories/campaign-participation-repository.js';
 import { removeByIds } from '../../src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js';
 import { commaSeparatedNumberParser } from '../../src/shared/application/scripts/parsers.js';
@@ -77,7 +78,7 @@ async function detachAssessments(participationIds, updatedAt) {
 
 async function detachRecommendedTrainings(participationIds, updatedAt) {
   const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('user-recommended-trainings')
+  await knexConnection(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
     .update({ campaignParticipationId: null, updatedAt })
     .whereIn('campaignParticipationId', participationIds);
 }

--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -1,3 +1,4 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { usecases } from '../../src/prescription/learner-management/domain/usecases/index.js';
 import { Script } from '../../src/shared/application/scripts/script.js';
 import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
@@ -150,7 +151,7 @@ export class DeleteOrganizationLearnersFromOrganizationScript extends Script {
 
   async #detachRecommendedTrainings({ campaignParticipationsIds, updatedAt }) {
     const knexConnection = DomainTransaction.getConnection();
-    await knexConnection('user-recommended-trainings')
+    await knexConnection(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
       .update({ campaignParticipationId: null, updatedAt })
       .whereIn('campaignParticipationId', campaignParticipationsIds);
   }

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -1,5 +1,6 @@
 import lodash from 'lodash';
 
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { TrainingTrigger } from '../../../shared/domain/models/index.js';
@@ -178,7 +179,7 @@ async function findPaginatedByUserId({ userId, locale, page }) {
   const query = knexConn(TABLE_NAME)
     .select('trainings.*')
     .distinct('trainings.id')
-    .join('user-recommended-trainings', 'trainings.id', 'trainingId')
+    .join(USER_RECOMMENDED_TRAININGS_TABLE_NAME, 'trainings.id', 'trainingId')
     .where({ userId, locale, isDisabled: false })
     .orderBy('id', 'asc');
   const { results, pagination } = await fetchPage(query, page);

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -1,11 +1,10 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 
-const TABLE_NAME = 'user-recommended-trainings';
-
 const save = function ({ userId, trainingId, campaignParticipationId }) {
   const knexConn = DomainTransaction.getConnection();
-  return knexConn(TABLE_NAME)
+  return knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
     .insert({ userId, trainingId, campaignParticipationId })
     .onConflict(['userId', 'trainingId', 'campaignParticipationId'])
     .merge({ updatedAt: knexConn.fn.now() });
@@ -13,9 +12,9 @@ const save = function ({ userId, trainingId, campaignParticipationId }) {
 
 const findByCampaignParticipationId = async function ({ campaignParticipationId, locale }) {
   const knexConn = DomainTransaction.getConnection();
-  const trainings = await knexConn(TABLE_NAME)
+  const trainings = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
     .select('trainings.*')
-    .innerJoin('trainings', 'trainings.id', `${TABLE_NAME}.trainingId`)
+    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
     .where({ campaignParticipationId, locale, isDisabled: false })
     .orderBy('id', 'asc');
   return trainings.map(_toDomain);
@@ -23,7 +22,7 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId,
 
 const hasRecommendedTrainings = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn(TABLE_NAME).select(1).where({ userId }).first();
+  const result = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME).select(1).where({ userId }).first();
   return Boolean(result);
 };
 

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -26,7 +26,14 @@ const hasRecommendedTrainings = async function ({ userId }) {
   return Boolean(result);
 };
 
-export { findByCampaignParticipationId, hasRecommendedTrainings, save };
+const deleteCampaignParticipationIds = async ({ campaignParticipationIds }) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+    .update({ campaignParticipationId: null })
+    .whereIn('campaignParticipationId', campaignParticipationIds);
+};
+
+export { deleteCampaignParticipationIds, findByCampaignParticipationId, hasRecommendedTrainings, save };
 
 function _toDomain(training) {
   return new UserRecommendedTraining({ ...training });

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -12,6 +12,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
   campaignParticipationRepository,
   eventLoggingJobRepository,
   assessmentRepository,
+  userRecommendedTrainingRepository,
 }) {
   const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
 
@@ -43,6 +44,8 @@ const deleteCampaignParticipation = withTransaction(async function ({
     await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
       campaignParticipationIds,
     );
+    await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
+
     const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
     for (const assessment of assessments) {
       assessment.detachCampaignParticipation();

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
+import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as compareStagesAndAcquiredStages from '../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeRepository from '../../../../evaluation/infrastructure/repositories/badge-repository.js';
@@ -80,6 +81,7 @@ import * as poleEmploiSendingRepository from '../../infrastructure/repositories/
  * @typedef { import ('../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js')} StageCollectionRepository
  * @typedef { import ('../../../../evaluation/infrastructure/repositories/stage-repository.js')} StageRepository
  * @typedef { import ('../../../../devcomp/infrastructure/repositories/tutorial-repository.js')} TutorialRepository
+ * @typedef { import ('../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js')} UserRecommendedTrainingRepository
  */
 
 function requirePoleEmploiNotifier() {
@@ -131,6 +133,7 @@ const dependencies = {
   stageRepository,
   tutorialRepository,
   userRepository,
+  userRecommendedTrainingRepository,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -9,6 +9,7 @@ const deleteCampaigns = async ({
   organizationMembershipRepository,
   campaignAdministrationRepository,
   campaignParticipationRepository,
+  userRecommendedTrainingRepository,
   eventLoggingJobRepository,
 }) => {
   const membership = await organizationMembershipRepository.getByUserIdAndOrganizationId({ userId, organizationId });
@@ -41,6 +42,14 @@ const deleteCampaigns = async ({
         }),
       );
     }
+  }
+
+  if (isAnonymizationWithDeletionEnabled) {
+    const campaignParticipationIds = campaignParticipationsToDelete.map(({ id }) => id);
+
+    await userRecommendedTrainingRepository.deleteCampaignParticipationIds({
+      campaignParticipationIds,
+    });
   }
 
   await campaignAdministrationRepository.remove(campaignsToDelete);

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as learningContentRepository from '../../../../../lib/infrastructure/re
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
+import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeRepository from '../../../../evaluation/infrastructure/repositories/badge-repository.js';
 import * as stageAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js';
@@ -119,6 +120,7 @@ const dependencies = {
   targetProfileRepository: campaignRepositories.targetProfileRepository, // TODO
   tutorialRepository,
   userRepository,
+  userRecommendedTrainingRepository,
   campaignMediaComplianceService,
 };
 

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -14,6 +14,7 @@ const deleteOrganizationLearners = withTransaction(async function ({
   badgeAcquisitionRepository,
   assessmentRepository,
   eventLoggingJobRepository,
+  userRecommendedTrainingRepository,
 }) {
   const organizationLearnersFromOrganization =
     await organizationLearnerRepository.findOrganizationLearnersByOrganizationId({
@@ -82,6 +83,8 @@ const deleteOrganizationLearners = withTransaction(async function ({
         assessment.detachCampaignParticipation();
         await assessmentRepository.updateCampaignParticipationId(assessment);
       }
+
+      await userRecommendedTrainingRepository.deleteCampaignParticipationIds({ campaignParticipationIds });
     }
   }
 });

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import { eventLoggingJobRepository } from '../../../../identity-access-management/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
@@ -88,6 +89,7 @@ const dependencies = {
   studentRepository,
   supOrganizationLearnerRepository,
   userReconciliationService,
+  userRecommendedTrainingRepository,
   badgeAcquisitionRepository,
   userRepository,
   validateCommonOrganizationImportFileJobRepository,

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import * as userRecommendedTrainingRepository from '../../../../../src/devcomp/infrastructure/repositories/user-recommended-training-repository.js';
+import { deleteCampaignParticipationIds } from '../../../../../src/devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | user-recommended-training-repository', function () {
@@ -192,6 +193,51 @@ describe('Integration | Repository | user-recommended-training-repository', func
 
       // then
       expect(result).to.equal(false);
+    });
+  });
+
+  describe(deleteCampaignParticipationIds.name, function () {
+    it('should set campaignParticipationId to null for given campaignParticipationIds', async function () {
+      // given
+      const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation();
+      const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation();
+      const campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation();
+
+      const userRecommendedTraining1 = databaseBuilder.factory.buildUserRecommendedTraining({
+        campaignParticipationId: campaignParticipation1.id,
+        userId: campaignParticipation1.userId,
+      });
+      const userRecommendedTraining2 = databaseBuilder.factory.buildUserRecommendedTraining({
+        campaignParticipationId: campaignParticipation2.id,
+        userId: campaignParticipation2.userId,
+      });
+      const userRecommendedTraining3 = databaseBuilder.factory.buildUserRecommendedTraining({
+        campaignParticipationId: campaignParticipation3.id,
+        userId: campaignParticipation3.userId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await userRecommendedTrainingRepository.deleteCampaignParticipationIds({
+        campaignParticipationIds: [campaignParticipation1.id, campaignParticipation2.id],
+      });
+
+      // then
+      const updatedUserRecommendedTrainings = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereIn('id', [
+        userRecommendedTraining1.id,
+        userRecommendedTraining2.id,
+      ]);
+
+      expect(updatedUserRecommendedTrainings).to.have.lengthOf(2);
+      updatedUserRecommendedTrainings.forEach((training) => {
+        expect(training.campaignParticipationId).to.be.null;
+      });
+
+      const otherRecommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+        .where('id', userRecommendedTraining3.id)
+        .first();
+
+      expect(otherRecommendedTraining.campaignParticipationId).to.equal(campaignParticipation3.id);
     });
   });
 });

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import * as userRecommendedTrainingRepository from '../../../../../src/devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
@@ -19,7 +20,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       await userRecommendedTrainingRepository.save(userRecommendedTraining);
 
       // then
-      const persistedUserRecommendedTraining = await knex('user-recommended-trainings')
+      const persistedUserRecommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
         .where({
           userId: userRecommendedTraining.userId,
           trainingId: userRecommendedTraining.trainingId,
@@ -50,7 +51,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(async () => {
         await saveSameUserRecommendedTraining();
 
-        const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
+        const updatedUserRecommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
           .where({
             id: userRecommendedTraining.id,
           })

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { CertificationCompletedJob } from '../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
 import * as badgeAcquisitionRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import {
@@ -638,7 +639,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         });
 
         // then
-        const recommendedTraining = await knex('user-recommended-trainings')
+        const recommendedTraining = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
           .where({
             userId: user.id,
             trainingId: training.id,

--- a/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
+++ b/api/tests/integration/scripts/prod/delete-and-anonymise-organization-learners_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DeleteAndAnonymiseOrgnizationLearnerScript } from '../../../../scripts/prod/delete-and-anonymise-organization-learners.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
@@ -218,10 +219,11 @@ describe('DeleteAndAnonymiseOrgnizationLearnerScript', function () {
         });
 
         // then
-        const anonymizedRecommendedTrainingResults =
-          await knex('user-recommended-trainings').whereNull('campaignParticipationId');
+        const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
+          'campaignParticipationId',
+        );
 
-        const otherRecommendedTrainingResults = await knex('user-recommended-trainings').where({
+        const otherRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).where({
           campaignParticipationId: otherParticipation.id,
         });
 

--- a/api/tests/integration/scripts/prod/delete-organization-learners-from-organization_test.js
+++ b/api/tests/integration/scripts/prod/delete-organization-learners-from-organization_test.js
@@ -1,3 +1,4 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { DeleteOrganizationLearnersFromOrganizationScript } from '../../../../scripts/prod/delete-organization-learners-from-organization.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
@@ -265,8 +266,9 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
         .first();
       const participationResult = await knex('campaign-participations').where({ id: campaignParticipation.id }).first();
       const assessmentResult = await knex('assessments').where({ id: assessmentId }).first();
-      const anonymizedRecommendedTrainingResults =
-        await knex('user-recommended-trainings').whereNull('campaignParticipationId');
+      const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
+        'campaignParticipationId',
+      );
 
       expect(organizationLearnerResult.userId).to.equal(null);
       expect(participationResult.userId).to.equal(null);
@@ -307,8 +309,9 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
       const organizationLearnerResult = await knex('organization-learners').where({ organizationId }).first();
       const participationResult = await knex('campaign-participations').where({ organizationLearnerId }).first();
       const assessmentResult = await knex('assessments').where({ id: assessmentId }).first();
-      const anonymizedRecommendedTrainingResults =
-        await knex('user-recommended-trainings').whereNull('campaignParticipationId');
+      const anonymizedRecommendedTrainingResults = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME).whereNull(
+        'campaignParticipationId',
+      );
       expect(organizationLearnerResult.firstName).to.not.equal('');
       expect(organizationLearnerResult.lastName).to.not.equal('');
       expect(participationResult.participantExternalId).to.be.not.null;

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -434,6 +434,8 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
           userId: adminUserId,
           campaignId,
           campaignParticipationId,
+          userRole: 'ORGA_ADMIN',
+          client: 'PIX_ORGA',
         });
 
         //then
@@ -455,6 +457,8 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
           userId: adminUserId,
           campaignId,
           campaignParticipationId,
+          userRole: 'ORGA_ADMIN',
+          client: 'PIX_ORGA',
         });
 
         //then

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/delete-campaign-participation_test.js
@@ -1,3 +1,4 @@
+import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../../db/migrations/20221017085933_create-user-recommended-trainings.js';
 import { EventLoggingJob } from '../../../../../../src/identity-access-management/domain/models/jobs/EventLoggingJob.js';
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
 import { CampaignParticipationLoggerContext } from '../../../../../../src/prescription/shared/domain/constants.js';
@@ -5,8 +6,16 @@ import { Assessment } from '../../../../../../src/shared/domain/models/Assessmen
 import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
-const { buildAssessment, buildTargetProfile, buildBadge, buildCampaignParticipation, buildBadgeAcquisition } =
-  databaseBuilder.factory;
+const {
+  buildAssessment,
+  buildTargetProfile,
+  buildBadge,
+  buildUser,
+  buildCampaignParticipation,
+  buildUserRecommendedTraining,
+  buildCampaign,
+  buildBadgeAcquisition,
+} = databaseBuilder.factory;
 
 describe('Integration | UseCases | delete-campaign-participation', function () {
   let clock, now;
@@ -399,6 +408,61 @@ describe('Integration | UseCases | delete-campaign-participation', function () {
         });
         const otherAssessmentsInDb = await knex('assessments').where('id', otherAssessment.id).first();
         expect(otherAssessmentsInDb.campaignParticipationId).equal(otherAssessment.campaignParticipationId);
+      });
+    });
+  });
+
+  context('when there are user-recommended-trainings linked to campaign participations', function () {
+    let adminUserId, campaignParticipationId, userId, userRecommendedTrainingId, campaignId;
+    beforeEach(async function () {
+      //given
+      adminUserId = buildUser().id;
+      userId = buildUser().id;
+      campaignId = buildCampaign().id;
+      campaignParticipationId = buildCampaignParticipation({ userId, campaignId }).id;
+      userRecommendedTrainingId = buildUserRecommendedTraining({ userId, campaignParticipationId }).id;
+
+      await databaseBuilder.commit();
+    });
+    context('when feature toggle `isAnonymizationWithDeletionEnabled` is true', function () {
+      it('should delete campaignParticipationId', async function () {
+        //given
+        await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
+
+        //when
+        await usecases.deleteCampaignParticipation({
+          userId: adminUserId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        //then
+        const userRecommendedTrainingAnonymized = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+          .where('id', userRecommendedTrainingId)
+          .first();
+
+        expect(userRecommendedTrainingAnonymized.campaignParticipationId).to.be.null;
+      });
+    });
+
+    context('when feature toggle `isAnonymizationWithDeletionEnabled` is false', function () {
+      it('should not delete campaignParticipationId', async function () {
+        //given
+        await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
+
+        //when
+        await usecases.deleteCampaignParticipation({
+          userId: adminUserId,
+          campaignId,
+          campaignParticipationId,
+        });
+
+        //then
+        const userRecommendedTrainingAnonymized = await knex(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+          .where('id', userRecommendedTrainingId)
+          .first();
+
+        expect(userRecommendedTrainingAnonymized.campaignParticipationId).to.equal(campaignParticipationId);
       });
     });
   });

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -5,6 +5,8 @@ import * as campaignParticipationRepository from '../../../../../../src/prescrip
 import { CampaignParticipationLoggerContext } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
+const { buildCampaign, buildCampaignParticipation, buildMembership, buildOrganization, buildUser } =
+  databaseBuilder.factory;
 
 describe('Integration | UseCases | delete-campaign', function () {
   describe('success case', function () {
@@ -22,11 +24,11 @@ describe('Integration | UseCases | delete-campaign', function () {
 
     it('should not throw', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
-      const campaignId = databaseBuilder.factory.buildCampaign({ ownerId: userId, organizationId }).id;
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+      const userId = buildUser().id;
+      const organizationId = buildOrganization().id;
+      buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
+      const campaignId = buildCampaign({ ownerId: userId, organizationId }).id;
+      buildCampaignParticipation({ campaignId });
 
       await databaseBuilder.commit();
       let error;
@@ -42,16 +44,16 @@ describe('Integration | UseCases | delete-campaign', function () {
 
     it('should delete campaign for given id and participation associated', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
-      const campaignId = databaseBuilder.factory.buildCampaign({
+      const userId = buildUser().id;
+      const organizationId = buildOrganization().id;
+      buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
+      const campaignId = buildCampaign({
         ownerId: userId,
         organizationId,
         name: 'nom de campagne',
         title: 'titre de campagne',
       }).id;
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      const campaignParticipationId = buildCampaignParticipation({
         campaignId,
         participantExternalId: 'externalId',
       });
@@ -80,16 +82,16 @@ describe('Integration | UseCases | delete-campaign', function () {
 
     it('should also anonymize when flag is true', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
-      const campaignId = databaseBuilder.factory.buildCampaign({
+      const userId = buildUser().id;
+      const organizationId = buildOrganization().id;
+      buildMembership({ userId, organizationId, organizationRole: 'MEMBER' });
+      const campaignId = buildCampaign({
         ownerId: userId,
         organizationId,
         name: 'nom de campagne',
         title: 'titre de campagne',
       }).id;
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      const campaignParticipationId = buildCampaignParticipation({
         campaignId,
         participantExternalId: 'externalId',
       }).id;

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -16,6 +16,9 @@ const {
   buildCampaign,
   buildCampaignParticipation,
   buildUser,
+  buildBadge,
+  buildAssessment,
+  buildBadgeAcquisition,
   buildOrganizationLearner,
   buildUserRecommendedTraining,
 } = databaseBuilder.factory;
@@ -30,20 +33,20 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
   let now, clock;
 
   beforeEach(async function () {
-    adminUserId = databaseBuilder.factory.buildUser().id;
-    organizationId = databaseBuilder.factory.buildOrganization().id;
-    campaign = databaseBuilder.factory.buildCampaign({ organizationId, type: CampaignTypes.ASSESSMENT });
-    organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+    adminUserId = buildUser().id;
+    organizationId = buildOrganization().id;
+    campaign = buildCampaign({ organizationId, type: CampaignTypes.ASSESSMENT });
+    organizationLearner1 = buildOrganizationLearner({
       organizationId,
       firstName: 'POUET',
       birthdate: '2020-05-12',
     });
-    organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+    organizationLearner2 = buildOrganizationLearner({
       organizationId,
       firstName: 'TEUOP',
       birthdate: '2020-12-12',
     });
-    campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
+    campaignParticipation1 = buildCampaignParticipation({
       organizationLearnerId: organizationLearner1.id,
       participantExternalId,
       userId: organizationLearner1.userId,
@@ -66,14 +69,14 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
 
     it('should delete given organizationLearners with their related participations', async function () {
       // given
-      databaseBuilder.factory.buildCampaignParticipation({
+      buildCampaignParticipation({
         organizationLearnerId: organizationLearner1.id,
         participantExternalId,
         isImproved: true,
         userId: organizationLearner1.userId,
       });
 
-      databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      buildOrganizationLearner({ organizationId });
       await databaseBuilder.commit();
 
       // when
@@ -127,21 +130,21 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
 
       beforeEach(async function () {
         // given
-        nonCertifiableBadge = databaseBuilder.factory.buildBadge({
+        nonCertifiableBadge = buildBadge({
           targetProfileId: campaign.targetProfileId,
           isCertifiable: false,
         });
-        certifiableBadge = databaseBuilder.factory.buildBadge({
+        certifiableBadge = buildBadge({
           targetProfileId: campaign.targetProfileId,
           isCertifiable: true,
         });
 
-        databaseBuilder.factory.buildBadgeAcquisition({
+        buildBadgeAcquisition({
           badgeId: certifiableBadge.id,
           campaignParticipationId: campaignParticipation1.id,
           userId: campaignParticipation1.userId,
         });
-        databaseBuilder.factory.buildBadgeAcquisition({
+        buildBadgeAcquisition({
           badgeId: nonCertifiableBadge.id,
           campaignParticipationId: campaignParticipation1.id,
           userId: campaignParticipation1.userId,
@@ -200,15 +203,15 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
 
     it('should delete and anonymize learner and all theirs campaignParticipations', async function () {
       // given
-      databaseBuilder.factory.buildCampaignParticipation({
+      buildCampaignParticipation({
         organizationLearnerId: organizationLearner1.id,
         participantExternalId,
         isImproved: true,
         userId: organizationLearner1.userId,
       });
 
-      const otherLearner = databaseBuilder.factory.buildOrganizationLearner();
-      const otherParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      const otherLearner = buildOrganizationLearner();
+      const otherParticipation = buildCampaignParticipation({
         organizationLearnerId: otherLearner.id,
         participantExternalId,
         userId: otherLearner.userId,
@@ -279,26 +282,26 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
 
     it('should detach assessments for deleted campaignParticipations', async function () {
       // given
-      const otherLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
-      const otherParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      const otherLearner = buildOrganizationLearner({ organizationId });
+      const otherParticipation = buildCampaignParticipation({
         organizationLearnerId: otherLearner.id,
         participantExternalId,
         userId: otherLearner.userId,
       });
-      const assessment1 = databaseBuilder.factory.buildAssessment({
+      const assessment1 = buildAssessment({
         id: 1,
         campaignParticipationId: campaignParticipation1.id,
         isImproved: false,
         type: Assessment.types.CAMPAIGN,
       });
-      const assessment2 = databaseBuilder.factory.buildAssessment({
+      const assessment2 = buildAssessment({
         id: 2,
         campaignParticipationId: campaignParticipation1.id,
         isImproved: true,
         type: Assessment.types.CAMPAIGN,
       });
 
-      databaseBuilder.factory.buildAssessment({
+      buildAssessment({
         id: 4,
         campaignParticipationId: otherParticipation.id,
       });
@@ -363,21 +366,21 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
 
       beforeEach(async function () {
         // given
-        nonCertifiableBadge = databaseBuilder.factory.buildBadge({
+        nonCertifiableBadge = buildBadge({
           targetProfileId: campaign.targetProfileId,
           isCertifiable: false,
         });
-        certifiableBadge = databaseBuilder.factory.buildBadge({
+        certifiableBadge = buildBadge({
           targetProfileId: campaign.targetProfileId,
           isCertifiable: true,
         });
 
-        databaseBuilder.factory.buildBadgeAcquisition({
+        buildBadgeAcquisition({
           badgeId: certifiableBadge.id,
           campaignParticipationId: campaignParticipation1.id,
           userId: campaignParticipation1.userId,
         });
-        databaseBuilder.factory.buildBadgeAcquisition({
+        buildBadgeAcquisition({
           badgeId: nonCertifiableBadge.id,
           campaignParticipationId: campaignParticipation1.id,
           userId: campaignParticipation1.userId,


### PR DESCRIPTION
## 🔆 Problème
Lorsqu’on supprime des campaign-participation et que le flag d’anonymisation isAnonymizationWithDeletionEnabled est actif on souhaite couper le lien avec les user-recommended-trainings 

## ⛱️ Proposition
Il faut vider le champ campaignParticiaptionId  de la table user-recommended-trainings pour les participations à supprimer

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Suppression d'une campagne
Suppression d'une participation
Suppression d'un learner

instructions a venir