### PR TITLE
[TECH] Ajouter la permission pour le contenu dans le workflow qui ferme les PRs inactive depuis un mois

### DIFF
--- a/.github/workflows/check-old-pull-requests.yml
+++ b/.github/workflows/check-old-pull-requests.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  contents: write
 
 jobs:
   check-inactive-prs:


### PR DESCRIPTION
## 🔆 Problème

Lors de la fermeture,la branche ne se supprime pas.

## ⛱️ Proposition

Ajouter dans les permisssions de l'action la clef content avec la valeur write.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

On teste depuis la branche.
https://github.com/1024pix/pix/actions/runs/15607780887/job/43961289251
