### PR TITLE
[TECH] :hammer: Création d'un référentiel cadre à partir d'un profil cible (PIX-18131)

### DIFF
--- a/api/scripts/certification/target-profile-to-calibrated-framework.js
+++ b/api/scripts/certification/target-profile-to-calibrated-framework.js
@@ -1,0 +1,50 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { usecases } from '../../src/certification/configuration/domain/usecases/index.js';
+import { ComplementaryCertificationKeys } from '../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class TargetProfileToCalibratedFrameworkScript extends Script {
+  constructor() {
+    super({
+      description: 'Create a new version of  consolidated framework from a target profile',
+      permanent: false,
+      options: {
+        complementaryCertificationKey: {
+          type: 'string',
+          describe: 'Complementary Certification key',
+          requiresArg: true,
+        },
+        targetProfileId: {
+          type: 'number',
+          describe: 'Target profile ID',
+          requiresArg: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info(`Check ${options.complementaryCertificationKey} existence in the domain`);
+    if (!Object.values(ComplementaryCertificationKeys).includes(options.complementaryCertificationKey)) {
+      throw new Error('The certification key is missing');
+    }
+
+    logger.info(`Retrieve target-profile #${options.targetProfileId} tubes`);
+    const tubeIds = await knex('target-profile_tubes')
+      .pluck('tubeId')
+      .where('targetProfileId', options.targetProfileId);
+
+    if (tubeIds?.length < 1) {
+      throw new RangeError('This target profile does not hold any tubes');
+    }
+
+    logger.info(`Handle retrieving tubes to create ${tubeIds.length} new certification frameworks challenges`);
+    await usecases.createConsolidatedFramework({
+      complementaryCertificationKey: options.complementaryCertificationKey,
+      tubeIds,
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, TargetProfileToCalibratedFrameworkScript);

--- a/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
+++ b/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
@@ -1,0 +1,82 @@
+import { TargetProfileToCalibratedFrameworkScript } from '../../../../scripts/certification/target-profile-to-calibrated-framework.js';
+import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | target-profile-to-calibrated-framework', function () {
+  let logger, script;
+
+  beforeEach(function () {
+    logger = { info: sinon.stub(), error: sinon.stub() };
+    script = new TargetProfileToCalibratedFrameworkScript();
+  });
+
+  it('should create a calibrated framework from given complementary certification key and target profile id', async function () {
+    // given
+    const learningContent = {
+      tubes: [{ id: 'tube1', skillIds: ['skill1'] }],
+      skills: [{ id: 'skill1', status: 'actif', tubeId: 'tube1' }],
+      challenges: [{ id: 'challenge1', skillId: 'skill1', locales: ['fr'] }],
+    };
+    await mockLearningContent(learningContent);
+
+    const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: learningContent.tubes[0].id });
+    const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+    await databaseBuilder.commit();
+
+    // when
+    await script.handle({
+      options: { complementaryCertificationKey: complementaryCertification.key, targetProfileId },
+      logger,
+    });
+
+    // then
+    const frameworksChallenges = await knex('certification-frameworks-challenges');
+    expect(frameworksChallenges).to.have.length(1);
+    expect(frameworksChallenges[0].challengeId).to.equal(learningContent.challenges[0].id);
+    expect(frameworksChallenges[0].complementaryCertificationId).to.equal(complementaryCertification.id);
+    expect(frameworksChallenges[0].createdAt).to.be.instanceOf(Date);
+    expect(frameworksChallenges[0].alpha).to.be.null;
+    expect(frameworksChallenges[0].delta).to.be.null;
+  });
+
+  context('when the certification key option does not exist in the domain', function () {
+    it('should throw an error', async function () {
+      // given
+      const unknownComplementaryKey = 'unknown';
+
+      // when
+      const error = await catchErr(script.handle)({
+        options: { complementaryCertificationKey: unknownComplementaryKey, targetProfileId: 1 },
+        logger,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('The certification key is missing');
+    });
+  });
+
+  context('when there are no tubeIds retrieved', function () {
+    it('should throw an error', async function () {
+      // given
+      const learningContent = { tubes: [] };
+      await mockLearningContent(learningContent);
+
+      const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(script.handle)({
+        options: { complementaryCertificationKey: complementaryCertification.key, targetProfileId },
+        logger,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(RangeError);
+      expect(error.message).to.equal('This target profile does not hold any tubes');
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

- L'interface permettant de créer un référentiel cadre depuis PixAdmin n'est pas encore en place
- L'équipe des données a besoin de la liste des épreuves d'un référentiel cadre pour pouvoir en faire la calibration.

## ⛱️ Proposition

Ajout d'un script permettant de créer d'ajouter des épreuves d'un référentiel cadre donné (certification complémentaire) à partir d'un profil cible.

## 🌊 Remarques

N/A

## 🏄 Pour tester

- [x] Choisir un profil cible dans PixAdmin (par exemple (8000)
- [x] Un référentiel cadre dans PixAdmin (par exemple "DROIT") 
- [x] Lancer le script avec 
```
scalingo -a "pix-api-review-pr12498" run "LOG_LEVEL=info node scripts/certification/target-profile-to-calibrated-framework.js --complementaryCertificationKey='DROIT' --targetProfileId=8000"
```
- [x] Constater, en base de donnée, qu'il y a bien des  `certification-frameworks-challenges` qui correspondent 

Exemple de requête pour vérifier : 
```sql
select * from "certification-frameworks-challenges" where "complementaryCertificationKey" = 'DROIT';
```
