### PR TITLE
[TECH] Passer les feature toggles de metric à des variables d'environnement classique

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -79,7 +79,7 @@ const createServer = async () => {
 
   if (logOpsMetrics) {
     // OPS metrics via direct metrics
-    if (config.featureToggles.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
+    if (config.metrics.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
     // OPS metrics via Oppsy
     if (!config.featureToggles.isOppsyDisabled) await enableLegacyOpsMetrics(server);
   }

--- a/api/server.js
+++ b/api/server.js
@@ -81,7 +81,7 @@ const createServer = async () => {
     // OPS metrics via direct metrics
     if (config.metrics.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
     // OPS metrics via Oppsy
-    if (!config.featureToggles.isOppsyDisabled) await enableLegacyOpsMetrics(server);
+    if (!config.metrics.isOppsyDisabled) await enableLegacyOpsMetrics(server);
   }
 
   setupErrorHandling(server);

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -32,7 +32,7 @@ const createMaddoServer = async () => {
 
   if (logOpsMetrics) {
     // OPS metrics via direct metrics
-    if (config.featureToggles.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
+    if (config.metrics.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
     // OPS metrics via Oppsy
     if (!config.featureToggles.isOppsyDisabled) await enableLegacyOpsMetrics(server);
   }

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -34,7 +34,7 @@ const createMaddoServer = async () => {
     // OPS metrics via direct metrics
     if (config.metrics.isDirectMetricsEnabled) await enableOpsMetrics(server, metrics);
     // OPS metrics via Oppsy
-    if (!config.featureToggles.isOppsyDisabled) await enableLegacyOpsMetrics(server);
+    if (!config.metrics.isOppsyDisabled) await enableLegacyOpsMetrics(server);
   }
 
   setupErrorHandling(server);

--- a/api/src/monitoring/infrastructure/metrics.js
+++ b/api/src/monitoring/infrastructure/metrics.js
@@ -9,12 +9,12 @@ export class Metrics {
   static metricDefinitions = {};
 
   constructor({ config }) {
-    if (!config.featureToggles.isDirectMetricsEnabled) {
+    if (!config.metrics.isDirectMetricsEnabled) {
       logger.info('Metric initialisation : no reporter => no metrics sent');
       metrics.init({ reporter: new metrics.reporters.NullReporter(), flushIntervalSeconds: 0 });
     }
 
-    if (config.featureToggles.isDirectMetricsEnabled) {
+    if (config.metrics.isDirectMetricsEnabled) {
       logger.info('Metric initialisation : linked to Datadog');
       metrics.init({
         host: config.infra.containerName,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -298,7 +298,6 @@ const configuration = (function () {
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
@@ -390,6 +389,7 @@ const configuration = (function () {
     },
     metrics: {
       flushIntervalSeconds: _getNumber(process.env.DIRECT_METRICS_FLUSH_INTERVAL, 5),
+      isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
     },
     partner: {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
@@ -523,7 +523,7 @@ const configuration = (function () {
 
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
-    config.featureToggles.isDirectMetricsEnabled = false;
+    config.metrics.isDirectMetricsEnabled = false;
     config.featureToggles.isOppsyDisabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -298,7 +298,6 @@ const configuration = (function () {
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
@@ -390,6 +389,7 @@ const configuration = (function () {
     metrics: {
       flushIntervalSeconds: _getNumber(process.env.DIRECT_METRICS_FLUSH_INTERVAL, 5),
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
+      isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
     },
     partner: {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
@@ -524,7 +524,7 @@ const configuration = (function () {
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.metrics.isDirectMetricsEnabled = false;
-    config.featureToggles.isOppsyDisabled = false;
+    config.metrics.isOppsyDisabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
     config.featureToggles.showNewResultPage = false;
 

--- a/api/src/shared/infrastructure/plugins/pino.js
+++ b/api/src/shared/infrastructure/plugins/pino.js
@@ -82,7 +82,7 @@ const plugin = {
     server.events.on('response', (request) => {
       const info = request.info;
 
-      const shouldLog = !config.featureToggles.isDirectMetricsEnabled;
+      const shouldLog = !config.metrics.isDirectMetricsEnabled;
 
       if (shouldLog || request.raw.res.statusCode != 200) {
         logger.info(

--- a/api/tests/monitoring/integration/infrastructure/metrics_test.js
+++ b/api/tests/monitoring/integration/infrastructure/metrics_test.js
@@ -12,7 +12,7 @@ describe('Integration | Monitoring | Infrastructure | metrics', function () {
         process.env.DATADOG_API_KEY = 'API_KEY';
         process.env.DEBUG = 'metrics';
 
-        const config = { featureToggles: { isDirectMetricsEnabled: false }, infra: { containerName: 'web-1' } };
+        const config = { metrics: { isDirectMetricsEnabled: false }, infra: { containerName: 'web-1' } };
         nock('https://api.datadog_fake.com').post('/api/v1/series').reply(200);
 
         // when
@@ -32,7 +32,7 @@ describe('Integration | Monitoring | Infrastructure | metrics', function () {
         process.env.DATADOG_API_KEY = 'API_KEY';
         process.env.DEBUG = 'metrics';
 
-        const config = { featureToggles: { isDirectMetricsEnabled: true }, infra: { containerName: 'web-1' } };
+        const config = { metrics: { isDirectMetricsEnabled: true }, infra: { containerName: 'web-1' } };
         nock('https://api.datadog_fake.com').post('/api/v1/series').reply(200);
 
         // when

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -25,7 +25,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-new-account-recovery-enabled': false,
-            'is-oppsy-disabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': false,

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,7 +24,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'dynamic-feature-toggle-system': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-direct-metrics-enabled': false,
             'is-new-account-recovery-enabled': false,
             'is-oppsy-disabled': false,
             'is-quest-enabled': true,

--- a/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
+++ b/api/tests/shared/integration/infrastructure/jobs/JobQueue_test.js
@@ -46,11 +46,7 @@ describe('Integration | Infrastructure | Jobs | JobQueue', function () {
           }
         };
 
-        jobQueue.register(
-          new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
-          name,
-          handler,
-        );
+        jobQueue.register(new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }), name, handler);
       });
 
       return promise;

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -39,7 +39,7 @@ describe('Unit | Worker', function () {
 
       // then
       expect(jobQueueStub.register).to.have.been.calledWithExactly(
-        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         UserAnonymizedEventLoggingJob.name,
         UserAnonymizedEventLoggingJobController,
       );
@@ -60,7 +60,7 @@ describe('Unit | Worker', function () {
 
       // then
       expect(jobQueueStub.register).to.have.been.calledWithExactly(
-        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         'legyNameForUserAnonymizedEventLoggingJobController',
         UserAnonymizedEventLoggingJobController,
       );
@@ -81,7 +81,7 @@ describe('Unit | Worker', function () {
 
       // then
       expect(jobQueueStub.register).to.have.been.calledWithExactly(
-        new Metrics({ config: { featureToggles: { isDirectMetricsEnabled: false } } }),
+        new Metrics({ config: { metrics: { isDirectMetricsEnabled: false } } }),
         ValidateOrganizationImportFileJob.name,
         ValidateOrganizationLearnersImportFileJobController,
       );


### PR DESCRIPTION
## 🔆 Problème

Dans le processus de migration des feature toggles, on s'occupe ici des toggles des metrics. On ne souhaite pas mettre ces variables en feature toggles mais juste les retirer du système de feature toggle.

## ⛱️ Proposition

Déplacer les variables dans la section metrics du fichier config.js.

## 🌊 Remarques

Faudrait-il renommer les variables dans le .env ?