### PR TITLE
[TECH] Renomme une chaine de caractère dans un test

### DIFF
--- a/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
@@ -93,7 +93,7 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
         const response = await httpTestServer.request(
           'POST',
           `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/consolidated-framework`,
-          { data: { attributes: { tubeIds: ['challId'] } } },
+          { data: { attributes: { tubeIds: ['tubeId'] } } },
         );
 
         // then


### PR DESCRIPTION
## 🔆 Problème

La chaine de caractère dans un paramètre d'un fichier de test laisse crois que l'on manipule un challenge alors que c'est un tube

## ⛱️ Proposition

Modifier la chaine de caractère pour faire référence à un tube

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

