### PR TITLE
[TECH] Eviter d'appeler le endpoint GET /api/answers?assessmentId="assessmentId" pour gérer des affichages concernant le numéro d'épreuve courant côté PixApp

### DIFF
--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -14,7 +14,7 @@ const save = async function (
   const answer = dependencies.answerSerializer.deserialize(request.payload);
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
   const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
-  const assessment = await dependencies.assessmentRepository.get(answer.assessmentId);
+  const assessment = await dependencies.assessmentRepository.getWithAnswers(answer.assessmentId);
   let correctedAnswer;
   if (assessment.isCompetenceEvaluation()) {
     correctedAnswer = await evaluationUsecases.saveAndCorrectAnswerForCompetenceEvaluation({

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -1,6 +1,6 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/index.js';
 import { EmptyAnswerError } from '../errors.js';
@@ -24,6 +24,9 @@ const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
 } = {}) {
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
     throw new ChallengeNotAskedError();

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -2,6 +2,7 @@ import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedBySupervisorError,
+  ChallengeAlreadyAnsweredError,
   ForbiddenAccess,
 } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
@@ -26,6 +27,9 @@ const saveAndCorrectAnswerForCertification = withTransaction(async function ({
   }
   if (assessment.hasBeenEndedDueToFinalization()) {
     throw new CertificationEndedByFinalizationError();
+  }
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {
     throw new ChallengeNotAskedError();

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js
@@ -1,6 +1,6 @@
 import { AnswerJob } from '../../../quest/domain/models/AnwserJob.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ForbiddenAccess } from '../../../shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { KnowledgeElement } from '../../../shared/domain/models/index.js';
 import { EmptyAnswerError } from '../errors.js';
@@ -24,6 +24,9 @@ const saveAndCorrectAnswerForCompetenceEvaluation = withTransaction(async functi
 } = {}) {
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
+  }
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
     throw new ChallengeNotAskedError();

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-demo-and-preview.js
@@ -1,5 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
-import { ChallengeNotAskedError } from '../../../shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../shared/domain/errors.js';
 import { EmptyAnswerError } from '../errors.js';
 
 const saveAndCorrectAnswerForDemoAndPreview = withTransaction(async function ({
@@ -10,6 +10,9 @@ const saveAndCorrectAnswerForDemoAndPreview = withTransaction(async function ({
   challengeRepository,
   correctionService,
 } = {}) {
+  if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
+    throw new ChallengeAlreadyAnsweredError();
+  }
   if (assessment.lastChallengeId && assessment.lastChallengeId !== answer.challengeId) {
     throw new ChallengeNotAskedError();
   }

--- a/api/src/shared/infrastructure/repositories/answer-repository.js
+++ b/api/src/shared/infrastructure/repositories/answer-repository.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
-import { ChallengeAlreadyAnsweredError, NotFoundError } from '../../domain/errors.js';
+import { NotFoundError } from '../../domain/errors.js';
 import * as answerStatusDatabaseAdapter from '../adapters/answer-status-database-adapter.js';
 
 function _adaptAnswerToDb(answer) {
@@ -96,12 +96,6 @@ const findChallengeIdsFromAnswerIds = async function (ids) {
 const save = async function ({ answer }) {
   const knexConn = DomainTransaction.getConnection();
   const answerForDB = _adaptAnswerToDb(answer);
-  const alreadySavedAnswer = await knexConn('answers')
-    .select('id')
-    .where({ challengeId: answer.challengeId, assessmentId: answer.assessmentId });
-  if (alreadySavedAnswer.length !== 0) {
-    throw new ChallengeAlreadyAnsweredError();
-  }
   const [savedAnswerDTO] = await knexConn('answers').insert(answerForDB).returning(COLUMNS);
   return _toDomain(savedAnswerDTO);
 };

--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -34,6 +34,8 @@ const serialize = function (assessments) {
         assessment.course = { id: currentAssessment.courseId };
       }
 
+      // ordered in the repository call
+      assessment.orderedChallengeIdsAnswered = assessment.answers?.map((answer) => answer.challengeId) ?? [];
       return assessment;
     },
     attributes: [
@@ -55,6 +57,7 @@ const serialize = function (assessments) {
       'hasCheckpoints',
       'showLevelup',
       'showQuestionCounter',
+      'orderedChallengeIdsAnswered',
     ],
     answers: {
       ref: 'id',

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -106,7 +106,7 @@ describe('Unit | Controller | answer-controller', function () {
         challengeId,
         focusedOut,
       });
-      assessmentRepository = { get: sinon.stub() };
+      assessmentRepository = { getWithAnswers: sinon.stub() };
       deserializedAnswer.id = undefined;
       deserializedAnswer.timeSpent = undefined;
       answerSerializerStub.serialize.returns(serializedAnswer);
@@ -126,7 +126,7 @@ describe('Unit | Controller | answer-controller', function () {
       it('should call appropriate usecase when assessment is of type COMPETENCE_EVALUATION', async function () {
         // given
         const assessment = domainBuilder.buildAssessment({ type: Assessment.types.COMPETENCE_EVALUATION });
-        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when
         response = await answerController.save(request, hFake, {
@@ -150,7 +150,7 @@ describe('Unit | Controller | answer-controller', function () {
       it('should call appropriate usecase when assessment is of type CAMPAIGN', async function () {
         // given
         const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CAMPAIGN });
-        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when
         response = await answerController.save(request, hFake, {
@@ -174,7 +174,7 @@ describe('Unit | Controller | answer-controller', function () {
       it('should call appropriate usecase when assessment is of type CERTIFICATION', async function () {
         // given
         const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CERTIFICATION });
-        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when
         response = await answerController.save(request, hFake, {
@@ -198,7 +198,7 @@ describe('Unit | Controller | answer-controller', function () {
       it('should call appropriate usecase when assessment is of type DEMO', async function () {
         // given
         const assessment = domainBuilder.buildAssessment({ type: Assessment.types.DEMO });
-        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when
         response = await answerController.save(request, hFake, {
@@ -222,7 +222,7 @@ describe('Unit | Controller | answer-controller', function () {
       it('should call appropriate usecase when assessment is of type PREVIEW', async function () {
         // given
         const assessment = domainBuilder.buildAssessment({ type: Assessment.types.PREVIEW });
-        assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when
         response = await answerController.save(request, hFake, {
@@ -246,7 +246,7 @@ describe('Unit | Controller | answer-controller', function () {
 
     context('quests', function () {
       beforeEach(function () {
-        assessmentRepository.get.resolves(
+        assessmentRepository.getWithAnswers.resolves(
           domainBuilder.buildAssessment({ type: Assessment.types.COMPETENCE_EVALUATION }),
         );
         sinon.stub(config, 'featureToggles');

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
@@ -6,6 +6,7 @@ import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransa
 import {
   CertificationEndedByFinalizationError,
   CertificationEndedBySupervisorError,
+  ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
 } from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
@@ -52,6 +53,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       userId,
       lastQuestionDate: nowDate,
       type: Assessment.types.CERTIFICATION,
+      answers: [],
     });
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue, challengeId });
     answer.id = undefined;
@@ -75,6 +77,25 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
   afterEach(async function () {
     clock.restore();
+  });
+
+  context('when an answer for that challenge has already been provided', function () {
+    it('should fail because ChallengeAlreadyAnsweredError', async function () {
+      // given
+      assessment.answers = [domainBuilder.buildAnswer({ challengeId: answer.challengeId })];
+
+      // when
+      const error = await catchErr(saveAndCorrectAnswerForCertification)({
+        answer,
+        userId,
+        assessment,
+        locale,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(ChallengeAlreadyAnsweredError);
+    });
   });
 
   context('when an answer for that challenge is not for an asked challenge', function () {
@@ -124,6 +145,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: nowDate,
         state: Assessment.states.ENDED_DUE_TO_FINALIZATION,
+        answers: [],
       });
 
       // when
@@ -193,6 +215,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           userId,
           type: Assessment.types.CERTIFICATION,
           lastQuestionDate: nowDate,
+          answers: [],
         });
 
         challengeRepository.get.resolves(challenge);
@@ -253,7 +276,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
     beforeEach(function () {
       answer = domainBuilder.buildAnswer();
-      assessment = domainBuilder.buildAssessment({ userId: userId + 1 });
+      assessment = domainBuilder.buildAssessment({ userId: userId + 1, answers: [] });
     });
 
     it('should throw an error if no userId is passed', function () {
@@ -281,6 +304,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CERTIFICATION,
+        answers: [],
       });
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;
@@ -320,6 +344,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CERTIFICATION,
+        answers: [],
       });
       answerSaved = domainBuilder.buildAnswer(focusedOutAnswer);
       answerRepository.save.resolves(answerSaved);
@@ -367,6 +392,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           userId,
           lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
           type: Assessment.types.CERTIFICATION,
+          answers: [],
         });
         certificationEvaluationCandidateRepository.findByAssessmentId
           .withArgs({ assessmentId: assessment.id })
@@ -437,6 +463,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           userId,
           lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
           type: Assessment.types.CERTIFICATION,
+          answers: [],
         });
         certificationEvaluationCandidateRepository.findByAssessmentId
           .withArgs({ assessmentId: assessment.id })
@@ -499,6 +526,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           userId,
           lastQuestionDate: nowDate,
           state: Assessment.states.STARTED,
+          answers: [],
         });
         const answer = domainBuilder.buildAnswer({ challengeId: challenge.id });
         const certificationChallengeLiveAlert = domainBuilder.buildCertificationChallengeLiveAlert({
@@ -534,6 +562,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
           userId,
           lastQuestionDate: nowDate,
           state: Assessment.states.STARTED,
+          answers: [],
         });
         const answer = domainBuilder.buildAnswer({ challengeId: challenge.id });
         const certificationChallengeLiveAlert = domainBuilder.buildCertificationChallengeLiveAlert({
@@ -575,6 +604,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.COMPETENCE_EVALUATION,
+        answers: [],
       });
 
       // when
@@ -605,6 +635,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.CERTIFICATION,
+        answers: [],
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
       answerRepository.save.resolves(answerSaved);

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-competence-evaluation_test.js
@@ -3,7 +3,7 @@ import * as correctionService from '../../../../../src/evaluation/domain/service
 import { saveAndCorrectAnswerForCompetenceEvaluation } from '../../../../../src/evaluation/domain/usecases/save-and-correct-answer-for-competence-evaluation.js';
 import { AnswerJob } from '../../../../../src/quest/domain/models/AnwserJob.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { ChallengeNotAskedError } from '../../../../../src/shared/domain/errors.js';
+import { ChallengeAlreadyAnsweredError, ChallengeNotAskedError } from '../../../../../src/shared/domain/errors.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus, Assessment, KnowledgeElement } from '../../../../../src/shared/domain/models/index.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -61,6 +61,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       userId,
       lastQuestionDate: nowDate,
       type: Assessment.types.COMPETENCE_EVALUATION,
+      answers: [],
     });
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue, challengeId });
     answer.id = undefined;
@@ -96,7 +97,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
     beforeEach(function () {
       answer = domainBuilder.buildAnswer();
-      assessment = domainBuilder.buildAssessment({ userId: userId + 1 });
+      assessment = domainBuilder.buildAssessment({ userId: userId + 1, answers: [] });
     });
 
     it('should throw an error if no userId is passed', function () {
@@ -111,6 +112,25 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
 
       // then
       return expect(result).to.be.rejectedWith(ForbiddenAccess);
+    });
+  });
+
+  context('when an answer for that challenge has already been provided', function () {
+    it('should fail because ChallengeAlreadyAnsweredError', async function () {
+      // given
+      assessment.answers = [domainBuilder.buildAnswer({ challengeId: answer.challengeId })];
+
+      // when
+      const error = await catchErr(saveAndCorrectAnswerForCompetenceEvaluation)({
+        answer,
+        userId,
+        assessment,
+        locale,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(ChallengeAlreadyAnsweredError);
     });
   });
 
@@ -146,6 +166,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.COMPETENCE_EVALUATION,
+        answers: [],
       });
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([]);
 
@@ -181,6 +202,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
         type: Assessment.types.COMPETENCE_EVALUATION,
+        answers: [],
       });
       const answerSaved = domainBuilder.buildAnswer(emptyAnswer);
       answerRepository.save.resolves(answerSaved);
@@ -378,6 +400,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       assessment = domainBuilder.buildAssessment({
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
+        answers: [],
       });
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -173,6 +173,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'show-levelup': false,
           'show-progress-bar': false,
           'show-question-counter': true,
+          'ordered-challenge-ids-answered': [],
         },
         relationships: {
           course: {
@@ -235,8 +236,16 @@ describe('Acceptance | API | assessment-controller-get', function () {
         type: Assessment.types.PREVIEW,
       }).id;
 
-      answer1 = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: 'rec1' });
-      answer2 = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId: 'rec2' });
+      answer1 = databaseBuilder.factory.buildAnswer({
+        assessmentId,
+        challengeId: 'rec1',
+        createdAt: new Date('2020-01-01'),
+      });
+      answer2 = databaseBuilder.factory.buildAnswer({
+        assessmentId,
+        challengeId: 'rec2',
+        createdAt: new Date('2020-01-02'),
+      });
 
       await databaseBuilder.commit();
     });
@@ -300,6 +309,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'show-levelup': false,
           'show-progress-bar': false,
           'show-question-counter': true,
+          'ordered-challenge-ids-answered': ['rec1', 'rec2'],
         },
         relationships: {
           course: { data: { type: 'courses', id: courseId } },

--- a/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/answer-repository_test.js
@@ -1,7 +1,7 @@
-import { ChallengeAlreadyAnsweredError, NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import * as answerRepository from '../../../../../src/shared/infrastructure/repositories/answer-repository.js';
-import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | answerRepository', function () {
   describe('#get', function () {
@@ -420,33 +420,6 @@ describe('Integration | Repository | answerRepository', function () {
       // then
       const answerInDB = await answerRepository.get(savedAnswer.id);
       expect(savedAnswer).to.deepEqualInstance(answerInDB);
-    });
-
-    context('when there is already an answer for one challenge in one assessment', function () {
-      it('should not have saved anything', async function () {
-        // given
-        const assessmentId = 123;
-        const answerToSave = domainBuilder.buildAnswer({
-          id: null,
-          assessmentId,
-          challengeId: 'challengeId',
-        });
-        databaseBuilder.factory.buildAssessment({ id: assessmentId });
-        const alreadyCreatedAnswerId = databaseBuilder.factory.buildAnswer({
-          challengeId: 'challengeId',
-          assessmentId,
-        }).id;
-        await databaseBuilder.commit();
-
-        // when
-        const error = await catchErr(answerRepository.save)({ answer: answerToSave });
-
-        // then
-        expect(error).to.be.instanceOf(ChallengeAlreadyAnsweredError);
-        const answerInDB = await knex('answers');
-        expect(answerInDB).to.have.lengthOf(1);
-        expect(answerInDB[0].id).to.be.equal(alreadyCreatedAnswerId);
-      });
     });
   });
 });

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -8,7 +8,16 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
     it('should convert an Assessment model object (of type CERTIFICATION) into JSON API data', function () {
       //given
       const certificationCourseId = 1;
-      const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CERTIFICATION, certificationCourseId });
+      const answers = [
+        domainBuilder.buildAnswer({ id: 123, challengeId: 'challenge0' }),
+        domainBuilder.buildAnswer({ id: 456, challengeId: 'challenge1' }),
+        domainBuilder.buildAnswer({ id: 789, challengeId: 'challenge2' }),
+      ];
+      const assessment = domainBuilder.buildAssessment({
+        type: Assessment.types.CERTIFICATION,
+        certificationCourseId,
+        answers,
+      });
       assessment.hasCheckpoints = false;
       assessment.showProgressBar = false;
       assessment.showLevelup = false;
@@ -32,12 +41,21 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
             'has-checkpoints': false,
             'show-question-counter': true,
             'code-campaign': undefined,
+            'ordered-challenge-ids-answered': ['challenge0', 'challenge1', 'challenge2'],
           },
           relationships: {
             answers: {
               data: [
                 {
-                  id: assessment.answers[0].id.toString(),
+                  id: '123',
+                  type: 'answers',
+                },
+                {
+                  id: '456',
+                  type: 'answers',
+                },
+                {
+                  id: '789',
                   type: 'answers',
                 },
               ],

--- a/mon-pix/app/components/challenge/item.gjs
+++ b/mon-pix/app/components/challenge/item.gjs
@@ -98,14 +98,6 @@ export default class Item extends Component {
     return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.args.challenge.focused;
   }
 
-  async _findOrCreateAnswer(challenge, assessment) {
-    let answer = (await assessment.answers).find((answer) => answer.challenge.get('id') === challenge.id);
-    if (!answer) {
-      answer = this.store.createRecord('answer', { assessment, challenge });
-    }
-    return answer;
-  }
-
   _isAssessmentEndedBySupervisorOrByFinalization(error) {
     return (
       error?.errors?.[0]?.detail === 'Le surveillant a mis fin à votre test de certification.' ||
@@ -121,7 +113,7 @@ export default class Item extends Component {
 
     this.args.onChallengeSubmit();
 
-    const answer = await this._findOrCreateAnswer(challenge, assessment);
+    const answer = this.store.createRecord('answer', { assessment, challenge });
     answer.setProperties({
       value: answerValue.trim(),
       timeout: answerTimeout,
@@ -130,6 +122,7 @@ export default class Item extends Component {
 
     try {
       await answer.save();
+      assessment.orderedChallengeIdsAnswered.push(challenge.id);
 
       let queryParams = { queryParams: {} };
       const levelup = await answer.get('levelup');

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -26,6 +26,7 @@ export default class Assessment extends Model {
   @attr('boolean') showProgressBar;
   @attr('boolean') showLevelup;
   @attr('boolean') showQuestionCounter;
+  @attr orderedChallengeIdsAnswered;
 
   // references
   @attr('string') competenceId;
@@ -61,6 +62,6 @@ export default class Assessment extends Model {
   }
 
   get currentChallengeNumber() {
-    return this.hasMany('answers').value().length;
+    return this.orderedChallengeIdsAnswered.length;
   }
 }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -12,14 +12,13 @@ export default class ChallengeRoute extends Route {
   async model(params) {
     const assessment = await this.modelFor('assessments');
     await assessment.certificationCourse;
-    await assessment.answers;
 
     let challenge;
     const currentChallengeNumber = parseInt(params.challenge_number);
-    const isBackToPreviousChallenge = currentChallengeNumber < assessment.answers.length;
+    const isBackToPreviousChallenge = currentChallengeNumber < assessment.orderedChallengeIdsAnswered.length;
     if (isBackToPreviousChallenge) {
-      const answers = await assessment.answers;
-      challenge = await answers[currentChallengeNumber].challenge;
+      const challengeId = assessment.orderedChallengeIdsAnswered.at(currentChallengeNumber);
+      challenge = await this.store.findRecord('challenge', challengeId);
     } else {
       if (assessment.isPreview && params.challengeId) {
         challenge = await this.store.findRecord('challenge', params.challengeId);

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -38,8 +38,6 @@ export default class ResumeRoute extends Route {
       return this._routeToResults(assessment);
     }
 
-    await assessment.answers.reload();
-
     if (assessment.hasCheckpoints) {
       return this._resumeAssessmentWithCheckpoint(assessment);
     }
@@ -83,7 +81,7 @@ export default class ResumeRoute extends Route {
   _parseState(assessment) {
     const userHasSeenCheckpoint = this.hasSeenCheckpoint;
 
-    const quantityOfAnswersInAssessment = assessment.get('answers.length');
+    const quantityOfAnswersInAssessment = assessment.orderedChallengeIdsAnswered.length;
     const userHasReachedCheckpoint =
       quantityOfAnswersInAssessment > 0 &&
       quantityOfAnswersInAssessment % ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS === 0;

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -18,6 +18,6 @@ export default class ResumeRoute extends Route {
 
   async redirect(competenceEvaluation) {
     const assessment = await competenceEvaluation.assessment;
-    return this.router.replaceWith('assessments.resume', assessment.id);
+    this.router.replaceWith('assessments.resume', assessment.id);
   }
 }

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -32,7 +32,7 @@ export default class EvaluationStartOrResumeRoute extends Route {
   _shouldShowTutorial(assessment, isCampaignForAbsoluteNovice) {
     return (
       !this.userHasJustConsultedTutorial &&
-      assessment.answers?.length === 0 &&
+      assessment.orderedChallengeIdsAnswered.length === 0 &&
       !assessment.isCompleted &&
       !this.currentUser.user.hasSeenAssessmentInstructions &&
       !isCampaignForAbsoluteNovice

--- a/mon-pix/app/routes/courses/start.js
+++ b/mon-pix/app/routes/courses/start.js
@@ -15,6 +15,6 @@ export default class CreateAssessmentRoute extends Route {
 
   async redirect(course) {
     const assessment = await this.store.createRecord('assessment', { course, type: 'DEMO' }).save();
-    return this.router.replaceWith('assessments.resume', assessment.id);
+    this.router.replaceWith('assessments.resume', assessment.id);
   }
 }

--- a/mon-pix/mirage/factories/answer.js
+++ b/mon-pix/mirage/factories/answer.js
@@ -9,6 +9,7 @@ export default Factory.extend({
   }),
 
   afterCreate(answer, server) {
+    answer.assessment.orderedChallengeIdsAnswered.push(answer.challenge.id);
     if (!answer.correction) {
       answer.update({
         correction: server.create('correction'),

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -25,6 +25,10 @@ export default Factory.extend({
     return true;
   },
 
+  orderedChallengeIdsAnswered() {
+    return [];
+  },
+
   withStartedState: trait({
     state: 'started',
   }),

--- a/mon-pix/mirage/routes/assessments/post-assessments.js
+++ b/mon-pix/mirage/routes/assessments/post-assessments.js
@@ -16,6 +16,7 @@ export default function (schema, request) {
       showProgressBar: true,
       showLevelup: false,
       showQuestionCounter: true,
+      orderedChallengeIdsAnswered: [],
     });
   }
 

--- a/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/campaign-participations/post-campaign-participation.js
@@ -47,6 +47,7 @@ export default function (schema, request) {
     showProgressBar: campaign.type === 'ASSESSMENT',
     showLevelup: campaign.type === 'ASSESSMENT',
     showQuestionCounter: campaign.type === 'ASSESSMENT',
+    orderedChallengeIdsAnswered: [],
   };
 
   const assessment = schema.assessments.create(newAssessment);

--- a/mon-pix/mirage/routes/post-competence-evaluation.js
+++ b/mon-pix/mirage/routes/post-competence-evaluation.js
@@ -16,6 +16,7 @@ export default function (schema, request) {
     showProgressBar: true,
     showLevelup: true,
     showQuestionCounter: true,
+    orderedChallengeIdsAnswered: [],
   });
   return schema.competenceEvaluations.create({ assessment, competenceId });
 }

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -18,7 +18,7 @@ module('Unit | Model | Assessment', function (hooks) {
 
     test('should return an empty array when no answers has been given', function (assert) {
       // given
-      const assessment = store.createRecord('assessment', { answers: [] });
+      const assessment = store.createRecord('assessment', { answers: [], orderedChallengeIdsAnswered: [] });
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;
@@ -30,7 +30,7 @@ module('Unit | Model | Assessment', function (hooks) {
     test('should return the one answer when only one answer has been given', function (assert) {
       // given
       const answer = store.createRecord('answer');
-      const assessment = store.createRecord('assessment');
+      const assessment = store.createRecord('assessment', { orderedChallengeIdsAnswered: [answer.challengeId] });
       const answers = [answer];
       assessment.answers = answers;
 
@@ -45,7 +45,9 @@ module('Unit | Model | Assessment', function (hooks) {
       // given
       const answers = newAnswers(store, 7);
       const [answer6, answer7] = answers.slice(5);
-      const assessment = store.createRecord('assessment');
+      const assessment = store.createRecord('assessment', {
+        orderedChallengeIdsAnswered: answers.map((answer) => answer.challengeId),
+      });
       assessment.answers = answers;
 
       // when
@@ -59,7 +61,9 @@ module('Unit | Model | Assessment', function (hooks) {
       // given
       const answers = newAnswers(store, 10);
       const [answer6, answer7, answer8, answer9, answer10] = answers.slice(5);
-      const assessment = store.createRecord('assessment');
+      const assessment = store.createRecord('assessment', {
+        orderedChallengeIdsAnswered: answers.map((answer) => answer.challengeId),
+      });
       assessment.answers = answers;
 
       // when
@@ -73,7 +77,9 @@ module('Unit | Model | Assessment', function (hooks) {
       // given
       const answers = newAnswers(store, 11);
       const answer11 = answers[10];
-      const assessment = store.createRecord('assessment');
+      const assessment = store.createRecord('assessment', {
+        orderedChallengeIdsAnswered: answers.map((answer) => answer.challengeId),
+      });
       assessment.answers = answers;
 
       // when

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -21,7 +21,7 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
     id: 'assessment_id',
     get: sinon.stub().callsFake(() => 'ASSESSMENT_TYPE'),
     type: 'PLACEMENT',
-    answers: [],
+    orderedChallengeIdsAnswered: [],
   };
 
   const model = {
@@ -81,6 +81,7 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
           answers: [],
           type: 'PREVIEW',
           isPreview: true,
+          orderedChallengeIdsAnswered: [],
         };
         route.modelFor.returns(assessmentForPreview);
       });
@@ -117,36 +118,29 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
       });
     });
 
-    module('when the asked challenges is already answered', function (hooks) {
-      let answer;
-
+    module('when the asked challenge is already answered', function (hooks) {
       hooks.beforeEach(function () {
-        answer = {
-          id: '3',
-          challenge: {
-            id: 'oldRecId',
-            get: () => 'oldRecId',
-          },
-        };
         const assessmentWithAnswers = {
-          answers: [answer],
           type: 'COMPETENCE',
+          orderedChallengeIdsAnswered: ['recId'],
         };
         route.modelFor.returns(assessmentWithAnswers);
       });
 
-      test('should use challenge from answer', async function (assert) {
+      test('should get challenge from its id', async function (assert) {
         // given
+        const challenge = { id: 'recId' };
         const params = {
           challengeId: 'recId',
           challenge_number: 0,
         };
+        storeStub.findRecord.resolves(challenge);
 
         // when
         const model = await route.model(params);
 
         // then
-        assert.strictEqual(model.challenge, answer.challenge);
+        assert.strictEqual(model.challenge, challenge);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -13,7 +13,6 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
   let queryRecordStub;
 
   hooks.beforeEach(function () {
-    // define stubs
     findRecordStub = sinon.stub();
     queryRecordStub = sinon.stub();
     storeStub = Service.create({
@@ -32,7 +31,13 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
     hooks.beforeEach(function () {
       const answers = EmberObject.create();
       answers.reload = sinon.stub().resolves();
-      assessment = EmberObject.create({ id: '123', isDemo: true, competenceId: 'recCompetenceId', answers });
+      assessment = EmberObject.create({
+        id: '123',
+        isDemo: true,
+        competenceId: 'recCompetenceId',
+        answers,
+        orderedChallengeIdsAnswered: ['someChallengeId'],
+      });
       assessment.save = sinon.stub().resolves();
     });
 
@@ -55,6 +60,7 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
         module('when checkpoint is reached', function (hooks) {
           hooks.beforeEach(function () {
             assessment.answers = [{}, {}, {}, {}, {}];
+            assessment.orderedChallengeIdsAnswered = ['chal1', 'chal2', 'chal3', 'chal4', 'chal5'];
             assessment.answers.reload = sinon.stub().resolves();
           });
 


### PR DESCRIPTION
## 🔆 Problème
Pour raisonner sur les sujets tels que "à quelle numéro d'épreuve suis-je ?", "à combien d'épreuves ai-je répondu jusqu'à présent" etc, on faisait un appel régulier à GET /api/answers?assessmentId=id_de_mon_assessment

Aujourd'hui vu le trafic sur Pix, c'est une des routes les plus appelées (~4 millions d'appels par jour), qui récupère beaucoup de données par rapport à ce dont il y a vraiment besoin. De plus, on pense qu'il y a moyen de ne pas avoir à appeler cette route du tout, ni un équivalent.

## ⛱️ Proposition

Cette proposition est "temporaire". Dans le cadre du possible tech days sur du taff à réaliser sur l'enchainement des épreuves, idéalement ce genre d'info concernant le numéro d'épreuve courante etc... ce serait bien que ce soit connu après chaque appel de get/next.
En attendant, on renvoie dans le modèle Assessment un tableau avec les IDs des épreuves auxquelles on a déjà répondu, puis on tient à jour ce tableau côté front au fur et à mesure des réponses apportées (car l'assessment n'est pas rafraîchi régulièrement)

## 🌊 Remarques

- On avait des pbs de transitionAborted. Pas trop compris pourquoi, mais si on retire les return des replaceWith ça remarche. Et vu que c'est comme ça qu'il faut utiliser les replaceWith de toute façon, je ne cherche pas plus loin
- On renvoie également une erreur plus cohérente côté back quand on tente de post la réponse à une épreuve déjà répondue

## 🏄 Pour tester

Tester l'enchainement des épreuves, affichage de checkpoints, accès direct via URL de l'épreuve courante, d'une épreuve précédente, d'un numéro d'épreuve pas encore atteint etc.
Toutes les modalités d'assessment.
