### PR TITLE
[FEATURE] Ajouter l'élément Custom message-conversation à la validation Joi (PIX-18220)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -211,12 +211,17 @@ function getCustomErrorMessage(rules) {
 function getAlternativeSwitchCaseJsonSchema(switchCase) {
   const childJsonSchema = convertFromType(switchCase.then);
 
-  const optionalTitle = getOptionalTitleBasedOnChildrenType(switchCase);
+  const optionalTitle =
+    getOptionalTitleBasedOnChildrenType(switchCase) || getOptionalTitleBasedOnSiblingTagName(switchCase);
   if (optionalTitle !== undefined) {
     childJsonSchema.title = optionalTitle;
   }
 
   return childJsonSchema;
+}
+
+function getOptionalTitleBasedOnSiblingTagName(switchCase) {
+  return switchCase.is?.allow[1];
 }
 
 function getOptionalTitleBasedOnChildrenType(switchCase) {

--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -211,7 +211,7 @@ function getCustomErrorMessage(rules) {
 function getAlternativeSwitchCaseJsonSchema(switchCase) {
   const childJsonSchema = convertFromType(switchCase.then);
 
-  const optionalTitle = getOptionalTitleBasedOnKey(switchCase.then, 'type');
+  const optionalTitle = getOptionalTitleBasedOnChildrenType(switchCase);
   if (optionalTitle !== undefined) {
     childJsonSchema.title = optionalTitle;
   }
@@ -219,8 +219,8 @@ function getAlternativeSwitchCaseJsonSchema(switchCase) {
   return childJsonSchema;
 }
 
-function getOptionalTitleBasedOnKey(joiDescribedObject, keyName) {
-  return joiDescribedObject.keys[keyName]?.allow[0];
+function getOptionalTitleBasedOnChildrenType(switchCase) {
+  return switchCase.then.keys.type?.allow[0];
 }
 
 function findRule(rules, ruleName) {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/custom/message-conversation.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/custom/message-conversation.sample.js
@@ -1,0 +1,49 @@
+import { randomUUID } from 'node:crypto';
+
+export function getMessageConversationSample() {
+  return {
+    id: randomUUID(),
+    type: 'custom',
+    tagName: 'message-conversation',
+    props: {
+      title: 'Conversation entre Naomi et Mickaël à propos d’une adresse mail',
+      messages: [
+        {
+          userName: 'Naomi',
+          direction: 'outgoing',
+          content: 'Salut, tu peux me redonner ton adresse mail stp ? 😇',
+        },
+        {
+          userName: 'Mickaël',
+          direction: 'incoming',
+          content: 'Oui, c’est mickael.aubert123#laposte.net',
+        },
+        {
+          userName: 'Naomi',
+          direction: 'outgoing',
+          content: 'T’es sûr ? 😬',
+        },
+        {
+          userName: 'Naomi',
+          direction: 'outgoing',
+          content: 'Tu veux dire mickael.aubert123@laposte.net',
+        },
+        {
+          userName: 'Mickaël',
+          direction: 'incoming',
+          content: 'Ah oui désolé ! 😣',
+        },
+        {
+          userName: 'Mickaël',
+          direction: 'incoming',
+          content: 'comment tu as su ? ',
+        },
+        {
+          userName: 'Naomi',
+          direction: 'outgoing',
+          content: 'Dans une adresse mail, il y a toujours le symbole arobase !',
+        },
+      ],
+    },
+  };
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/conversion/joi-to-json-schema_test.js
@@ -307,7 +307,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
     });
 
     describe('Joi.alternatives.conditional', function () {
-      it('should convert conditional deep ref switch is/then to JSON Schema', function () {
+      it('should convert conditional deep ref switch is/then to JSON Schema and add title if an allowed property exist', function () {
         const joiSchema = Joi.alternatives().conditional('.sport', {
           switch: [
             {
@@ -345,6 +345,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 },
               },
               required: ['sport', 'value'],
+              title: 'handball',
               type: 'object',
             },
             {
@@ -359,6 +360,7 @@ describe('Unit | Infrastructure | Datasources | Conversion | joi-to-json-schema'
                 },
               },
               required: ['sport', 'value'],
+              title: 'volleyball',
               type: 'object',
             },
           ],

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -2,11 +2,29 @@ import Joi from 'joi';
 
 import { uuidSchema } from '../utils.js';
 
+const messageConversationPropsSchema = Joi.object({
+  title: Joi.string().required(),
+  messages: Joi.array()
+    .items(
+      Joi.object({
+        userName: Joi.string().required(),
+        direction: Joi.string().valid('incoming', 'outgoing').required(),
+        content: Joi.string().required(),
+      }),
+    )
+    .required(),
+}).required();
+
 const customElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
-  tagName: Joi.string().required(),
-  props: Joi.object().required(),
+  tagName: Joi.string().valid('message-conversation', 'cartes-a-retourner', 'qcu-image').required(),
+  props: Joi.alternatives()
+    .conditional('tagName', {
+      switch: [{ is: 'message-conversation', then: messageConversationPropsSchema }],
+      otherwise: Joi.object().required(),
+    })
+    .required(),
 }).required();
 
 export { customElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,3 +1,4 @@
+import { getMessageConversationSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/custom/message-conversation.sample.js';
 import { getDownloadSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/download.sample.js';
 import { getEmbedSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js';
 import { getFlashcardsSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/flashcards.sample.js';
@@ -9,6 +10,7 @@ import { getSeparatorSample } from '../../../../../../../src/devcomp/infrastruct
 import { getTextSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
 import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
 import { expect } from '../../../../../../test-helper.js';
+import { customElementSchema } from './element/custom-element-schema.js';
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
 import { flashcardsElementSchema } from './element/flashcards-schema.js';
@@ -24,6 +26,17 @@ import { grainSchema, moduleSchema } from './module-schema.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
   describe('when element has a valid structure', function () {
+    describe('when element is a custom element', function () {
+      it('should validate sample custom message-conversation structure', async function () {
+        try {
+          await customElementSchema.validateAsync(getMessageConversationSample(), { abortEarly: false });
+        } catch (joiError) {
+          const formattedError = joiErrorParser.format(joiError);
+          expect(joiError).to.equal(undefined, formattedError);
+        }
+      });
+    });
+
     it('should validate sample download structure', async function () {
       try {
         await downloadElementSchema.validateAsync(getDownloadSample(), { abortEarly: false });


### PR DESCRIPTION
## 🔆 Problème

Il n'y a pas de validation pour les éléments Custom "message-conversation" et donc pas de possibilité des les contribuer depuis Modulix Editor.

## ⛱️ Proposition

Ajouter le schéma de ce POI à la validation.

## 🌊 Remarques

- On a du faire évoluer le script de conversion JOI => JSON Schema pour pouvoir afficher les "tagName" dans le menu de selection "Props" de Modulix Editor
- On a traité que le cas du POI "message-conversation" car on était pas sûr que "qcu-image" et "cartes-a-retourner" soient secs mais ils seront faciles à ajouter.
- [Modulix Editor a été mis à jour](https://github.com/1024pix/modulix-editor/commit/b692ed07f31d0a8fbce57ee2597e01add7a46681)

## 🪣 Questions

Le POI "message-conversation" a une propriété `animationSpeed` qui permet de définir la durée de l'animation (et non sa vitesse, comme son nom laisse penser). Est-ce quelque chose qu'on veut pouvoir configurer pour chaque POI et laisser à la main du contributeur ? Si oui il faudrait l'ajouter dans le schema.

## 🏄 Pour tester

- Modifier l'élément custom dans le json du bac à sable en introduisant une incohérence dans les props et constater que les tests Modulix échouent
