### PR TITLE
[TECH] Corriger le test flaky sur le filter utilisateur dans PixAdmin (PIX-18163).

### DIFF
--- a/admin/tests/integration/components/users/filter-banner-test.gjs
+++ b/admin/tests/integration/components/users/filter-banner-test.gjs
@@ -188,9 +188,10 @@ module('Integration | Component | users | filter-banner', function (hooks) {
 
       await screen.findByRole('listbox');
 
-      await click(screen.getByRole('option', { name: t('pages.users-list.query.contains') }));
-
-      await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
+      await Promise.all([
+        waitForElementToBeRemoved(() => screen.queryByRole('listbox')),
+        click(screen.getByRole('option', { name: t('pages.users-list.query.contains') })),
+      ]);
 
       // then
       assert.ok(onChangeQueryType.calledOnce);


### PR DESCRIPTION
## 🔆 Problème

Un test flaky est présent sur la bannière des utilisateurs dans PixAdmin

## ⛱️ Proposition

Corriger ce flaky

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI au vert