### PR TITLE
[TECH] Création de la table des challenges calibrés dans le datamart (PIX-18232).

### DIFF
--- a/api/datamart/migrations/20250613145435_create-active_calibrated_challenges-table.js
+++ b/api/datamart/migrations/20250613145435_create-active_calibrated_challenges-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'active_calibrated_challenges';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('challenge_id');
+    table.float('alpha');
+    table.float('delta');
+    table.string('scope').index();
+    table.string('calibration_id').index();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Pour récupérer la calibration des challenges d’une certification complémentaire côté Data, nous ne pouvons pas directement faire appel au data-warehouse.

## ⛱️ Proposition

Nous créons donc une nouvelle table dans le datamart qui servira à répliquer les données de data-warehouse et sur laquelle nous nous appuierons pour récupérer la calibration à injecter côté pix.

## 🌊 Remarques

Ajout d'un index sur le scope aussi ? 🤔 

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
