### PR TITLE
[BUGFIX] Problème d'affichage sur l'écran de réponse QROCM (PIX-18176)

### DIFF
--- a/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.gjs
@@ -133,7 +133,7 @@ export default class QrocmIndSolutionPanel extends Component {
         const answerOutcome = this._computeAnswerOutcome(answers[block.input], resultDetails[block.input]);
         const inputClass = this._computeInputClass(answerOutcome);
         const ariaLabel = this._computeAriaLabel(answerOutcome);
-        if (answers[block.input] === '') {
+        if (answers[block.input] == undefined || answers[block.input] === '') {
           answers[block.input] = this.intl.t('pages.result-item.aband');
         }
         block.ariaLabel = ariaLabel;
@@ -147,7 +147,7 @@ export default class QrocmIndSolutionPanel extends Component {
   }
 
   _computeAnswerOutcome(inputFieldValue, resultDetail) {
-    if (inputFieldValue === '') {
+    if (inputFieldValue == undefined || inputFieldValue === '') {
       return 'empty';
     }
     return resultDetail === true ? 'ok' : 'ko';


### PR DESCRIPTION
## 🔆 Problème

Si on passe une épreuve QROCM-ind avec des selects, dans le panneau de solutions les champs avec indiqué "Pas de réponse" sont absents.

## ⛱️ Proposition

Faire apparaître les champs.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Passer une épreuve QROCM-ind (challenge1tj4I2dkPl9MP5) et vérifier dans le panneau de solutions.