### PR TITLE
[TECH] Supprimer la méthode lock du RedisClient

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -71,7 +71,6 @@
         "pino": "^9.0.0",
         "pino-pretty": "^13.0.0",
         "randomstring": "^1.2.2",
-        "redlock": "^4.2.0",
         "samlify": "^2.8.5",
         "sax": "^1.2.4",
         "saxpath": "^0.6.5",
@@ -11423,18 +11422,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/redlock": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redlock/-/redlock-4.2.0.tgz",
-      "integrity": "sha512-j+oQlG+dOwcetUt2WJWttu4CZVeRzUrcVcISFmEmfyuwCVSJ93rDT7YSgg7H7rnxwoRyk/jU46kycVka5tW7jA==",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/regenerator-runtime": {

--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,6 @@
     "pino": "^9.0.0",
     "pino-pretty": "^13.0.0",
     "randomstring": "^1.2.2",
-    "redlock": "^4.2.0",
     "samlify": "^2.8.5",
     "sax": "^1.2.4",
     "saxpath": "^0.6.5",

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -1,5 +1,4 @@
 import Redis from 'ioredis';
-import Redlock from 'redlock';
 
 import { logger } from './logger.js';
 
@@ -15,13 +14,6 @@ class RedisClient {
     this._client.on('end', () => logger.info({ redisClient: this._clientName }, 'Disconnected from server'));
     this._client.on('error', (err) => logger.error({ redisClient: this._clientName, err }, 'Error encountered'));
 
-    this._clientWithLock = new Redlock(
-      [this._client],
-      // As said in the doc, setting retryCount to 0 and treating a failure as the resource being "locked"
-      // is a good practice
-      { retryCount: 0 },
-    );
-
     this.ttl = this._wrapWithPrefix(this._client.ttl).bind(this._client);
     this.get = this._wrapWithPrefix(this._client.get).bind(this._client);
     this.incr = this._wrapWithPrefix(this._client.incr).bind(this._client);
@@ -36,7 +28,6 @@ class RedisClient {
     this.keys = this._wrapWithPrefix(this._client.keys).bind(this._client);
     this.ping = this._client.ping.bind(this._client);
     this.flushall = this._client.flushall.bind(this._client);
-    this.lock = this._clientWithLock.lock.bind(this._clientWithLock);
   }
 
   _wrapWithPrefix(fn) {

--- a/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
@@ -1,11 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
-import Redis from 'ioredis';
-import Redlock from 'redlock';
-
 import { config } from '../../../../../src/shared/config.js';
 import { RedisClient } from '../../../../../src/shared/infrastructure/utils/RedisClient.js';
-import { catchErr, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Utils | RedisClient', function () {
   beforeEach(async function () {
@@ -152,47 +149,6 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
     // then
     expect(result).to.equal('PONG');
-  });
-
-  describe('lock', function () {
-    it('locks a key', async function () {
-      // given
-      const client = new RedisClient(config.redis.url);
-      const otherClient = new Redis(config.redis.url);
-
-      // when
-      await client.lock('locks:toto', 10000);
-
-      // then
-      const count = await otherClient.exists('locks:toto');
-      expect(count).to.equal(1);
-    });
-
-    it('unlocks a key', async function () {
-      // given
-      const client = new RedisClient(config.redis.url);
-      const otherClient = new Redis(config.redis.url);
-      const lock = await client.lock('locks:toto', 10000);
-
-      // when
-      await lock.unlock();
-
-      // then
-      const count = await otherClient.exists('locks:toto');
-      expect(count).to.equal(0);
-    });
-
-    it('throws a LockError when locking a locked resource', async function () {
-      // given
-      const client = new RedisClient(config.redis.url);
-      await client.lock('locks:toto', 10000);
-
-      // when
-      const error = await catchErr(client.lock)('locks:toto', 10000);
-
-      // then
-      expect(error).to.be.instanceOf(Redlock.LockError);
-    });
   });
 
   describe('quit', function () {


### PR DESCRIPTION
## 🔆 Problème
Depuis la nouvelle version de la gestion du learningContent, la fonction `lock` du RedisClient n'est plus utilisée (cf: [dernier commit avec la suppression](https://github.com/1024pix/pix/commit/91f428b6b078d3f1ccd68b1ac7b0eb33b79ad95d)).

## ⛱️ Proposition
Supprimer la méthode et le package npm associé. 

## 🌊 Remarques

Merci @Anne-Gaelle-S <3 #12490 

## 🏄 Pour tester

CI OK