### PR TITLE
[FEATURE] Ajouter un feature toggle pour conserver ses pix après avoir participé à une campagne et s'être créé un compte (PIX-18015)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -71,4 +71,10 @@ export default {
     defaultValue: false,
     tags: ['modulix', 'team-contenu', 'llm', 'embed', 'pix-app'],
   },
+  upgradeToRealUserEnabled: {
+    type: 'boolean',
+    description: 'Enable upgrade of anonymous accounts to true accounts after anonymous campaign participation.',
+    defaultValue: false,
+    tags: ['frontend', 'team-acces', 'pix-app'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -34,6 +34,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'should-display-new-analysis-page': false,
             'show-new-result-page': false,
             'is-v3-certification-page-enabled': false,
+            'upgrade-to-real-user-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,4 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isV3CertificationPageEnabled;
   @attr('boolean') isNewAccountRecoveryEnabled;
+  @attr('boolean') upgradeToRealUserEnabled;
 }


### PR DESCRIPTION
## 🔆 Problème

On souhaite ajouter un feature toggle pour développer et tester la création d'un compte Pix après avoir participer à une campagne en conservant ses pix. 

## ⛱️ Proposition

Créer le feature toggle 'upgradeToRealUserEnabled'.

## 🌊 Remarques

On a ajouté aussi le ft dans le front.

## 🏄 Pour tester

Afficher les feature toggles et constater que le nouveau est présent.
```shell
npm run toggles -- --list
```
