### PR TITLE
[FEATURE] Echanger le nom et le prénom du user dans le nom de l'attestation (PIX-17951)

### DIFF
--- a/api/src/profile/domain/models/User.js
+++ b/api/src/profile/domain/models/User.js
@@ -23,7 +23,7 @@ export class User {
     const map = new Map();
 
     const filename =
-      transformStringForFileName(this.firstName) + '_' + transformStringForFileName(this.lastName) + '_' + Date.now();
+      transformStringForFileName(this.lastName) + '_' + transformStringForFileName(this.firstName) + '_' + Date.now();
 
     map.set('firstName', this.firstName);
     map.set('lastName', this.lastName);

--- a/api/tests/profile/unit/domain/models/User_test.js
+++ b/api/tests/profile/unit/domain/models/User_test.js
@@ -44,7 +44,7 @@ describe('Unit | Profile | Domain | Models | User', function () {
     // then
     expect(form.get('firstName')).to.deep.equal(user.firstName);
     expect(form.get('lastName')).to.deep.equal(user.lastName);
-    expect(form.get('filename')).to.deep.equal('theo_courant_' + Date.now());
+    expect(form.get('filename')).to.deep.equal('courant_theo_' + Date.now());
     expect(form.get('date')).to.deep.equal('02/10/2024');
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Il serait plus confortable pour le prescripteur que les attestations soient nommées d’abord par le nom de l'élève pour comparer avec leurs listes. 

Actuellement on a : prenom-nom-xxxxx.pdf

## ⛱️ Proposition

On inverse pour avoir nom-prenom-xxxxx.pdf

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- aller dans l'orga "Attestation"
- dans l'onglet "Attestations", télécharger les attestations de la 6emeA
- vérifier qu'on a bien le nom ("attestation") avant le prénom ("attestation-success-shared")
- 🫰 