### PR TITLE
[FEATURE] Revoir le comportement de la barre de progression du module (PIX-18090)

### DIFF
--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -19,13 +19,6 @@ export default class ModulePassage extends Component {
   displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
 
-  displayableGrainsInNavbar = this.displayableGrains.filter((grain) => grain.type !== 'transition');
-  @tracked grainsToDisplayInNavbar = this.grainsToDisplay.filter((grain) => grain.type !== 'transition');
-
-  get navbarCurrentPassageStep() {
-    return this.grainsToDisplayInNavbar.length;
-  }
-
   @action
   hasGrainJustAppeared(index) {
     if (this.grainsToDisplay.length === 1) {
@@ -94,10 +87,6 @@ export default class ModulePassage extends Component {
 
     const nextGrain = this.displayableGrains[this.currentGrainIndex + 1];
     this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
-
-    if (nextGrain.type !== 'transition') {
-      this.grainsToDisplayInNavbar = [...this.grainsToDisplayInNavbar, nextGrain];
-    }
   }
 
   @action
@@ -236,8 +225,8 @@ export default class ModulePassage extends Component {
       <BetaBanner />
     {{/if}}
     <ModuleNavbar
-      @currentStep={{this.navbarCurrentPassageStep}}
-      @totalSteps={{this.displayableGrainsInNavbar.length}}
+      @currentStep={{this.currentPassageStep}}
+      @totalSteps={{this.displayableGrains.length}}
       @module={{@module}}
     />
 

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -78,39 +78,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 1' })).exists();
     });
-
-    module('when grain is transition', function () {
-      test('should display navigation with step 0/0', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = { content: 'content', type: 'text' };
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-        };
-        const components = [
-          {
-            type: 'element',
-            element: textElement,
-          },
-          {
-            type: 'element',
-            element: qcuElement,
-          },
-        ];
-        const grain = store.createRecord('grain', { id: 'grainId1', type: 'transition', components });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
-        const passage = store.createRecord('passage');
-
-        // when
-        const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-
-        // then
-        assert.dom(screen.getByRole('navigation', { name: 'Étape 0 sur 0' })).exists();
-      });
-    });
   });
 
   module('when a grain contains non existing elements', function () {
@@ -268,68 +235,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 2' })).exists();
-    });
-
-    module('when one grain is transition', function () {
-      module('when transition is first grain', function () {
-        test('should start at 0 and not count transition in navbar', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const textElement = { content: 'content', type: 'text' };
-          const qcuElement = {
-            instruction: 'instruction',
-            proposals: ['radio1', 'radio2'],
-            type: 'qcu',
-          };
-          const grain1 = store.createRecord('grain', {
-            type: 'transition',
-            components: [{ type: 'element', element: textElement }],
-          });
-          const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-
-          const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-          const passage = store.createRecord('passage');
-
-          // when
-          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-
-          // then
-          assert.dom(screen.getByRole('navigation', { name: 'Étape 0 sur 1' })).exists();
-        });
-      });
-
-      module('when transition is last grain', function () {
-        test('should not count transition in navbar', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const textElement = { content: 'content', type: 'text' };
-          const qcuElement = {
-            instruction: 'instruction',
-            proposals: ['radio1', 'radio2'],
-            type: 'qcu',
-          };
-          const grain1 = store.createRecord('grain', {
-            components: [{ type: 'element', element: textElement }],
-          });
-          const grain2 = store.createRecord('grain', {
-            type: 'transition',
-            components: [{ type: 'element', element: qcuElement }],
-          });
-
-          const module = store.createRecord('module', {
-            slug: 'module-slug',
-            title: 'Module title',
-            grains: [grain1, grain2],
-          });
-          const passage = store.createRecord('passage');
-
-          // when
-          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-
-          // then
-          assert.dom(screen.getByRole('navigation', { name: 'Étape 1 sur 1' })).exists();
-        });
-      });
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème
Dû au fait qu’on n’incrémente pas quand on passe un grain transition, c'est un peu perturbant selon le contenu des modules.

## ⛱️ Proposition
Compter tous les grains de la même manière.

## 🌊 Remarques
RAS

## 🏄 Pour tester
Sur un ou plusieurs module(s), vérifier que le comportement est plus naturel.

Exemple : 
- [actuel](https://app.integration.pix.fr/modules/ports-connexions-essentiels/passage) vs. [avec cette proposition](https://app-pr12441.review.pix.fr/modules/ports-connexions-essentiels/passage)
