### PR TITLE
[TECH] Renommer la variable SetupEchoSystemBeforeStart et la retirer des feature toggles

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -26,7 +26,7 @@ async function _setupEcosystem() {
 }
 
 const start = async function () {
-  if (config.featureToggles.setupEcosystemBeforeStart) {
+  if (config.hapi.setupEcosystemBeforeStart) {
     await _setupEcosystem();
   }
   server = await createServer();

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -298,12 +298,12 @@ const configuration = (function () {
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
       showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {
       options: {},
       enableRequestMonitoring: toBoolean(process.env.ENABLE_REQUEST_MONITORING),
+      setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
     },
     infra: {
       appName: process.env.APP,


### PR DESCRIPTION
## 🔆 Problème

Dans l'objectif de continuer la supression des anciens feature toggles, on s'attaque cette fois à setupEchoSystemBeforeStart.

## ⛱️ Proposition

La variable est utilisée dans index.js, on la déplace dans la section hapi.

## 🌊 Remarques

RAS.