### PR TITLE
[FEATURE] Détacher les campaignParticipation supprimés des assessments et des badges non certifiants (PIX-18164).

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -6,6 +6,8 @@ const deleteCampaigns = async ({
   organizationId,
   campaignIds,
   featureToggles,
+  assessmentRepository,
+  badgeAcquisitionRepository,
   organizationMembershipRepository,
   campaignAdministrationRepository,
   campaignParticipationRepository,
@@ -50,6 +52,14 @@ const deleteCampaigns = async ({
     await userRecommendedTrainingRepository.deleteCampaignParticipationIds({
       campaignParticipationIds,
     });
+    await badgeAcquisitionRepository.deleteUserIdOnNonCertifiableBadgesForCampaignParticipations(
+      campaignParticipationIds,
+    );
+    const assessments = await assessmentRepository.getByCampaignParticipationIds(campaignParticipationIds);
+    for (const assessment of assessments) {
+      assessment.detachCampaignParticipation();
+      await assessmentRepository.updateCampaignParticipationId(assessment);
+    }
   }
 
   await campaignAdministrationRepository.remove(campaignsToDelete);

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -16,6 +16,7 @@ import * as organizationFeatureApi from '../../../../organizational-entities/app
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
+import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
@@ -43,45 +44,8 @@ import * as knowledgeElementSnapshotRepository from '../../infrastructure/reposi
 import * as campaignMediaComplianceService from '../services/campaign-media-compliance-service.js';
 import * as campaignUpdateValidator from '../validators/campaign-update-validator.js';
 
-/**
- * @typedef { import ('../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js')} BadgeAcquisitionRepository
- * @typedef { import ('../../../../evaluation/infrastructure/repositories/stage-acquisition-repository.js')} StageAcquisitionRepository
- * @typedef { import ('../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js')} CampaignRepository
- * @typedef { import ('../../../../devcomp/infrastructure/repositories/tutorial-repository.js')} TutorialRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-repository.js')} KnowledgeElementRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js')} KnowledgeElementSnapshotRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/learning-content-repository.js')} LearningContentRepository
- * @typedef { import ('../../../../team/infrastructure/repositories/membership-repository.js')} MembershipRepository
- * @typedef { import ('../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js')} StageCollectionRepository
- * @typedef { import ('../../../../evaluation/infrastructure/repositories/badge-repository.js')} BadgeRepository
- * @typedef { import ('../../../../identity-access-management/infrastructure/repositories/user.repository.js')} UserRepository
- * @typedef { import ('../../../../organizational-entities/application/api/organization-features-api.js')} OrganizationFeatureApi
- * @typedef { import ('../../../../shared/domain/services/code-generator.js')} CodeGenerator
- * @typedef { import ('../../../../shared/domain/services/placement-profile-service.js')} PlacementProfileService
- * @typedef { import ('../../../../shared/infrastructure/repositories/competence-repository.js')} CompetenceRepository
- * @typedef { import ('../../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
- * @typedef { import ('../../../campaign-participation/infrastructure/repositories/campaign-analysis-repository.js')} CampaignAnalysisRepository
- * @typedef { import ('../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js')} CampaignParticipationRepository
- * @typedef { import ('../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js')} OrganizationLearnerImportFormat
- * @typedef { import ('../../infrastructure/repositories/campaign-administration-repository.js')} CampaignAdministrationRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js')} CampaignAssessmentParticipationResultListRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-collective-result-repository.js')} CampaignCollectiveResultRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-creator-repository.js')} CampaignCreatorRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-management-repository.js')} CampaignManagementRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-participant-activity-repository.js')} CampaignParticipantActivityRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-participation-info-repository.js')} CampaignParticipationInfoRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-participations-stats-repository.js')} CampaignParticipationsStatsRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js')} CampaignProfilesCollectionParticipationSummaryRepository
- * @typedef { import ('../../infrastructure/repositories/campaign-report-repository.js')} CampaignReportRepository
- * @typedef { import ('../../infrastructure/repositories/division-repository.js')} DivisionRepository
- * @typedef { import ('../../infrastructure/repositories/group-repository.js')} GroupRepository
- * @typedef { import ('../../infrastructure/repositories/index.js').CampaignToJoinRepository} CampaignToJoinRepository
- * @typedef { import ('../../infrastructure/repositories/index.js').OrganizationMembershipRepository} OrganizationMembershipRepository
- * @typedef { import ('../../infrastructure/repositories/target-profile-repository.js')} TargetProfileRepository
- * @typedef { import ('../validators/campaign-update-validator.js')} CampaignUpdateValidator
- * @typedef { import ('../services/campaign-media-compliance-service')} CampaignMediaComplianceService
- */
 const dependencies = {
+  assessmentRepository,
   badgeAcquisitionRepository,
   badgeRepository,
   campaignAdministrationRepository,

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -2,17 +2,22 @@ import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../../db/migr
 import { EventLoggingJob } from '../../../../../../src/identity-access-management/domain/models/jobs/EventLoggingJob.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
-import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import { CampaignParticipationLoggerContext } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { featureToggles } from '../../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
+
 const {
+  buildAssessment,
+  buildBadge,
+  buildBadgeAcquisition,
   buildCampaign,
   buildCampaignParticipation,
   buildMembership,
   buildUserRecommendedTraining,
   buildOrganization,
   buildUser,
+  buildTargetProfile,
 } = databaseBuilder.factory;
 
 describe('Integration | UseCases | delete-campaign', function () {
@@ -49,7 +54,7 @@ describe('Integration | UseCases | delete-campaign', function () {
       expect(error).to.be.undefined;
     });
 
-    it('should delete campaign for given id and participation associated', async function () {
+    it('should delete campaign for given id', async function () {
       // given
       const userId = buildUser().id;
       const organizationId = buildOrganization().id;
@@ -60,10 +65,7 @@ describe('Integration | UseCases | delete-campaign', function () {
         name: 'nom de campagne',
         title: 'titre de campagne',
       }).id;
-      const campaignParticipationId = buildCampaignParticipation({
-        campaignId,
-        participantExternalId: 'externalId',
-      });
+
       await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
 
       await databaseBuilder.commit();
@@ -72,22 +74,17 @@ describe('Integration | UseCases | delete-campaign', function () {
       await usecases.deleteCampaigns({ userId, organizationId, campaignIds: [campaignId] });
 
       const updatedCampaign = await campaignAdministrationRepository.get(campaignId);
-      const updatedCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId.id);
 
       // then
       expect(updatedCampaign.deletedAt).to.deep.equal(now);
       expect(updatedCampaign.deletedBy).to.equal(userId);
       expect(updatedCampaign.name).to.equal('nom de campagne');
       expect(updatedCampaign.title).to.equal('titre de campagne');
-      expect(updatedCampaignParticipation.participantExternalId).to.equal('externalId');
-      expect(updatedCampaignParticipation.userId).to.equal(campaignParticipationId.userId);
-      expect(updatedCampaignParticipation.deletedAt).to.deep.equal(now);
-      expect(updatedCampaignParticipation.deletedBy).to.equal(userId);
 
       await expect(EventLoggingJob.name).to.have.been.performed.withJobsCount(0);
     });
 
-    it('should also anonymize when flag is true', async function () {
+    it('should also anonymize campaign when flag is true', async function () {
       // given
       const userId = buildUser().id;
       const organizationId = buildOrganization().id;
@@ -98,10 +95,7 @@ describe('Integration | UseCases | delete-campaign', function () {
         name: 'nom de campagne',
         title: 'titre de campagne',
       }).id;
-      const campaignParticipationId = buildCampaignParticipation({
-        campaignId,
-        participantExternalId: 'externalId',
-      }).id;
+
       await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
 
       await databaseBuilder.commit();
@@ -110,27 +104,12 @@ describe('Integration | UseCases | delete-campaign', function () {
       await usecases.deleteCampaigns({ userId, organizationId, campaignIds: [campaignId] });
 
       const updatedCampaign = await campaignAdministrationRepository.get(campaignId);
-      const updatedCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
       // then
       expect(updatedCampaign.deletedAt).to.deep.equal(now);
       expect(updatedCampaign.deletedBy).to.equal(userId);
       expect(updatedCampaign.name).to.equal('(anonymized)');
       expect(updatedCampaign.title).to.be.null;
-      expect(updatedCampaignParticipation.deletedAt).to.deep.equal(now);
-      expect(updatedCampaignParticipation.deletedBy).to.equal(userId);
-      expect(updatedCampaignParticipation.participantExternalId).to.be.null;
-      expect(updatedCampaignParticipation.userId).to.be.null;
-
-      await expect(EventLoggingJob.name).to.have.been.performed.withJobPayload({
-        client: 'PIX_ORGA',
-        action: CampaignParticipationLoggerContext.DELETION,
-        role: 'ORGA_ADMIN',
-        userId: userId,
-        occurredAt: now.toISOString(),
-        targetUserId: campaignParticipationId,
-        data: {},
-      });
     });
 
     context('when there are user-recommended-trainings linked to campaign participations', function () {
@@ -187,6 +166,376 @@ describe('Integration | UseCases | delete-campaign', function () {
             .first();
 
           expect(userRecommendedTrainingAnonymized.campaignParticipationId).to.equal(campaignParticipationId);
+        });
+      });
+    });
+
+    context('With campaign participations', function () {
+      let adminUserId;
+      let campaignId;
+      let organizationId;
+      let userId;
+      let campaignParticipationId;
+      let organizationLearnerId;
+      let targetProfileId;
+      beforeEach(async function () {
+        adminUserId = databaseBuilder.factory.buildUser().id;
+        organizationId = buildOrganization().id;
+        buildMembership({ userId: adminUserId, organizationId, organizationRole: 'ADMIN' });
+        userId = databaseBuilder.factory.buildUser().id;
+        targetProfileId = buildTargetProfile().id;
+        campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+        organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          isImproved: false,
+          organizationLearnerId,
+          userId,
+          deletedAt: null,
+          deletedBy: null,
+          participantExternalId: 'email olala',
+          campaignId,
+        }).id;
+
+        await databaseBuilder.commit();
+      });
+
+      context('when feature toggle `isAnonymizationWithDeletionEnabled` is false', function () {
+        beforeEach(async function () {
+          await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
+        });
+
+        it('should delete all campaignParticipations', async function () {
+          // given
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            isImproved: true,
+            participantExternalId: 'email olala',
+            organizationLearnerId,
+            userId,
+            deletedAt: null,
+            deletedBy: null,
+            campaignId,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          await usecases.deleteCampaigns({
+            userId: adminUserId,
+            campaignIds: [campaignId],
+            organizationId,
+          });
+
+          // then
+          const results = await knex('campaign-participations').where({ organizationLearnerId });
+
+          expect(results).to.have.lengthOf(2);
+          results.forEach((campaignParticipaton) => {
+            expect(campaignParticipaton.participantExternalId).not.to.equal(null);
+            expect(campaignParticipaton.userId).to.equal(userId);
+            expect(campaignParticipaton.deletedAt).to.deep.equal(now);
+            expect(campaignParticipaton.deletedBy).to.equal(adminUserId);
+          });
+        });
+
+        context('when there are badges linked to the campaign participations', function () {
+          let badgesAcquisitions;
+          let certifiableBadge;
+          let nonCertifiableBadge;
+
+          beforeEach(async function () {
+            // given
+
+            nonCertifiableBadge = buildBadge({
+              targetProfileId,
+              isCertifiable: false,
+            });
+            certifiableBadge = buildBadge({
+              targetProfileId,
+              isCertifiable: true,
+            });
+
+            buildBadgeAcquisition({
+              badgeId: certifiableBadge.id,
+              campaignParticipationId,
+              userId,
+            });
+            buildBadgeAcquisition({
+              badgeId: nonCertifiableBadge.id,
+              campaignParticipationId,
+              userId,
+            });
+
+            await databaseBuilder.commit();
+          });
+
+          it('should not delete userId on non certifiable badgesAcquisitions', async function () {
+            // given
+            await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
+
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            badgesAcquisitions = await knex('badge-acquisitions').where({
+              campaignParticipationId,
+            });
+            const nonCertifiableBadgeAcquisition = badgesAcquisitions.find(
+              (badgeAcquisition) => badgeAcquisition.badgeId === nonCertifiableBadge.id,
+            );
+            expect(nonCertifiableBadgeAcquisition.userId).to.equal(userId);
+          });
+
+          it('should not delete userId on certifiable badgesAcquisitions', async function () {
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            badgesAcquisitions = await knex('badge-acquisitions').where({
+              campaignParticipationId,
+            });
+
+            const certifiableBadgeAcquisition = badgesAcquisitions.find(
+              (badgeAcquisition) => badgeAcquisition.badgeId === certifiableBadge.id,
+            );
+            expect(certifiableBadgeAcquisition.userId).to.equal(userId);
+          });
+        });
+
+        context('when there is assessment linked to campaign participation', function () {
+          it('should not detach assesmment', async function () {
+            // given
+            const assessment1 = buildAssessment({ userId, campaignParticipationId, type: Assessment.types.CAMPAIGN });
+
+            await databaseBuilder.commit();
+
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            const assessmentInDb = await knex('assessments').where({ id: assessment1.id }).first();
+            expect(assessmentInDb.campaignParticipationId).equal(campaignParticipationId);
+          });
+        });
+
+        it('should not publish an event to historize action', async function () {
+          // when
+          await usecases.deleteCampaigns({
+            userId: adminUserId,
+            campaignIds: [campaignId],
+            organizationId,
+          });
+
+          // then
+          await expect(EventLoggingJob.name).to.have.been.performed.withJobsCount(0);
+        });
+      });
+
+      context('when feature toggle `isAnonymizationWithDeletionEnabled` is true', function () {
+        beforeEach(async function () {
+          await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
+        });
+
+        it('should delete all campaignParticipations with anonymization', async function () {
+          // given
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            isImproved: true,
+            participantExternalId: 'email olala',
+            organizationLearnerId,
+            userId,
+            deletedAt: null,
+            deletedBy: null,
+            campaignId,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          // when
+          await usecases.deleteCampaigns({
+            userId: adminUserId,
+            campaignIds: [campaignId],
+            organizationId,
+          });
+
+          // then
+          const results = await knex('campaign-participations').where({ organizationLearnerId });
+
+          expect(results).to.have.lengthOf(2);
+          results.forEach((campaignParticipaton) => {
+            expect(campaignParticipaton.userId).to.equal(null);
+            expect(campaignParticipaton.participantExternalId).to.equal(null);
+            expect(campaignParticipaton.deletedAt).to.deep.equal(now);
+            expect(campaignParticipaton.deletedBy).to.equal(adminUserId);
+          });
+        });
+
+        it('should publish an event to historize action', async function () {
+          // when
+          // when
+          await usecases.deleteCampaigns({
+            userId: adminUserId,
+            campaignIds: [campaignId],
+            organizationId,
+          });
+
+          // then
+          await expect(EventLoggingJob.name).to.have.been.performed.withJobPayload({
+            client: 'PIX_ORGA',
+            action: CampaignParticipationLoggerContext.DELETION,
+            role: 'ORGA_ADMIN',
+            userId: adminUserId,
+            occurredAt: now.toISOString(),
+            targetUserId: campaignParticipationId,
+            data: {},
+          });
+        });
+
+        context('when there are badges linked to the campaign participations', function () {
+          let badgesAcquisitions;
+          let certifiableBadge;
+          let nonCertifiableBadge;
+
+          beforeEach(async function () {
+            // given
+            nonCertifiableBadge = buildBadge({
+              targetProfileId,
+              isCertifiable: false,
+            });
+            certifiableBadge = buildBadge({
+              targetProfileId,
+              isCertifiable: true,
+            });
+
+            buildBadgeAcquisition({
+              badgeId: certifiableBadge.id,
+              campaignParticipationId,
+              userId,
+            });
+            buildBadgeAcquisition({
+              badgeId: nonCertifiableBadge.id,
+              campaignParticipationId,
+              userId,
+            });
+
+            await databaseBuilder.commit();
+          });
+
+          it('should delete userId on non certifiable badgesAcquisitions', async function () {
+            // given
+            await featureToggles.set('isAnonymizationWithDeletionEnabled', true);
+
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            badgesAcquisitions = await knex('badge-acquisitions').where({
+              campaignParticipationId,
+            });
+            const nonCertifiableBadgeAcquisition = badgesAcquisitions.find(
+              (badgeAcquisition) => badgeAcquisition.badgeId === nonCertifiableBadge.id,
+            );
+            expect(nonCertifiableBadgeAcquisition.userId).to.be.null;
+          });
+
+          context('when feature toggle `isAnonymizationWithDeletionEnabled` is false', function () {
+            it('should not delete userId on non certifiable badgesAcquisitions', async function () {
+              // given
+              await featureToggles.set('isAnonymizationWithDeletionEnabled', false);
+
+              // when
+              await usecases.deleteCampaigns({
+                userId: adminUserId,
+                campaignIds: [campaignId],
+                organizationId,
+              });
+
+              // then
+              badgesAcquisitions = await knex('badge-acquisitions').where({
+                campaignParticipationId,
+              });
+              const nonCertifiableBadgeAcquisition = badgesAcquisitions.find(
+                (badgeAcquisition) => badgeAcquisition.badgeId === nonCertifiableBadge.id,
+              );
+              expect(nonCertifiableBadgeAcquisition.userId).to.equal(userId);
+            });
+          });
+
+          it('should not delete userId on certifiable badgesAcquisitions', async function () {
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            badgesAcquisitions = await knex('badge-acquisitions').where({
+              campaignParticipationId,
+            });
+
+            const certifiableBadgeAcquisition = badgesAcquisitions.find(
+              (badgeAcquisition) => badgeAcquisition.badgeId === certifiableBadge.id,
+            );
+            expect(certifiableBadgeAcquisition.userId).to.equal(userId);
+          });
+        });
+
+        context('when there is assessment linked to campaign participation', function () {
+          it('should detach assessments', async function () {
+            // given
+            const assessment1 = buildAssessment({ userId, campaignParticipationId, type: Assessment.types.CAMPAIGN });
+
+            const assessment2 = buildAssessment({
+              userId,
+              campaignParticipationId,
+              type: Assessment.types.CAMPAIGN,
+              isImproving: true,
+            });
+            const otherCampaignParticipationId = buildCampaignParticipation({
+              organizationLearnerId,
+              userId,
+            }).id;
+            const otherAssessment = buildAssessment({
+              userId,
+              campaignParticipationId: otherCampaignParticipationId,
+              type: Assessment.types.CAMPAIGN,
+              isImproving: true,
+            });
+            await databaseBuilder.commit();
+
+            // when
+            await usecases.deleteCampaigns({
+              userId: adminUserId,
+              campaignIds: [campaignId],
+              organizationId,
+            });
+
+            // then
+            const assessmentsInDb = await knex('assessments').whereIn('id', [assessment1.id, assessment2.id]);
+            assessmentsInDb.forEach((assessment) => {
+              expect(assessment.campaignParticipationId).null;
+            });
+            const otherAssessmentsInDb = await knex('assessments').where('id', otherAssessment.id).first();
+            expect(otherAssessmentsInDb.campaignParticipationId).equal(otherAssessment.campaignParticipationId);
+          });
         });
       });
     });


### PR DESCRIPTION
## :egg: Problème
Actuellement, on détache les assessments des campaign-participations lorsqu’on passe par le usecase de suppression d’une participation ou celui d’un learner, mais pas lorsqu’on supprime une campagne.



## :bowl_with_spoon: Proposition
On ajoute la même logique de suppression du campaignParticipationId dans la table assessments et dans les badges pour tout les campaignParticipationId de la campagne.

## :milk_glass: Remarques
On duplique-plique-plique les tests

## :butter: Pour tester 
- Dans pix, avec l'utilisateur `admin-orga@example.net`, [participer à la campagne KWMYBN577](https://app-pr12504.review.pix.fr/campagnes/KWMYBN577/presentation) en utilisant le bouton magique et partager ses résultats 
- dans Admin, vérifier qu'on voit les participations à la campagne
- scalingo -a pix-api-review-pr12504 run "npm run toggles -- -k shouldDisplayNewAnalysisPage -v true"
- supprimer la campagne
- Sur admin, ne plus voir [les infos des participations de l'utilisateur](https://admin-pr12504.review.pix.fr/users/1000/participations) (
- via pgsql-console
```sql
select "userId", "campaignParticipationId", "badges".* from "badge-acquisitions" join badges on badges.id = "badge-acquisitions"."badgeId"  where "userId"=1000 ;
```
- ne voir que les badges certifiants