### PR TITLE
[FEATURE] Remplacer le campaignCode par un organizationId et redirectionUrl dans le usecase createAndReconcileUserToOrganizationLearner (PIX-18094)

### DIFF
--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -136,7 +136,7 @@ const createUser = async function (request, h, dependencies = { userSerializer, 
   const canonicalLocaleFromCookie = localeFromCookie
     ? dependencies.localeService.getCanonicalLocale(localeFromCookie)
     : undefined;
-  const campaignCode = request.payload.meta ? request.payload.meta['campaign-code'] : null;
+  const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
   const user = { ...dependencies.userSerializer.deserialize(request.payload), locale: canonicalLocaleFromCookie };
   const localeFromHeader = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
@@ -145,7 +145,7 @@ const createUser = async function (request, h, dependencies = { userSerializer, 
   const savedUser = await usecases.createUser({
     user,
     password,
-    campaignCode,
+    redirectionUrl,
     localeFromHeader,
     i18n: request.i18n,
   });

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -1,6 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
-import { urlBuilder } from '../../../shared/infrastructure/utils/url-builder.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
 import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
 
@@ -22,12 +21,11 @@ import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
  * @return {Promise<User|undefined>}
  */
 const createUser = withTransaction(async function ({
-  campaignCode,
   localeFromHeader,
   password,
   user,
   authenticationMethodRepository,
-  campaignRepository,
+  redirectionUrl,
   emailRepository,
   emailValidationDemandRepository,
   userRepository,
@@ -58,14 +56,6 @@ const createUser = withTransaction(async function ({
     userToCreateRepository,
     authenticationMethodRepository,
   });
-
-  let redirectionUrl = null;
-  if (campaignCode) {
-    const campaign = await campaignRepository.getByCode(campaignCode);
-    if (campaign) {
-      redirectionUrl = urlBuilder.getCampaignUrl(localeFromHeader, campaignCode);
-    }
-  }
 
   const token = await emailValidationDemandRepository.save(savedUser.id);
 

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -59,7 +59,8 @@ const createAndReconcileUserToOrganizationLearner = async function (
   await usecases.createAndReconcileUserToOrganizationLearner({
     userAttributes,
     password: payload.password,
-    campaignCode: payload['campaign-code'],
+    organizationId: payload['organization-id'],
+    redirectionUrl: payload['redirection-url'],
     locale,
     i18n: request.i18n,
   });

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-route.js
@@ -1,16 +1,16 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
-const Joi = BaseJoi.extend(JoiDate);
 import XRegExp from 'xregexp';
-
-import { config } from '../../../shared/config.js';
-
-const { passwordValidationPattern } = config.account;
 
 import { BadRequestError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { config } from '../../../shared/config.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
+
+const Joi = BaseJoi.extend(JoiDate);
+
+const { passwordValidationPattern } = config.account;
 
 const register = async function (server) {
   server.route([
@@ -60,7 +60,8 @@ const register = async function (server) {
                 'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 birthdate: Joi.date().format('YYYY-MM-DD').raw().required(),
-                'campaign-code': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'organization-id': Joi.number().empty(null).required(),
+                'redirection-url': Joi.string().uri().empty(null).required(),
                 password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
                 'with-username': Joi.boolean().required(),
                 username: Joi.string().pattern(XRegExp('^([a-z]+[.]+[a-z]+[0-9]{4})$')).allow(null),

--- a/api/src/shared/infrastructure/utils/url-builder.js
+++ b/api/src/shared/infrastructure/utils/url-builder.js
@@ -20,28 +20,6 @@ function getPixAppBaseUrl(locale) {
 
 /**
  * @param {string} locale
- * @param {string} campaignCode
- * @returns {string|null} - Campaign URL according to the locale
- */
-function getCampaignUrl(locale, campaignCode) {
-  if (!campaignCode) {
-    return null;
-  }
-
-  switch (locale) {
-    case LOCALE.FRENCH_SPOKEN:
-      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=fr`;
-    case LOCALE.ENGLISH_SPOKEN:
-      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=en`;
-    case LOCALE.DUTCH_SPOKEN:
-      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=nl`;
-    default:
-      return `${PIX_APP_DOMAIN_FR}/campagnes/${campaignCode}`;
-  }
-}
-
-/**
- * @param {string} locale
  * @param {string} redirectUrl - URL to redirect the user to after email validation
  * @param {string} token
  * @returns {string} - generated URL to validate user account email
@@ -61,7 +39,6 @@ function getEmailValidationUrl({ locale, redirectUrl, token } = {}) {
  * @typedef UrlBuilder
  */
 export const urlBuilder = {
-  getCampaignUrl,
   getEmailValidationUrl,
   getPixAppBaseUrl,
 };

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -268,7 +268,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
             user: { ...deserializedUser, locale: localeFromCookie },
             password,
             localeFromHeader,
-            campaignCode: null,
+            redirectionUrl: null,
             i18n: undefined,
           };
 

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -2,10 +2,8 @@ import { createAccountCreationEmail } from '../../../../../src/identity-access-m
 import { InvalidOrAlreadyUsedEmailError } from '../../../../../src/identity-access-management/domain/errors.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { createUser } from '../../../../../src/identity-access-management/domain/usecases/create-user.usecase.js';
-import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import { urlBuilder } from '../../../../../src/shared/infrastructure/utils/url-builder.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | create-user', function () {
@@ -434,6 +432,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
 
     context('step send account creation email to user', function () {
       const user = new User({ email: userEmail, locale: localeFromHeader });
+      let redirectionUrl;
+
+      beforeEach(function () {
+        redirectionUrl = 'https://pixapp/campagnes/ABCDEFGHI';
+      });
 
       it('should send the account creation email', async function () {
         // given
@@ -443,7 +446,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           firstName: user.firstName,
           locale: localeFromHeader,
           token,
-          redirectionUrl: `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`,
+          redirectionUrl,
         });
 
         // when
@@ -451,9 +454,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           user,
           localeFromHeader,
           password,
-          campaignCode,
+          redirectionUrl,
           authenticationMethodRepository,
-          campaignRepository,
           emailRepository,
           emailValidationDemandRepository,
           userRepository,
@@ -546,7 +548,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // given
       campaignRepository.getByCode.resolves({ organizationId: 1 });
       const redirectionUrl = 'https://redirect.uri';
-      sinon.stub(urlBuilder, 'getCampaignUrl').returns(redirectionUrl);
       emailRepository.sendEmailAsync.resolves();
 
       const expectedEmail = createAccountCreationEmail({
@@ -562,9 +563,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         user,
         localeFromHeader,
         password,
-        campaignCode,
+        redirectionUrl,
         authenticationMethodRepository,
-        campaignRepository,
         emailRepository,
         emailValidationDemandRepository,
         userRepository,

--- a/api/tests/integration/application/sco-organization-learners/index_test.js
+++ b/api/tests/integration/application/sco-organization-learners/index_test.js
@@ -33,7 +33,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: '2012-12-12',
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };
@@ -62,7 +62,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': INVALID_FIRSTNAME,
             'last-name': 'Smith',
             birthdate: '2012-12-12',
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };
@@ -83,7 +83,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': 'Robert',
             'last-name': INVALID_LASTNAME,
             birthdate: '2012-12-12',
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };
@@ -104,7 +104,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: INVALID_BIRTHDATE,
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };
@@ -127,7 +127,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: INVALID_BIRTHDATE,
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };
@@ -148,7 +148,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: INVALID_BIRTHDATE,
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };

--- a/api/tests/prescription/learner-management/integration/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/integration/application/organization-learners-route_test.js
@@ -247,7 +247,7 @@ describe('Integration | Application | Organization Learners Management | Routes'
       const payload = {
         data: {
           attributes: {
-            'organization-id': 123,
+            'organization-id': 1,
           },
         },
       };

--- a/api/tests/prescription/learner-management/integration/application/sco-organization-management-route_test.js
+++ b/api/tests/prescription/learner-management/integration/application/sco-organization-management-route_test.js
@@ -27,7 +27,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: '2012-12-12',
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -47,7 +47,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert ',
               'last-name': 'Smith',
               birthdate: '2012-12-12',
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -77,7 +77,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': INVALID_FIRSTNAME,
               'last-name': 'Smith',
               birthdate: '2012-12-12',
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -98,7 +98,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert',
               'last-name': INVALID_LASTNAME,
               birthdate: '2012-12-12',
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -121,7 +121,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: INVALID_BIRTHDATE,
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -142,7 +142,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: INVALID_BIRTHDATE,
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };
@@ -163,7 +163,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: INVALID_BIRTHDATE,
-              'organization-id': 123,
+              'organization-id': 1,
             },
           },
         };

--- a/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/sco-organization-learner-route_test.js
@@ -195,7 +195,6 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
 
   describe('POST /api/sco-organization-learners/dependent', function () {
     let organization;
-    let campaign;
     let organizationLearner;
 
     beforeEach(async function () {
@@ -206,7 +205,6 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
         userId: null,
         nationalStudentId: 'salut',
       });
-      campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
       await databaseBuilder.commit();
     });
 
@@ -219,7 +217,8 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
           payload: {
             data: {
               attributes: {
-                'campaign-code': campaign.code,
+                'organization-id': organization.id,
+                'redirection-url': 'https://pixapp/campaigns/ABCDEFGHI',
                 'first-name': organizationLearner.firstName,
                 'last-name': organizationLearner.lastName,
                 birthdate: organizationLearner.birthdate,
@@ -245,7 +244,8 @@ describe('Prescription | Organization Learner | Acceptance | Application | sco-o
           payload: {
             data: {
               attributes: {
-                'campaign-code': campaign.code,
+                'organization-id': organization.id,
+                'redirection-url': 'https://pixapp/campaigns/ABCDEFGHI',
                 'first-name': organizationLearner.firstName,
                 'last-name': organizationLearner.lastName,
                 birthdate: organizationLearner.birthdate,

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
@@ -144,9 +144,9 @@ describe('Integration | Application | Route | sco-organization-learners', functi
         expect(response.statusCode).to.equal(400);
       });
 
-      it('should return 400 when organizationId is empty', async function () {
+      it('should return 400 when organizationId is null', async function () {
         // given
-        payload.data.attributes['organization-id'] = undefined;
+        payload.data.attributes['organization-id'] = null;
 
         // when
         response = await httpTestServer.request(method, url, payload);

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
@@ -34,7 +34,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
       payload = {
         data: {
           attributes: {
-            'organization-id': 123,
+            'organization-id': 1,
             'external-user-token': 'external-user-token',
             birthdate: '1948-12-21',
             'access-token': null,
@@ -99,7 +99,7 @@ describe('Integration | Application | Route | sco-organization-learners', functi
         payload = {
           data: {
             attributes: {
-              'organization-id': 123,
+              'organization-id': 1,
               'first-name': 'Robert',
               'last-name': 'Smith',
               birthdate: '2012-12-12',

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -3,7 +3,6 @@ const { pick } = lodash;
 
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import {
-  CampaignCodeError,
   NotFoundError,
   OrganizationLearnerAlreadyLinkedToUserError,
 } from '../../../../../../src/shared/domain/errors.js';
@@ -17,31 +16,14 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
   const pickUserAttributes = ['firstName', 'lastName', 'email', 'username', 'cgu'];
   const locale = 'fr';
 
-  let campaignCode;
   let organizationId;
   let password;
   let organizationLearner;
   let userAttributes;
 
-  context('When there is no campaign with the given code', function () {
-    it('should throw a campaign code error', async function () {
-      // when
-      const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-        campaignCode: 'NOTEXIST',
-        locale,
-        password,
-        userAttributes,
-        i18n,
-      });
-
-      // then
-      expect(error).to.be.instanceof(CampaignCodeError);
-    });
-  });
-
   context('When no organizationLearner is found', function () {
     beforeEach(async function () {
-      campaignCode = databaseBuilder.factory.buildCampaign().code;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
     });
 
@@ -55,7 +37,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
       // when
       const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-        campaignCode,
+        organizationId,
         locale,
         password,
         userAttributes,
@@ -71,9 +53,6 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
   context('When an organizationLearner matches on names', function () {
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
-      campaignCode = databaseBuilder.factory.buildCampaign({
-        organizationId,
-      }).code;
 
       await databaseBuilder.commit();
     });
@@ -96,7 +75,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
         // when
         const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-          campaignCode,
+          organizationId,
           locale,
           password,
           userAttributes,
@@ -146,7 +125,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
           // when
           const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-            campaignCode,
+            organizationId,
             locale,
             password: '',
             userAttributes,
@@ -181,7 +160,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
           // when
           const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-            campaignCode,
+            organizationId,
             locale,
             password,
             userAttributes,
@@ -202,7 +181,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
           // when
           const result = await usecases.createAndReconcileUserToOrganizationLearner({
-            campaignCode,
+            organizationId,
             locale,
             password,
             userAttributes,
@@ -261,7 +240,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
           // when
           const error = await catchErr(usecases.createAndReconcileUserToOrganizationLearner)({
-            campaignCode,
+            organizationId,
             locale,
             password,
             userAttributes,
@@ -291,7 +270,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
           // when
           const result = await usecases.createAndReconcileUserToOrganizationLearner({
-            campaignCode,
+            organizationId,
             locale,
             password,
             userAttributes,

--- a/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
@@ -28,7 +28,7 @@ describe('Prescription | Unit | Application | Controller | sco-organization-lear
           data: {
             attributes: {
               birthdate: '01-01-2000',
-              'organization-id': 123,
+              'organization-id': 1,
               'external-user-token': '123SamlId',
             },
           },

--- a/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/sco-organization-learner-controller_test.js
@@ -62,7 +62,7 @@ describe('Prescription | Unit | Application | Controller | sco-organization-lear
         'first-name': 'Robert',
         'last-name': 'Smith',
         birthdate: '2012-12-12',
-        'organization-id': 123,
+        'organization-id': 1,
         password: 'P@ssw0rd',
         username: 'robert.smith1212',
         'with-username': true,

--- a/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
@@ -33,52 +33,6 @@ describe('Unit | Shared | Infrastructure | Utils | url-builder', function () {
     });
   });
 
-  describe('#getCampaignUrl', function () {
-    it('returns null if campaignCode is not defined', function () {
-      expect(urlBuilder.getCampaignUrl('fr', null)).to.be.null;
-    });
-
-    describe('when campaignCode is defined', function () {
-      const campaignCode = 'AZERTY123';
-
-      it('returns campaignUrl with fr domain when locale is not supported', function () {
-        expect(urlBuilder.getCampaignUrl('ru', campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`,
-        );
-      });
-
-      it('returns campaignUrl with fr domain when locale is not defined', function () {
-        expect(urlBuilder.getCampaignUrl(undefined, campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`,
-        );
-      });
-
-      it('returns campaignUrl with fr domain when locale is fr-fr', function () {
-        expect(urlBuilder.getCampaignUrl('fr-fr', campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`,
-        );
-      });
-
-      it('returns campaignUrl with org domain when locale is fr', function () {
-        expect(urlBuilder.getCampaignUrl('fr', campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldOrg}/campagnes/${campaignCode}/?lang=fr`,
-        );
-      });
-
-      it('returns campaignUrl with org domain when locale is en', function () {
-        expect(urlBuilder.getCampaignUrl('en', campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldOrg}/campagnes/${campaignCode}/?lang=en`,
-        );
-      });
-
-      it('returns campaignUrl with org domain when locale is nl', function () {
-        expect(urlBuilder.getCampaignUrl('nl', campaignCode)).to.be.equal(
-          `${config.domain.pixApp + config.domain.tldOrg}/campagnes/${campaignCode}/?lang=nl`,
-        );
-      });
-    });
-  });
-
   describe('getEmailValidationUrl', function () {
     context('when locale is given', function () {
       it('returns email validation URL with domain .org', function () {

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -8,10 +8,10 @@ export default class User extends ApplicationAdapter {
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
 
-    if (adapterOptions && adapterOptions.campaignCode) {
+    if (adapterOptions && adapterOptions.redirectionUrl) {
       const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
       const { data } = this.serialize(snapshot);
-      const payload = { data: { data, meta: { 'campaign-code': adapterOptions.campaignCode } } };
+      const payload = { data: { data, meta: { 'redirection-url': adapterOptions.redirectionUrl } } };
       return this.ajax(url, 'POST', payload);
     }
 

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -92,10 +92,9 @@ export default class SignupForm extends Component {
     this.isLoading = true;
 
     try {
-      const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
       user.lang = this.intl.primaryLocale;
 
-      await user.save({ adapterOptions: { campaignCode } });
+      await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
       await this.session.authenticateUser(user.email, user.password);
 
       user.password = null;

--- a/mon-pix/app/components/routes/login-or-register.gjs
+++ b/mon-pix/app/components/routes/login-or-register.gjs
@@ -28,7 +28,7 @@ import RegisterForm from 'mon-pix/components/routes/register-form';
             }}
           >
             {{#if @displayRegisterForm}}
-              <RegisterForm @campaignCode={{@campaignCode}} @organizationId={{@organizationId}} />
+              <RegisterForm @redirectionUrl={{@redirectionUrl}} @organizationId={{@organizationId}} />
             {{/if}}
           </div>
         </div>

--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -235,6 +235,7 @@ export default class RegisterForm extends Component {
   @service session;
   @service store;
   @service intl;
+  @service router;
 
   @tracked isLoading = false;
   @tracked errorMessage = null;
@@ -311,8 +312,9 @@ export default class RegisterForm extends Component {
         this.isLoading = false;
         this.username = response.username;
         return (this.dependentUser = this.store.createRecord('dependent-user', {
-          id: this.args.campaignCode + '_' + this.lastName,
-          campaignCode: this.args.campaignCode,
+          id: this.args.organizationId + '_' + this.lastName,
+          redirectionUrl: this.args.redirectionUrl,
+          organizationId: this.args.organizationId,
           firstName: this.firstName,
           lastName: this.lastName,
           birthdate: this.birthdate,

--- a/mon-pix/app/controllers/campaigns/join/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/join/student-sco.js
@@ -27,14 +27,14 @@ export default class StudentScoController extends Controller {
     await this.currentUser.load();
     await this._reconcileUser();
 
-    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    this.campaignStorage.set(this.model.campaign.code, 'associationDone', true);
   }
 
   _reconcileUser() {
     return this.store
       .createRecord('sco-organization-learner', {
         userId: this.currentUser.user.id,
-        organizationId: this.model.organizationId,
+        organizationId: this.model.campaign.organizationId,
       })
       .save({ adapterOptions: { tryReconciliation: true } });
   }

--- a/mon-pix/app/models/dependent-user.js
+++ b/mon-pix/app/models/dependent-user.js
@@ -3,7 +3,8 @@ import Model, { attr } from '@ember-data/model';
 export default class DependentUser extends Model {
   // attributes
   @attr('date-only') birthdate;
-  @attr('string') campaignCode;
+  @attr('string') redirectionUrl;
+  @attr('number') organizationId;
   @attr('string') email;
   @attr('string') firstName;
   @attr('string') lastName;

--- a/mon-pix/app/routes/campaigns/join/student-sco.js
+++ b/mon-pix/app/routes/campaigns/join/student-sco.js
@@ -4,16 +4,23 @@ import { service } from '@ember/service';
 export default class StudentScoRoute extends Route {
   @service campaignStorage;
   @service session;
+  @service router;
 
   beforeModel() {
     this.session.prohibitAuthentication('authenticated.user-dashboard');
   }
 
   async model() {
-    return this.modelFor('campaigns');
+    const campaign = this.modelFor('campaigns');
+    const baseUrl = window.location.protocol + '//' + window.location.host;
+    const redirectionUrl = baseUrl + this.router.urlFor('campaigns', { code: campaign.code });
+    return {
+      campaign,
+      redirectionUrl,
+    };
   }
 
-  setupController(controller, campaign) {
-    controller.displayRegisterForm = !this.campaignStorage.get(campaign.code, 'hasUserSeenJoinPage');
+  setupController(controller, model) {
+    controller.displayRegisterForm = !this.campaignStorage.get(model.campaign.code, 'hasUserSeenJoinPage');
   }
 }

--- a/mon-pix/app/routes/campaigns/join/student-sco.js
+++ b/mon-pix/app/routes/campaigns/join/student-sco.js
@@ -12,8 +12,7 @@ export default class StudentScoRoute extends Route {
 
   async model() {
     const campaign = this.modelFor('campaigns');
-    const baseUrl = window.location.protocol + '//' + window.location.host;
-    const redirectionUrl = baseUrl + this.router.urlFor('campaigns', { code: campaign.code });
+    const redirectionUrl = this.session.redirectionUrl;
     return {
       campaign,
       redirectionUrl,

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -63,6 +63,15 @@ export default class CurrentSessionService extends SessionService {
     await this._loadCurrentUserAndSetLocale(language);
   }
 
+  get redirectionUrl() {
+    const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
+    if (campaignCode) {
+      const baseUrl = window.location.protocol + '//' + window.location.host;
+      return baseUrl + this.router.urlFor('campaigns', { code: campaignCode });
+    }
+    return null;
+  }
+
   requireAuthenticationAndApprovedTermsOfService(transition, authenticationRoute) {
     if (this.isAuthenticated && this.currentUser.user.mustValidateTermsOfService) {
       this.attemptedTransition = transition;

--- a/mon-pix/app/templates/campaigns/join/student-sco.gjs
+++ b/mon-pix/app/templates/campaigns/join/student-sco.gjs
@@ -2,9 +2,10 @@ import LoginOrRegister from 'mon-pix/components/routes/login-or-register';
 <template>
   <div class="student-sco">
     <LoginOrRegister
-      @organizationName={{@model.organizationName}}
-      @campaignCode={{@model.code}}
-      @organizationId={{@model.organizationId}}
+      @organizationName={{@model.campaign.organizationName}}
+      @redirectionUrl={{@model.redirectionUrl}}
+      @campaignCode={{@model.campaign.code}}
+      @organizationId={{@model.campaign.organizationId}}
       @displayRegisterForm={{@controller.displayRegisterForm}}
       @toggleFormsVisibility={{@controller.toggleFormsVisibility}}
       @addGarAuthenticationMethodToUser={{@controller.addGarAuthenticationMethodToUser}}

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -232,7 +232,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
                     'last-name': 'last',
                     'first-name': 'first',
                     birthdate: '2010-10-10',
-                    'campaign-code': 'RESTRICTD',
                     username: 'first.last1010',
                   },
                   id: 'foo',

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -74,8 +74,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           });
 
           module('When user create its account', function () {
-            test('should send campaignCode to API', async function (assert) {
-              let sentCampaignCode;
+            test('should send redirectionUrl to API', async function (assert) {
+              let sentRedirectionUrl;
 
               const prescritUser = {
                 firstName: 'firstName',
@@ -87,7 +87,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               this.server.post(
                 '/users',
                 (schema, request) => {
-                  sentCampaignCode = JSON.parse(request.requestBody).meta['campaign-code'];
+                  sentRedirectionUrl = JSON.parse(request.requestBody).meta['redirection-url'];
                   return schema.users.create({});
                 },
                 201,
@@ -122,7 +122,13 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await click(screen.getByRole('button', { name: t('pages.sign-up.actions.submit') }));
 
               // then
-              assert.strictEqual(sentCampaignCode, campaign.code);
+              const router = this.owner.lookup('service:router');
+              const redirectionUrl =
+                window.location.protocol +
+                '//' +
+                window.location.host +
+                router.urlFor('campaigns', { code: campaign.code });
+              assert.strictEqual(sentRedirectionUrl, redirectionUrl);
             });
           });
         });

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -96,21 +96,21 @@ module('Unit | Adapters | user', function (hooks) {
   });
 
   module('#createRecord', function () {
-    module('when campaignCode adapterOption is defined', function () {
-      test('should add campaign-code meta', async function (assert) {
+    module('when redirectionUrl adapterOption is defined', function () {
+      test('should add redirection-url meta', async function (assert) {
         // given
-        const campaignCode = 'AZERTY123';
+        const redirectionUrl = 'http://localhost:4200/campagnes/AZERTY123';
         const expectedUrl = 'http://localhost:3000/api/users';
         const expectedMethod = 'POST';
         const expectedData = {
           data: {
-            meta: { 'campaign-code': campaignCode },
+            meta: { 'redirection-url': redirectionUrl },
             data: {},
           },
         };
         const snapshot = {
           record: {},
-          adapterOptions: { campaignCode },
+          adapterOptions: { redirectionUrl },
           serialize: function () {
             return { data: {} };
           },

--- a/mon-pix/tests/unit/controllers/campaigns/join/student-sco-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join/student-sco-test.js
@@ -27,7 +27,7 @@ module('Unit | Controller | campaigns | join | student-sco', function (hooks) {
       },
     };
 
-    controller.set('model', { organizationId });
+    controller.set('model', { campaign: { organizationId } });
     controller.set('session', sessionStub);
     controller.set('currentUser', currentUserStub);
   });


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre des développements Combinix, on a besoin de pouvoir connecter / réconcilier les élèves sans campaignCode.

## ⛱️ Proposition
On remplace campaignCode par organizationId sur la route api/sco-organization-learners/dependent.

## 🏄 Pour tester
ORGA
Télécharger le template sco-ok du drive pour l'import, modifier l'ID_NATIONAL d'un élève. Importer la liste d'élèves sur SCO_SIECLE_MANAGING.
Relever le code d'une campagne d'évaluation.

APP
Créer un compte pour l'utilisateur en passant par la campagne dont on a relevé le code et vérifier que le lien reçu par mail est fonctionnel et renvoie vers la bonne campagne.