### PR TITLE
[TECH] :truck: Déplace le repository à propos des badges de certification vers `src/certification/shared/`

### DIFF
--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -3,7 +3,7 @@
  */
 import _ from 'lodash';
 
-import * as certifiableBadgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
+import * as certifiableBadgeAcquisitionRepository from '../../../../../src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../../../shared/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';

--- a/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
-import { CertifiableBadgeAcquisition } from '../../../src/shared/domain/models/CertifiableBadgeAcquisition.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { CertifiableBadgeAcquisition } from '../../../../shared/domain/models/CertifiableBadgeAcquisition.js';
 
 const BADGE_ACQUISITIONS_TABLE = 'badge-acquisitions';
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -1,6 +1,6 @@
-import * as certifiableBadgeAcquisitionRepository from '../../../../lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
-import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import * as certifiableBadgeAcquisitionRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Certifiable Badge Acquisition', function () {
   describe('#findHighestCertifiable', function () {


### PR DESCRIPTION
## 🔆 Problème

Le repository à propos des badges de certification est encore dans `lib/`

## ⛱️ Proposition

Déplacer le repository à propos des badges de certification vers `src/certification/shared/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
