### PR TITLE
[BUGFIX] Traduction manquante sur Mes attestations (PIX-18156)

### DIFF
--- a/mon-pix/app/components/attestations/card.gjs
+++ b/mon-pix/app/components/attestations/card.gjs
@@ -1,8 +1,8 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import {fn} from '@ember/helper';
+import { fn } from '@ember/helper';
 import dayjs from 'dayjs';
-import {t} from 'ember-intl';
+import { t } from 'ember-intl';
 
 const ATTESTATION_TYPES = {
   PARENTHOOD: 'PARENTHOOD',

--- a/mon-pix/app/components/attestations/card.gjs
+++ b/mon-pix/app/components/attestations/card.gjs
@@ -1,8 +1,8 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import { fn } from '@ember/helper';
+import {fn} from '@ember/helper';
 import dayjs from 'dayjs';
-import { t } from 'ember-intl';
+import {t} from 'ember-intl';
 
 const ATTESTATION_TYPES = {
   PARENTHOOD: 'PARENTHOOD',
@@ -48,7 +48,7 @@ function getAttesttationIcon(type) {
       @iconBefore="download"
       class="attestation-card__button"
     >
-      {{t "pages.certificate.actions.download"}}
+      {{t "pages.certificate.actions.download-attestation"}}
     </PixButton>
   </PixBlock>
 </template>


### PR DESCRIPTION
## 🔆 Problème
![image](https://github.com/user-attachments/assets/ed989864-69b3-4e2f-8d76-c449ee71e415)

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

Des erreurs de lint dans l'application `mon-pix` ont été détectées et corrigées au passage.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Se connecter à un compte ayant une attestation ( attestation-success@example.net).
Vérifier dans l'onglet Mes attestations que le bouton indique "Télécharger mon attestation"

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
