### PR TITLE
[TECH] envoie une url de redirection au lieu d'un code de campagne lors de la création d'utilisateur (PIX-18098)

### DIFF
--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -136,7 +136,7 @@ const createUser = async function (request, h, dependencies = { userSerializer, 
   const canonicalLocaleFromCookie = localeFromCookie
     ? dependencies.localeService.getCanonicalLocale(localeFromCookie)
     : undefined;
-  const campaignCode = request.payload.meta ? request.payload.meta['campaign-code'] : null;
+  const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
   const user = { ...dependencies.userSerializer.deserialize(request.payload), locale: canonicalLocaleFromCookie };
   const localeFromHeader = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
@@ -145,7 +145,7 @@ const createUser = async function (request, h, dependencies = { userSerializer, 
   const savedUser = await usecases.createUser({
     user,
     password,
-    campaignCode,
+    redirectionUrl,
     localeFromHeader,
     i18n: request.i18n,
   });

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -1,6 +1,5 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
-import { urlBuilder } from '../../../shared/infrastructure/utils/url-builder.js';
 import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
 import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
 
@@ -22,12 +21,11 @@ import { InvalidOrAlreadyUsedEmailError } from '../errors.js';
  * @return {Promise<User|undefined>}
  */
 const createUser = withTransaction(async function ({
-  campaignCode,
   localeFromHeader,
   password,
   user,
   authenticationMethodRepository,
-  campaignRepository,
+  redirectionUrl,
   emailRepository,
   emailValidationDemandRepository,
   userRepository,
@@ -58,14 +56,6 @@ const createUser = withTransaction(async function ({
     userToCreateRepository,
     authenticationMethodRepository,
   });
-
-  let redirectionUrl = null;
-  if (campaignCode) {
-    const campaign = await campaignRepository.getByCode(campaignCode);
-    if (campaign) {
-      redirectionUrl = urlBuilder.getCampaignUrl(localeFromHeader, campaignCode);
-    }
-  }
 
   const token = await emailValidationDemandRepository.save(savedUser.id);
 

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -268,7 +268,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
             user: { ...deserializedUser, locale: localeFromCookie },
             password,
             localeFromHeader,
-            campaignCode: null,
+            redirectionUrl: null,
             i18n: undefined,
           };
 

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -434,6 +434,11 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
 
     context('step send account creation email to user', function () {
       const user = new User({ email: userEmail, locale: localeFromHeader });
+      let redirectionUrl;
+
+      beforeEach(function () {
+        redirectionUrl = `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`;
+      });
 
       it('should send the account creation email', async function () {
         // given
@@ -443,7 +448,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           firstName: user.firstName,
           locale: localeFromHeader,
           token,
-          redirectionUrl: `${config.domain.pixApp + config.domain.tldFr}/campagnes/${campaignCode}`,
+          redirectionUrl,
         });
 
         // when
@@ -451,9 +456,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           user,
           localeFromHeader,
           password,
-          campaignCode,
+          redirectionUrl,
           authenticationMethodRepository,
-          campaignRepository,
           emailRepository,
           emailValidationDemandRepository,
           userRepository,
@@ -562,9 +566,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         user,
         localeFromHeader,
         password,
-        campaignCode,
+        redirectionUrl,
         authenticationMethodRepository,
-        campaignRepository,
         emailRepository,
         emailValidationDemandRepository,
         userRepository,

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -8,10 +8,10 @@ export default class User extends ApplicationAdapter {
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
 
-    if (adapterOptions && adapterOptions.campaignCode) {
+    if (adapterOptions && adapterOptions.redirectionUrl) {
       const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
       const { data } = this.serialize(snapshot);
-      const payload = { data: { data, meta: { 'campaign-code': adapterOptions.campaignCode } } };
+      const payload = { data: { data, meta: { 'redirection-url': adapterOptions.redirectionUrl } } };
       return this.ajax(url, 'POST', payload);
     }
 

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -92,10 +92,9 @@ export default class SignupForm extends Component {
     this.isLoading = true;
 
     try {
-      const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
       user.lang = this.intl.primaryLocale;
 
-      await user.save({ adapterOptions: { campaignCode } });
+      await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
       await this.session.authenticateUser(user.email, user.password);
 
       user.password = null;

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -63,6 +63,15 @@ export default class CurrentSessionService extends SessionService {
     await this._loadCurrentUserAndSetLocale(language);
   }
 
+  get redirectionUrl() {
+    const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
+    if (campaignCode) {
+      const baseUrl = window.location.protocol + '//' + window.location.host;
+      return baseUrl + this.router.urlFor('campaigns', { code: campaignCode });
+    }
+    return null;
+  }
+
   requireAuthenticationAndApprovedTermsOfService(transition, authenticationRoute) {
     if (this.isAuthenticated && this.currentUser.user.mustValidateTermsOfService) {
       this.attemptedTransition = transition;

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -74,8 +74,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           });
 
           module('When user create its account', function () {
-            test('should send campaignCode to API', async function (assert) {
-              let sentCampaignCode;
+            test('should send redirectionUrl to API', async function (assert) {
+              let sentRedirectionUrl;
 
               const prescritUser = {
                 firstName: 'firstName',
@@ -87,7 +87,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               this.server.post(
                 '/users',
                 (schema, request) => {
-                  sentCampaignCode = JSON.parse(request.requestBody).meta['campaign-code'];
+                  sentRedirectionUrl = JSON.parse(request.requestBody).meta['redirection-url'];
                   return schema.users.create({});
                 },
                 201,
@@ -122,7 +122,13 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await click(screen.getByRole('button', { name: t('pages.sign-up.actions.submit') }));
 
               // then
-              assert.strictEqual(sentCampaignCode, campaign.code);
+              const router = this.owner.lookup('service:router');
+              const redirectionUrl =
+                window.location.protocol +
+                '//' +
+                window.location.host +
+                router.urlFor('campaigns', { code: campaign.code });
+              assert.strictEqual(sentRedirectionUrl, redirectionUrl);
             });
           });
         });

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -96,21 +96,21 @@ module('Unit | Adapters | user', function (hooks) {
   });
 
   module('#createRecord', function () {
-    module('when campaignCode adapterOption is defined', function () {
-      test('should add campaign-code meta', async function (assert) {
+    module('when redirectionUrl adapterOption is defined', function () {
+      test('should add redirection-url meta', async function (assert) {
         // given
-        const campaignCode = 'AZERTY123';
+        const redirectionUrl = 'http://localhost:4200/campagnes/AZERTY123';
         const expectedUrl = 'http://localhost:3000/api/users';
         const expectedMethod = 'POST';
         const expectedData = {
           data: {
-            meta: { 'campaign-code': campaignCode },
+            meta: { 'redirection-url': redirectionUrl },
             data: {},
           },
         };
         const snapshot = {
           record: {},
-          adapterOptions: { campaignCode },
+          adapterOptions: { redirectionUrl },
           serialize: function () {
             return { data: {} };
           },


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre des travaux de Combinix, on a besoin de pouvoir réutiliser la brique accès hors du contexte de campagne. Le endpoint de création d'utilisateur se sert du code de campagne pour construire une url de redirection à envoyer par mail à l'utilisateur.

## ⛱️ Proposition

On déplace la logique de construction de l'url de redirection dans le front de manière à pouvoir créer des utilisateurs indistinctement depuis les campagnes ou les combinix.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Créer un compte utilisateur en passant par une campagne et vérifier que le lien reçu par mail est fonctionnel et renvoie vers la bonne campagne.