### PR TITLE
[TECH] :truck: Déplace `target-profile-training-repository` vers `src/devcomp/`

### DIFF
--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as targetProfileTrainingRepository from '../../../../lib/infrastructure/repositories/target-profile-training-repository.js';
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as llmApi from '../../../llm/application/api/llm-api.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
@@ -14,6 +13,7 @@ import * as tubeRepository from '../../../shared/infrastructure/repositories/tub
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
+import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
 

--- a/api/src/devcomp/infrastructure/repositories/target-profile-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/target-profile-training-repository.js
@@ -1,4 +1,4 @@
-import { DomainTransaction } from '../../../src/shared/domain/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 const TABLE_NAME = 'target-profile-trainings';
 
 const create = async function ({ trainingId, targetProfileIds }) {

--- a/api/tests/devcomp/integration/infrastructure/repositories/target-profile-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/target-profile-training-repository_test.js
@@ -1,5 +1,5 @@
-import * as targetProfileTrainingRepository from '../../../../lib/infrastructure/repositories/target-profile-training-repository.js';
-import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+import * as targetProfileTrainingRepository from '../../../../../src/devcomp/infrastructure/repositories/target-profile-training-repository.js';
+import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Repository | target-profile-training-repository', function () {
   describe('#create', function () {


### PR DESCRIPTION
## 🔆 Problème

Le fichier `target-profile-training-repository` est encore dans `lib/`

## ⛱️ Proposition

Déplacer `target-profile-training-repository` vers `src/devcomp/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
