### PR TITLE
[FEATURE] Enlever un mot d'une description (PIX-18168)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -570,7 +570,7 @@
       "description": {
         "explanation": "Each test assesses a selection of digital skills from the Pix reference framework. Positioning reflects the average level achieved by participants in relation to the maximum level achievable on the test.",
         "nota-bene": "All the data presented comes from shared and undeleted participation in assessment campaigns, and is updated in real time.",
-        "resume": "Analyse, overall and by topic, the positioning of your participants in this campaign, which covers a selection of subjects from the Pix reference framework."
+        "resume": "Analyse by topic or skill, the positioning of your participants in this campaign, which covers a selection of subjects from the Pix reference framework."
       },
       "levels-correspondence": {
         "infos": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -570,7 +570,7 @@
       "description": {
         "explanation": "Le positionnement reflète le niveau moyen atteint par les participants, par rapport au niveau maximal accessible dans cette campagne.",
         "nota-bene": "Toutes les données présentées proviennent des participations partagées et non-supprimées des campagnes d’évaluation et sont actualisées à chaque visite.",
-        "resume": "Analysez, globalement, par compétence ou par sujet, le positionnement de vos participants dans cette campagne qui porte sur une sélection de sujets du référentiel Pix."
+        "resume": "Analysez par compétence ou par sujet, le positionnement de vos participants dans cette campagne qui porte sur une sélection de sujets du référentiel Pix."
       },
       "levels-correspondence": {
         "infos": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -535,7 +535,7 @@
       "description": {
         "explanation": "Elke toets beoordeelt een selectie van digitale vaardigheden uit het Pix referentiekader. De positionering geeft het gemiddelde niveau weer dat deelnemers hebben bereikt ten opzichte van het maximaal haalbare niveau op de toets.",
         "nota-bene": "Alle gepresenteerde gegevens zijn afkomstig van gedeelde en niet verwijderde deelname aan beoordelingscampagnes en worden in realtime bijgewerkt.",
-        "resume": "Analyseer, globaal en per onderwerp, de positionering van je deelnemers aan deze campagne, die een selectie van onderwerpen uit het Pix-referentiekader omvat."
+        "resume": "Analyseer op onderwerp of vaardigheid, de positionering van je deelnemers aan deze campagne, die een selectie van onderwerpen uit het Pix-referentiekader omvat."
       },
       "levels-correspondence": {
         "title": "Correspondentie tussen niveaus",


### PR DESCRIPTION
## 🔆 Problème

On nous remonte que c'est lourd d'utiliser "globalement" dans la description de la page analyse de résultats de campagne. 

## ⛱️ Proposition

Supprimer "globalement" de la description de la page analyse de résultats de campagne.  

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Voir si "globalement" c'est bon 🫰 