### PR TITLE
[FEATURE] Gérer le bouton "Continuer" pour les modalités QAB, QCU déclarative et flashcards (PIX-18067)

### DIFF
--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -9,6 +9,7 @@ class Flashcards extends Element {
     this.instruction = instruction;
     this.setIntroImage(introImage);
     this.cards = cards.map(({ id, recto, verso }) => new Card({ id, recto, verso }));
+    this.isAnswerable = true;
   }
 
   setIntroImage(introImage) {

--- a/api/src/devcomp/domain/models/element/qab/QAB.js
+++ b/api/src/devcomp/domain/models/element/qab/QAB.js
@@ -5,6 +5,7 @@ class QAB {
     this.id = id;
     this.type = type;
     this.instruction = instruction;
+    this.isAnswerable = true;
     this.cards = cards.map((card) => new QABCard(card));
   }
 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -117,53 +117,13 @@
               }
             ]
           }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
-            "type": "text",
-            "content": "<p>Voici une iframe :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f00133f5-0653-425b-a25f-3c9604820529",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/cartes2.html\" height=\"420\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "32e9196a-d854-4553-bb93-5a341213f6e2",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/videoCaroline.html\" height=\"800\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a5e32f35-889c-45aa-8151-2da532de4eeb",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/objectif.html\" height=\"600\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
-            "type": "text",
-            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
-          }
         }
       ]
     },
     {
-      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
-      "type": "discovery",
-      "title": "Voici un grain de découverte",
+      "id": "628bd37d-e5da-411f-9b06-1035b073411b",
+      "type": "lesson",
+      "title": "test flashcards",
       "components": [
         {
           "type": "element",
@@ -217,7 +177,61 @@
               }
             ]
           }
+        }
+      ]
+    },
+    {
+      "id": "df111992-ff3a-4c3f-ae5a-78bc359af23c",
+      "type": "lesson",
+      "title": "test POI",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
+            "type": "text",
+            "content": "<p>Voici une iframe :</p>"
+          }
         },
+        {
+          "type": "element",
+          "element": {
+            "id": "f00133f5-0653-425b-a25f-3c9604820529",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/cartes2.html\" height=\"420\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "32e9196a-d854-4553-bb93-5a341213f6e2",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/videoCaroline.html\" height=\"800\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "a5e32f35-889c-45aa-8151-2da532de4eeb",
+            "type": "text",
+            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/objectif.html\" height=\"600\"></iframe>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
+            "type": "text",
+            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
+      "type": "discovery",
+      "title": "Voici un grain de découverte",
+      "components": [
         {
           "type": "element",
           "element": {

--- a/api/tests/devcomp/shared/validateFlashcards.js
+++ b/api/tests/devcomp/shared/validateFlashcards.js
@@ -8,6 +8,7 @@ function validateFlashcards(flashcards, expectedFlashcards) {
   expect(flashcards.title).to.equal(expectedFlashcards.title);
   expect(flashcards.instruction).to.equal(expectedFlashcards.instruction);
   expect(flashcards.introImage.url).to.equal(expectedFlashcards.introImage.url);
+  expect(flashcards.isAnswerable).to.equal(true);
   validateCard(flashcards.cards[0], expectedFlashcards.cards[0]);
 }
 

--- a/api/tests/devcomp/unit/domain/models/element/qab/QAB_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/qab/QAB_test.js
@@ -40,6 +40,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QAB', function () {
       expect(qab.id).equal('a4e36fa9-dc56-4fd3-a7f2-708cf94b1728');
       expect(qab.type).equal('qab');
       expect(qab.instruction).equal('instruction');
+      expect(qab.isAnswerable).equal(true);
       expect(qab.cards).deep.equal([
         new QABCard({
           id: 'f2a601fa-a5a2-4c75-90bf-74977acb89b4',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -226,6 +226,7 @@ function getComponents() {
           },
         ],
         instruction: 'question declarative',
+        isAnswerable: true,
       }),
     }),
     new ComponentElement({
@@ -502,7 +503,7 @@ function getAttributesComponents() {
       type: 'element',
       element: {
         id: '7',
-        isAnswerable: false,
+        isAnswerable: true,
         title: 'title',
         instruction: 'instruction',
         introImage: {

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -31,6 +31,8 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -65,7 +65,7 @@ export default class ModulixElement extends Component {
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{else if (eq @element.type "qab")}}
-      <QabElement @element={{@element}} />
+      <QabElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
     {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -49,7 +49,7 @@ export default class ModulixElement extends Component {
         @correction={{this.getLastCorrectionForElement @element}}
       />
     {{else if (eq @element.type "qcu-declarative")}}
-      <QcuDeclarativeElement @element={{@element}} />
+      <QcuDeclarativeElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "qcm")}}
       <QcmElement
         @element={{@element}}

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -40,7 +40,11 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "separator")}}
       <SeparatorElement />
     {{else if (eq @element.type "flashcards")}}
-      <FlashcardsElement @flashcards={{@element}} @onSelfAssessment={{@onSelfAssessment}} />
+      <FlashcardsElement
+        @flashcards={{@element}}
+        @onAnswer={{@onElementAnswer}}
+        @onSelfAssessment={{@onSelfAssessment}}
+      />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -113,20 +113,26 @@ export default class ModulixFlashcards extends Component {
     this.counters[userAssessment]++;
   }
 
-  goToNextCard() {
+  async goToNextCard() {
     if (this.currentCardIndex < this.numberOfCards - 1) {
       this.currentCardIndex++;
       this.displayedSideName = 'recto';
     } else {
       this.currentStep = 'outro';
+      await this.onAnswer();
     }
+  }
+
+  @action
+  async onAnswer() {
+    await this.args.onAnswer({ element: this.args.flashcards });
   }
 
   @action
   noop() {}
 
   @action
-  onSelfAssessment(userAssessment) {
+  async onSelfAssessment(userAssessment) {
     const selfAssessmentData = {
       userAssessment,
       cardId: this.currentCard.id,
@@ -143,7 +149,7 @@ export default class ModulixFlashcards extends Component {
     });
 
     this.incrementCounterFor(userAssessment);
-    this.goToNextCard();
+    await this.goToNextCard();
 
     const elementToFocus = document.querySelector('.element-flashcards');
     elementToFocus.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'start' });

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -49,23 +49,29 @@ export default class ModuleQab extends ModuleElement {
   }
 
   @action
-  goToNextCard() {
+  async goToNextCard() {
     this.removedCards.set(this.currentCard.id, true);
     this.removedCards = new Map(this.removedCards);
 
-    window.setTimeout(() => {
+    window.setTimeout(async () => {
       this.displayedCards = this.displayedCards.slice(1);
       this.currentCardStatus = '';
       this.selectedOption = null;
 
       if (this.displayedCards.length === 0) {
         this.currentStep = 'score';
+        await this.onAnswer();
       }
     }, NEXT_CARD_REMOVE_DELAY);
   }
 
   @action
-  onSubmit(event) {
+  async onAnswer() {
+    await this.args.onAnswer({ element: this.element });
+  }
+
+  @action
+  async onSubmit(event) {
     event.preventDefault();
     this.selectedOption = event.submitter.value;
     this.currentCardStatus = 'error';
@@ -77,7 +83,7 @@ export default class ModuleQab extends ModuleElement {
     this.cardStatuses.set(this.currentCard.id, this.currentCardStatus);
     this.cardStatuses = new Map(this.cardStatuses);
 
-    window.setTimeout(() => this.goToNextCard(), NEXT_CARD_TRANSITION_DELAY);
+    window.setTimeout(async () => await this.goToNextCard(), NEXT_CARD_TRANSITION_DELAY);
   }
 
   @action

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import QabCard from 'mon-pix/components/module/element/qab/qab-card';
 import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
+import { TrackedArray, TrackedMap } from 'tracked-built-ins';
 
 import { htmlUnsafe } from '../../../../helpers/html-unsafe';
 import ModuleElement from '../module-element';
@@ -17,13 +18,13 @@ export default class ModuleQab extends ModuleElement {
   @tracked currentCardStatus = '';
   @tracked currentCardIndex = 0;
   @tracked score = 0;
-  @tracked displayedCards = [];
-  @tracked cardStatuses = new Map();
-  @tracked removedCards = new Map();
+  @tracked displayedCards;
+  @tracked cardStatuses = new TrackedMap();
+  @tracked removedCards = new TrackedMap();
 
   constructor() {
     super(...arguments);
-    this.displayedCards = this.element.cards;
+    this.displayedCards = new TrackedArray(this.element.cards);
   }
 
   get numberOfCards() {
@@ -51,10 +52,9 @@ export default class ModuleQab extends ModuleElement {
   @action
   async goToNextCard() {
     this.removedCards.set(this.currentCard.id, true);
-    this.removedCards = new Map(this.removedCards);
 
     window.setTimeout(async () => {
-      this.displayedCards = this.displayedCards.slice(1);
+      this.displayedCards.shift();
       this.currentCardStatus = '';
       this.selectedOption = null;
 
@@ -81,17 +81,15 @@ export default class ModuleQab extends ModuleElement {
     }
 
     this.cardStatuses.set(this.currentCard.id, this.currentCardStatus);
-    this.cardStatuses = new Map(this.cardStatuses);
-
     window.setTimeout(async () => await this.goToNextCard(), NEXT_CARD_TRANSITION_DELAY);
   }
 
   @action
   onRetry() {
     this.currentStep = 'cards';
-    this.removedCards = new Map();
-    this.cardStatuses = new Map();
-    this.displayedCards = this.element.cards;
+    this.removedCards.clear();
+    this.cardStatuses.clear();
+    this.displayedCards = new TrackedArray(this.element.cards);
     this.score = 0;
   }
 

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -37,6 +37,8 @@ export default class ModuleQcuDeclarative extends ModuleElement {
         answer: this.selectedProposalAnswer,
       },
     });
+
+    await this.args.onAnswer({ element: this.element });
   }
 
   get isAnswered() {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -95,6 +95,7 @@
         "sinon": "^20.0.0",
         "stylelint": "^16.0.0",
         "stylelint-order": "^6.0.0",
+        "tracked-built-ins": "^4.0.0",
         "webpack": "^5.95.0",
         "xss": "^1.0.13"
       },
@@ -27578,6 +27579,799 @@
         "rsvp": "^4.8.4"
       }
     },
+    "node_modules/ember-tracked-storage-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz",
+      "integrity": "sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ember-cli-babel": "^7.26.3",
+        "ember-cli-htmlbars": "^5.7.1"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-babel-transpiler/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-funnel/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-merge-trees/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ember-cli-htmlbars/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/find-babel-config": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
+      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^1.0.2",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-tracked-storage-polyfill/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
+    },
     "node_modules/ember-truth-helpers": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.3.tgz",
@@ -46683,6 +47477,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tracked-built-ins": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-4.0.0.tgz",
+      "integrity": "sha512-0Jl43A1SDZd+yYCJvXfgDSn4Wk/zcawkyFTBPqOETU5UJRngnVEnQ8oOjawqPRg6qja3sKjIQ8z6X9xJzcUTUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^2.0.0",
+        "ember-tracked-storage-polyfill": "^1.0.0"
       }
     },
     "node_modules/tree-sync": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -128,6 +128,7 @@
     "sinon": "^20.0.0",
     "stylelint": "^16.0.0",
     "stylelint-order": "^6.0.0",
+    "tracked-built-ins": "^4.0.0",
     "webpack": "^5.95.0",
     "xss": "^1.0.13"
   },

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -247,16 +247,21 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     });
 
     module('then user gives an answer for the last card', function () {
-      test('should display the outro card', async function (assert) {
+      test('should display the outro card and call "onAnswer" function passed as argument', async function (assert) {
         // given
         const { flashcards } = _getFlashcards();
 
+        const onAnswerStub = sinon.stub();
         const onSelfAssessmentStub = sinon.stub();
 
         // when
         const screen = await render(
           <template>
-            <ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessmentStub}} />
+            <ModulixFlashcards
+              @flashcards={{flashcards}}
+              @onAnswer={{onAnswerStub}}
+              @onSelfAssessment={{onSelfAssessmentStub}}
+            />
           </template>,
         );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
@@ -266,6 +271,10 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         await clickByName(t('pages.modulix.buttons.flashcards.answers.yes'));
 
         // then
+        sinon.assert.calledWithExactly(onAnswerStub, {
+          element: flashcards,
+        });
+
         assert.ok(screen.getByText('Terminé'));
       });
     });
@@ -297,11 +306,18 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       // given
       const { flashcards } = _getFlashcards();
 
+      const onAnswerStub = sinon.stub();
       const onSelfAssessment = sinon.stub();
 
       // when
       const screen = await render(
-        <template><ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessment}} /></template>,
+        <template>
+          <ModulixFlashcards
+            @flashcards={{flashcards}}
+            @onAnswer={{onAnswerStub}}
+            @onSelfAssessment={{onSelfAssessment}}
+          />
+        </template>,
       );
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
       await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
@@ -321,12 +337,17 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       // given
       const { flashcards } = _getFlashcards();
 
+      const onAnswerStub = sinon.stub();
       const onSelfAssessmentStub = sinon.stub();
 
       // when
       const screen = await render(
         <template>
-          <ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessmentStub}} />
+          <ModulixFlashcards
+            @flashcards={{flashcards}}
+            @onAnswer={{onAnswerStub}}
+            @onSelfAssessment={{onSelfAssessmentStub}}
+          />
         </template>,
       );
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
@@ -351,12 +372,17 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         // given
         const { flashcards, firstCard } = _getFlashcards();
 
+        const onAnswerStub = sinon.stub();
         const onSelfAssessmentStub = sinon.stub();
 
         // when
         const screen = await render(
           <template>
-            <ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessmentStub}} />
+            <ModulixFlashcards
+              @flashcards={{flashcards}}
+              @onAnswer={{onAnswerStub}}
+              @onSelfAssessment={{onSelfAssessmentStub}}
+            />
           </template>,
         );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -199,6 +199,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           id: 'ed795d29-5f04-499c-a9c8-4019125c5cb1',
           type: 'qab',
           instruction: '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong></p>',
+          isAnswerable: true,
           cards: [
             {
               id: 'e222b060-7c18-4ee2-afe2-2ae27c28946a',

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -329,6 +329,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           title: "Introduction à l'adresse e-mail",
           instruction: '<p>...</p>',
           introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+          isAnswerable: true,
           cards: [
             {
               id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1,5 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import { findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
@@ -415,10 +415,48 @@ module('Integration | Component | Module | Grain', function (hooks) {
         test('should display continue button', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
+          const passageEventService = this.owner.lookup('service:passage-events');
+          sinon.stub(passageEventService, 'record');
           const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
+          const qcuDeclarativeElement = {
+            id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+            isAnswerable: true,
+            type: 'qcu-declarative',
+            instruction: '<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>',
+            proposals: [
+              {
+                id: '1',
+                content: 'Avant de mettre le dentifrice',
+                feedback: {
+                  state: '',
+                  diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+                },
+              },
+              {
+                id: '2',
+                content: 'Après avoir mis le dentifrice',
+                feedback: {
+                  state: '',
+                  diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
+                },
+              },
+              {
+                id: '3',
+                content: 'Pendant que le dentifrice est mis',
+                feedback: {
+                  state: '',
+                  diagnosis: '<p>Digne des plus grands acrobates !</p>',
+                },
+              },
+            ],
+          };
+
           const grain = store.createRecord('grain', {
             title: '1st Grain title',
-            components: [{ type: 'element', element }],
+            components: [
+              { type: 'element', element },
+              { type: 'element', element: qcuDeclarativeElement },
+            ],
           });
           store.createRecord('module', { grains: [grain] });
           this.set('grain', grain);
@@ -431,6 +469,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // when
           const screen = await render(hbs`
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+          await click(screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content }));
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
@@ -461,6 +500,28 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
 
     module('when at least one element has not been answered', function () {
+      module('when this element is a locally answerable element', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu-declarative', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+            <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+      });
+
       module('when canMoveToNextGrain is true', function () {
         test('should not display continue button', async function (assert) {
           // given
@@ -1500,6 +1561,83 @@ module('Integration | Component | Module | Grain', function (hooks) {
               assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.continue') })).exists();
             });
           });
+        });
+      });
+    });
+
+    module('when there are locally answerable elements in stepper', function () {
+      module('when elements have not been answered', function () {
+        test('should not display continue button', async function (assert) {
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+          const onElementRetryStub = sinon.stub();
+          const onStepperNextStepStub = sinon.stub();
+
+          const qabElement = {
+            id: 'ed795d29-5f04-499c-a9c8-4019125c5cb1',
+            type: 'qab',
+            instruction:
+              '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>',
+            isAnswerable: true,
+            cards: [
+              {
+                id: 'e222b060-7c18-4ee2-afe2-2ae27c28946a',
+                image: {
+                  url: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+                  altText: '',
+                },
+                text: 'Les boules de pétanques sont creuses.',
+                proposalA: 'Vrai',
+                proposalB: 'Faux',
+                solution: 'A',
+              },
+              {
+                id: '57056894-8e1b-4da9-96b6-0bd4187412b8',
+                text: 'Les chiens ne transpirent pas.',
+                proposalA: 'Vrai',
+                proposalB: 'Faux',
+                solution: 'B',
+              },
+            ],
+          };
+
+          const steps = [
+            {
+              elements: [qabElement],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+
+          const grain = {
+            title: 'Grain title',
+            components: [
+              {
+                type: 'stepper',
+                steps,
+              },
+            ],
+          };
+
+          this.set('grain', grain);
+          this.set('passage', passage);
+          this.set('onElementRetry', onElementRetryStub);
+          this.set('onStepperNextStep', onStepperNextStepStub);
+
+          // when
+          const screen = await render(hbs`
+          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.continue') })).doesNotExist();
         });
       });
     });

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -117,18 +117,25 @@ module('Integration | Component | Module | QAB', function (hooks) {
     });
 
     module('when user answers the last card', function () {
-      test('should display the score card', async function (assert) {
+      test('should display the score card and call "onAnswer" function passed as argument', async function (assert) {
         // given
         const qabElement = _getQabElement();
+        const onAnswerStub = sinon.stub();
 
         // when
-        const screen = await render(<template><ModuleQabElement @element={{qabElement}} /></template>);
+        const screen = await render(
+          <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+        );
         await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
         await clock.tickAsync(NEXT_CARD_DELAY);
         await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
         await clock.tickAsync(NEXT_CARD_DELAY);
 
         // then
+        sinon.assert.calledWithExactly(onAnswerStub, {
+          element: qabElement,
+        });
+
         assert.dom(screen.getByText('Votre score : 1/2')).exists();
         assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
       });
@@ -137,9 +144,12 @@ module('Integration | Component | Module | QAB', function (hooks) {
         test('should reset the component and display the first card', async function (assert) {
           // given
           const qabElement = _getQabElement();
+          const onAnswerStub = sinon.stub();
 
           // when
-          const screen = await render(<template><ModuleQabElement @element={{qabElement}} /></template>);
+          const screen = await render(
+            <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+          );
           await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
           await clock.tickAsync(NEXT_CARD_DELAY);
           await click(screen.getByRole('button', { name: 'Option A: Vrai' }));

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -11,42 +11,14 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
 
   test('it should display an instruction, a complementary instruction and a list of proposals', async function (assert) {
     // given
-    const instruction = '<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>';
-    const complementaryInstruction = 'Il n’y a pas de bonne ou de mauvaise réponse.';
-    const proposals = [
-      {
-        id: '1',
-        content: 'Avant de mettre le dentifrice',
-        feedback: {
-          state: '',
-          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
-        },
-      },
-      {
-        id: '2',
-        content: 'Après avoir mis le dentifrice',
-        feedback: {
-          state: '',
-          diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
-        },
-      },
-      {
-        id: '3',
-        content: 'Pendant que le dentifrice est mis',
-        feedback: {
-          state: '',
-          diagnosis: '<p>Digne des plus grands acrobates !</p>',
-        },
-      },
-    ];
-
-    const qcuDeclarativeElement = { instruction, proposals };
+    const qcuDeclarativeElement = _getQcuDeclarativeElement();
+    const { complementaryInstruction, proposals } = qcuDeclarativeElement;
 
     // when
     const screen = await render(<template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} /></template>);
 
     // then
-    assert.ok(screen.getByText('Quand faut-il mouiller sa brosse à dents ?'));
+    assert.ok(screen.getByText('De quoi le ‘oui‘ a-t-il besoin pour gagner ?'));
     assert.ok(screen.getByText(complementaryInstruction));
     assert.ok(screen.getByRole('button', { name: proposals[0].content }));
     assert.ok(screen.getByRole('button', { name: proposals[1].content }));
@@ -59,36 +31,9 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       const passageEventService = this.owner.lookup('service:passageEvents');
       const passageEventRecordStub = sinon.stub(passageEventService, 'record');
 
-      const instruction = '<p>De quoi le ‘oui‘ a-t-il besoin pour gagner ?</p>';
+      const qcuDeclarativeElement = _getQcuDeclarativeElement();
+      const { proposals } = qcuDeclarativeElement;
 
-      const proposals = [
-        {
-          id: '1',
-          content: 'Du ‘oui‘',
-          feedback: {
-            state: '',
-            diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
-          },
-        },
-        {
-          id: '2',
-          content: 'Du ‘non‘',
-          feedback: {
-            state: '',
-            diagnosis: '<p>Possible, mais attention à ne pas faire une rafarinade !</p>',
-          },
-        },
-        {
-          id: '3',
-          content: 'Du ‘peut-être‘',
-          feedback: {
-            state: '',
-            diagnosis: '<p>Digne des plus grands acrobates !</p>',
-          },
-        },
-      ];
-
-      const qcuDeclarativeElement = { instruction, proposals };
 
       // when
       const screen = await render(<template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} /></template>);
@@ -112,3 +57,37 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
     });
   });
 });
+
+function _getQcuDeclarativeElement() {
+  const instruction = '<p>De quoi le ‘oui‘ a-t-il besoin pour gagner ?</p>';
+  const complementaryInstruction = 'Il n’y a pas de bonne ou de mauvaise réponse.';
+
+  const proposals = [
+    {
+      id: '1',
+      content: 'Du ‘oui‘',
+      feedback: {
+        state: '',
+        diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+      },
+    },
+    {
+      id: '2',
+      content: 'Du ‘non‘',
+      feedback: {
+        state: '',
+        diagnosis: '<p>Possible, mais attention à ne pas faire une rafarinade !</p>',
+      },
+    },
+    {
+      id: '3',
+      content: 'Du ‘peut-être‘',
+      feedback: {
+        state: '',
+        diagnosis: '<p>Digne des plus grands acrobates !</p>',
+      },
+    },
+  ];
+
+  return { instruction, complementaryInstruction, proposals };
+}

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -30,13 +30,15 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       // given
       const passageEventService = this.owner.lookup('service:passageEvents');
       const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
 
       const qcuDeclarativeElement = _getQcuDeclarativeElement();
       const { proposals } = qcuDeclarativeElement;
 
-
       // when
-      const screen = await render(<template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} /></template>);
+      const screen = await render(
+        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
 
@@ -54,6 +56,28 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
           answer: proposals[0].content,
         },
       });
+    });
+    test('it should call "onAnswer" function pass as argument', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcuDeclarativeElement = _getQcuDeclarativeElement();
+      const { proposals } = qcuDeclarativeElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const button1 = screen.getByRole('button', { name: proposals[0].content });
+      await click(button1);
+
+      // then
+      sinon.assert.calledWithExactly(onAnswerStub, {
+        element: qcuDeclarativeElement,
+      });
+      assert.ok(true);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le bouton “Continuer” apparaît toujours dans un grain contenant une modalité `qab`, `qcu-declarative` ou `flashcards` alors qu’il ne devrait apparaître qu'après avoir répondu à ces éléments.

## ⛱️ Proposition

Afficher le bouton Continuer après avoir répondu à ces éléments. 

## 🌊 Remarques

- Le fait d'avoir répondu à ces éléments ne déclenchent pas d'appels au serveur pour vérifier la réponse. Cela pose la première pierre pour gérer les corrections / feedback uniquement côté front 💪 

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12516.review.pix.fr/modules/bac-a-sable)
- Vérifier, dans les 3 premiers grains, que le bouton `Continuer` ne s'affiche qu'après avoir répondu aux éléments flashcards, qab, et qcu-declarative
