### PR TITLE
:construction: :sparkles: Expose la calibration calculé par l'équipe DATA via MADDO (pix-18112)

### DIFF
--- a/api/src/maddo/application/complementary-certification-controller.js
+++ b/api/src/maddo/application/complementary-certification-controller.js
@@ -1,0 +1,8 @@
+import { usecases } from '../domain/usecases/index.js';
+
+export function getCalibration({ scope, dependencies = { getCalibration: usecases.getCalibration } }) {
+  // liste des challenges avec leur calibration
+  const calibration = dependencies.getCalibration({ scope });
+
+  return calibration;
+}

--- a/api/src/maddo/application/complementary-certification-route.js
+++ b/api/src/maddo/application/complementary-certification-route.js
@@ -1,0 +1,30 @@
+import Joi from 'joi';
+
+import { getCalibration } from './complementary-certification-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/complementary-certification/{scope}',
+      config: {
+        validate: {
+          params: {
+            scope: Joi.string().required(),
+          },
+        },
+        auth: { access: { scope: 'meta' } },
+        handler: getCalibration,
+        description: "récupère la calibration d'une certification complémentaire",
+        notes: [
+          'Retourne la liste des challenges de la complémentaire avec les difficultés et discriminant qui ont été calculés',
+          '**Cette route nécessite le scope de complémentaire.**',
+        ],
+        tags: ['api', 'calibration', 'certificaiton', 'complementary'],
+      },
+    },
+  ]);
+};
+
+const name = 'maddo-certification-complementary-api';
+export { name, register };

--- a/api/src/maddo/domain/usecases/get-calibration.js
+++ b/api/src/maddo/domain/usecases/get-calibration.js
@@ -1,0 +1,4 @@
+export function getCalibration({ scope }) {
+  calibratedChallengeRepository.getAllByScope({ scope });
+  return [];
+}

--- a/api/src/maddo/infrastructure/repositories/calibrated-challenge-repository.js
+++ b/api/src/maddo/infrastructure/repositories/calibrated-challenge-repository.js
@@ -1,0 +1,4 @@
+
+export function getAllCalibratedChallenges() {
+  return [];
+}

--- a/api/tests/maddo/application/acceptance/complementary-certification-route_test.js
+++ b/api/tests/maddo/application/acceptance/complementary-certification-route_test.js
@@ -1,0 +1,35 @@
+import { createMaddoServer, databaseBuilder, expect } from '../../../test-helper.js';
+
+describe('Acceptance | Maddo | Route | Complementary Certification', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createMaddoServer();
+  });
+
+  describe('GET /api/complementary-certification/{scope}', function () {
+    it('returns all challenges of the given scope with calibration', async function () {
+      // given
+      // sur datawharehouse
+      const challengePremier = databaseBuilder.factory.buildChallenge({ alpha: 12, delta: 13 });
+      const challengeSecond = databaseBuilder.factory.buildChallenge({ alpha: 11, delta: 14 });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: '/api/complementary-certification/droit',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal([
+        new Challenge({ id: challengePremier.id, alpha: 12, delta: 13 }),
+        new Challenge({ id: challengeSecond.id, alpha: 11, delta: 14 }),
+      ]);
+    });
+  });
+});

--- a/api/tests/maddo/domain/integration/usecases/get-calibration_test.js
+++ b/api/tests/maddo/domain/integration/usecases/get-calibration_test.js
@@ -1,0 +1,12 @@
+import { getCalibration } from '../../../../../src/maddo/domain/usecases/get-calibration.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Maddo | Domain | Usecases | Integration | get-calibration', function () {
+  it('should run calibration for given scope', async function () {
+    // when
+    const result = await getCalibration({ scope: 'droit' });
+
+    // then
+    expect(result).to.deep.equal([]);
+  });
+});

--- a/api/tests/maddo/infrastructure/integration/repositories/calibrated-challenge-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/calibrated-challenge-repository_test.js
@@ -1,0 +1,26 @@
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Maddo | Infrastructure | Repositories | Integration | calibrated-challenge', function () {
+  describe('#getAllByScope', function () {
+    it('lists challenges from given scope', async function () {
+      // given
+
+      // TODO add scope filter
+      const firstChallenge = databaseBuilder.factory.buildCalibratedChallenge();
+      const secondChallenge = databaseBuilder.factory.buildCalibratedChallenge();
+
+      await databaseBuilder.commit();
+
+      const expectedCalibratedChallenges = [
+        domainBuilder.factory.buildCalibratedChallenge(firstChallenge),
+        domainBuilder.factory.buildCalibratedChallenge(secondChallenge),
+      ];
+
+      // when
+      const calibratedChallenges = await getAllByScope({ scope: 'droit' });
+
+      // then
+      expect(calibratedChallenges).to.deep.equal(expectedCalibratedChallenges);
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

L'équipe DATA fait une calibration par l'intermédiaire de certains calculs. Le résultat est stocké dans des tables dites « froides ».
Nous avons besoin de ces données de calibration pour faire les certifications complémentaires.

## ⛱️ Proposition

Exposer les données de calibration, par scope, depuis MADDO.


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
