### PR TITLE
[FEATURE] Ajouter l'audit logger dans la suppression d'une participation d'une campagne (Pix-17975).

### DIFF
--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -65,6 +65,8 @@ export class DeleteOrganizationLearnersFromOrganizationScript extends Script {
         organizationLearnerIds: organizationLearnerToDeleteIds,
         userId: engineeringUserId,
         organizationId,
+        userRole: 'SUPER_ADMIN',
+        client: 'SCRIPT',
       });
 
       if (executeAnonymization) {

--- a/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
+++ b/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { CampaignParticipationLoggerContext } from '../../../../prescription/shared/domain/constants.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 
-const CLIENTS = ['PIX_ADMIN', 'PIX_APP', 'PIX_ORGA'];
+const CLIENTS = ['PIX_ADMIN', 'PIX_APP', 'PIX_ORGA', 'SCRIPT'];
 const ACTIONS = [
   'ANONYMIZATION',
   'ANONYMIZATION_GAR',

--- a/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
+++ b/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
@@ -1,10 +1,16 @@
 import Joi from 'joi';
 
+import { CampaignParticipationLoggerContext } from '../../../../prescription/shared/domain/constants.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 
-const CLIENTS = ['PIX_ADMIN', 'PIX_APP'];
-const ACTIONS = ['ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED'];
-const ROLES = ['SUPER_ADMIN', 'SUPPORT', 'USER'];
+const CLIENTS = ['PIX_ADMIN', 'PIX_APP', 'PIX_ORGA'];
+const ACTIONS = [
+  'ANONYMIZATION',
+  'ANONYMIZATION_GAR',
+  'EMAIL_CHANGED',
+  ...Object.values(CampaignParticipationLoggerContext),
+];
+const ROLES = ['SUPER_ADMIN', 'SUPPORT', 'USER', 'ORGA_ADMIN'];
 
 const EventLogSchema = Joi.object({
   client: Joi.string()

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -76,6 +76,21 @@ const deleteParticipation = async function (request, h) {
     userId,
     campaignId,
     campaignParticipationId,
+    userRole: 'ORGA_ADMIN',
+    client: 'PIX_ORGA',
+  });
+  return h.response({}).code(204);
+};
+
+const deleteParticipationFromAdmin = async function (request, h) {
+  const { userId } = request.auth.credentials;
+  const { campaignId, campaignParticipationId } = request.params;
+  await usecases.deleteCampaignParticipation({
+    userId,
+    campaignId,
+    campaignParticipationId,
+    userRole: 'SUPER_ADMIN',
+    client: 'PIX_ADMIN',
   });
   return h.response({}).code(204);
 };
@@ -179,6 +194,7 @@ const getUserCampaignAssessmentResult = async function (
 
 const campaignParticipationController = {
   deleteParticipation,
+  deleteParticipationFromAdmin,
   findPaginatedParticipationsForCampaignManagement,
   getAnalysis,
   getAnonymisedCampaignAssessments,

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -6,7 +6,7 @@ import {
   CantImproveCampaignParticipationError,
 } from '../../../../../src/shared/domain/errors.js';
 import { ArchivedCampaignError } from '../../../campaign/domain/errors.js';
-import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+import { CampaignParticipationLoggerContext, CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { CampaignParticiationInvalidStatus, CampaignParticipationDeletedError } from '../errors.js';
 
 class CampaignParticipation {
@@ -104,7 +104,7 @@ class CampaignParticipation {
     this.participantExternalId = null;
     this.userId = null;
 
-    this.#loggerContext = 'ANONYMIZATION';
+    this.#loggerContext = CampaignParticipationLoggerContext.ANONYMIZATION;
   }
 
   delete(userId, isAnonymizedEnabled = false) {
@@ -115,7 +115,7 @@ class CampaignParticipation {
     this.deletedAt = new Date();
     this.deletedBy = userId;
 
-    this.#loggerContext = 'DELETION';
+    this.#loggerContext = CampaignParticipationLoggerContext.DELETION;
   }
 
   _canBeImproved() {

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -11,6 +11,7 @@ import * as competenceEvaluationRepository from '../../../../evaluation/infrastr
 import * as stageAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js';
 import * as stageRepository from '../../../../evaluation/infrastructure/repositories/stage-repository.js';
 import * as authenticationMethodRepository from '../../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
+import { eventLoggingJobRepository } from '../../../../identity-access-management/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import { config } from '../../../../shared/config.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
@@ -44,7 +45,6 @@ import { participantResultsSharedRepository } from '../../infrastructure/reposit
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
 import * as poleEmploiSendingRepository from '../../infrastructure/repositories/pole-emploi-sending-repository.js';
-
 /**
  * @typedef { import ('../../../../shared/infrastructure/feature-toggles/index.js')} FeatureToggles
  * @typedef { import ('../../../../shared/infrastructure/repositories/area-repository.js')} AreaRepository
@@ -110,6 +110,7 @@ const dependencies = {
   compareStagesAndAcquiredStages,
   competenceEvaluationRepository,
   competenceRepository,
+  eventLoggingJobRepository,
   featureToggles,
   knowledgeElementRepository: injectedSharedRepositories.knowledgeElementRepository,
   knowledgeElementSnapshotRepository,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -52,10 +52,6 @@ const update = async function (campaignParticipation) {
     .update(pick(campaignParticipation, CAMPAIGN_PARTICIPATION_ATTRIBUTES));
 };
 
-const batchUpdate = async function (campaignParticipations) {
-  return Promise.all(campaignParticipations.map((campaignParticipation) => update(campaignParticipation)));
-};
-
 const getLocked = async function (id) {
   const knexConn = DomainTransaction.getConnection();
 
@@ -295,7 +291,6 @@ async function getSharedParticipationIds(campaignId) {
 }
 
 export {
-  batchUpdate,
   findInfoByCampaignId,
   findOneByCampaignIdAndUserId,
   get,

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -9,6 +9,7 @@ import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructu
 import * as badgeRepository from '../../../../evaluation/infrastructure/repositories/badge-repository.js';
 import * as stageAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js';
 import * as stageRepository from '../../../../evaluation/infrastructure/repositories/stage-repository.js';
+import { eventLoggingJobRepository } from '../../../../identity-access-management/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
@@ -100,6 +101,7 @@ const dependencies = {
   codeGenerator,
   competenceRepository,
   divisionRepository,
+  eventLoggingJobRepository,
   featureToggles,
   groupRepository,
   knowledgeElementRepository,

--- a/api/src/prescription/learner-management/application/api/learners-api.js
+++ b/api/src/prescription/learner-management/application/api/learners-api.js
@@ -39,5 +39,11 @@ export const deleteOrganizationLearnerBeforeImportFeature = withTransaction(asyn
 
   const organizationLearnerIds = await usecases.findOrganizationLearnersBeforeImportFeature({ organizationId });
 
-  return usecases.deleteOrganizationLearners({ userId, organizationId, organizationLearnerIds });
+  return usecases.deleteOrganizationLearners({
+    userId,
+    organizationId,
+    organizationLearnerIds,
+    userRole: 'SUPER_ADMIN',
+    client: 'PIX_ADMIN',
+  });
 });

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -12,6 +12,8 @@ const deleteOrganizationLearners = async function (request, h) {
       organizationLearnerIds: listLearners,
       userId: authenticatedUserId,
       organizationId,
+      userRole: 'ORGA_ADMIN',
+      client: 'PIX_ORGA',
     });
   });
   return h.response().code(200);

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
+import { eventLoggingJobRepository } from '../../../../identity-access-management/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as obfuscationService from '../../../../shared/domain/services/obfuscation-service.js';
@@ -33,7 +34,6 @@ import * as organizationLearnerRepository from '../../infrastructure/repositorie
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import { importStorage } from '../../infrastructure/storage/import-storage.js';
-
 /**
  * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} CampaignParticipationRepository
  * @typedef {import ('../../../campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
@@ -65,6 +65,7 @@ const dependencies = {
   assessmentRepository,
   campaignParticipationRepository: repositories.campaignParticipationRepository,
   campaignRepository,
+  eventLoggingJobRepository,
   importCommonOrganizationLearnersJobRepository,
   importOrganizationLearnersJobRepository,
   importScoCsvOrganizationLearnersJobRepository,

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -15,4 +15,9 @@ const CampaignExternalIdTypes = {
   EMAIL: 'EMAIL',
 };
 
-export { CampaignExternalIdTypes, CampaignParticipationStatuses, CampaignTypes };
+const CampaignParticipationLoggerContext = {
+  DELETION: 'CAMPAIGN_PARTICIPATION_DELETION',
+  ANONYMIZATION: 'CAMPAIGN_PARTICIPATION_ANONYMIZATION',
+};
+
+export { CampaignExternalIdTypes, CampaignParticipationLoggerContext, CampaignParticipationStatuses, CampaignTypes };

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -516,60 +516,6 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
-  describe('#batchUpdate', function () {
-    let clock;
-    const frozenTime = new Date('1987-09-01T00:00:00Z');
-
-    beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
-    it('save the changes of multiple campaignParticipations', async function () {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      const firstCampaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
-        deletedAt: null,
-        deletedBy: null,
-      });
-      const secondCampaignParticipationToUpdate = databaseBuilder.factory.buildCampaignParticipation({
-        deletedAt: null,
-        deletedBy: null,
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const participations = [
-        new CampaignParticipation(firstCampaignParticipationToUpdate),
-        new CampaignParticipation(secondCampaignParticipationToUpdate),
-      ];
-      participations.forEach((participation) => {
-        participation.delete(user.id);
-      });
-      await campaignParticipationRepository.batchUpdate(participations);
-
-      // then
-      const updatedFirstParticipation = await campaignParticipationRepository.get(
-        firstCampaignParticipationToUpdate.id,
-      );
-      const updatedSecondParticipation = await campaignParticipationRepository.get(
-        secondCampaignParticipationToUpdate.id,
-      );
-      expect(updatedFirstParticipation).to.deep.include({
-        deletedAt: frozenTime,
-        deletedBy: user.id,
-      });
-      expect(updatedSecondParticipation).to.deep.include({
-        deletedAt: frozenTime,
-        deletedBy: user.id,
-      });
-    });
-  });
-
   describe('#remove', function () {
     it('should mark as deleted given participation', async function () {
       const ownerId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -398,6 +398,36 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
         campaignParticipationId,
         campaignId,
         userId,
+        userRole: 'ORGA_ADMIN',
+        client: 'PIX_ORGA',
+      });
+    });
+  });
+
+  describe('#deleteParticipationFromAdmin', function () {
+    it('should call the usecase to delete the campaignParticipation', async function () {
+      // given
+      const campaignParticipationId = 1;
+      const campaignId = 6;
+      const userId = 2;
+      const request = {
+        params: { campaignId, campaignParticipationId },
+        auth: { credentials: { userId } },
+      };
+
+      sinon.stub(usecases, 'deleteCampaignParticipation');
+      usecases.deleteCampaignParticipation.resolves();
+
+      // when
+      await campaignParticipationController.deleteParticipationFromAdmin(request, hFake);
+
+      // then
+      expect(usecases.deleteCampaignParticipation).to.have.been.calledOnceWith({
+        campaignParticipationId,
+        campaignId,
+        userId,
+        userRole: 'SUPER_ADMIN',
+        client: 'PIX_ADMIN',
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -5,6 +5,7 @@ import {
 } from '../../../../../../src/prescription/campaign-participation/domain/errors.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import {
+  CampaignParticipationLoggerContext,
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
@@ -37,7 +38,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
       campaignParticipation.delete(userId);
 
-      expect(campaignParticipation.loggerContext).to.equal('DELETION');
+      expect(campaignParticipation.loggerContext).to.equal(CampaignParticipationLoggerContext.DELETION);
       expect(campaignParticipation.userId).to.equal(666);
       expect(campaignParticipation.deletedAt).to.deep.equal(now);
       expect(campaignParticipation.deletedBy).to.deep.equal(userId);
@@ -49,7 +50,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
       campaignParticipation.delete(userId, true);
 
-      expect(campaignParticipation.loggerContext).to.equal('DELETION');
+      expect(campaignParticipation.loggerContext).to.equal(CampaignParticipationLoggerContext.DELETION);
       expect(campaignParticipation.userId).to.equal(null);
       expect(campaignParticipation.deletedAt).to.deep.equal(now);
       expect(campaignParticipation.deletedBy).to.deep.equal(userId);
@@ -67,7 +68,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
       campaignParticipation.anonymize();
 
-      expect(campaignParticipation.loggerContext).to.equal('ANONYMIZATION');
+      expect(campaignParticipation.loggerContext).to.equal(CampaignParticipationLoggerContext.ANONYMIZATION);
       expect(campaignParticipation.userId).to.equal(null);
       expect(campaignParticipation.participantExternalId).to.equal(null);
     });

--- a/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
+++ b/api/tests/prescription/learner-management/unit/application/api/learners-api_test.js
@@ -81,7 +81,9 @@ describe('Unit | Prescription | learner management | Api | learners', function (
       const organizationLearnerIds = Symbol('organizationLearnerIds');
 
       findOrganizationLearnersBeforeImportFeatureStub.withArgs({ organizationId }).resolves(organizationLearnerIds);
-      deleteOrganizationLearnersStub.withArgs({ userId, organizationId, organizationLearnerIds }).resolves();
+      deleteOrganizationLearnersStub
+        .withArgs({ userId, organizationId, organizationLearnerIds, userRole: 'SUPER_ADMIN', client: 'PIX_ADMIN' })
+        .resolves();
 
       // when
       await deleteOrganizationLearnerBeforeImportFeature({ userId, organizationId });


### PR DESCRIPTION
## 🔆 Problème

Lors d'une action d'anonymisation nous n'enregistrons pas l'historique de qui a effectué l'action.

## ⛱️ Proposition

Ajouter un envoi dans Audit Logger avec les paramètres adéquats.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier qu'une entrée est archivé dans AuditLogger lorsque la feature `isAnonymizedWithDeletionEnabled` à `true`