### PR TITLE
[TECH] Supprimer le campaignCode dans l'appel à la route /api/organization-learners (PIX-18191)

### DIFF
--- a/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
@@ -5,12 +5,12 @@ const findAssociation = async function (request, h, dependencies = { organizatio
   const authenticatedUserId = request.auth.credentials.userId;
 
   const requestedUserId = parseInt(request.query.userId);
-  const campaignCode = request.query.campaignCode;
+  const organizationId = request.query.organizationId;
 
   const organizationLearner = await usecases.findAssociationBetweenUserAndOrganizationLearner({
     authenticatedUserId,
     requestedUserId,
-    campaignCode,
+    organizationId,
   });
 
   return h.response(dependencies.organizationLearnerIdentitySerializer.serialize(organizationLearner)).code(200);

--- a/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/registration-organization-learner-controller.js
@@ -4,12 +4,11 @@ import * as organizationLearnerIdentitySerializer from '../infrastructure/serial
 const findAssociation = async function (request, h, dependencies = { organizationLearnerIdentitySerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
 
-  const requestedUserId = parseInt(request.query.userId);
-  const organizationId = request.query.organizationId;
+  const { userId, organizationId } = request.query;
 
   const organizationLearner = await usecases.findAssociationBetweenUserAndOrganizationLearner({
     authenticatedUserId,
-    requestedUserId,
+    requestedUserId: userId,
     organizationId,
   });
 

--- a/api/src/prescription/organization-learner/application/registration-organization-learner-route.js
+++ b/api/src/prescription/organization-learner/application/registration-organization-learner-route.js
@@ -1,3 +1,6 @@
+import Joi from 'joi';
+
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { registrationOrganizationLearnerController } from './registration-organization-learner-controller.js';
 
 const register = async function (server) {
@@ -13,6 +16,12 @@ const register = async function (server) {
             '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api', 'organization-learners'],
+        validate: {
+          query: Joi.object({
+            userId: identifiersType.userId,
+            organizationId: identifiersType.organizationId,
+          }),
+        },
       },
     },
   ]);

--- a/api/src/prescription/organization-learner/domain/usecases/find-association-between-user-and-organization-learner.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-association-between-user-and-organization-learner.js
@@ -1,5 +1,4 @@
 import {
-  CampaignCodeError,
   OrganizationLearnerDisabledError,
   UserNotAuthorizedToAccessEntityError,
 } from '../../../../shared/domain/errors.js';
@@ -7,22 +6,16 @@ import {
 const findAssociationBetweenUserAndOrganizationLearner = async function ({
   authenticatedUserId,
   requestedUserId,
-  campaignCode,
-  campaignRepository,
+  organizationId,
   registrationOrganizationLearnerRepository,
 }) {
   if (authenticatedUserId !== requestedUserId) {
     throw new UserNotAuthorizedToAccessEntityError();
   }
 
-  const campaign = await campaignRepository.getByCode(campaignCode);
-  if (!campaign) {
-    throw new CampaignCodeError();
-  }
-
   const organizationLearner = await registrationOrganizationLearnerRepository.findOneByUserIdAndOrganizationId({
     userId: authenticatedUserId,
-    organizationId: campaign.organizationId,
+    organizationId,
   });
 
   if (organizationLearner && organizationLearner.isDisabled) {

--- a/api/tests/prescription/organization-learner/acceptance/registration-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/registration-organization-learner-route_test.js
@@ -17,11 +17,9 @@ describe('Acceptance | Application | registration-organization-learner-route', f
     let user;
     let organization;
     let organizationLearner;
-    let campaignCode;
 
     beforeEach(async function () {
       organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
-      campaignCode = databaseBuilder.factory.buildCampaign({ organizationId: organization.id, code: 'YUTR789' }).code;
       user = databaseBuilder.factory.buildUser();
       organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         firstName: 'josé',
@@ -34,7 +32,7 @@ describe('Acceptance | Application | registration-organization-learner-route', f
       await databaseBuilder.commit();
       options = {
         method: 'GET',
-        url: `/api/organization-learners?userId=${user.id}&campaignCode=${campaignCode}`,
+        url: `/api/organization-learners?userId=${user.id}&organizationId=${organization.id}`,
         headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
       };
     });

--- a/api/tests/prescription/organization-learner/unit/application/registration-organization-learner-route_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/registration-organization-learner-route_test.js
@@ -14,7 +14,7 @@ describe('Unit | Application | Router | organization-learner-router', function (
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
-      const url = '/api/organization-learners?userId=1&campaignCode=ABCDEF123';
+      const url = '/api/organization-learners?userId=1&organizationId=1';
 
       // when
       const response = await httpTestServer.request(method, url);

--- a/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
+++ b/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
@@ -25,7 +25,7 @@ export default class InvitedWrapper extends Component {
     this.isLoading = true;
     this.errorMessage = null;
     const organizationLearner = this.store.createRecord('organization-learner', {
-      campaignCode: this.args.model.code,
+      organizationId: this.args.model.organizationId,
       reconciliationInfos,
     });
 

--- a/mon-pix/app/routes/campaigns/invited/reconciliation.js
+++ b/mon-pix/app/routes/campaigns/invited/reconciliation.js
@@ -19,7 +19,7 @@ export default class ReconciliationRoute extends Route {
   async afterModel(campaign) {
     const organizationLearner = await this.store.queryRecord('organization-learner-identity', {
       userId: this.currentUser.user.id,
-      campaignCode: campaign.code,
+      organizationId: campaign.organizationId,
     });
 
     if (organizationLearner) {

--- a/mon-pix/app/routes/campaigns/invited/student-sco.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sco.js
@@ -20,7 +20,7 @@ export default class StudentScoRoute extends Route {
   async afterModel(campaign) {
     let organizationLearner = await this.store.queryRecord('organization-learner-identity', {
       userId: this.currentUser.user.id,
-      campaignCode: campaign.code,
+      organizationId: campaign.organizationId,
     });
 
     if (!organizationLearner) {

--- a/mon-pix/app/routes/campaigns/invited/student-sup.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sup.js
@@ -19,7 +19,7 @@ export default class StudentSupRoute extends Route {
   async afterModel(campaign) {
     const organizationLearner = await this.store.queryRecord('organization-learner-identity', {
       userId: this.currentUser.user.id,
-      campaignCode: campaign.code,
+      organizationId: campaign.organizationId,
     });
 
     if (organizationLearner) {

--- a/mon-pix/mirage/routes/organization-learners/index.js
+++ b/mon-pix/mirage/routes/organization-learners/index.js
@@ -1,23 +1,6 @@
-import { Response } from 'miragejs';
-
 export default function index(config) {
-  config.get('/organization-learners', (schema, request) => {
-    const campaignCode = request.queryParams.campaignCode;
+  config.get('/organization-learners', (schema) => {
     const organizationLearnerIdentity = schema.organizationLearnerIdentities.first();
-    if (campaignCode === 'FORBIDDEN') {
-      return new Response(
-        412,
-        {},
-        {
-          errors: [
-            {
-              status: '412',
-              title: 'Precondition failed',
-            },
-          ],
-        },
-      );
-    }
     return organizationLearnerIdentity ? organizationLearnerIdentity : { data: null };
   });
 }

--- a/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
+++ b/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation-test.js
@@ -39,7 +39,7 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     const reconciliationInfos = Symbol('reconciliationInfos');
     component.store.createRecord
       .withArgs('organization-learner', {
-        campaignCode,
+        organizationId,
         reconciliationInfos,
       })
       .returns(createRecordStub);
@@ -63,7 +63,7 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     const reconciliationInfos = Symbol('reconciliationInfos');
     component.store.createRecord
       .withArgs('organization-learner', {
-        campaignCode,
+        organizationId,
         reconciliationInfos,
       })
       .returns(createRecordStub);
@@ -83,7 +83,7 @@ module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', funct
     const reconciliationInfos = Symbol('reconciliationInfos');
     component.store.createRecord
       .withArgs('organization-learner', {
-        campaignCode,
+        organizationId,
         reconciliationInfos,
       })
       .returns(createRecordStub);

--- a/mon-pix/tests/unit/routes/campaigns/invited/student-sco-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/student-sco-test.js
@@ -10,18 +10,22 @@ module('Unit | Route | campaigns/invited/student-sco', function (hooks) {
     test('should redirect to campaigns.invited.fill-in-participant-external-id when an association already exists', async function (assert) {
       // given
       const route = this.owner.lookup('route:campaigns.invited.student-sco');
-      const campaign = { code: 'campaignCode' };
+      const campaign = { code: 'campaignCode', organizationId: 1 };
       route.paramsFor = sinon.stub().returns(campaign);
+      const user = { id: 'id' };
+      const queryRecordStub = sinon.stub();
       route.set(
         'store',
         Service.create({
-          queryRecord: sinon.stub().resolves('a student user association'),
+          queryRecord: queryRecordStub
+            .withArgs({ organizationId: campaign.organizationId, userId: user.id })
+            .resolves('a student user association'),
         }),
       );
       route.set(
         'currentUser',
         Service.create({
-          user: { id: 'id' },
+          user,
         }),
       );
       route.router = { replaceWith: sinon.stub() };

--- a/mon-pix/tests/unit/routes/campaigns/invited/student-sup-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/student-sup-test.js
@@ -10,18 +10,20 @@ module('Unit | Route | campaigns/invited/student-sup', function (hooks) {
     test('should redirect to campaigns.invited.fill-in-participant-external-id when an association already exists', async function (assert) {
       // given
       const route = this.owner.lookup('route:campaigns.invited.student-sup');
-      const campaign = { code: 'campaignCode' };
+      const campaign = { code: 'campaignCode', organizationId: 1 };
       route.paramsFor = sinon.stub().returns(campaign);
+      const user = { id: 'id' };
+      const queryRecordStub = sinon.stub();
       route.set(
         'store',
         Service.create({
-          queryRecord: sinon.stub().resolves('a student user association'),
+          queryRecord: queryRecordStub.resolves('a student association'),
         }),
       );
       route.set(
         'currentUser',
         Service.create({
-          user: { id: 'id' },
+          user,
         }),
       );
       route.router = { replaceWith: sinon.stub() };
@@ -30,6 +32,10 @@ module('Unit | Route | campaigns/invited/student-sup', function (hooks) {
       await route.afterModel(campaign);
 
       // then
+      sinon.assert.calledWith(queryRecordStub, 'organization-learner-identity', {
+        organizationId: campaign.organizationId,
+        userId: user.id,
+      });
       sinon.assert.calledWith(
         route.router.replaceWith,
         'campaigns.invited.fill-in-participant-external-id',


### PR DESCRIPTION
## 🔆 Problème

On doit découpler la route organization-learners des campagnes. 

## ⛱️ Proposition

Pour ça, on remplace campaignCode par organizationId.

## 🌊 Remarques

La validation des paramètres de la route n'était pas faite par Joi, on a donc refactoré ce point-là.

## 🏄 Pour tester

Tester sur SCOASSMUL, SUPASSMUL et PROGENCOL que les appels vers /api/organization-learners partent bien avec les paramètres attendus.