### PR TITLE
[FEATURE] Améliorer les transitions entre les cartes de la modalité Question A/B (QAB) (PIX-18069)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -43,10 +43,35 @@
                 "solution": "B"
               },
               {
-                "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
                 "text": "Quel est l'organe qui rougit ?",
                 "proposalA": "L'estomac",
                 "proposalB": "Le coeur",
+                "solution": "A"
+              },
+              {
+                "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
+                "image": {
+                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                  "altText": ""
+                },
+                "text": "Les dauphins sont des poissons.",
+                "proposalA": "Vrai",
+                "proposalB": "Faux",
+                "solution": "B"
+              },
+              {
+                "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
+                "text": "La Terre est plus proche du Soleil que Mars.",
+                "proposalA": "Vrai",
+                "proposalB": "Faux",
+                "solution": "B"
+              },
+              {
+                "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
+                "text": "L’eau bout à 100°C au niveau de la mer.",
+                "proposalA": "Vrai",
+                "proposalB": "Faux",
                 "solution": "A"
               }
             ]

--- a/mon-pix/app/components/module/element/qab/_qab-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-card.scss
@@ -2,8 +2,8 @@
 @use 'pix-design-tokens/typography';
 
 .qab-card {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-area: center;
   width: 100%;
   max-width: 240px;
   min-height: 380px;
@@ -11,6 +11,37 @@
   background: var(--pix-neutral-0);
   border-radius: var(--pix-spacing-3x);
   box-shadow: 8px 8px 28px 0 rgb(0 0 0 / 25%);
+  transition: translate 400ms ease-in, rotate 400ms ease-in, transform 250ms;
+
+  &:nth-of-type(1) {
+    z-index: 6;
+    transform: scale(1) translateY(0%);
+  }
+
+  &:nth-of-type(2) {
+    z-index: 5;
+    transform: scale(0.9) translateY(9%);
+  }
+
+  &:nth-of-type(3) {
+    z-index: 4;
+    transform: scale(0.8) translateY(20%);
+  }
+
+  &:nth-of-type(4) {
+    z-index: 3;
+    transform: scale(0.7) translateY(34%);
+  }
+
+  &:nth-of-type(5) {
+    z-index: 2;
+    transform: scale(0.6) translateY(52%);
+  }
+
+  &:nth-of-type(6) {
+    z-index: 1;
+    transform: scale(0.5) translateY(77%);
+  }
 
   &__container {
     --qab-card-content-border-color: var(--pix-primary-300);
@@ -53,7 +84,7 @@
 
 @include breakpoints.device-is('tablet') {
   .qab-card {
-    max-width: none;
+    max-width: 560px;
   }
 
   .qab-card-container-content {

--- a/mon-pix/app/components/module/element/qab/_qab-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-card.scss
@@ -43,6 +43,11 @@
     transform: scale(0.5) translateY(77%);
   }
 
+  &--removed {
+    translate: -100vw -10vh;
+    rotate: -20deg;
+  }
+
   &__container {
     --qab-card-content-border-color: var(--pix-primary-300);
 
@@ -61,6 +66,12 @@
     &--success {
       --qab-card-content-border-color: var(--pix-success-300);
     }
+  }
+
+  &--without-transition {
+    transition: none;
+    translate: none;
+    rotate: none;
   }
 }
 

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -11,8 +11,6 @@
   }
 
   &__cards {
-    display: flex;
-    justify-content: center;
     display: grid;
     grid-template-areas: 'center';
     justify-content: center;

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -13,6 +13,10 @@
   &__cards {
     display: flex;
     justify-content: center;
+    display: grid;
+    grid-template-areas: 'center';
+    justify-content: center;
+    margin-bottom: var(--pix-spacing-12x);
   }
 
   &__proposals {
@@ -23,6 +27,10 @@
     max-width: 240px;
     margin: auto;
   }
+}
+
+.element-qab-cards {
+  margin-bottom: var(--pix-spacing-6x);
 }
 
 @include breakpoints.device-is('tablet') {

--- a/mon-pix/app/components/module/element/qab/qab-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-card.gjs
@@ -14,8 +14,17 @@ export default class QabCard extends Component {
     return this.args.card.image?.url?.length > 0;
   }
 
+  get userPrefersReducedMotion() {
+    const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    return userPrefersReducedMotion.matches;
+  }
+
   <template>
-    <div class="qab-card">
+    <div
+      class="qab-card
+        {{if @isRemoved 'qab-card--removed'}}
+        {{if this.userPrefersReducedMotion 'qab-card--without-transition'}}"
+    >
       {{#if this.isSuccess}}
         <p role="status" class="sr-only"> {{t "pages.modulix.qab.correct-answer"}} </p>
       {{/if}}


### PR DESCRIPTION
## 🔆 Problème

Manque de Cool pour dépiler les cartes QAB d'un paquet.

## ⛱️ Proposition

Ajouter des animations pour dépiler les cartes.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Se rendre dans le modules [bac-a-sable](https://app-pr12447.review.pix.fr/modules/bac-a-sable/passage)
- Commencer
- Afficher le premier grain
