### PR TITLE
[FEATURE] Faire disparaître les élements du toaster automatiquement lors du changement de page sur Pix Admin (PIX-18169).

### DIFF
--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -1,7 +1,10 @@
 import EmberRouter from '@ember/routing/router';
+import { service } from '@ember/service';
 import config from 'pix-admin/config/environment';
 
 export default class Router extends EmberRouter {
+  @service pixToast;
+
   location = config.locationType;
   rootURL = config.rootURL;
 
@@ -9,6 +12,11 @@ export default class Router extends EmberRouter {
     super(...arguments);
     this.on('routeDidChange', (transition) => {
       if (transition.from && transition.to.name !== transition.from.name) {
+        const isFromSameParent = transition.to.parent.name.includes(transition.from.parent.name);
+
+        if (!isFromSameParent) {
+          this.pixToast.removeAllNotifications();
+        }
         window.scrollTo(0, 0);
       }
     });
@@ -29,10 +37,10 @@ Router.map(function () {
       this.route('new');
       this.route('list');
       this.route('get', { path: '/:organization_id' }, function () {
+        this.route('all-tags');
+        this.route('campaigns');
         this.route('team');
         this.route('target-profiles');
-        this.route('campaigns');
-        this.route('all-tags');
         this.route('places', function () {
           this.route('list', { path: '/' });
           this.route('new');

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -12,9 +12,12 @@ export default class Router extends EmberRouter {
     super(...arguments);
     this.on('routeDidChange', (transition) => {
       if (transition.from && transition.to.name !== transition.from.name) {
+        const isTransitionFromCreateOrUpdate = ['.edit', '.new', '.update'].every((route) =>
+          transition.from.name.includes(route),
+        );
         const isFromSameParent = transition.to.parent.name.includes(transition.from.parent.name);
 
-        if (!isFromSameParent) {
+        if (!isFromSameParent && isTransitionFromCreateOrUpdate) {
           this.pixToast.removeAllNotifications();
         }
         window.scrollTo(0, 0);
@@ -37,10 +40,10 @@ Router.map(function () {
       this.route('new');
       this.route('list');
       this.route('get', { path: '/:organization_id' }, function () {
-        this.route('all-tags');
-        this.route('campaigns');
         this.route('team');
         this.route('target-profiles');
+        this.route('campaigns');
+        this.route('all-tags');
         this.route('places', function () {
           this.route('list', { path: '/' });
           this.route('new');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
@@ -636,8 +636,11 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
         await click(selectLevelTubeThematicDeuxNiveauQuatre[1]);
         await screen.findByRole('listbox');
-        await click(screen.getByRole('option', { name: '3' }));
-        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
+
+        await Promise.all([
+          waitForElementToBeRemoved(() => screen.queryByRole('listbox')),
+          click(screen.getByRole('option', { name: '3' })),
+        ]);
 
         await clickByName('Enregistrer le badge');
         await clickByName('Voir le détail du badge Mon nouveau badge');


### PR DESCRIPTION
## 🔆 Problème

Le nouveau toaster ne permet pas de poser de limite de temps à l'affichage. ( pour des raisons d'accessiblité et de simplicité ), Ce qui a pour effet de stacker les toaster si on ne les supprime pas au fil de l'eau

## ⛱️ Proposition

Au changement de page supprimer automatiquement les toaster étant donnée que c'est une page qui n'a rien à voir avec les toaster précédent

## 🌊 Remarques

RAS

## 🏄 Pour tester

Sur Pix Admin, aller sur la page equipe. desactiver les compte. change de page. les toaster disparaissent