### PR TITLE
[BUGFIX] Corriger l'affichage du progress bar sur PixOrga (PIX-17762).

### DIFF
--- a/orga/app/styles/components/progress-bar.scss
+++ b/orga/app/styles/components/progress-bar.scss
@@ -1,7 +1,6 @@
 .progress-bar {
   width: 160px;
   height: 6px;
-  background-color: var(--pix-neutral-20);
   border-radius: 10px;
 
   &--completion {


### PR DESCRIPTION
## 🔆 Problème

la progress bar a un zigouigoui bizarre qui apparaît

## ⛱️ Proposition

l'enlever

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI au vert. et vérifier que sur la page contenant la progress bar. que le zigouigoui a disparu