### PR TITLE
[TECH] Supprimer le feature toggle isNewAccountRecoveryEnabled (PIX-17518)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -29,12 +29,6 @@ export default {
     defaultValue: false,
     tags: ['team-prescription', 'pix-api', 'backend'],
   },
-  isNewAccountRecoveryEnabled: {
-    type: 'boolean',
-    description: 'Using and testing feature account recovery process',
-    defaultValue: false,
-    tags: ['team-acces', 'frontend'],
-  },
   isSelfAccountDeletionEnabled: {
     description: 'Toggle self account deletion feature',
     type: 'boolean',

--- a/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-for-account-recovery.usecase.js
@@ -1,4 +1,3 @@
-import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 
@@ -53,23 +52,16 @@ export const updateUserForAccountRecovery = async function ({
 
   const now = new Date();
   const userValuesToUpdate = {
-    // username: null // Uncomment this line when the feature toggle will be deleted
+    username: null,
     cgu: true,
     email: newEmail,
     emailConfirmedAt: now,
     lastTermsOfServiceValidatedAt: now,
   };
-
-  // Remove this if when the feature toggle will be activated
-  const toggle = await featureToggles.get('isNewAccountRecoveryEnabled');
-  if (toggle) {
-    userValuesToUpdate.username = null;
-    // move the following line out if
-    await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
-      userId,
-      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
-    });
-  }
+  await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
+    userId,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+  });
 
   await userRepository.updateWithEmailConfirmed({
     id: userId,

--- a/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/account-recovery/account-recovery.route.test.js
@@ -98,10 +98,7 @@ describe('Acceptance | Identity Access Management | Application | Route | accoun
         expect(response.statusCode).to.equal(204);
         expect(newUserEmail).to.equal('new-email@example.net');
         expect(cgu).to.equal(true);
-        expect(userAuthenticationMethods).to.have.deep.members([
-          { identityProvider: 'GAR' },
-          { identityProvider: 'PIX' },
-        ]);
+        expect(userAuthenticationMethods).to.have.deep.members([{ identityProvider: 'PIX' }]);
       });
     });
   });

--- a/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/update-user-for-account-recovery.usecase.test.js
@@ -1,7 +1,6 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
-import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | update-user-for-account-recovery', function () {
@@ -121,7 +120,6 @@ describe('Integration | Identity Access Management | Domain | UseCase | update-u
     context('when user has GAR authentication method', function () {
       it('sets username to null and removes GAR authentication method', async function () {
         // given
-        await featureToggles.set('isNewAccountRecoveryEnabled', true);
 
         const password = 'pix123';
         const user = databaseBuilder.factory.buildUser({ email: null });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,7 +24,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'dynamic-feature-toggle-system': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-new-account-recovery-enabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.gjs
@@ -37,25 +37,19 @@ export default class UpdateScoRecordFormComponent extends Component {
     <h1 class="account-recovery__content--title">
       {{t "pages.account-recovery.update-sco-record.welcome-message" firstName=@firstName}}
     </h1>
-    {{#if this.isNewAccountRecoveryEnabled}}
-      <p id="choose-password" class="account-recovery__content--information-text--details">
-        {{t "pages.account-recovery.update-sco-record.form.choose-password"}}
+    <p id="choose-password" class="account-recovery__content--information-text--details">
+      {{t "pages.account-recovery.update-sco-record.form.choose-password"}}
+    </p>
+    {{#if (or @hasGarAuthenticationMethod @hasScoUsername)}}
+      <p id="removal-notice" class="account-recovery__content--information-text--details">
+        {{t
+          "pages.account-recovery.update-sco-record.form.authentication-methods-removal-notice"
+          connections=this.scoConnectionsText
+          htmlSafe=true
+        }}
       </p>
-      {{#if (or @hasGarAuthenticationMethod @hasScoUsername)}}
-        <p id="removal-notice" class="account-recovery__content--information-text--details">
-          {{t
-            "pages.account-recovery.update-sco-record.form.authentication-methods-removal-notice"
-            connections=this.scoConnectionsText
-            htmlSafe=true
-          }}
-        </p>
-        <p id="new-connection-info" class="account-recovery__content--information-text--details">
-          {{t "pages.account-recovery.update-sco-record.form.new-connection-info"}}
-        </p>
-      {{/if}}
-    {{else}}
-      <p class="account-recovery__content--information-text--details">
-        {{t "pages.account-recovery.update-sco-record.fill-password"}}
+      <p id="new-connection-info" class="account-recovery__content--information-text--details">
+        {{t "pages.account-recovery.update-sco-record.form.new-connection-info"}}
       </p>
     {{/if}}
     <form onSubmit={{this.submitUpdate}} class="account-recovery__content--form">
@@ -100,15 +94,12 @@ export default class UpdateScoRecordFormComponent extends Component {
       </div>
     </form>
 
-    {{#if this.isNewAccountRecoveryEnabled}}
-      <PixButtonLink @route="logout" class="account-recovery__content--actions update-sco-record-form__buttons">
-        {{t "common.actions.quit"}}
-      </PixButtonLink>
-    {{/if}}
+    <PixButtonLink @route="logout" class="account-recovery__content--actions update-sco-record-form__buttons">
+      {{t "common.actions.quit"}}
+    </PixButtonLink>
   </template>
   @service intl;
   @service url;
-  @service featureToggles;
   @tracked cguAndProtectionPoliciesAccepted = false;
   @tracked password = '';
   @tracked passwordValidation = new PasswordValidation();
@@ -128,10 +119,6 @@ export default class UpdateScoRecordFormComponent extends Component {
       this.cguAndProtectionPoliciesAccepted &&
       !this.args.isLoading
     );
-  }
-
-  get isNewAccountRecoveryEnabled() {
-    return this.featureToggles.featureToggles?.isNewAccountRecoveryEnabled;
   }
 
   get scoConnectionsText() {

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,6 +4,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isV3CertificationPageEnabled;
-  @attr('boolean') isNewAccountRecoveryEnabled;
   @attr('boolean') upgradeToRealUserEnabled;
 }

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -10,7 +10,6 @@ const USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES = [FER_IDENTITY_PROVIDER
 export default class OidcIdentityProviders extends Service {
   @service store;
   @service currentDomain;
-  @service featureToggles;
 
   get list() {
     return this.store.peekAll('oidc-identity-provider');
@@ -55,9 +54,6 @@ export default class OidcIdentityProviders extends Service {
   }
 
   shouldDisplayAccountRecoveryBanner(identityProviderCode) {
-    return (
-      this.featureToggles.featureToggles.isNewAccountRecoveryEnabled &&
-      USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES.includes(identityProviderCode)
-    );
+    return USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES.includes(identityProviderCode);
   }
 }

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record-test.js
@@ -391,36 +391,24 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
     });
   });
 
-  module('when feature toggle isNewAccountRecovery is enabled', function (hooks) {
-    let replaceLocationStub;
+  test('should display on reset passord form a quit button redirecting to login page ', async function (assert) {
+    // given
+    const replaceLocationStub = sinon.stub().resolves();
+    this.owner.register(
+      'service:location',
+      Service.extend({
+        replace: replaceLocationStub,
+      }),
+    );
 
-    hooks.beforeEach(async function () {
-      replaceLocationStub = sinon.stub().resolves();
-      this.owner.register(
-        'service:location',
-        Service.extend({
-          replace: replaceLocationStub,
-        }),
-      );
-    });
+    const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
-    test('should display on reset passord form a quit button redirecting to login page ', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isNewAccountRecoveryEnabled: true };
-        async load() {}
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
+    // when
+    const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
+    await settled();
+    await click(screen.getByText(t('common.actions.quit')));
 
-      const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
-
-      // when
-      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
-      await settled();
-      await click(screen.getByText(t('common.actions.quit')));
-
-      // then
-      assert.ok(replaceLocationStub.calledWith('/?lang=fr'));
-    });
+    // then
+    assert.ok(replaceLocationStub.calledWith('/?lang=fr'));
   });
 });

--- a/mon-pix/tests/unit/services/oidc-identity-providers-test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers-test.js
@@ -288,10 +288,6 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
   module('shouldDisplayAccountRecoveryBanner', function () {
     test('returns true if SSO code is in USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES', async function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isNewAccountRecoveryEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
       const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
 
       // when
@@ -300,24 +296,6 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
 
       // then
       assert.true(shouldDisplayAccountRecoveryBanner);
-    });
-
-    module('when feature toggle is set to false', function () {
-      test('returns false if feature toggle is inactive', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isNewAccountRecoveryEnabled: false };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        const oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
-
-        // when
-        const shouldDisplayAccountRecoveryBanner =
-          await oidcIdentityProvidersService.shouldDisplayAccountRecoveryBanner('FER');
-
-        // then
-        assert.false(shouldDisplayAccountRecoveryBanner);
-      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

L'évolution de la sortie du sco est fonctionnelle et ne présente pas de bug. On a donc plus besoin du feature toggle isNewAccountRecoveryEnabled

## ⛱️ Proposition

Retirer le feature toggle et mettre le code en exécution par défaut.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

- Aller sur Pix App, sur la page de récupération du compte,
- Mettre comme INE 123456789BL, comme prénom Bob, comme nom Leponge, et comme date de naissance 02/02/2012,
- Mettre son email,
- Cliquer sur le lien envoyé par mail,
- Mettre un nouveau mot de passe,
- Confirmer.
Il faut constater que:
- Les écrans sont les nouveaux écrans,
- Une fois la récupération faite, dans la section Mon-compte>Méthode de connexion il n'y a plus media-centre ou nom d'utilisateur.
