### PR TITLE
[FEATURE] Ajouter l'historisation des actions lors de la suppression de prescrits (PIX-17974).

### DIFF
--- a/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
+++ b/api/src/identity-access-management/domain/models/jobs/EventLoggingJob.js
@@ -1,6 +1,9 @@
 import Joi from 'joi';
 
-import { CampaignParticipationLoggerContext } from '../../../../prescription/shared/domain/constants.js';
+import {
+  CampaignParticipationLoggerContext,
+  OrganizationLearnerLoggerContext,
+} from '../../../../prescription/shared/domain/constants.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 
 const CLIENTS = ['PIX_ADMIN', 'PIX_APP', 'PIX_ORGA', 'SCRIPT'];
@@ -9,6 +12,7 @@ const ACTIONS = [
   'ANONYMIZATION_GAR',
   'EMAIL_CHANGED',
   ...Object.values(CampaignParticipationLoggerContext),
+  ...Object.values(OrganizationLearnerLoggerContext),
 ];
 const ROLES = ['SUPER_ADMIN', 'SUPPORT', 'USER', 'ORGA_ADMIN'];
 

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+import { OrganizationLearnerLoggerContext } from '../../../shared/domain/constants.js';
+
 const STATUS = {
   STUDENT: 'ST',
   APPRENTICE: 'AP',
@@ -87,7 +89,7 @@ class OrganizationLearner {
   }
 
   anonymize() {
-    this.#loggerContext = 'ORGANIZATION_LEARNER_ANONYMIZATION';
+    this.#loggerContext = OrganizationLearnerLoggerContext.ANONYMIZATION;
     this.firstName = '(anonymized)';
     this.lastName = '(anonymized)';
     this.preferredLastName = null;
@@ -121,7 +123,7 @@ class OrganizationLearner {
   delete(userId, isAnonymizedWithDeletionEnabled) {
     if (isAnonymizedWithDeletionEnabled) {
       this.anonymize();
-      this.#loggerContext = 'ORGANIZATION_LEARNER_DELETION';
+      this.#loggerContext = OrganizationLearnerLoggerContext.DELETION;
     }
 
     this.deletedAt = new Date();

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -36,6 +36,19 @@ const deleteOrganizationLearners = withTransaction(async function ({
     organizationLearner.delete(userId, isAnonymizationWithDeletionEnabled);
     await organizationLearnerRepository.remove(organizationLearner.dataToUpdateOnDeletion);
 
+    if (isAnonymizationWithDeletionEnabled) {
+      await eventLoggingJobRepository.performAsync(
+        new EventLoggingJob({
+          client,
+          action: organizationLearner.loggerContext,
+          role: userRole,
+          userId,
+          targetUserId: organizationLearner.id,
+          data: {},
+        }),
+      );
+    }
+
     const campaignParticipations =
       await campaignParticipationRepositoryfromBC.getAllCampaignParticipationsForOrganizationLearner({
         organizationLearnerId: organizationLearner.id,

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -20,4 +20,15 @@ const CampaignParticipationLoggerContext = {
   ANONYMIZATION: 'CAMPAIGN_PARTICIPATION_ANONYMIZATION',
 };
 
-export { CampaignExternalIdTypes, CampaignParticipationLoggerContext, CampaignParticipationStatuses, CampaignTypes };
+const OrganizationLearnerLoggerContext = {
+  DELETION: 'ORGANIZATION_LEARNER_DELETION',
+  ANONYMIZATION: 'ORGANIZATION_LEARNER_ANONYMIZATION',
+};
+
+export {
+  CampaignExternalIdTypes,
+  CampaignParticipationLoggerContext,
+  CampaignParticipationStatuses,
+  CampaignTypes,
+  OrganizationLearnerLoggerContext,
+};

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -3,6 +3,7 @@ import { usecases } from '../../../../../../src/prescription/learner-management/
 import {
   CampaignParticipationLoggerContext,
   CampaignTypes,
+  OrganizationLearnerLoggerContext,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
@@ -322,15 +323,26 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
       });
 
       // then
-      await expect(EventLoggingJob.name).to.have.been.performed.withJobPayload({
-        client: 'PIX_ORGA',
-        action: CampaignParticipationLoggerContext.DELETION,
-        role: 'ORGA_ADMIN',
-        userId: adminUserId,
-        occurredAt: now.toISOString(),
-        targetUserId: campaignParticipation1.id,
-        data: {},
-      });
+      await expect(EventLoggingJob.name).to.have.been.performed.withJobPayloads([
+        {
+          client: 'PIX_ORGA',
+          action: OrganizationLearnerLoggerContext.DELETION,
+          role: 'ORGA_ADMIN',
+          userId: adminUserId,
+          occurredAt: now.toISOString(),
+          targetUserId: organizationLearner1.id,
+          data: {},
+        },
+        {
+          client: 'PIX_ORGA',
+          action: CampaignParticipationLoggerContext.DELETION,
+          role: 'ORGA_ADMIN',
+          userId: adminUserId,
+          occurredAt: now.toISOString(),
+          targetUserId: campaignParticipation1.id,
+          data: {},
+        },
+      ]);
     });
 
     context('when there are badges linked to the campaign participations', function () {


### PR DESCRIPTION
## 🔆 Problème

Nous n'historisons pas les actions d'anonymisation, ni de suppression. 

## ⛱️ Proposition

Ajouter cette historisation pour s'aligner avec les règles CNIL

## 🌊 Remarques

RAS

## 🏄 Pour tester

Supprimer un learner sans la feature => pas d'audit logger
Supprimer un learner avec la feature `npm run toggles -- -k isAnonymizationWithDeletion -v true` et vérifier qu'on event a été publié dans l'audit logger.

