### PR TITLE
[TECH] :truck: Déplace la route `Campaign-participation` vers `src/devcomp/`

### DIFF
--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,7 +1,6 @@
 import * as healthcheck from '../src/shared/application/healthcheck/index.js';
-import * as campaignParticipations from './application/campaign-participations/index.js';
 import * as scoOrganizationLearners from './application/sco-organization-learners/index.js';
 
-const routes = [campaignParticipations, healthcheck, scoOrganizationLearners];
+const routes = [healthcheck, scoOrganizationLearners];
 
 export { routes };

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -1,6 +1,6 @@
-import { usecases as devcompUsecases } from '../../../src/devcomp/domain/usecases/index.js';
-import * as trainingSerializer from '../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
-import { extractLocaleFromRequest } from '../../../src/shared/infrastructure/utils/request-response-utils.js';
+import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
+import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
 const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
   const { userId } = request.auth.credentials;

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { campaignParticipationController } from './campaign-participation-controller.js';
 
 const register = async function (server) {

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -1,3 +1,4 @@
+import * as campaignParticipationRoute from './application/campaign-participations/campaign-participation-route.js';
 import * as modulesRoutes from './application/modules/index.js';
 import * as passageEvents from './application/passage-events/index.js';
 import * as passages from './application/passages/index.js';
@@ -7,6 +8,7 @@ import * as userTrainings from './application/user-trainings/index.js';
 import * as userTutorials from './application/user-tutorials/index.js';
 
 const devcompRoutes = [
+  campaignParticipationRoute,
   modulesRoutes,
   passages,
   passageEvents,

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -3,7 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
 describe('Acceptance | API | Campaign Participations', function () {
   let server, user;

--- a/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
@@ -1,4 +1,4 @@
-import { campaignParticipationController } from '../../../../lib/application/campaign-participations/campaign-participation-controller.js';
+import { campaignParticipationController } from '../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
 import { usecases as devcompUsecases } from '../../../../src/devcomp/domain/usecases/index.js';
 import { expect, sinon } from '../../../test-helper.js';
 describe('Unit | Application | Controller | Campaign-Participation', function () {

--- a/api/tests/unit/application/campaign-participations/index_test.js
+++ b/api/tests/unit/application/campaign-participations/index_test.js
@@ -1,5 +1,5 @@
-import { campaignParticipationController } from '../../../../lib/application/campaign-participations/campaign-participation-controller.js';
-import * as moduleUnderTest from '../../../../lib/application/campaign-participations/index.js';
+import { campaignParticipationController } from '../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
+import * as moduleUnderTest from '../../../../src/devcomp/application/campaign-participations/campaign-participation-route.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 describe('Unit | Application | Router | campaign-participation-router ', function () {


### PR DESCRIPTION
## 🔆 Problème

La route `Campaign-participation` vers `src/devcomp/`

## ⛱️ Proposition

Déplacer la route `Campaign-participation` vers `src/devcomp/`

## 🌊 Remarques

Un peu surpris de déplacer cette route dans `devcomp` alors que ça parle de campaign. Mais le contrôleur appel un cas d'utilisation de devcomp...

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
