### PR TITLE
[TECH] Faire une requête à Pix-bot à la fin des déploiements

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -1,4 +1,13 @@
 postdeploy: npm run postdeploy
+# notify succeeded deployment
+curl -X POST --location "$NOTIFY_URL" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "app-name": "$APP_NAME",
+          "environment": "$ENVIRONMENT",
+          "version": "v$npm pkg get version"
+        }'
+
 # Do not call npm start directly
 # npm does not forward process signals (e.g. SIGINT / SIGKILL ...)
 # see https://github.com/1024pix/pix/pull/796

--- a/api/Procfile-maddo
+++ b/api/Procfile-maddo
@@ -1,4 +1,13 @@
 postdeploy: npm run postdeploy:maddo
+# notify succeeded deployment
+curl -X POST --location "$NOTIFY_URL" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "app-name": "$APP_NAME",
+          "environment": "$ENVIRONMENT",
+          "version": "v$npm pkg get version"
+        }'
+
 # Do not call npm start directly
 # npm does not forward process signals (e.g. SIGINT / SIGKILL ...)
 # see https://github.com/1024pix/pix/pull/796

--- a/audit-logger/Procfile
+++ b/audit-logger/Procfile
@@ -1,4 +1,13 @@
 postdeploy: npm run postdeploy
+# notify succeeded deployment
+curl -X POST --location "$NOTIFY_URL" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "app-name": "$APP_NAME",
+          "environment": "$ENVIRONMENT",
+          "version": "v$npm pkg get version"
+        }'
+
 # Do not call npm start directly
 # npm does not forward process signals (e.g. SIGINT / SIGKILL ...)
 # see https://github.com/1024pix/pix/pull/796

--- a/scripts/scalingo-post-ra-creation.sh
+++ b/scripts/scalingo-post-ra-creation.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
 echo "nothing to do"
+# notify succeeded deployment
+curl -X POST --location "$NOTIFY_URL" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "app-name": "$APP_NAME",
+          "environment": "$ENVIRONMENT",
+          "version": "v$npm pkg get version"
+        }'


### PR DESCRIPTION
## 🔆 Problème

On a besoin d'appeler l'api de Pix-Bot à la fin d'un déploiement, afin d'indiquer qu'une application est déployée. Pix-bot notifira ensuite via Slack lorsque toutes les applications seront déployer. On peut voir la PR pix-bot [ici](https://github.com/1024pix/pix-bot/pull/574).

## ⛱️ Proposition

Ajouter un script qui appellera l'api de PIx-bot en variabilisant l'URL, l'environnement et le nom de l'app, afin de pouvoir faire un appel par application.

## 🌊 Remarques

Il faudra ajouter les variables:
- NOTIFY_URL=L'url de l'api,
- ENVIRONMENT=recette ou production,
- APP_NAME=Le nom de l'app (pix-app/pix-api/pix-certif).