### PR TITLE
[TECH] :sparkles: ajoute une colonne `version` pour distinguer les référentiels cadre (PIX-18190)

### DIFF
--- a/api/db/database-builder/factory/build-certification-frameworks-challenge.js
+++ b/api/db/database-builder/factory/build-certification-frameworks-challenge.js
@@ -10,6 +10,7 @@ const buildCertificationFrameworksChallenge = function ({
   delta = 3.5,
   complementaryCertificationId,
   challengeId,
+  version = 'xxx-yyy-zzz',
 } = {}) {
   complementaryCertificationId = _.isUndefined(complementaryCertificationId)
     ? buildComplementaryCertification().id
@@ -23,6 +24,7 @@ const buildCertificationFrameworksChallenge = function ({
     delta,
     complementaryCertificationId,
     challengeId,
+    version,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20250612134349_add-calibration_id-to-certification-frameworks-challenges.js
+++ b/api/db/migrations/20250612134349_add-calibration_id-to-certification-frameworks-challenges.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'version';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().index().comment('framework version');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -7,6 +7,7 @@
  */
 
 import { LOCALE } from '../../../../shared/domain/constants.js';
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 /**
  * @param {Object} params
@@ -17,20 +18,30 @@ import { LOCALE } from '../../../../shared/domain/constants.js';
  * @param {ChallengeRepository} params.challengeRepository
  * @param {ConsolidatedFrameworkRepository} params.consolidatedFrameworkRepository
  */
-export const createConsolidatedFramework = async ({
-  complementaryCertificationKey,
-  tubeIds,
-  tubeRepository,
-  skillRepository,
-  challengeRepository,
-  consolidatedFrameworkRepository,
-}) => {
-  const tubes = await tubeRepository.findActiveByRecordIds(tubeIds, LOCALE.FRENCH_SPOKEN);
 
-  const skillIds = tubes.flatMap((tube) => tube.skillIds);
-  const skills = await skillRepository.findActiveByRecordIds(skillIds);
+export const createConsolidatedFramework = withTransaction(
+  async ({
+    complementaryCertificationKey,
+    tubeIds,
+    tubeRepository,
+    skillRepository,
+    challengeRepository,
+    uuidService,
+    consolidatedFrameworkRepository,
+    complementaryCertificationRepository,
+  }) => {
+    const tubes = await tubeRepository.findActiveByRecordIds(tubeIds, LOCALE.FRENCH_SPOKEN);
 
-  const challenges = await challengeRepository.findOperativeBySkills(skills, LOCALE.FRENCH_SPOKEN);
+    const skillIds = tubes.flatMap((tube) => tube.skillIds);
+    const skills = await skillRepository.findActiveByRecordIds(skillIds);
 
-  return consolidatedFrameworkRepository.create({ complementaryCertificationKey, challenges });
-};
+    const challenges = await challengeRepository.findOperativeBySkills(skills, LOCALE.FRENCH_SPOKEN);
+
+    return consolidatedFrameworkRepository.create({
+      complementaryCertificationKey,
+      challenges,
+      uuidService,
+      complementaryCertificationRepository,
+    });
+  },
+);

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -1,3 +1,4 @@
+import * as uuidService from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -37,6 +38,7 @@ const dependencies = {
   consolidatedFrameworkRepository,
   skillRepository,
   tubeRepository,
+  uuidService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -1,7 +1,11 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { complementaryCertificationRepository } from '../../../shared/infrastructure/repositories/complementary-certification-repository.js';
 
-export async function create({ complementaryCertificationKey, challenges }) {
+export async function create({
+  complementaryCertificationKey,
+  challenges,
+  uuidService,
+  complementaryCertificationRepository,
+}) {
   const knexConn = DomainTransaction.getConnection();
 
   const complementaryCertification = await complementaryCertificationRepository.getByKey(complementaryCertificationKey);
@@ -11,7 +15,8 @@ export async function create({ complementaryCertificationKey, challenges }) {
     challengeId: challenge.id,
   }));
 
+  const versionUuid = uuidService.randomUUID();
   for (const challengeDTO of challengesDTO) {
-    await knexConn('certification-frameworks-challenges').insert({ ...challengeDTO });
+    await knexConn('certification-frameworks-challenges').insert({ ...challengeDTO, version: versionUuid });
   }
 }

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -1,12 +1,11 @@
 import * as consolidatedFrameworkRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js';
-import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Integration | Repository | consolidated-framework', function () {
   describe('#create', function () {
     it('should create a consolidated framework for a given certification key', async function () {
       // given
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
-
       const challenge1 = databaseBuilder.factory.learningContent.buildChallenge({
         id: 'challenge1',
         alpha: 1.33,
@@ -17,12 +16,22 @@ describe('Certification | Configuration | Integration | Repository | consolidate
         alpha: 4.2,
         delta: -2,
       });
+
       await databaseBuilder.commit();
+
+      const fakeUuid = 'xxx-yyy-zzz';
+      const uuidService = { randomUUID: sinon.stub() };
+      uuidService.randomUUID.returns(fakeUuid);
+
+      const complementaryCertificationRepository = { getByKey: sinon.stub() };
+      complementaryCertificationRepository.getByKey.resolves(complementaryCertification);
 
       // when
       await consolidatedFrameworkRepository.create({
         complementaryCertificationKey: complementaryCertification.key,
         challenges: [challenge1, challenge2],
+        uuidService,
+        complementaryCertificationRepository,
       });
 
       // then
@@ -31,6 +40,7 @@ describe('Certification | Configuration | Integration | Repository | consolidate
         'challengeId',
         'alpha',
         'delta',
+        'version',
       );
       expect(consolidatedFrameworkInDB).to.deep.equal([
         {
@@ -38,12 +48,14 @@ describe('Certification | Configuration | Integration | Repository | consolidate
           challengeId: challenge1.id,
           alpha: null,
           delta: null,
+          version: fakeUuid,
         },
         {
           complementaryCertificationId: complementaryCertification.id,
           challengeId: challenge2.id,
           alpha: null,
           delta: null,
+          version: fakeUuid,
         },
       ]);
     });

--- a/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
@@ -1,12 +1,19 @@
 import { createConsolidatedFramework } from '../../../../../../src/certification/configuration/domain/usecases/create-consolidated-framework.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Unit | UseCase | create-consolidated-framework', function () {
-  let challengeRepository, consolidatedFrameworkRepository, tubeRepository, skillRepository;
+  let challengeRepository,
+    consolidatedFrameworkRepository,
+    tubeRepository,
+    skillRepository,
+    complementaryCertificationRepository,
+    uuidService;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     tubeRepository = {
       findActiveByRecordIds: sinon.stub(),
     };
@@ -19,6 +26,8 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     consolidatedFrameworkRepository = {
       create: sinon.stub(),
     };
+    complementaryCertificationRepository = Symbol('complementaryCertificationRepository');
+    uuidService = Symbol('uuidService');
   });
 
   it('should create a new consolidated framework', async function () {
@@ -51,6 +60,8 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
       skillRepository,
       challengeRepository,
       consolidatedFrameworkRepository,
+      uuidService,
+      complementaryCertificationRepository,
     });
 
     // then
@@ -66,6 +77,8 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     expect(consolidatedFrameworkRepository.create).to.have.been.calledOnceWithExactly({
       complementaryCertificationKey,
       challenges,
+      uuidService,
+      complementaryCertificationRepository,
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Nous ne pouvons pas distinguer les référentiels cadre

## ⛱️ Proposition

Ajouter une notion de version pour distinguer les référentiels cadre.

## 🌊 Remarques


## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
