### PR TITLE
[TECH] :truck: Renomme le script de génération de certificats par id de session (pix-18092)

### DIFF
--- a/api/src/certification/results/scripts/generate-certificates-by-session-ids.js
+++ b/api/src/certification/results/scripts/generate-certificates-by-session-ids.js
@@ -66,7 +66,7 @@ async function main() {
     );
 
     if (isEmpty(certificates)) {
-      logger.error(`Pas de certificat trouvée pour la session ${sessionId}.`);
+      logger.error(`Pas de certificat trouvé pour la session ${sessionId}.`);
       continue;
     }
 

--- a/api/src/certification/results/scripts/generate-certificates-by-session-ids.js
+++ b/api/src/certification/results/scripts/generate-certificates-by-session-ids.js
@@ -29,14 +29,14 @@ i18n.configure({
 
 /**
  * Avant de lancer le script, remplacer la variable DATABASE_URL par l'url de la base de réplication
- * Usage: LOG_LEVEL=info NODE_TLS_REJECT_UNAUTHORIZED='0' PGSSLMODE=require node scripts/certification/generate-certification-attestations-by-session-ids.js 86781
+ * Usage: LOG_LEVEL=info NODE_TLS_REJECT_UNAUTHORIZED='0' PGSSLMODE=require node scripts/certification/generate-certificates-by-session-ids.js 86781
  */
 async function main() {
-  logger.info("Début du script de génération d'attestations pour une session.");
+  logger.info('Début du script de génération de certificats pour une session.');
 
   if (process.argv.length <= 2) {
     logger.info(
-      'Usage: NODE_TLS_REJECT_UNAUTHORIZED="0" PGSSLMODE=require node scripts/generate-certification-attestations-by-session-id.js 1234,5678,9012',
+      'Usage: NODE_TLS_REJECT_UNAUTHORIZED="0" PGSSLMODE=require node scripts/generate-certificates-by-session-id.js 1234,5678,9012',
     );
     return;
   }
@@ -51,7 +51,7 @@ async function main() {
       continue;
     }
 
-    const certificationAttestations = compact(
+    const certificates = compact(
       await PromiseUtils.mapSeries(certificationCourses, async (certificationCourse) => {
         try {
           return await certificateRepository.getCertificate({
@@ -65,19 +65,19 @@ async function main() {
       }),
     );
 
-    if (isEmpty(certificationAttestations)) {
-      logger.error(`Pas d'attestation trouvée pour la session ${sessionId}.`);
+    if (isEmpty(certificates)) {
+      logger.error(`Pas de certificat trouvée pour la session ${sessionId}.`);
       continue;
     }
 
-    logger.info(`${certificationAttestations.length} attestations récupérées pour la session ${sessionId}.`);
+    logger.info(`${certificates.length} certificats récupérées pour la session ${sessionId}.`);
 
     const { buffer } = await getCertificatesPdfBuffer({
-      certificates: certificationAttestations,
+      certificates: certificates,
       i18n,
     });
 
-    const filename = `attestation-pix-session-${sessionId}.pdf`;
+    const filename = `certificats-pix-session-${sessionId}.pdf`;
     logger.info(`Génération du fichier pdf ${filename}.`);
 
     await fs.promises.writeFile(filename, buffer);


### PR DESCRIPTION
## 🔆 Problème

Le script de génération de certificats par id de session contient encore le mot `attestion` dans des noms de variable et dans le nom du fichier source...

## ⛱️ Proposition

Renommer le script de génération de certificats par id de session

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
