### PR TITLE
[TECH] :card_file_box: Ajoute la notion de version pour les référentiels cadre (PIX-18190)

### DIFF
--- a/api/db/migrations/20250612134349_add-calibration_id-to-certification-frameworks-challenges.js
+++ b/api/db/migrations/20250612134349_add-calibration_id-to-certification-frameworks-challenges.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'version';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().index().comment('framework version');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous ne pouvons pas distinguer les versions de référentiel cadre dans la table.

## ⛱️ Proposition

Ajout d'une colonne permettant de distinguer plusieurs versions.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
