### PR TITLE
[TECH] Retirer le feature toggle showNewResultPage

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -299,7 +299,6 @@ const configuration = (function () {
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
       setupEcosystemBeforeStart: toBoolean(process.env.FT_SETUP_ECOSYSTEM_BEFORE_START) || false,
-      showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {
       options: {},
@@ -526,7 +525,6 @@ const configuration = (function () {
     config.metrics.isDirectMetricsEnabled = false;
     config.metrics.isOppsyDisabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
-    config.featureToggles.showNewResultPage = false;
 
     config.lti.authorizedPlatforms = ['https://moodle.example.net'];
     config.lti.jwkModulusLength = 2048;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -524,7 +524,6 @@ const configuration = (function () {
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.metrics.isDirectMetricsEnabled = false;
     config.metrics.isOppsyDisabled = false;
-    config.featureToggles.isTextToSpeechButtonEnabled = false;
 
     config.lti.authorizedPlatforms = ['https://moodle.example.net'];
     config.lti.jwkModulusLength = 2048;

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -30,7 +30,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-text-to-speech-button-enabled': false,
             'setup-ecosystem-before-start': false,
             'should-display-new-analysis-page': false,
-            'show-new-result-page': false,
             'is-v3-certification-page-enabled': false,
             'upgrade-to-real-user-enabled': false,
           },

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-new-account-recovery-enabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
-            'is-text-to-speech-button-enabled': false,
+            'is-text-to-speech-button-enabled': true,
             'setup-ecosystem-before-start': false,
             'should-display-new-analysis-page': false,
             'is-v3-certification-page-enabled': false,


### PR DESCRIPTION
## 🔆 Problème

On a plus besoin du ft showNewResultPage car il n'est plus utilisé.

## ⛱️ Proposition

Retirer le ft.