### PR TITLE
[FEATURE] Ajouter un bouton d'inscription à la fin d'un parcours anonyme (PIX-18016)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -63,6 +63,12 @@ export default class EvaluationResultsHero extends Component {
     return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous;
   }
 
+  get dynamicRoute() {
+    return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous
+      ? 'inscription'
+      : 'authentication.login';
+  }
+
   get hasQuestResults() {
     return this.args.questResults && this.args.questResults.length > 0;
   }
@@ -275,9 +281,16 @@ export default class EvaluationResultsHero extends Component {
           {{else}}
             {{#unless @campaign.hasCustomResultPageButton}}
               {{this.handleBackToHomepageDisplay}}
-              <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
-                {{if this.currentUser.user.isAnonymous (t "common.actions.login") (t "navigation.back-to-homepage")}}
-              </PixButtonLink>
+              {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
+                <p>{{t "pages.sign-up.save-progress-message"}}</p>
+                <PixButtonLink @route={{this.dynamicRoute}} @size="large" onclick={{this.handleBackToHomepageClick}}>
+                  {{t "pages.sign-up.actions.sign-up-on-pix"}}
+                </PixButtonLink>
+              {{else}}
+                <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
+                  {{t "navigation.back-to-homepage"}}
+                </PixButtonLink>
+              {{/if}}
             {{/unless}}
           {{/if}}
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
+import or from 'ember-truth-helpers/helpers/or';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 import AcquiredBadges from './acquired-badges';
@@ -56,6 +57,10 @@ export default class EvaluationResultsHero extends Component {
     return (
       this.featureToggles.featureToggles?.isQuestEnabled && !this.currentUser.user.isAnonymous && this.hasQuestResults
     );
+  }
+
+  get isUserAnonymousAndUpgradeToRealUserEnabled() {
+    return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous;
   }
 
   get hasQuestResults() {
@@ -224,12 +229,18 @@ export default class EvaluationResultsHero extends Component {
         <div class="evaluation-results-hero-details__actions">
           {{#if @isSharableCampaign}}
             {{#if @campaignParticipationResult.isShared}}
+              {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
+                <p>{{t "pages.sign-up.save-progress-message"}}</p>
+                <PixButtonLink @route="inscription" @size="large">
+                  {{t "pages.sign-up.actions.sign-up-on-pix"}}
+                </PixButtonLink>
+              {{/if}}
               {{#if @hasTrainings}}
                 <PixButton @triggerAction={{this.handleSeeTrainingsClick}} @size="large">
                   {{t "pages.skill-review.hero.see-trainings"}}
                 </PixButton>
               {{else}}
-                {{#unless @campaign.hasCustomResultPageButton}}
+                {{#unless (or @campaign.hasCustomResultPageButton this.isUserAnonymousAndUpgradeToRealUserEnabled)}}
                   {{this.handleBackToHomepageDisplay}}
                   <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
                     {{t "navigation.back-to-homepage"}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -180,7 +180,7 @@ module.exports = function (environment) {
     ENV.APP.LOG_TRANSITIONS = false;
     ENV.APP.LOG_TRANSITIONS_INTERNAL = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
-
+    ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 9000000;
     ENV.companion.disabled = true;
   }
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1885,6 +1885,7 @@
     "sign-up": {
       "actions": {
         "login": "Log in",
+        "sign-up-on-Pix": "Sign up for Pix",
         "submit": "Sign up"
       },
       "errors": {
@@ -1897,6 +1898,7 @@
         }
       },
       "first-title": "Sign up",
+      "save-progress-message": "To keep track of your progress and continue to evaluate yourself, register with Pix!",
       "title": "Sign up"
     },
     "sitemap": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1877,7 +1877,8 @@
     "sign-up": {
       "actions": {
         "login": "Iniciar sesión",
-        "submit": "Crear cuenta"
+        "submit": "Crear cuenta",
+        "sign-up-on-Pix": "Crear cuenta en Pix"
       },
       "errors": {
         "invalid-locale-format": "Tu configuración local «{invalidLocale}» tiene un formato incorrecto.",
@@ -1889,6 +1890,7 @@
         }
       },
       "first-title": "Inscríbete",
+      "save-progress-message": "Para hacer un seguimiento de tus progresos y seguir evaluándote, ¡regístrate en Pix!",
       "title": "Inscripción"
     },
     "sitemap": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1885,6 +1885,7 @@
     "sign-up": {
       "actions": {
         "login": "Se connecter",
+        "sign-up-on-pix": "S'inscrire sur Pix",
         "submit": "Je m'inscris"
       },
       "errors": {
@@ -1897,6 +1898,7 @@
         }
       },
       "first-title": "Inscrivez-vous",
+      "save-progress-message": "Pour conserver votre progression et continuer à vous évaluer, inscrivez-vous sur Pix !",
       "title": "Inscription"
     },
     "sitemap": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1880,7 +1880,8 @@
     "sign-up": {
       "actions": {
         "login": "Inloggen",
-        "submit": "Registreren"
+        "submit": "Registreren",
+        "sign-up-on-Pix": "Inschrijven bij Pix"
       },
       "errors": {
         "invalid-locale-format": "Uw locale \"{invalidLocale}\" heeft de verkeerde indeling.",
@@ -1892,6 +1893,7 @@
         }
       },
       "first-title": "Registreren",
+      "save-progress-message": "Om je voortgang bij te houden en jezelf te blijven evalueren, registreer je bij Pix!",
       "title": "Registratie"
     },
     "sitemap": {


### PR DESCRIPTION
## 🔆 Problème

Un utilisateur anonyme doit pouvoir, à la fin d'un parcours, cliquer sur un bouton "S'inscrire sur Pix" qui lui permet de se créer un compte tout en gardant ses points.

## ⛱️ Proposition

Ajouter un bouton “S’inscrire sur Pix” ainsi qu’une phrase précisant l’intérêt de se créer un compte.
Afficher le bouton et la phrase si : 
    l’utilisateur est anonyme
    le Feature Toggle “upgradeToRealUserEnabled” est activé


Parcours simplifié et autonome : 
    1. dans le cas d’un parcours simplifié : 
Le bouton “S’inscrire sur Pix” sera affiché seulement après l’envoi des résultats. L’envoi des résultats est obligatoire si on veut s’inscrire sur Pix dans ce cadre.
     2. Dans le cas d’un parcours autonome :  
Mettre aussi le bouton “S’inscrire sur Pix” qui remplace le bouton “continuez votre expérience Pix”. 
    > Dans les tests, penser à ces deux scénarios


## 🌊 Remarques

La spec précise "Dans le cas d’un parcours autonome :  mettre aussi le bouton “S’inscrire sur Pix” qui remplace le bouton “continuez votre expérience Pix”. 
Cependant,
- La clé skill-review.actions.continue (“Continuez votre expérience PIX”) n’est plus utilisée en fin de parcours autonome
-  Ce bouton a été remplacé par "Se connecter"

## 🏄 Pour tester

Attention: si vous testez en local il faut 
- passer le FT upgradeToRealUser à TRUE
`npm run toggles -- --key upgradeToRealUserEnabled --value true`
- modifier en base la valeur `isSimplifiedAccess` **de la campagne EVALSTAG1**
Pour cela, récupérer l'id de la campagne (table `campaigns`) pour le rechercher dans la table `target-profile`, et passer la valeur de` isSimplifiedAccess `à true.
Ensuite passez les campagnes et faites les mêmes vérifications que pour la RA.


En RA :
- parcours autonome sur une campagne à envoi de résultats : https://app-pr12499.review.pix.fr/campagnes/EVALSTAG1/presentation
-- passez la campagne
-- Vérifiez que la phrase et le bouton "S'inscrire sur Pix" n'apparaissent qu'après l'envoi des résultats
- parcours autonome sur une campagne sans envoi de résultats : https://app-pr12499.review.pix.fr/campagnes/AUTOCOURS1
-- passez la campagne
-- L'envoi de résultats n'est pas proposé, vérifiez la présence de la phrase et du bouton "S'inscrire sur Pix" qui remplace le bouton "Se connecter".
