### PR TITLE
[TECH] Déplace le flag hasUserSeenJoinPage dans un storage spécifique à la logique d'accès (PIX-18100)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.gjs
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.gjs
@@ -8,7 +8,6 @@ import ScoForm from 'mon-pix/components/routes/campaigns/sco-form';
 export default class AssociateScoStudentForm extends Component {
   <template>
     <ScoForm
-      @campaignCode={{@campaignCode}}
       @organizationName={{@organizationName}}
       @areNamesDisabled={{false}}
       @onSubmit={{this.submit}}
@@ -17,7 +16,7 @@ export default class AssociateScoStudentForm extends Component {
 
     {{#if this.displayInformationModal}}
       <JoinScoInformationModal
-        @campaignCode={{@campaignCode}}
+        @goToConnectionPage={{@goToConnectionPage}}
         @reconciliationError={{this.reconciliationError}}
         @reconciliationWarning={{this.reconciliationWarning}}
         @closeModal={{this.closeModal}}

--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.gjs
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.gjs
@@ -64,7 +64,7 @@ export default class JoinScoInformationModal extends Component {
               {{t "common.actions.quit"}}
             </PixButton>
             {{#if this.displayContinueButton}}
-              <PixButton @triggerAction={{this.goToCampaignConnectionForm}}>
+              <PixButton @triggerAction={{@goToConnectionPage}}>
                 {{t "pages.join.sco.continue-with-pix"}}
               </PixButton>
             {{/if}}
@@ -113,13 +113,5 @@ export default class JoinScoInformationModal extends Component {
   async goToHome() {
     await this.session.invalidate();
     return window.location.replace(this.url.homeUrl);
-  }
-
-  @action
-  async goToCampaignConnectionForm() {
-    this.session.set('skipRedirectAfterSessionInvalidation', true);
-    await this.session.invalidate();
-    this.campaignStorage.set(this.args.campaignCode, 'hasUserSeenJoinPage', true);
-    this.router.replaceWith('campaigns.access', this.args.campaignCode);
   }
 }

--- a/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.gjs
+++ b/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.gjs
@@ -9,7 +9,6 @@ import { decodeToken } from 'mon-pix/helpers/jwt';
 export default class AssociateScoStudentWithMediacentreForm extends Component {
   <template>
     <ScoForm
-      @campaignCode={{@campaignCode}}
       @organizationName={{@organizationName}}
       @areNamesDisabled={{true}}
       @firstName={{this.firstName}}
@@ -20,7 +19,7 @@ export default class AssociateScoStudentWithMediacentreForm extends Component {
 
     {{#if this.displayInformationModal}}
       <JoinScoInformationModal
-        @campaignCode={{@campaignCode}}
+        @goToConnectionPage={{@goToConnectionPage}}
         @reconciliationError={{this.reconciliationError}}
         @reconciliationWarning={{this.reconciliationWarning}}
         @closeModal={{this.closeModal}}

--- a/mon-pix/app/controllers/campaigns/invited/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/invited/student-sco.js
@@ -5,6 +5,8 @@ import { service } from '@ember/service';
 export default class StudentScoController extends Controller {
   @service campaignStorage;
   @service router;
+  @service accessStorage;
+  @service session;
 
   @action
   async reconcile(scoOrganizationLearner, adapterOptions) {
@@ -18,5 +20,13 @@ export default class StudentScoController extends Controller {
     this.campaignStorage.set(this.model.code, 'associationDone', true);
     this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.model.code);
     return;
+  }
+
+  @action
+  async goToConnectionPage() {
+    this.session.set('skipRedirectAfterSessionInvalidation', true);
+    await this.session.invalidate();
+    this.accessStorage.set(this.model.organizationId, 'hasUserSeenJoinPage', true);
+    this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/invited/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/invited/student-sco.js
@@ -26,7 +26,7 @@ export default class StudentScoController extends Controller {
   async goToConnectionPage() {
     this.session.set('skipRedirectAfterSessionInvalidation', true);
     await this.session.invalidate();
-    this.accessStorage.set(this.model.organizationId, 'hasUserSeenJoinPage', true);
+    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId, true);
     this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -6,6 +6,8 @@ export default class ScoMediacentreController extends Controller {
   @service session;
   @service currentUser;
   @service campaignStorage;
+  @service accessStorage;
+  @service router;
 
   @action
   async createAndReconcile(externalUser) {
@@ -17,5 +19,13 @@ export default class ScoMediacentreController extends Controller {
     await this.currentUser.load();
 
     this.campaignStorage.set(this.model.code, 'associationDone', true);
+  }
+
+  @action
+  async goToConnectionPage() {
+    this.session.set('skipRedirectAfterSessionInvalidation', true);
+    await this.session.invalidate();
+    this.accessStorage.set(this.model.organizationId, 'hasUserSeenJoinPage', true);
+    this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -25,7 +25,7 @@ export default class ScoMediacentreController extends Controller {
   async goToConnectionPage() {
     this.session.set('skipRedirectAfterSessionInvalidation', true);
     await this.session.invalidate();
-    this.accessStorage.set(this.model.organizationId, 'hasUserSeenJoinPage', true);
+    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId, true);
     this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -6,6 +6,7 @@ export default class AccessRoute extends Route {
   @service currentUser;
   @service session;
   @service campaignStorage;
+  @service accessStorage;
   @service router;
   @service store;
   @service oidcIdentityProviders;
@@ -63,7 +64,7 @@ export default class AccessRoute extends Route {
 
   _shouldLoginToAccessSCORestrictedCampaign(campaign) {
     const isAuthenticatedByGar = this.session.isAuthenticatedByGar;
-    const hasUserSeenJoinPage = this.campaignStorage.get(campaign.code, 'hasUserSeenJoinPage');
+    const hasUserSeenJoinPage = this.accessStorage.get(campaign.organizationId, 'hasUserSeenJoinPage');
     return (
       campaign.isRestricted &&
       campaign.organizationType === 'SCO' &&

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -64,7 +64,7 @@ export default class AccessRoute extends Route {
 
   _shouldLoginToAccessSCORestrictedCampaign(campaign) {
     const isAuthenticatedByGar = this.session.isAuthenticatedByGar;
-    const hasUserSeenJoinPage = this.accessStorage.get(campaign.organizationId, 'hasUserSeenJoinPage');
+    const hasUserSeenJoinPage = this.accessStorage.hasUserSeenJoinPage(campaign.organizationId);
     return (
       campaign.isRestricted &&
       campaign.organizationType === 'SCO' &&

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -7,6 +7,7 @@ export default class EntryPoint extends Route {
   @service currentUser;
   @service currentDomain;
   @service campaignStorage;
+  @service accessStorage;
   @service session;
   @service router;
   @service store;
@@ -27,8 +28,8 @@ export default class EntryPoint extends Route {
   }
 
   async afterModel(campaign, transition) {
+    this.accessStorage.clear(campaign.organizationId);
     this.campaignStorage.clear(campaign.code);
-
     // TODO: Change this when identity providers target apps are managed through the API
     if (campaign.identityProvider === 'FWB' && this.currentDomain.isFranceDomain && !this.currentDomain.isLocalhost) {
       const redirectUrl = this.currentDomain.convertUrlToOrgDomain();

--- a/mon-pix/app/routes/campaigns/join/student-sco.js
+++ b/mon-pix/app/routes/campaigns/join/student-sco.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class StudentScoRoute extends Route {
   @service campaignStorage;
+  @service accessStorage;
   @service session;
   @service router;
 
@@ -20,6 +21,6 @@ export default class StudentScoRoute extends Route {
   }
 
   setupController(controller, model) {
-    controller.displayRegisterForm = !this.campaignStorage.get(model.campaign.code, 'hasUserSeenJoinPage');
+    controller.displayRegisterForm = !this.accessStorage.get(model.campaign.organizationId, 'hasUserSeenJoinPage');
   }
 }

--- a/mon-pix/app/routes/campaigns/join/student-sco.js
+++ b/mon-pix/app/routes/campaigns/join/student-sco.js
@@ -21,6 +21,6 @@ export default class StudentScoRoute extends Route {
   }
 
   setupController(controller, model) {
-    controller.displayRegisterForm = !this.accessStorage.get(model.campaign.organizationId, 'hasUserSeenJoinPage');
+    controller.displayRegisterForm = !this.accessStorage.hasUserSeenJoinPage(model.campaign.organizationId);
   }
 }

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -7,12 +7,14 @@ export default class LogoutRoute extends Route {
   @service session;
   @service url;
   @service campaignStorage;
+  @service accessStorage;
   @service router;
   @service location;
 
   beforeModel() {
     this.session.revokeGarExternalUserToken();
     this.campaignStorage.clearAll();
+    this.accessStorage.clearAll();
 
     if (this.session.isAuthenticated) {
       if (this.session.data.authenticated.source === AUTHENTICATED_SOURCE_FROM_GAR) {

--- a/mon-pix/app/services/access-storage.js
+++ b/mon-pix/app/services/access-storage.js
@@ -1,0 +1,5 @@
+import BaseStorage from './base-storage.js';
+
+export default class AccessStorage extends BaseStorage {
+  collectionName = 'access';
+}

--- a/mon-pix/app/services/access-storage.js
+++ b/mon-pix/app/services/access-storage.js
@@ -2,4 +2,13 @@ import BaseStorage from './base-storage.js';
 
 export default class AccessStorage extends BaseStorage {
   collectionName = 'access';
+  #hasUserSeenJoinPageKey = 'hasUserSeenJoinPage';
+
+  hasUserSeenJoinPage(organizationId) {
+    return super.get(organizationId, this.#hasUserSeenJoinPageKey) ?? false;
+  }
+
+  setHasUserSeenJoinPage(organizationId, value) {
+    super.set(organizationId, this.#hasUserSeenJoinPageKey, value);
+  }
 }

--- a/mon-pix/app/services/base-storage.js
+++ b/mon-pix/app/services/base-storage.js
@@ -1,0 +1,41 @@
+import Service from '@ember/service';
+
+export default class BaseStorage extends Service {
+  collectionName;
+
+  set(id, key, value) {
+    const data = _getData(this.collectionName, id);
+    data[key] = value;
+    _setData(this.collectionName, id, data);
+  }
+
+  get(id, key) {
+    const data = _getData(this.collectionName, id);
+    return data[key];
+  }
+
+  clear(id) {
+    _setData(this.collectionName, id, {});
+  }
+
+  clearAll() {
+    sessionStorage.setItem(this.collectionName, JSON.stringify({}));
+  }
+}
+
+function _getData(collectionName, id) {
+  const value = sessionStorage.getItem(collectionName);
+
+  const json = value ? JSON.parse(value) : {};
+
+  return json[id] || {};
+}
+
+function _setData(collectionName, id, value) {
+  const data = sessionStorage.getItem(collectionName);
+
+  const dataParsed = data ? JSON.parse(data) : {};
+
+  dataParsed[id] = value;
+  sessionStorage.setItem(collectionName, JSON.stringify(dataParsed));
+}

--- a/mon-pix/app/services/campaign-storage.js
+++ b/mon-pix/app/services/campaign-storage.js
@@ -1,39 +1,5 @@
-import Service from '@ember/service';
+import BaseStorage from './base-storage.js';
 
-export default class CampaignStorage extends Service {
-  set(campaignCode, key, value) {
-    const campaignData = _getCampaignData(campaignCode);
-    campaignData[key] = value;
-    _setCampaignData(campaignCode, campaignData);
-  }
-
-  get(campaignCode, key) {
-    const campaignData = _getCampaignData(campaignCode);
-    return campaignData[key];
-  }
-
-  clear(campaignCode) {
-    _setCampaignData(campaignCode, {});
-  }
-
-  clearAll() {
-    sessionStorage.setItem('campaigns', JSON.stringify({}));
-  }
-}
-
-function _getCampaignData(campaignCode) {
-  const value = sessionStorage.getItem('campaigns');
-
-  const json = value ? JSON.parse(value) : {};
-
-  return json[campaignCode] || {};
-}
-
-function _setCampaignData(campaignCode, campaignData) {
-  const allCampaignsData = sessionStorage.getItem('campaigns');
-
-  const allCampaignsDataParsed = allCampaignsData ? JSON.parse(allCampaignsData) : {};
-
-  allCampaignsDataParsed[campaignCode] = campaignData;
-  sessionStorage.setItem('campaigns', JSON.stringify(allCampaignsDataParsed));
+export default class CampaignStorage extends BaseStorage {
+  collectionName = 'campaigns';
 }

--- a/mon-pix/app/templates/campaigns/invited/student-sco.gjs
+++ b/mon-pix/app/templates/campaigns/invited/student-sco.gjs
@@ -14,7 +14,7 @@ import AssociateScoStudentForm from 'mon-pix/components/routes/campaigns/invited
         <AssociateScoStudentForm
           @organizationName={{@model.organizationName}}
           @organizationId={{@model.organizationId}}
-          @campaignCode={{@model.code}}
+          @goToConnectionPage={{@controller.goToConnectionPage}}
           @onSubmit={{@controller.reconcile}}
         />
       </div>

--- a/mon-pix/app/templates/campaigns/join/sco-mediacentre.gjs
+++ b/mon-pix/app/templates/campaigns/join/sco-mediacentre.gjs
@@ -14,7 +14,7 @@ import AssociateScoStudentWithMediacentreForm from 'mon-pix/components/routes/ca
         <AssociateScoStudentWithMediacentreForm
           @organizationName={{@model.organizationName}}
           @organizationId={{@model.organizationId}}
-          @campaignCode={{@model.code}}
+          @goToConnectionPage={{@controller.goToConnectionPage}}
           @onSubmit={{@controller.createAndReconcile}}
         />
       </div>

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -41,6 +41,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             campaign = server.create('campaign', {
               externalIdLabel: 'email',
               externaIdType: 'EMAIL',
+              organizationId: 1,
               type: ASSESSMENT,
             });
             const screen = await startCampaignByCode(campaign.code);
@@ -72,7 +73,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
           module('When campaign is not restricted', function () {
             test('should redirect to assessment', async function (assert) {
               // given
-              campaign = server.create('campaign', { isRestricted: false, externalIdLabel: 'toto', type: ASSESSMENT });
+              campaign = server.create('campaign', {
+                isRestricted: false,
+                externalIdLabel: 'toto',
+                type: ASSESSMENT,
+                organizationId: 1,
+              });
               const screen = await startCampaignByCodeAndExternalId(campaign.code);
               await _fillInputsToCreateUserPixAccount({ prescritUser, screen, t });
 
@@ -85,6 +91,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             test('should redirect to assessment', async function (assert) {
               // given
               campaign = server.create('campaign', 'restricted', {
+                organizationId: 1,
                 externalIdLabel: 'toto',
                 organizationType: 'SCO',
                 type: ASSESSMENT,
@@ -123,7 +130,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not have external id', function () {
         test('should redirect to assessment after signup', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT });
+          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT, organizationId: 1 });
           const screen = await startCampaignByCode(campaign.code);
           await _fillInputsToCreateUserPixAccount({ prescritUser, screen, t });
 
@@ -135,7 +142,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not have external id but a participant external id is set in the url', function () {
         test('should redirect to assessment after signup', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { type: ASSESSMENT });
+          campaign = server.create('campaign', { type: ASSESSMENT, organizationId: 1 });
           const screen = await startCampaignByCodeAndExternalId(campaign.code);
           await _fillInputsToCreateUserPixAccount({ prescritUser, screen, t });
 
@@ -147,7 +154,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not require external id and is for absolute novice', function () {
         test('should redirect to signup page when starting a campaign', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT, isForAbsoluteNovice: true });
+          campaign = server.create('campaign', {
+            externalIdLabel: null,
+            type: ASSESSMENT,
+            isForAbsoluteNovice: true,
+            organizationId: 1,
+          });
           await visit(`/campagnes/${campaign.code}`);
 
           // then
@@ -164,7 +176,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign is not restricted', function () {
         test('should redirect to landing page', async function (assert) {
           // when
-          campaign = server.create('campaign', { type: ASSESSMENT });
+          campaign = server.create('campaign', { type: ASSESSMENT, organizationId: 1 });
           const screen = await visit(`/campagnes/${campaign.code}`);
 
           // then
@@ -182,6 +194,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
               externalIdLabel: 'nom de naissance de maman',
               type: ASSESSMENT,
               organizationType: 'SCO',
+              organizationId: 1,
             });
             const screen = await visit(`/campagnes/${campaign.code}`);
             await click(screen.getByRole('button', { name: 'Je commence' }));
@@ -207,7 +220,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
         module('When participant external id is not set in the url', function () {
           test('should go to the tutorial when the user fill in his id', async function (assert) {
             // given
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman', type: ASSESSMENT });
+            campaign = server.create('campaign', {
+              externalIdLabel: 'nom de naissance de maman',
+              type: ASSESSMENT,
+              organizationId: 1,
+            });
             const screen = await startCampaignByCode(campaign.code);
 
             // when
@@ -220,7 +237,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
 
           test('should start the assessment when the user has seen tutorial', async function (assert) {
             // given
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman', type: ASSESSMENT });
+            campaign = server.create('campaign', {
+              externalIdLabel: 'nom de naissance de maman',
+              type: ASSESSMENT,
+              organizationId: 1,
+            });
             const screen = await startCampaignByCode(campaign.code);
 
             // when
@@ -238,7 +259,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             // given & when
             const externalId256Characters =
               '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-            campaign = server.create('campaign', { isRestricted: false, externalIdLabel: 'toto', type: ASSESSMENT });
+            campaign = server.create('campaign', {
+              isRestricted: false,
+              externalIdLabel: 'toto',
+              type: ASSESSMENT,
+              organizationId: 1,
+            });
             await startCampaignByCodeAndExternalId(campaign.code, externalId256Characters);
 
             // then
@@ -249,7 +275,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
         module('When participant external id is set in the url', function () {
           test('should redirect to assessment', async function (assert) {
             // given
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman', type: ASSESSMENT });
+            campaign = server.create('campaign', {
+              externalIdLabel: 'nom de naissance de maman',
+              type: ASSESSMENT,
+              organizationId: 1,
+            });
 
             // when
             await startCampaignByCodeAndExternalId(campaign.code);
@@ -260,7 +290,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
 
           test('should start the assessment when the user has seen tutorial', async function (assert) {
             // given
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman', type: ASSESSMENT });
+            campaign = server.create('campaign', {
+              externalIdLabel: 'nom de naissance de maman',
+              type: ASSESSMENT,
+              organizationId: 1,
+            });
             const screen = await startCampaignByCodeAndExternalId(campaign.code);
 
             // when
@@ -275,7 +309,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not have external id', function () {
         test('should redirect to tutorial after clicking on start button in landing page', async function (assert) {
           // given
-          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT });
+          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT, organizationId: 1 });
           const screen = await visit(`campagnes/${campaign.code}`);
 
           // when
@@ -289,7 +323,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not have external id but a participant external id is set in the url', function () {
         test('should redirect to tutorial after clicking on start button in landing page', async function (assert) {
           // given
-          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT });
+          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT, organizationId: 1 });
           const screen = await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
 
           // when
@@ -303,7 +337,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
       module('When campaign does not have external id and is for absolute novice', function () {
         test('should redirect to assessment when starting a campaign', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { externalIdLabel: null, type: ASSESSMENT, isForAbsoluteNovice: true });
+          campaign = server.create('campaign', {
+            externalIdLabel: null,
+            type: ASSESSMENT,
+            isForAbsoluteNovice: true,
+            organizationId: 1,
+          });
           await visit(`campagnes/${campaign.code}`);
 
           // then
@@ -316,7 +355,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
         module('when the campaign allows multiple participations', function () {
           test('should redirect to assessment when retrying the campaign', async function (assert) {
             // given
-            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: true });
+            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: true, organizationId: 1 });
             const assessment = server.create('assessment', {
               type: 'CAMPAIGN',
               state: 'completed',
@@ -343,7 +382,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
         module('when the campaign does not allow multiple participations', function () {
           test('should redirect to assessment results when retrying the campaign', async function (assert) {
             // given
-            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: false });
+            campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: false, organizationId: 1 });
             const assessment = server.create('assessment', {
               type: 'CAMPAIGN',
               state: 'completed',

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -246,7 +246,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               };
               return new Response(200, {}, studentFoundWithUsernameGenerated);
             });
-
             this.server.post('sco-organization-learners/dependent', () => {
               const emailAlreadyExistResponse = {
                 errors: [
@@ -275,7 +274,6 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             //go to email-based authentication window
             await click(screen.getByText('Mon adresse e-mail'));
-
             await fillIn(screen.getByLabelText('Adresse e-mail', { exact: false }), prescritUser.email);
             await fillIn(screen.getByLabelText('Mot de passe', { exact: false }), 'pix123');
 

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal-test.js
@@ -1,11 +1,8 @@
-import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import createComponent from '../../../../helpers/create-glimmer-component';
-import { stubSessionService } from '../../../../helpers/service-stubs.js';
 import setupIntl from '../../../../helpers/setup-intl';
 
 module('Unit | Component | routes/campaigns/join-sco-information-modal', function (hooks) {
@@ -157,32 +154,6 @@ module('Unit | Component | routes/campaigns/join-sco-information-modal', functio
         // then
         assert.deepEqual(component.message, expectedWarningMessage);
       });
-    });
-  });
-
-  module('#goToCampaignConnectionForm', function () {
-    test('should not redirect user to login page when session is invalidated', function (assert) {
-      // given
-      const component = createComponent('routes/campaigns/join-sco-information-modal');
-
-      const sessionStub = stubSessionService(this.owner);
-
-      class CampaignStorageStub extends Service {
-        set = sinon.stub();
-      }
-
-      this.owner.register('service:campaignStorage', CampaignStorageStub);
-
-      const routerObserver = this.owner.lookup('service:router');
-      routerObserver.replaceWith = sinon.stub();
-
-      // when
-      component.goToCampaignConnectionForm();
-
-      // then
-      sinon.assert.calledOnce(sessionStub.invalidate);
-      assert.true(sessionStub.skipRedirectAfterSessionInvalidation);
-      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/access-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access-test.js
@@ -19,6 +19,7 @@ module('Unit | Route | Access', function (hooks) {
     route = this.owner.lookup('route:campaigns.access');
     route.modelFor = sinon.stub().returns(campaign);
     route.campaignStorage = { get: sinon.stub() };
+    route.accessStorage = { get: sinon.stub() };
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
     class OidcIdentityProvidersStub extends Service {
       list = [];
@@ -158,7 +159,7 @@ module('Unit | Route | Access', function (hooks) {
         route.session = sessionStub;
         campaign.isRestricted = true;
         campaign.organizationType = 'SCO';
-        route.campaignStorage.get.withArgs(campaign.code, 'hasUserSeenJoinPage').returns(true);
+        route.accessStorage.get.withArgs(campaign.organizationId, 'hasUserSeenJoinPage').returns(true);
 
         // when
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });

--- a/mon-pix/tests/unit/routes/campaigns/access-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access-test.js
@@ -19,11 +19,13 @@ module('Unit | Route | Access', function (hooks) {
     route = this.owner.lookup('route:campaigns.access');
     route.modelFor = sinon.stub().returns(campaign);
     route.campaignStorage = { get: sinon.stub() };
-    route.accessStorage = { get: sinon.stub() };
+    route.accessStorage = { hasUserSeenJoinPage: sinon.stub() };
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
+
     class OidcIdentityProvidersStub extends Service {
       list = [];
     }
+
     this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
   });
 
@@ -159,7 +161,7 @@ module('Unit | Route | Access', function (hooks) {
         route.session = sessionStub;
         campaign.isRestricted = true;
         campaign.organizationType = 'SCO';
-        route.accessStorage.get.withArgs(campaign.organizationId, 'hasUserSeenJoinPage').returns(true);
+        route.accessStorage.hasUserSeenJoinPage.withArgs(campaign.organizationId).returns(true);
 
         // when
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });

--- a/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point-test.js
@@ -22,6 +22,7 @@ module('Unit | Route | Entry Point', function (hooks) {
     route.router = { replaceWith: sinon.stub() };
     route.modelFor = sinon.stub();
     route.campaignStorage = { set: sinon.stub(), clear: sinon.stub() };
+    route.accessStorage = { clear: sinon.stub() };
     route.session = { isAuthenticated: false, invalidate: sinon.stub() };
     route.currentUser = { user: {} };
   });
@@ -75,12 +76,13 @@ module('Unit | Route | Entry Point', function (hooks) {
       transition = { to: { queryParams: {} } };
     });
 
-    test('should erase campaign storage', async function (assert) {
+    test('should erase campaign and access storage', async function (assert) {
       //given/when
-      await route.afterModel({ code: 'CODE' }, transition);
+      await route.afterModel({ code: 'CODE', organizationId: 1 }, transition);
 
       //then
       sinon.assert.calledWith(route.campaignStorage.clear, 'CODE');
+      sinon.assert.calledWith(route.accessStorage.clear, 1);
       assert.ok(true);
     });
 

--- a/mon-pix/tests/unit/services/access-storage-test.js
+++ b/mon-pix/tests/unit/services/access-storage-test.js
@@ -1,0 +1,32 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Service | Access Storage', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    const service = this.owner.lookup('service:access-storage');
+    service.clearAll();
+  });
+
+  module('#hasUserSeenJoinPage', function () {
+    test(`returns false as default value`, function (assert) {
+      const service = this.owner.lookup('service:access-storage');
+      const organizationId = 1;
+
+      const hasUserSeenJoinPage = service.hasUserSeenJoinPage(organizationId);
+
+      assert.false(hasUserSeenJoinPage);
+    });
+
+    test('returns true when it has been set to true', function (assert) {
+      const service = this.owner.lookup('service:access-storage');
+      const organizationId = 1;
+      service.setHasUserSeenJoinPage(organizationId, true);
+
+      const hasUserSeenJoinPage = service.hasUserSeenJoinPage(organizationId);
+
+      assert.ok(hasUserSeenJoinPage);
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

La brique d'accès utilise un session storage, cependant c'est celui des campagnes et on veut s'en découpler.

## ⛱️ Proposition

Ajoute un storage spécifique à la brique d'accès. On en profite pour déplacer un premier flag dedans qui est hasUserSeenJoinPage.

## 🌊 Remarques

Cette PR dépend de deux autres PRs: 
- https://github.com/1024pix/pix/pull/12449
- https://github.com/1024pix/pix/pull/12430

En attendant qu'elles soient mergées, je me suis basé sur une branche qui contient les changements de ces deux PRs.

## 🏄 Pour tester
Simuler le faux GAR https://1024pix.atlassian.net/wiki/spaces/DA/pages/1743323153/Simuler+le+GAR+protocole+SAML+appel+faux+GAR avec les infos d'un élève déjà réconcilié sur SCO SIECLE -> C'est ici : https://test-idp.integration.pix.fr/
Voir l'écran de réconciliation et le remplir avec les bonnes informations.
On a la modal avec le bouton "Continuer avec mon compte Pix". Ouvrir l'onglet Application du navigateur et vérifier qu'on arrive bien sur la page de connexion.