### PR TITLE
[TECH] Rendre la date de finalisation de session dépendante de la BDD (PIX-17939).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/finalize-session.js
+++ b/api/src/certification/session-management/domain/usecases/finalize-session.js
@@ -73,7 +73,6 @@ const finalizeSession = async function ({
   const finalizedSession = await sessionRepository.finalize({
     id: sessionId,
     examinerGlobalComment,
-    finalizedAt: new Date(),
     hasIncident,
     hasJoiningIssue,
   });

--- a/api/src/certification/session-management/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-repository.js
@@ -44,12 +44,19 @@ const doesUserHaveCertificationCenterMembershipForSession = async function ({ us
   return Boolean(sessions.length);
 };
 
-const finalize = async function ({ id, examinerGlobalComment, hasIncident, hasJoiningIssue, finalizedAt }) {
+const finalize = async function ({ id, examinerGlobalComment, hasIncident, hasJoiningIssue }) {
   const knexConn = DomainTransaction.getConnection();
+
   const [finalizedSession] = await knexConn('sessions')
     .where({ id })
-    .update({ examinerGlobalComment, hasIncident, hasJoiningIssue, finalizedAt })
+    .update({
+      examinerGlobalComment,
+      hasIncident,
+      hasJoiningIssue,
+      finalizedAt: knexConn.fn.now(),
+    })
     .returning('*');
+
   return new SessionManagement(finalizedSession);
 };
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
@@ -195,35 +195,33 @@ describe('Integration | Repository | Certification | session | SessionManagement
   });
 
   describe('#finalize', function () {
-    let id;
+    let sessionToFinalize;
     const examinerGlobalComment = '';
     const hasIncident = false;
     const hasJoiningIssue = true;
-    const finalizedAt = new Date('2017-09-01T12:14:33Z');
 
     beforeEach(function () {
-      id = databaseBuilder.factory.buildSession({ finalizedAt: null }).id;
-
+      sessionToFinalize = databaseBuilder.factory.buildSession({ finalizedAt: null });
       return databaseBuilder.commit();
     });
 
     it('should return an updated SessionManagement domain object', async function () {
       // when
       const sessionSaved = await sessionRepository.finalize({
-        id,
+        id: sessionToFinalize.id,
         examinerGlobalComment,
         hasIncident,
         hasJoiningIssue,
-        finalizedAt,
       });
 
       // then
       expect(sessionSaved).to.be.an.instanceof(SessionManagement);
-      expect(sessionSaved.id).to.deep.equal(id);
+      expect(sessionSaved.id).to.deep.equal(sessionToFinalize.id);
       expect(sessionSaved.examinerGlobalComment).to.deep.equal(examinerGlobalComment);
       expect(sessionSaved.hasIncident).to.deep.equal(hasIncident);
       expect(sessionSaved.hasJoiningIssue).to.deep.equal(hasJoiningIssue);
       expect(sessionSaved.status).to.deep.equal(SESSION_STATUSES.FINALIZED);
+      expect(sessionSaved.finalizedAt).to.be.an.instanceof(Date);
     });
   });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
@@ -144,7 +144,6 @@ describe('Unit | UseCase | finalize-session', function () {
 
     context('When the certificationReports are valid', function () {
       let now;
-      let clock;
 
       beforeEach(function () {
         const validReportForFinalization = domainBuilder.buildCertificationReport({
@@ -162,14 +161,8 @@ describe('Unit | UseCase | finalize-session', function () {
           .resolves(updatedSession);
       });
 
-      afterEach(function () {
-        clock.restore();
-      });
-
       it('should finalize session with expected arguments', async function () {
         // given
-        clock = sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
-        now = new Date(clock.now);
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
           isCompleted: true,
@@ -183,7 +176,6 @@ describe('Unit | UseCase | finalize-session', function () {
             examinerGlobalComment,
             hasIncident,
             hasJoiningIssue,
-            finalizedAt: now,
           })
           .resolves(updatedSession);
 
@@ -206,7 +198,6 @@ describe('Unit | UseCase | finalize-session', function () {
             examinerGlobalComment,
             hasIncident,
             hasJoiningIssue,
-            finalizedAt: now,
           }),
         ).to.be.true;
       });
@@ -220,7 +211,6 @@ describe('Unit | UseCase | finalize-session', function () {
           date: '2019-12-12',
           time: '16:00:00',
         });
-        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
           isCompleted: true,
@@ -234,7 +224,6 @@ describe('Unit | UseCase | finalize-session', function () {
             examinerGlobalComment,
             hasIncident,
             hasJoiningIssue,
-            finalizedAt: now,
           })
           .resolves(updatedSession);
 


### PR DESCRIPTION
## 🔆 Problème

Quand on enregistre la date de finalisation, on fait un new Date(). Ca peut sembler OK, sauf que en vrai on fait confiance au fait que le serveur (un container en plus) a une date bien synchronisee.
Ce n'est pas toujours le cas, la preuve en local, ou souvent il considère qu’il est a minuit.

## ⛱️ Proposition

On a déjà rencontre cela, il faut remplacer le `new Date()` par un `knex.fn.now`, c’est a dire que la date sera enregistrée automatiquement a l’insertion en BDD.

## 🏄 Pour tester

Vérifier le test modifé
