### PR TITLE
[FEATURE] Créer la page Référentiel cadre sur Pix Admin (PIX-18186).

### DIFF
--- a/admin/app/components/complementary-certifications/item/header.gjs
+++ b/admin/app/components/complementary-certifications/item/header.gjs
@@ -15,8 +15,15 @@ export default class Header extends Component {
   }
 
   <template>
-    <header class="page-header">
+    <header>
       <PixBreadcrumb @links={{this.links}} />
     </header>
+
+    <div class="complementary-certification-header">
+      <h1 class="complementary-certification-header__title">
+        <small>Certification complémentaire</small>
+        <span>{{@complementaryCertificationLabel}}</span>
+      </h1>
+    </div>
   </template>
 }

--- a/admin/app/components/complementary-certifications/item/header.gjs
+++ b/admin/app/components/complementary-certifications/item/header.gjs
@@ -1,12 +1,16 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class Header extends Component {
+  @service intl;
+
   get links() {
     return [
       {
         route: 'authenticated.complementary-certifications.list',
-        label: 'Toutes les certifications complémentaires',
+        label: this.intl.t('components.complementary-certifications.title'),
       },
       {
         label: this.args.complementaryCertificationLabel,
@@ -21,7 +25,7 @@ export default class Header extends Component {
 
     <div class="complementary-certification-header">
       <h1 class="complementary-certification-header__title">
-        <small>Certification complémentaire</small>
+        <small>{{t "components.complementary-certifications.item.complementary-certification"}}</small>
         <span>{{@complementaryCertificationLabel}}</span>
       </h1>
     </div>

--- a/admin/app/components/complementary-certifications/target-profiles/information.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.gjs
@@ -19,9 +19,6 @@ export default class Information extends Component {
   <template>
     <section class="page-section">
       <div class="content-text content-text--small complementary-certification-details">
-        <h1 class="complementary-certification-details__title">Certification complémentaire</h1>
-
-        <span class="complementary-certification-details__label">{{@complementaryCertification.label}}</span>
         {{#if @currentTargetProfile}}
           <LinkToCurrentTargetProfile @model={{@currentTargetProfile}} />
         {{/if}}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -97,6 +97,10 @@ Router.map(function () {
 
     this.route('complementary-certifications', function () {
       this.route('list');
+      this.route('item', { path: '/item/:complementary_certification_id' }, function () {
+        this.route('framework');
+        this.route('target-profile');
+      });
       this.route('complementary-certification', { path: '/:complementary_certification_id' }, function () {
         this.route('details');
         this.route('attach-target-profile', function () {

--- a/admin/app/routes/authenticated/complementary-certifications/item.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ItemRoute extends Route {
+  @service store;
+
+  model(params) {
+    return this.store.findRecord('complementary-certification', params.complementary_certification_id, {
+      reload: true,
+    });
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -56,6 +56,7 @@
 @use 'components/complementary-certifications/attach-target-profile' as *;
 @use 'components/complementary-certifications/details' as *;
 @use 'components/complementary-certifications/header' as *;
+@use 'components/complementary-certifications/item' as *;
 @use 'components/complementary-certifications/link-to-current-target-profile' as *;
 @use 'components/complementary-certifications/search-bar' as *;
 @use 'components/complementary-certifications/selected-target-profile' as *;

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -55,6 +55,7 @@
 @use 'components/complementary-certifications/attach-badges/list' as *;
 @use 'components/complementary-certifications/attach-target-profile' as *;
 @use 'components/complementary-certifications/details' as *;
+@use 'components/complementary-certifications/header' as *;
 @use 'components/complementary-certifications/link-to-current-target-profile' as *;
 @use 'components/complementary-certifications/search-bar' as *;
 @use 'components/complementary-certifications/selected-target-profile' as *;

--- a/admin/app/styles/components/complementary-certifications/details.scss
+++ b/admin/app/styles/components/complementary-certifications/details.scss
@@ -5,27 +5,6 @@
   flex-direction: column;
   gap: 15px;
 
-  &__title {
-    color: var(--pix-neutral-500);
-    font-weight: 400;
-    font-size: 12px;
-
-    @extend %pix-title-xs;
-
-    line-height: 18px;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-  }
-
-
-  &__label {
-    color: var(--pix-neutral-800);
-    font-weight: 500;
-    font-size: 28px;
-    line-height: 36px;
-    letter-spacing: -0.04em;
-  }
-
   &__badges-title,
   &__history-title {
     padding-bottom: var(--pix-spacing-4x);

--- a/admin/app/styles/components/complementary-certifications/header.scss
+++ b/admin/app/styles/components/complementary-certifications/header.scss
@@ -1,0 +1,20 @@
+@use 'pix-design-tokens/typography';
+
+.complementary-certification-header {
+  &__title {
+    small {
+      display: block;
+      margin-bottom: var(--pix-spacing-3x);
+      color: var(--pix-neutral-500);
+      text-transform: uppercase;
+
+      @extend %pix-body-s;
+    }
+
+    span {
+      color: var(--pix-neutral-800);
+
+      @extend %pix-title-s;
+    }
+  }
+}

--- a/admin/app/styles/components/complementary-certifications/item.scss
+++ b/admin/app/styles/components/complementary-certifications/item.scss
@@ -1,0 +1,3 @@
+.complementary-certification__tabs {
+  margin-top: var(--pix-spacing-6x);
+}

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification.hbs
@@ -2,6 +2,6 @@
 
 <ComplementaryCertifications::Item::Header @complementaryCertificationLabel={{@model.label}} />
 
-<main class="page-body">
+<main class="page-body complementary-certification">
   {{outlet}}
 </main>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification.hbs
@@ -1,6 +1,6 @@
 {{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
 
-<ComplementaryCertifications::Header @complementaryCertificationLabel={{@model.label}} />
+<ComplementaryCertifications::Item::Header @complementaryCertificationLabel={{@model.label}} />
 
 <main class="page-body">
   {{outlet}}

--- a/admin/app/templates/authenticated/complementary-certifications/item.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item.hbs
@@ -1,0 +1,19 @@
+{{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
+
+<ComplementaryCertifications::Item::Header @complementaryCertificationLabel={{@model.label}} />
+
+<PixTabs
+  class="complementary-certification__tabs"
+  @ariaLabel={{t "components.complementary-certifications.item.navigation.aria-label"}}
+>
+  <LinkTo @route="authenticated.complementary-certifications.item.framework">
+    {{t "components.complementary-certifications.item.framework"}}
+  </LinkTo>
+  <LinkTo @route="authenticated.complementary-certifications.item.target-profile">
+    {{t "components.complementary-certifications.item.target-profile"}}
+  </LinkTo>
+</PixTabs>
+
+<main class="page-body complementary-certification">
+  {{outlet}}
+</main>

--- a/admin/app/templates/authenticated/complementary-certifications/item/framework.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/framework.hbs
@@ -1,0 +1,1 @@
+<h2>Framework</h2>

--- a/admin/app/templates/authenticated/complementary-certifications/item/target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/target-profile.hbs
@@ -1,0 +1,1 @@
+<h2>Target profiles</h2>

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
@@ -1,0 +1,40 @@
+import { visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { module, test } from 'qunit';
+
+module('Acceptance | Complementary certifications | Complementary certification | item ', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('it should display target profile and framework tabs', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    server.create('complementary-certification', {
+      id: 1,
+      key: 'KEY',
+      label: 'Pix+Droit',
+    });
+
+    // when
+    const screen = await visit('/complementary-certifications/item/1/framework');
+
+    // then
+    const navigation = screen.getByRole('navigation', {
+      name: t('components.complementary-certifications.item.navigation.aria-label'),
+    });
+    assert.ok(
+      within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.framework') }),
+    );
+    assert.ok(
+      within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.target-profile') }),
+    );
+    await click(
+      within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.target-profile') }),
+    );
+    assert.strictEqual(currentURL(), '/complementary-certifications/item/1/target-profile');
+  });
+});

--- a/admin/tests/integration/components/complementary-certifications/header-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/header-test.gjs
@@ -1,0 +1,29 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import Header from 'pix-admin/components/complementary-certifications/item/header';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | complementary-certifications/item/header', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display complementary certification information', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const complementaryCertification = store.createRecord('complementary-certification', {
+      id: 0,
+      key: 'DROIT',
+      label: 'Pix+Droit',
+    });
+
+    // when
+    const screen = await render(
+      <template><Header @complementaryCertificationLabel={{complementaryCertification.label}} /></template>,
+    );
+
+    // then
+    assert.ok(screen.getByRole('heading', { name: 'Certification complémentaire Pix+Droit', level: 1 }));
+    const nav = screen.getByRole('navigation');
+    assert.ok(within(nav).getByRole('link', { name: 'Toutes les certifications complémentaires' }));
+  });
+});

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/information-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/information-test.gjs
@@ -12,7 +12,7 @@ module('Integration | Component | complementary-certifications/target-profiles/i
     const currentUser = this.owner.lookup('service:currentUser');
     currentUser.adminMember = { isSuperAdmin: true };
     const complementaryCertification = store.createRecord('complementary-certification', {
-      label: 'MARIANNE CERTIF',
+      label: 'Pix+ Droit',
       targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
     });
     const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
@@ -28,9 +28,7 @@ module('Integration | Component | complementary-certifications/target-profiles/i
     );
 
     // then
-    assert.dom(screen.getByRole('heading', { name: 'Certification complémentaire' })).exists();
     assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
-    assert.dom(screen.getByText('MARIANNE CERTIF')).exists();
   });
 
   module('when there is multiple current target profiles', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -372,6 +372,13 @@
       }
     },
     "complementary-certifications": {
+      "item": {
+        "framework": "Consolidated framework",
+        "navigation": {
+          "aria-label": "Navigation of the complementary certification section"
+        },
+        "target-profile": "Target profile"
+      },
       "list": {
         "caption": "Liste des certifications complémentaires, comprenant l'identifiant unique et le nom.",
         "id": "ID",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -373,6 +373,7 @@
     },
     "complementary-certifications": {
       "item": {
+        "complementary-certification": "Complementary certification",
         "framework": "Consolidated framework",
         "navigation": {
           "aria-label": "Navigation of the complementary certification section"
@@ -406,7 +407,7 @@
           "title": "Historique des profils cibles rattachés"
         }
       },
-      "title": "Toutes les certifications complémentaires"
+      "title": "All complementary certifications"
     },
     "layout": {
       "menu-bar": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -372,6 +372,13 @@
       }
     },
     "complementary-certifications": {
+      "item": {
+        "framework": "Référentiel cadre",
+        "navigation": {
+          "aria-label": "Navigation de la section certification complémentaire"
+        },
+        "target-profile": "Profil cible"
+      },
       "list": {
         "caption": "Liste des certifications complémentaires, comprenant l'identifiant unique et le nom.",
         "id": "ID",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -373,6 +373,7 @@
     },
     "complementary-certifications": {
       "item": {
+        "complementary-certification": "Certification complémentaire",
         "framework": "Référentiel cadre",
         "navigation": {
           "aria-label": "Navigation de la section certification complémentaire"


### PR DESCRIPTION
## 🔆 Problème

Pour les complémentaires adapatées pour la V3, nous changeons le design des pages sur Admin.

## ⛱️ Proposition

- Commencer par ajouter de nouvelles routes pour développer ces pages sans toucher à l'existant.
- Dans ces nouvelles pages, ajouter la séparation du réf cadre et des profils cibles via un système d'onglets

## 🌊 Remarques

Les nouvelles routes seront amenées à être modifiées après finalisation de ces pages.

## 🏄 Pour tester

- Aller sur Admin en RA
- Aller sur https://admin-pr12530.review.pix.fr/complementary-certifications/item/53/framework
