### PR TITLE
[FEATURE] Ne plus parler de session de version dans admin (PIX-18109).

### DIFF
--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -44,7 +44,7 @@ module('Acceptance | Session List', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/sessions/list');
-      assert.dom(screen.getByText('Sessions à traiter V3 (10)')).exists();
+      assert.dom(screen.getByText(`${t('pages.sessions.list.required-actions.v3')} (10)`)).exists();
     });
 
     module('#Pagination', function (hooks) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -954,21 +954,21 @@
             "aria-label": "Filtrer les sessions en sélectionnant un type de centre de certification"
           },
           "version": {
-            "aria-label": "Filtrer les sessions par leur version",
+            "aria-label": "Filter sessions by certification version",
             "label": "Version"
           }
         },
         "required-actions": {
-          "v2": "Sessions with required actions",
-          "v3": "V3 sessions with required actions"
+          "v2": "V2 — Sessions with required actions",
+          "v3": "V3 — Sessions with required actions"
         },
         "to-be-published": {
-          "v2": "Sessions to be published",
-          "v3": "V3 sessions to be published"
+          "v2": "V2 — Sessions to be published",
+          "v3": "V3 — Sessions to be published"
         }
       },
       "table": {
-        "caption": "Tableau listant les sessions de certification. Il indique l'identifiant unique, le nom du centre de certification auquel il appartient, l'identifiant externe, la catégorie, le statut, les dates de passage, de finalisation et de publication et la version de la session.",
+        "caption": "Table listing the certification sessions. It indicates the unique identifier, the name of the certification centre to which it belongs, the external identifier, the category, the status, the passing, finalisation and publication dates and the certification version.",
         "headers": {
           "certification-name": "Centre de certification",
           "external-id": "Identifiant externe",
@@ -978,7 +978,7 @@
           "session-date": "Date de session",
           "status": "Statut",
           "type": "Catégorie",
-          "version": "Version de la session"
+          "version": "Certification version"
         },
         "required-actions": {
           "caption": "Liste des sessions nécessitant un traitement par un interne Pix. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et le nom de l'interne en charge du traitement.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -954,21 +954,21 @@
             "aria-label": "Filtrer les sessions en sélectionnant un type de centre de certification"
           },
           "version": {
-            "aria-label": "Filtrer les sessions par leur version",
+            "aria-label": "Filtrer les sessions par version de certification",
             "label": "Version"
           }
         },
         "required-actions": {
-          "v2": "Sessions à traiter V2",
-          "v3": "Sessions à traiter V3"
+          "v2": "V2 — Sessions à traiter",
+          "v3": "V3 — Sessions à traiter"
         },
         "to-be-published": {
-          "v2": "Sessions à publier V2",
-          "v3": "Sessions à publier V3"
+          "v2": "V2 — Sessions à publier",
+          "v3": "V3 — Sessions à publier"
         }
       },
       "table": {
-        "caption": "Tableau listant les sessions de certification. Il indique l'identifiant unique, le nom du centre de certification auquel il appartient, l'identifiant externe, la catégorie, le statut, les dates de passage, de finalisation et de publication et la version de la session.",
+        "caption": "Tableau listant les sessions de certification. Il indique l'identifiant unique, le nom du centre de certification auquel il appartient, l'identifiant externe, la catégorie, le statut, les dates de passage, de finalisation et de publication et la version de certification.",
         "headers": {
           "certification-name": "Centre de certification",
           "external-id": "Identifiant externe",
@@ -978,7 +978,7 @@
           "session-date": "Date de session",
           "status": "Statut",
           "type": "Catégorie",
-          "version": "Version de la session"
+          "version": "Version de certification"
         },
         "required-actions": {
           "caption": "Liste des sessions nécessitant un traitement par un interne Pix. Contient l'identifiant unique de la session, le nom du centre de certification, la date de finalisation et le nom de l'interne en charge du traitement.",


### PR DESCRIPTION
## 🔆 Problème

On ne souhaite plus parler de "session de version", mais uniquement de "version de certification / d'algo de certification".

## ⛱️ Proposition

Remplacer les textes en FR et EN.

## 🏄 Pour tester

Aller dans la page "Sessions de certif" sur Admin en RA : 
- Les intitulés des onglets ont été modifiés
- Cliquer sur "Toutes les sessions" et voir l'en-tête de tableau "version de certification"
