### PR TITLE
[FEATURE] Permettre la création d'un `client-application` sans juridiction via le script dédié.

### DIFF
--- a/api/scripts/identity-access-management/client-applications.js
+++ b/api/scripts/identity-access-management/client-applications.js
@@ -37,7 +37,8 @@ class ClientApplicationsScript extends Script {
             jurisdiction: {
               description:
                 'Jurisdiction definition, currently, only an object like `{ "rules": [{ "name": "tags", "value": ["tag name"] }] }` is supported. \nThe juridiction restricts the data access to organizations tagged with specified "tag name".',
-              demandOption: true,
+              demandOption: false,
+              default: null,
               type: 'object',
             },
           },

--- a/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/client-application.repository.js
@@ -30,7 +30,9 @@ export const clientApplicationRepository = {
         .required()
         .min(1),
     });
-    await jurisdictionSchema.validateAsync(jurisdiction);
+    if (jurisdiction) {
+      await jurisdictionSchema.validateAsync(jurisdiction);
+    }
     await knex.insert({ name, clientId, clientSecret, scopes, jurisdiction }).into(TABLE_NAME);
   },
 

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/client-application.repository.test.js
@@ -93,6 +93,27 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(applications[2]).to.deep.contain(application2);
     });
 
+    it('should insert a new client application with no given jurisdiction', async function () {
+      // given
+      const newApplication = {
+        name: 'appli0',
+        clientId: 'clientId-appli0',
+        clientSecret: 'secret-app0',
+        scopes: ['scope0'],
+        jurisdiction: null,
+      };
+
+      // when
+      await clientApplicationRepository.create(newApplication);
+
+      // then
+      const applications = await knex.select().from('client_applications').orderBy('name');
+      expect(applications).to.have.lengthOf(3);
+      expect(applications[0]).to.deep.contain(newApplication);
+      expect(applications[1]).to.deep.contain(application1);
+      expect(applications[2]).to.deep.contain(application2);
+    });
+
     it('should not insert a client application with invalid juridiction json format', async function () {
       // given
       const newApplication = {


### PR DESCRIPTION
## 🔆 Problème

Les règles de juridiction (actuellement basées sur des tags) n'est pas une donnée obligatoire pour les `client-application` en base de données **mais** le script de gestion de ces `client-applications` rend obligatoire la spécification de ces règles.

## ⛱️ Proposition

Rendre optionnelles les règles de juridiction dans le script de création d'un `client-application`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

sur la review app, créer une application cliente sans juridiction et vérifier que cela fonctionne : 
```
node ./scripts/identity-access-management/client-applications.js add --name client --clientId identifiant --clientSecret secret --scope perimetre
```
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
