### PR TITLE
[TECH] Déplace l'information `associationDone` dans l'access-storage (PIX-18167).

### DIFF
--- a/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
+++ b/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
@@ -7,7 +7,7 @@ import LearnerReconciliation from '../../../campaigns/invited/learner-reconcilia
 
 export default class InvitedWrapper extends Component {
   @service store;
-  @service campaignStorage;
+  @service accessStorage;
   @service router;
   @service intl;
 
@@ -32,7 +32,7 @@ export default class InvitedWrapper extends Component {
     try {
       await organizationLearner.save();
 
-      this.campaignStorage.set(this.args.model.code, 'associationDone', true);
+      this.accessStorage.setAssociationDone(this.args.model.organizationId, true);
       return this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.args.model.code);
     } catch (errorResponse) {
       this.handleError(errorResponse);

--- a/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
+++ b/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
@@ -32,7 +32,7 @@ export default class InvitedWrapper extends Component {
     try {
       await organizationLearner.save();
 
-      this.accessStorage.setAssociationDone(this.args.model.organizationId, true);
+      this.accessStorage.setAssociationDone(this.args.model.organizationId);
       return this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.args.model.code);
     } catch (errorResponse) {
       this.handleError(errorResponse);

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.gjs
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.gjs
@@ -147,7 +147,7 @@ export default class AssociateSupStudentForm extends Component {
   </template>
   @service store;
   @service intl;
-  @service campaignStorage;
+  @service accessStorage;
   @service router;
 
   @tracked firstName = '';
@@ -258,7 +258,7 @@ export default class AssociateSupStudentForm extends Component {
 
     try {
       await supOrganizationLearner.save();
-      this.campaignStorage.set(this.args.campaignCode, 'associationDone', true);
+      this.accessStorage.setAssociationDone(this.args.organizationId, true);
       this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.args.campaignCode);
       return;
     } catch (errorResponse) {

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.gjs
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.gjs
@@ -258,7 +258,7 @@ export default class AssociateSupStudentForm extends Component {
 
     try {
       await supOrganizationLearner.save();
-      this.accessStorage.setAssociationDone(this.args.organizationId, true);
+      this.accessStorage.setAssociationDone(this.args.organizationId);
       this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.args.campaignCode);
       return;
     } catch (errorResponse) {

--- a/mon-pix/app/controllers/campaigns/invited/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/invited/student-sco.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class StudentScoController extends Controller {
-  @service campaignStorage;
   @service router;
   @service accessStorage;
   @service session;
@@ -17,7 +16,7 @@ export default class StudentScoController extends Controller {
       return;
     }
 
-    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    this.accessStorage.setAssociationDone(this.model.organizationId, true);
     this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.model.code);
     return;
   }

--- a/mon-pix/app/controllers/campaigns/invited/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/invited/student-sco.js
@@ -16,7 +16,7 @@ export default class StudentScoController extends Controller {
       return;
     }
 
-    this.accessStorage.setAssociationDone(this.model.organizationId, true);
+    this.accessStorage.setAssociationDone(this.model.organizationId);
     this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.model.code);
     return;
   }
@@ -25,7 +25,7 @@ export default class StudentScoController extends Controller {
   async goToConnectionPage() {
     this.session.set('skipRedirectAfterSessionInvalidation', true);
     await this.session.invalidate();
-    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId, true);
+    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId);
     this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -5,7 +5,6 @@ import { service } from '@ember/service';
 export default class ScoMediacentreController extends Controller {
   @service session;
   @service currentUser;
-  @service campaignStorage;
   @service accessStorage;
   @service router;
 
@@ -18,7 +17,7 @@ export default class ScoMediacentreController extends Controller {
     await this.session.authenticate('authenticator:oauth2', { token: response.accessToken });
     await this.currentUser.load();
 
-    this.campaignStorage.set(this.model.code, 'associationDone', true);
+    this.accessStorage.setAssociationDone(this.model.organizationId, true);
   }
 
   @action

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -17,14 +17,14 @@ export default class ScoMediacentreController extends Controller {
     await this.session.authenticate('authenticator:oauth2', { token: response.accessToken });
     await this.currentUser.load();
 
-    this.accessStorage.setAssociationDone(this.model.organizationId, true);
+    this.accessStorage.setAssociationDone(this.model.organizationId);
   }
 
   @action
   async goToConnectionPage() {
     this.session.set('skipRedirectAfterSessionInvalidation', true);
     await this.session.invalidate();
-    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId, true);
+    this.accessStorage.setHasUserSeenJoinPage(this.model.organizationId);
     this.router.replaceWith('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/controllers/campaigns/join/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/join/student-sco.js
@@ -27,7 +27,7 @@ export default class StudentScoController extends Controller {
     await this.currentUser.load();
     await this._reconcileUser();
 
-    this.accessStorage.setAssociationDone(this.model.campaign.organizationId, true);
+    this.accessStorage.setAssociationDone(this.model.campaign.organizationId);
   }
 
   _reconcileUser() {

--- a/mon-pix/app/controllers/campaigns/join/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/join/student-sco.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class StudentScoController extends Controller {
   @service currentUser;
-  @service campaignStorage;
+  @service accessStorage;
   @service session;
   @service store;
 
@@ -27,7 +27,7 @@ export default class StudentScoController extends Controller {
     await this.currentUser.load();
     await this._reconcileUser();
 
-    this.campaignStorage.set(this.model.campaign.code, 'associationDone', true);
+    this.accessStorage.setAssociationDone(this.model.campaign.organizationId, true);
   }
 
   _reconcileUser() {

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -23,7 +23,7 @@ export default class InvitedRoute extends Route {
   }
 
   afterModel(campaign) {
-    const associationDone = this.accessStorage.associationDone(campaign.organizationId);
+    const associationDone = this.accessStorage.isAssociationDone(campaign.organizationId);
 
     if (this.shouldAssociateInformation(campaign, associationDone)) {
       this.router.replaceWith('campaigns.invited.reconciliation', campaign.code);

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class InvitedRoute extends Route {
-  @service campaignStorage;
+  @service accessStorage;
   @service session;
   @service router;
 
@@ -23,7 +23,7 @@ export default class InvitedRoute extends Route {
   }
 
   afterModel(campaign) {
-    const associationDone = this.campaignStorage.get(campaign.code, 'associationDone');
+    const associationDone = this.accessStorage.associationDone(campaign.organizationId);
 
     if (this.shouldAssociateInformation(campaign, associationDone)) {
       this.router.replaceWith('campaigns.invited.reconciliation', campaign.code);

--- a/mon-pix/app/routes/campaigns/invited/reconciliation.js
+++ b/mon-pix/app/routes/campaigns/invited/reconciliation.js
@@ -23,7 +23,7 @@ export default class ReconciliationRoute extends Route {
     });
 
     if (organizationLearner) {
-      this.accessStorage.setAssociationDone(campaign.organizationId, true);
+      this.accessStorage.setAssociationDone(campaign.organizationId);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/routes/campaigns/invited/reconciliation.js
+++ b/mon-pix/app/routes/campaigns/invited/reconciliation.js
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 
 export default class ReconciliationRoute extends Route {
   @service currentUser;
-  @service campaignStorage;
+  @service accessStorage;
   @service store;
   @service session;
   @service router;
@@ -23,7 +23,7 @@ export default class ReconciliationRoute extends Route {
     });
 
     if (organizationLearner) {
-      this.campaignStorage.set(campaign.code, 'associationDone', true);
+      this.accessStorage.setAssociationDone(campaign.organizationId, true);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/routes/campaigns/invited/student-sco.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sco.js
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 
 export default class StudentScoRoute extends Route {
   @service currentUser;
-  @service campaignStorage;
+  @service accessStorage;
   @service store;
   @service session;
   @service router;
@@ -39,7 +39,7 @@ export default class StudentScoRoute extends Route {
     }
 
     if (organizationLearner) {
-      this.campaignStorage.set(campaign.code, 'associationDone', true);
+      this.accessStorage.setAssociationDone(campaign.organizationId, true);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/routes/campaigns/invited/student-sco.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sco.js
@@ -39,7 +39,7 @@ export default class StudentScoRoute extends Route {
     }
 
     if (organizationLearner) {
-      this.accessStorage.setAssociationDone(campaign.organizationId, true);
+      this.accessStorage.setAssociationDone(campaign.organizationId);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/routes/campaigns/invited/student-sup.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sup.js
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 
 export default class StudentSupRoute extends Route {
   @service currentUser;
-  @service campaignStorage;
+  @service accessStorage;
   @service store;
   @service session;
   @service router;
@@ -23,7 +23,7 @@ export default class StudentSupRoute extends Route {
     });
 
     if (organizationLearner) {
-      this.campaignStorage.set(campaign.code, 'associationDone', true);
+      this.accessStorage.setAssociationDone(campaign.organizationId, true);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/routes/campaigns/invited/student-sup.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sup.js
@@ -23,7 +23,7 @@ export default class StudentSupRoute extends Route {
     });
 
     if (organizationLearner) {
-      this.accessStorage.setAssociationDone(campaign.organizationId, true);
+      this.accessStorage.setAssociationDone(campaign.organizationId);
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }

--- a/mon-pix/app/services/access-storage.js
+++ b/mon-pix/app/services/access-storage.js
@@ -3,6 +3,7 @@ import BaseStorage from './base-storage.js';
 export default class AccessStorage extends BaseStorage {
   collectionName = 'access';
   #hasUserSeenJoinPageKey = 'hasUserSeenJoinPage';
+  #associationDoneKey = 'associationDone';
 
   hasUserSeenJoinPage(organizationId) {
     return super.get(organizationId, this.#hasUserSeenJoinPageKey) ?? false;
@@ -10,5 +11,13 @@ export default class AccessStorage extends BaseStorage {
 
   setHasUserSeenJoinPage(organizationId, value) {
     super.set(organizationId, this.#hasUserSeenJoinPageKey, value);
+  }
+
+  associationDone(id) {
+    return super.get(id, this.#associationDoneKey) ?? false;
+  }
+
+  setAssociationDone(id, value) {
+    super.set(id, this.#associationDoneKey, value);
   }
 }

--- a/mon-pix/app/services/access-storage.js
+++ b/mon-pix/app/services/access-storage.js
@@ -9,15 +9,15 @@ export default class AccessStorage extends BaseStorage {
     return super.get(organizationId, this.#hasUserSeenJoinPageKey) ?? false;
   }
 
-  setHasUserSeenJoinPage(organizationId, value) {
-    super.set(organizationId, this.#hasUserSeenJoinPageKey, value);
+  setHasUserSeenJoinPage(organizationId) {
+    super.set(organizationId, this.#hasUserSeenJoinPageKey, true);
   }
 
-  associationDone(id) {
+  isAssociationDone(id) {
     return super.get(id, this.#associationDoneKey) ?? false;
   }
 
-  setAssociationDone(id, value) {
-    super.set(id, this.#associationDoneKey, value);
+  setAssociationDone(id) {
+    super.set(id, this.#associationDoneKey, true);
   }
 }

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
@@ -11,40 +11,55 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Component | routes/campaigns/invited/associate-sup-student-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  const organizationId = 1;
   let storeStub;
   let saveStub;
   let routerObserver;
+  let setAssociationDoneStub;
 
   hooks.beforeEach(function () {
     stubSessionService(this.owner, { isAuthenticated: false });
     routerObserver = this.owner.lookup('service:router');
     routerObserver.transitionTo = sinon.stub();
     saveStub = sinon.stub();
+    setAssociationDoneStub = sinon.stub();
+
     storeStub = class StoreStub extends Service {
       createRecord = () => ({
         save: saveStub,
         unloadRecord: () => sinon.stub(),
       });
     };
+    class AccessStorageStub extends Service {
+      setAssociationDone = setAssociationDoneStub;
+    }
     this.owner.register('service:store', storeStub);
+    this.owner.register('service:access-storage', AccessStorageStub);
   });
 
   module('when user fill the form correctly', function () {
     test('should save form', async function (assert) {
       // given
-      const screen = await render(hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} />`);
+      this.set('organizationId', organizationId);
+      const screen = await render(
+        hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} @organizationId={{this.organizationId}} />`,
+      );
 
       // when
       await _fillInputsAndValidate({ screen });
 
       // then
       sinon.assert.calledWithExactly(saveStub);
+      sinon.assert.calledWithExactly(setAssociationDoneStub, organizationId, true);
       assert.ok(true);
     });
 
     test('should transition to fill-in-participant-external-id', async function (assert) {
       // given
-      const screen = await render(hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} />`);
+      this.set('organizationId', organizationId);
+      const screen = await render(
+        hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} @organizationId={{this.organizationId}} />`,
+      );
 
       // when
       await _fillInputsAndValidate({ screen });
@@ -63,7 +78,10 @@ module('Integration | Component | routes/campaigns/invited/associate-sup-student
     test('should display server error', async function (assert) {
       // given
       saveStub.rejects();
-      const screen = await render(hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} />`);
+      this.set('organizationId', organizationId);
+      const screen = await render(
+        hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}} @organizationId={{this.organizationId}} />`,
+      );
 
       // when
       await _fillInputsAndValidate({ screen });

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form-test.js
@@ -30,9 +30,11 @@ module('Integration | Component | routes/campaigns/invited/associate-sup-student
         unloadRecord: () => sinon.stub(),
       });
     };
+
     class AccessStorageStub extends Service {
       setAssociationDone = setAssociationDoneStub;
     }
+
     this.owner.register('service:store', storeStub);
     this.owner.register('service:access-storage', AccessStorageStub);
   });
@@ -50,7 +52,7 @@ module('Integration | Component | routes/campaigns/invited/associate-sup-student
 
       // then
       sinon.assert.calledWithExactly(saveStub);
-      sinon.assert.calledWithExactly(setAssociationDoneStub, organizationId, true);
+      sinon.assert.calledWithExactly(setAssociationDoneStub, organizationId);
       assert.ok(true);
     });
 

--- a/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
+++ b/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
@@ -48,10 +48,7 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
 
     assert.true(createRecordStub.save.called, 'called save');
     assert.true(createRecordStub.unloadRecord.called, 'called unloadRecord');
-    assert.true(
-      component.accessStorage.setAssociationDone.calledWithExactly(organizationId, true),
-      'called accessStorage',
-    );
+    assert.true(component.accessStorage.setAssociationDone.calledWithExactly(organizationId), 'called accessStorage');
     assert.true(
       component.router.transitionTo.calledWithExactly(
         'campaigns.invited.fill-in-participant-external-id',

--- a/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
+++ b/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
@@ -6,15 +6,17 @@ import createGlimmerComponent from '../../../../../helpers/create-glimmer-compon
 
 module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', function (hooks) {
   setupTest(hooks);
-  let createRecordStub, component, model, campaignCode;
+  let createRecordStub, component, model, campaignCode, organizationId;
   hooks.beforeEach(function () {
     campaignCode = Symbol('code');
+    organizationId = Symbol(1);
     createRecordStub = {
       unloadRecord: sinon.stub(),
       save: sinon.stub(),
     };
     model = {
       code: campaignCode,
+      organizationId,
     };
 
     component = createGlimmerComponent('pages/campaigns/invited/reconciliation', { model });
@@ -22,8 +24,8 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     component.store = {
       createRecord: sinon.stub(),
     };
-    component.campaignStorage = {
-      set: sinon.stub(),
+    component.accessStorage = {
+      setAssociationDone: sinon.stub(),
     };
   });
 
@@ -47,8 +49,8 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     assert.true(createRecordStub.save.called, 'called save');
     assert.true(createRecordStub.unloadRecord.called, 'called unloadRecord');
     assert.true(
-      component.campaignStorage.set.calledWithExactly(campaignCode, 'associationDone', true),
-      'called campaignStorage',
+      component.accessStorage.setAssociationDone.calledWithExactly(organizationId, true),
+      'called accessStorage',
     );
     assert.true(
       component.router.transitionTo.calledWithExactly(
@@ -75,7 +77,7 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     // then
     assert.true(createRecordStub.save.called, 'call save method');
     assert.true(createRecordStub.unloadRecord.called, 'call unloadRecord record');
-    assert.true(component.campaignStorage.set.notCalled, 'not called campaignStorage');
+    assert.true(component.accessStorage.setAssociationDone.notCalled, 'not called accessStorage');
     assert.true(component.router.transitionTo.notCalled, 'not called transitionTo');
   });
 

--- a/mon-pix/tests/unit/controllers/campaigns/invited/student-sco-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/invited/student-sco-test.js
@@ -6,11 +6,13 @@ module('Unit | Controller | campaigns/invited/student-sco', function (hooks) {
   setupTest(hooks);
 
   let controller;
+  const organizationId = 1;
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:campaigns.invited.student-sco');
+    controller.accessStorage = { setAssociationDone: sinon.stub() };
     controller.router = { transitionTo: sinon.stub() };
-    controller.set('model', { code: 'AZERTY999' });
+    controller.set('model', { code: 'AZERTY999', organizationId });
   });
 
   module('#reconcile', function (hooks) {
@@ -47,6 +49,7 @@ module('Unit | Controller | campaigns/invited/student-sco', function (hooks) {
 
         // then
         sinon.assert.calledOnce(scoOrganizationLearner.save);
+        sinon.assert.calledWithExactly(controller.accessStorage.setAssociationDone, organizationId, true);
         sinon.assert.calledWith(
           controller.router.transitionTo,
           'campaigns.invited.fill-in-participant-external-id',

--- a/mon-pix/tests/unit/controllers/campaigns/invited/student-sco-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/invited/student-sco-test.js
@@ -49,7 +49,7 @@ module('Unit | Controller | campaigns/invited/student-sco', function (hooks) {
 
         // then
         sinon.assert.calledOnce(scoOrganizationLearner.save);
-        sinon.assert.calledWithExactly(controller.accessStorage.setAssociationDone, organizationId, true);
+        sinon.assert.calledWithExactly(controller.accessStorage.setAssociationDone, organizationId);
         sinon.assert.calledWith(
           controller.router.transitionTo,
           'campaigns.invited.fill-in-participant-external-id',

--- a/mon-pix/tests/unit/routes/campaigns/access-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access-test.js
@@ -18,7 +18,6 @@ module('Unit | Route | Access', function (hooks) {
 
     route = this.owner.lookup('route:campaigns.access');
     route.modelFor = sinon.stub().returns(campaign);
-    route.campaignStorage = { get: sinon.stub() };
     route.accessStorage = { hasUserSeenJoinPage: sinon.stub() };
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
 

--- a/mon-pix/tests/unit/routes/campaigns/invited-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited-test.js
@@ -12,7 +12,7 @@ module('Unit | Route | Invited', function (hooks) {
     route = this.owner.lookup('route:campaigns.invited');
     route.modelFor = sinon.stub();
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
-    route.accessStorage = { associationDone: sinon.stub() };
+    route.accessStorage = { isAssociationDone: sinon.stub() };
     route.session.requireAuthenticationAndApprovedTermsOfService = sinon.stub();
   });
 
@@ -56,7 +56,7 @@ module('Unit | Route | Invited', function (hooks) {
           organizationId: 1,
         });
 
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -76,7 +76,7 @@ module('Unit | Route | Invited', function (hooks) {
           organizationId: 1,
         });
 
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -98,7 +98,7 @@ module('Unit | Route | Invited', function (hooks) {
           isOrganizationSCO: true,
           organizationId: 1,
         });
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -118,7 +118,7 @@ module('Unit | Route | Invited', function (hooks) {
           isOrganizationSCO: true,
           organizationId: 1,
         });
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -140,7 +140,7 @@ module('Unit | Route | Invited', function (hooks) {
           isOrganizationSUP: true,
           organizationId: 1,
         });
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -160,7 +160,7 @@ module('Unit | Route | Invited', function (hooks) {
           isOrganizationSUP: true,
           organizationId: 1,
         });
-        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
+        route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -176,7 +176,7 @@ module('Unit | Route | Invited', function (hooks) {
 
     test('should redirect to fill in participant external otherwise', async function (assert) {
       //given
-      route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
+      route.accessStorage.isAssociationDone.withArgs(campaign.organizationId).returns(false);
       campaign = EmberObject.create({
         isRestricted: false,
         organizationId: 1,

--- a/mon-pix/tests/unit/routes/campaigns/invited-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited-test.js
@@ -12,7 +12,7 @@ module('Unit | Route | Invited', function (hooks) {
     route = this.owner.lookup('route:campaigns.invited');
     route.modelFor = sinon.stub();
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
-    route.campaignStorage = { get: sinon.stub() };
+    route.accessStorage = { associationDone: sinon.stub() };
     route.session.requireAuthenticationAndApprovedTermsOfService = sinon.stub();
   });
 
@@ -53,9 +53,10 @@ module('Unit | Route | Invited', function (hooks) {
         //given
         campaign = EmberObject.create({
           isReconciliationRequired: true,
+          organizationId: 1,
         });
 
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -72,9 +73,10 @@ module('Unit | Route | Invited', function (hooks) {
         //given
         campaign = EmberObject.create({
           isReconciliationRequired: true,
+          organizationId: 1,
         });
 
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -94,8 +96,9 @@ module('Unit | Route | Invited', function (hooks) {
         campaign = EmberObject.create({
           isRestricted: true,
           isOrganizationSCO: true,
+          organizationId: 1,
         });
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -113,8 +116,9 @@ module('Unit | Route | Invited', function (hooks) {
         campaign = EmberObject.create({
           isRestricted: true,
           isOrganizationSCO: true,
+          organizationId: 1,
         });
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -134,8 +138,9 @@ module('Unit | Route | Invited', function (hooks) {
         campaign = EmberObject.create({
           isRestricted: true,
           isOrganizationSUP: true,
+          organizationId: 1,
         });
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
 
         //when
         await route.afterModel(campaign);
@@ -153,8 +158,9 @@ module('Unit | Route | Invited', function (hooks) {
         campaign = EmberObject.create({
           isRestricted: true,
           isOrganizationSUP: true,
+          organizationId: 1,
         });
-        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
+        route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(true);
 
         //when
         await route.afterModel(campaign);
@@ -170,9 +176,10 @@ module('Unit | Route | Invited', function (hooks) {
 
     test('should redirect to fill in participant external otherwise', async function (assert) {
       //given
-      route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+      route.accessStorage.associationDone.withArgs(campaign.organizationId).returns(false);
       campaign = EmberObject.create({
         isRestricted: false,
+        organizationId: 1,
       });
 
       //when

--- a/mon-pix/tests/unit/services/access-storage-test.js
+++ b/mon-pix/tests/unit/services/access-storage-test.js
@@ -22,7 +22,7 @@ module('Unit | Service | Access Storage', function (hooks) {
     test('returns true when it has been set to true', function (assert) {
       const service = this.owner.lookup('service:access-storage');
       const organizationId = 1;
-      service.setHasUserSeenJoinPage(organizationId, true);
+      service.setHasUserSeenJoinPage(organizationId);
 
       const hasUserSeenJoinPage = service.hasUserSeenJoinPage(organizationId);
 
@@ -35,19 +35,19 @@ module('Unit | Service | Access Storage', function (hooks) {
       const service = this.owner.lookup('service:access-storage');
       const organizationId = 1;
 
-      const associationDone = service.associationDone(organizationId);
+      const isAssociationDone = service.isAssociationDone(organizationId);
 
-      assert.false(associationDone);
+      assert.false(isAssociationDone);
     });
 
     test('returns true when it has been set to true', function (assert) {
       const service = this.owner.lookup('service:access-storage');
       const organizationId = 1;
-      service.setAssociationDone(organizationId, true);
+      service.setAssociationDone(organizationId);
 
-      const associationDone = service.associationDone(organizationId);
+      const isAssociationDone = service.isAssociationDone(organizationId);
 
-      assert.ok(associationDone);
+      assert.ok(isAssociationDone);
     });
   });
 });

--- a/mon-pix/tests/unit/services/access-storage-test.js
+++ b/mon-pix/tests/unit/services/access-storage-test.js
@@ -10,7 +10,7 @@ module('Unit | Service | Access Storage', function (hooks) {
   });
 
   module('#hasUserSeenJoinPage', function () {
-    test(`returns false as default value`, function (assert) {
+    test('returns false as default value', function (assert) {
       const service = this.owner.lookup('service:access-storage');
       const organizationId = 1;
 
@@ -27,6 +27,27 @@ module('Unit | Service | Access Storage', function (hooks) {
       const hasUserSeenJoinPage = service.hasUserSeenJoinPage(organizationId);
 
       assert.ok(hasUserSeenJoinPage);
+    });
+  });
+
+  module('associationDone', function () {
+    test('returns false as default value', function (assert) {
+      const service = this.owner.lookup('service:access-storage');
+      const organizationId = 1;
+
+      const associationDone = service.associationDone(organizationId);
+
+      assert.false(associationDone);
+    });
+
+    test('returns true when it has been set to true', function (assert) {
+      const service = this.owner.lookup('service:access-storage');
+      const organizationId = 1;
+      service.setAssociationDone(organizationId, true);
+
+      const associationDone = service.associationDone(organizationId);
+
+      assert.ok(associationDone);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

L'information de réconciliation d'un utilisateur est stockée dans l'espace de stockage des campagnes, ce qui couple les fonctionnalités d'accès et de passage de campagnes.

## ⛱️ Proposition

On déplace cette information (le flag `associationDone`) dans l'espace de stockage `accessStorage`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Cas de test 1 : SCO non GAR ✅ 
ORGA
Faire un import d'élèves sur SCOSIECLE avec le fichier sco-ok.xml.

PIX APP
Rejoindre une campagne, ex: SCOASSMUL via l'URL campagnes/SCOASSMUL
Atterrir sur l'écran de réconciliation, remplir les informations d'un élève importé mais non réconcilié.
Vérifier la variable AssociationDone dans l'onglet application du navigateur et la bonne continuation du parcours.

Cas de test 2 : SCO GAR ✅ 
ORGA
Faire un import d'élèves sur SCOSIECLE avec le fichier sco-ok.xml.

Simuler un accès GAR avec les informations d'un des élèves importés https://1024pix.atlassian.net/wiki/spaces/DA/pages/1743323153/Simuler+le+GAR+protocole+SAML+appel+faux+GAR

PIX APP
Rejoindre une campagne, ex: SCOASSMUL via l'URL campagnes/SCOASSMUL
Atterrir sur l'écran de réconciliation, remplir les informations d'un élève importé mais non réconcilié.
Vérifier la variable AssociationDone dans l'onglet application du navigateur et la bonne continuation du parcours.