### PR TITLE
[TECH] :truck: Déplace `PrescriberRoleReporitory` vers `src/shared/`

### DIFF
--- a/api/src/shared/application/usecases/checkAuthorizationToAccessCampaign.js
+++ b/api/src/shared/application/usecases/checkAuthorizationToAccessCampaign.js
@@ -1,5 +1,5 @@
-import * as prescriberRoleRepository from '../../../../lib/infrastructure/repositories/prescriber-role-repository.js';
-import { CampaignAuthorization } from '../../../../src/shared/application/pre-handlers/CampaignAuthorization.js';
+import * as prescriberRoleRepository from '../../infrastructure/repositories/prescriber-role-repository.js';
+import { CampaignAuthorization } from '../pre-handlers/CampaignAuthorization.js';
 
 const execute = async function ({ userId, campaignId }) {
   const prescriberRole = await prescriberRoleRepository.getForCampaign({ userId, campaignId });

--- a/api/src/shared/application/usecases/checkAuthorizationToManageCampaign.js
+++ b/api/src/shared/application/usecases/checkAuthorizationToManageCampaign.js
@@ -1,4 +1,4 @@
-import * as prescriberRoleRepository from '../../../../lib/infrastructure/repositories/prescriber-role-repository.js';
+import * as prescriberRoleRepository from '../../infrastructure/repositories/prescriber-role-repository.js';
 import { CampaignAuthorization } from '../pre-handlers/CampaignAuthorization.js';
 
 const execute = async function ({ userId, campaignId }) {

--- a/api/src/shared/infrastructure/repositories/prescriber-role-repository.js
+++ b/api/src/shared/infrastructure/repositories/prescriber-role-repository.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { prescriberRoles } from '../../../src/shared/application/pre-handlers/CampaignAuthorization.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { prescriberRoles } from '../../application/pre-handlers/CampaignAuthorization.js';
 
 const getForCampaign = async function ({ userId, campaignId }) {
   const result = await _getCampaignAccess({ userId, campaignId });

--- a/api/tests/shared/integration/infrastructure/repositories/prescriber-role-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/prescriber-role-repository_test.js
@@ -1,5 +1,5 @@
-import * as prescriberRoleRepository from '../../../../lib/infrastructure/repositories/prescriber-role-repository.js';
-import { databaseBuilder, expect } from '../../../test-helper.js';
+import * as prescriberRoleRepository from '../../../../../src/shared/infrastructure/repositories/prescriber-role-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Repository | prescriber-role-repository', function () {
   describe('#getForCampaign', function () {


### PR DESCRIPTION
## 🔆 Problème

Le repository `PrescriberRoleReporitory` est encore dans `lib/`

## ⛱️ Proposition

Déplacer `PrescriberRoleReporitory` vers `src/shared/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
