### PR TITLE
[FEATURE] Communication avec l’embed pix-llm dans une épreuve (PIX-18172)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.gjs
+++ b/mon-pix/app/components/challenge-embed-simulator.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -62,6 +63,10 @@ export default class ChallengeEmbedSimulator extends Component {
       </div>
     </div>
   </template>
+
+  @service
+  embedApiProxy;
+
   @tracked
   isLoadingEmbed = true;
 
@@ -108,9 +113,15 @@ export default class ChallengeEmbedSimulator extends Component {
 
     iframe.addEventListener('load', loadListener);
 
-    thisComponent._embedMessageListener = ({ origin, data }) => {
+    thisComponent._embedMessageListener = ({ origin, data, ports }) => {
       if (!isEmbedAllowedOrigin(origin)) return;
       if (isInitMessage(data)) {
+        if (data.enableFetchFromApi) {
+          const [requestsPort] = ports;
+
+          this.embedApiProxy.forward(this, requestsPort, `/api/assessments/${this.args.assessmentId}/embed/`);
+        }
+
         if (data.autoLaunch || thisComponent.isSimulatorLaunched) {
           thisComponent.launchSimulator();
         }

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -141,7 +141,7 @@ export default class ChallengeStatement extends Component {
       {{/if}}
 
       {{#if @challenge.hasValidEmbedDocument}}
-        <ChallengeEmbedSimulator @embedDocument={{this.challengeEmbedDocument}} />
+        <ChallengeEmbedSimulator @embedDocument={{this.challengeEmbedDocument}} @assessmentId={{@assessment.id}} />
       {{/if}}
 
       {{#if @challenge.alternativeInstruction}}

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -1,10 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
-import { find } from '@ember/test-helpers';
+import { click, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { clickByLabel } from '../../helpers/click-by-label';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -86,7 +87,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
       });
 
       // when
-      screen = await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
+      screen = await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} @assessmentId='123' />`);
     });
 
     test('should have an height that is the one defined in the referential', function (assert) {
@@ -169,6 +170,66 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
           await new Promise((resolve) => setTimeout(resolve, 0));
 
           assert.dom(screen.queryByText(t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
+        });
+      });
+
+      module('when message data has enableFetchFromApi=true', function () {
+        test('should call embed api proxy service', async function (assert) {
+          // given
+          const requestsPort = new MessageChannel().port1;
+          const forwardStub = sinon.stub();
+          this.owner.register(
+            'service:embed-api-proxy',
+            {
+              forward: forwardStub,
+            },
+            { instantiate: false },
+          );
+
+          await click(screen.getByText(t('pages.challenge.embed-simulator.actions.launch')));
+
+          // when
+          const iframe = screen.getByTitle('Embed simulator');
+          const event = new MessageEvent('message', {
+            data: { type: 'init', from: 'pix', enableFetchFromApi: true },
+            origin: 'https://epreuves.pix.fr',
+            source: iframe.contentWindow,
+            ports: [requestsPort],
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.calledWith(forwardStub, sinon.match.object, requestsPort, `/api/assessments/123/embed/`);
+          assert.ok(true);
+        });
+      });
+
+      module('when message data has enableFetchFromApi=false', function () {
+        test('should not call embed api proxy service', async function (assert) {
+          // given
+          const forwardStub = sinon.stub();
+          this.owner.register(
+            'service:embed-api-proxy',
+            {
+              forward: forwardStub,
+            },
+            { instantiate: false },
+          );
+
+          await click(screen.getByText(t('pages.challenge.embed-simulator.actions.launch')));
+
+          // when
+          const iframe = screen.getByTitle('Embed simulator');
+          const event = new MessageEvent('message', {
+            data: { type: 'init', from: 'pix', enableFetchFromApi: false },
+            origin: 'https://epreuves.pix.fr/',
+            source: iframe.contentWindow,
+          });
+          window.dispatchEvent(event);
+
+          // then
+          sinon.assert.notCalled(forwardStub);
+          assert.ok(true);
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Dans le context évaluation, le composant des embeds ne prend pas en charge l'embed `pix-llm`.

## ⛱️ Proposition

Prendre en charge la communication bidirectionnelle déjà utilisée dans le contexte modulix.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Tests OK
- Tester en local avec l'api LLM et en remplaçant l'url d'un iframe.
