### PR TITLE
[TECH] :truck: Déplace la route de mise à jour de mot de passe pour l'organisationLearner (pix-17852)

### DIFF
--- a/api/lib/application/sco-organization-learners/index.js
+++ b/api/lib/application/sco-organization-learners/index.js
@@ -46,43 +46,6 @@ const register = async function (server) {
     },
     {
       method: 'POST',
-      path: '/api/sco-organization-learners/password-update',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
-            assign: 'belongsToScoOrganizationAndManageStudents',
-          },
-        ],
-        handler: libScoOrganizationLearnerController.updatePassword,
-        validate: {
-          options: {
-            allowUnknown: true,
-          },
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'organization-id': identifiersType.campaignId,
-                'organization-learner-id': identifiersType.organizationLearnerId,
-              },
-            },
-          }),
-          failAction: (request, h) => {
-            return sendJsonApiError(
-              new BadRequestError('The server could not understand the request due to invalid syntax.'),
-              h,
-            );
-          },
-        },
-        notes: [
-          "- Met à jour le mot de passe d'un utilisateur identifié par son identifiant élève\n" +
-            "- La demande de modification du mot de passe doit être effectuée par un membre de l'organisation à laquelle appartient l'élève.",
-        ],
-        tags: ['api', 'sco-organization-learners'],
-      },
-    },
-    {
-      method: 'POST',
       path: '/api/sco-organization-learners/batch-username-password-generate',
       config: {
         pre: [

--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -26,23 +26,6 @@ const generateUsername = async function (request, h, dependencies = { scoOrganiz
     .code(200);
 };
 
-const updatePassword = async function (request, h, dependencies = { scoOrganizationLearnerSerializer }) {
-  const payload = request.payload.data.attributes;
-  const userId = request.auth.credentials.userId;
-  const organizationId = payload['organization-id'];
-  const organizationLearnerId = payload['organization-learner-id'];
-
-  const scoOrganizationLearner = await usecases.updateOrganizationLearnerDependentUserPassword({
-    userId,
-    organizationId,
-    organizationLearnerId,
-  });
-
-  return h
-    .response(dependencies.scoOrganizationLearnerSerializer.serializeCredentialsForDependent(scoOrganizationLearner))
-    .code(200);
-};
-
 const generateUsernameWithTemporaryPassword = async function (
   request,
   h,
@@ -88,7 +71,6 @@ const batchGenerateOrganizationLearnersUsernameWithTemporaryPassword = async fun
 
 const libScoOrganizationLearnerController = {
   generateUsername,
-  updatePassword,
   generateUsernameWithTemporaryPassword,
   batchGenerateOrganizationLearnersUsernameWithTemporaryPassword,
 };

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -29,6 +29,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 
   return h.response(dependencies.scoOrganizationLearnerSerializer.serializeExternal(scoOrganizationLearner)).code(200);
 };
+
 const createAndReconcileUserToOrganizationLearner = async function (
   request,
   h,
@@ -58,9 +59,28 @@ const createAndReconcileUserToOrganizationLearner = async function (
 
   return h.response().code(204);
 };
+
+const updatePassword = async function (request, h, dependencies = { scoOrganizationLearnerSerializer }) {
+  const payload = request.payload.data.attributes;
+  const userId = request.auth.credentials.userId;
+  const organizationId = payload['organization-id'];
+  const organizationLearnerId = payload['organization-learner-id'];
+
+  const scoOrganizationLearner = await usecases.updateOrganizationLearnerDependentUserPassword({
+    userId,
+    organizationId,
+    organizationLearnerId,
+  });
+
+  return h
+    .response(dependencies.scoOrganizationLearnerSerializer.serializeCredentialsForDependent(scoOrganizationLearner))
+    .code(200);
+};
+
 const scoOrganizationLearnerController = {
   createUserAndReconcileToOrganizationLearnerFromExternalUser,
   createAndReconcileUserToOrganizationLearner,
+  updatePassword,
 };
 
 export { scoOrganizationLearnerController };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import * as campaignRepository from '../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as userReconciliationService from '../../../../../src/shared/domain/services/user-reconciliation-service.js';
+import * as passwordGenerator from '../../../../identity-access-management/domain/services/password-generator.service.js';
 import * as authenticationMethodRepository from '../../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { emailValidationDemandRepository } from '../../../../identity-access-management/infrastructure/repositories/email-validation-demand.repository.js';
 import { lastUserApplicationConnectionsRepository } from '../../../../identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js';
@@ -59,6 +60,7 @@ const dependencies = {
   organizationLearnerFeatureRepository,
   organizationLearnerImportFormatRepository,
   organizationFeaturesAPI,
+  passwordGenerator,
   campaignRepository,
   campaignParticipationOverviewRepository,
   registrationOrganizationLearnerRepository,

--- a/api/src/prescription/organization-learner/domain/usecases/update-organization-learner-dependent-user-password.js
+++ b/api/src/prescription/organization-learner/domain/usecases/update-organization-learner-dependent-user-password.js
@@ -1,6 +1,6 @@
 import lodash from 'lodash';
 
-import { UserNotAuthorizedToUpdatePasswordError } from '../../../src/shared/domain/errors.js';
+import { UserNotAuthorizedToUpdatePasswordError } from '../../../../shared/domain/errors.js';
 
 const { isEmpty } = lodash;
 

--- a/api/tests/integration/application/sco-organization-learners/index_test.js
+++ b/api/tests/integration/application/sco-organization-learners/index_test.js
@@ -14,9 +14,6 @@ describe('Integration | Application | Route | sco-organization-learners', functi
       .stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents')
       .callsFake((request, h) => h.response(true));
     sinon
-      .stub(libScoOrganizationLearnerController, 'updatePassword')
-      .callsFake((request, h) => h.response('ok').code(200));
-    sinon
       .stub(libScoOrganizationLearnerController, 'generateUsernameWithTemporaryPassword')
       .callsFake((request, h) => h.response('ok').code(200));
 
@@ -182,28 +179,6 @@ describe('Integration | Application | Route | sco-organization-learners', functi
 
       // then
       expect(response.statusCode).to.equal(422);
-    });
-  });
-
-  describe('POST /api/sco-organization-learners/password-update', function () {
-    it('should succeed', async function () {
-      // given
-      const method = 'POST';
-      const url = '/api/sco-organization-learners/password-update';
-      const payload = {
-        data: {
-          attributes: {
-            'organization-learner-id': 1,
-            'organization-id': 3,
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(200);
     });
   });
 

--- a/api/tests/integration/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/integration/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -2,7 +2,6 @@ import * as moduleUnderTest from '../../../../lib/application/sco-organization-l
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import {
-  NotFoundError,
   UserNotAuthorizedToGenerateUsernamePasswordError,
   UserNotAuthorizedToUpdatePasswordError,
 } from '../../../../src/shared/domain/errors.js';
@@ -14,7 +13,6 @@ describe('Integration | Application | sco-organization-learners | sco-organizati
 
   beforeEach(async function () {
     sandbox = sinon.createSandbox();
-    sandbox.stub(usecases, 'updateOrganizationLearnerDependentUserPassword').rejects(new Error('not expected error'));
     sandbox.stub(usecases, 'generateUsernameWithTemporaryPassword').rejects(new Error('not expected error'));
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     httpTestServer = new HttpTestServer();
@@ -23,85 +21,6 @@ describe('Integration | Application | sco-organization-learners | sco-organizati
 
   afterEach(function () {
     sandbox.restore();
-  });
-
-  describe('#updatePassword', function () {
-    const payload = { data: { attributes: {} } };
-    const auth = { credentials: {}, strategy: {} };
-    const generatedPassword = 'Passw0rd';
-
-    beforeEach(function () {
-      securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents.callsFake((request, h) =>
-        h.response(true),
-      );
-
-      payload.data.attributes = {
-        'organization-learner-id': 1,
-        'organization-id': 3,
-      };
-
-      auth.credentials.userId = domainBuilder.buildUser().id;
-    });
-
-    context('Success cases', function () {
-      it('should return an HTTP response with status code 200', async function () {
-        // given
-        usecases.updateOrganizationLearnerDependentUserPassword.resolves({
-          generatedPassword,
-          organizationLearnersId: 1,
-        });
-
-        // when
-        const response = await httpTestServer.request(
-          'POST',
-          '/api/sco-organization-learners/password-update',
-          payload,
-          auth,
-        );
-
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result.data.attributes['generated-password']).to.equal(generatedPassword);
-      });
-    });
-
-    context('Error cases', function () {
-      context('when a NotFoundError is thrown', function () {
-        it('should resolve a 404 HTTP response', async function () {
-          // given
-          usecases.updateOrganizationLearnerDependentUserPassword.rejects(new NotFoundError());
-
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/sco-organization-learners/password-update',
-            payload,
-            auth,
-          );
-
-          // then
-          expect(response.statusCode).to.equal(404);
-        });
-      });
-
-      context('when a UserNotAuthorizedToUpdatePasswordError is thrown', function () {
-        it('should resolve a 403 HTTP response', async function () {
-          // given
-          usecases.updateOrganizationLearnerDependentUserPassword.rejects(new UserNotAuthorizedToUpdatePasswordError());
-
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/sco-organization-learners/password-update',
-            payload,
-            auth,
-          );
-
-          // then
-          expect(response.statusCode).to.equal(403);
-        });
-      });
-    });
   });
 
   describe('#generateUsernameWithTemporaryPassword', function () {

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-controller_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-controller_test.js
@@ -1,0 +1,101 @@
+import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/sco-organization-learner-route.js';
+import { usecases } from '../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { NotFoundError, UserNotAuthorizedToUpdatePasswordError } from '../../../../../src/shared/domain/errors.js';
+import { domainBuilder, expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Application | sco-organization-learners | sco-organization-learner-controller', function () {
+  let sandbox;
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(usecases, 'updateOrganizationLearnerDependentUserPassword').rejects(new Error('not expected error'));
+    sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('#updatePassword', function () {
+    const payload = { data: { attributes: {} } };
+    const auth = { credentials: {}, strategy: {} };
+    const generatedPassword = 'Passw0rd';
+
+    beforeEach(function () {
+      securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents.callsFake((request, h) =>
+        h.response(true),
+      );
+
+      payload.data.attributes = {
+        'organization-learner-id': 1,
+        'organization-id': 3,
+      };
+
+      auth.credentials.userId = domainBuilder.buildUser().id;
+    });
+
+    context('Success cases', function () {
+      it('should return an HTTP response with status code 200', async function () {
+        // given
+        usecases.updateOrganizationLearnerDependentUserPassword.resolves({
+          generatedPassword,
+          organizationLearnersId: 1,
+        });
+
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/sco-organization-learners/password-update',
+          payload,
+          auth,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes['generated-password']).to.equal(generatedPassword);
+      });
+    });
+
+    context('Error cases', function () {
+      context('when a NotFoundError is thrown', function () {
+        it('should resolve a 404 HTTP response', async function () {
+          // given
+          usecases.updateOrganizationLearnerDependentUserPassword.rejects(new NotFoundError());
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/sco-organization-learners/password-update',
+            payload,
+            auth,
+          );
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
+
+      context('when a UserNotAuthorizedToUpdatePasswordError is thrown', function () {
+        it('should resolve a 403 HTTP response', async function () {
+          // given
+          usecases.updateOrganizationLearnerDependentUserPassword.rejects(new UserNotAuthorizedToUpdatePasswordError());
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/sco-organization-learners/password-update',
+            payload,
+            auth,
+          );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-organization-learner-route_test.js
@@ -1,11 +1,18 @@
 import { scoOrganizationLearnerController } from '../../../../../src/prescription/organization-learner/application/sco-organization-learner-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/sco-organization-learner-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Application | Route | sco-organization-learners', function () {
   let httpTestServer;
 
   beforeEach(async function () {
+    sinon
+      .stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents')
+      .callsFake((request, h) => h.response(true));
+    sinon
+      .stub(scoOrganizationLearnerController, 'updatePassword')
+      .callsFake((request, h) => h.response('ok').code(200));
     sinon
       .stub(scoOrganizationLearnerController, 'createUserAndReconcileToOrganizationLearnerFromExternalUser')
       .callsFake((request, h) => h.response('ok').code(200));
@@ -226,6 +233,28 @@ describe('Integration | Application | Route | sco-organization-learners', functi
           expect(response.statusCode).to.equal(400);
         });
       });
+    });
+  });
+
+  describe('POST /api/sco-organization-learners/password-update', function () {
+    it('should succeed', async function () {
+      // given
+      const method = 'POST';
+      const url = '/api/sco-organization-learners/password-update';
+      const payload = {
+        data: {
+          attributes: {
+            'organization-learner-id': 1,
+            'organization-id': 3,
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
@@ -1,4 +1,4 @@
-import { updateOrganizationLearnerDependentUserPassword } from '../../../../lib/domain/usecases/update-organization-learner-dependent-user-password.js';
+import { updateOrganizationLearnerDependentUserPassword } from '../../../../src/prescription/organization-learner/domain/usecases/update-organization-learner-dependent-user-password.js';
 import { UserNotFoundError } from '../../../../src/shared/domain/errors.js';
 import { UserNotAuthorizedToUpdatePasswordError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';


### PR DESCRIPTION
## 🔆 Problème

La route (et tout ce qui va avec) de mise à jour de mot de passe pour l'organisationLearner est encore dans le répretoire `lib/`

## ⛱️ Proposition

Déplacer la route de mise à jour de mot de passe pour l'organisationLearner

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
