### PR TITLE
[BUGFIX] Corriger les liens de fiches récap des modules premieres-marches

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -745,7 +745,7 @@
           "element": {
             "id": "52b120fe-5aa5-4ebc-aafc-ddd173377620",
             "type": "text",
-            "content": "<p>📌 Pour taper, modifier ou effacer du texte, on clique dans une zone de texte avec la souris. Puis, on utilise les touches du clavier.&nbsp; Voici les touches du clavier à retenir : </p><ul><li><strong>Les lettres</strong> pour taper des lettres.</li><li><strong>Espace </strong>pour ajouter un espace entre deux motsEntrée pour aller à la ligne.</li><li><strong>Effacer </strong>pour supprimer le caractère à gauche du curseur de texte.</li><li><strong>Les flèches directionnelles</strong> pour déplacer le curseur de texte.</li></ul><p><br>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://cloud.pix.fr/s/xRpPokaYdD85RM3\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+            "content": "<p>📌 Pour taper, modifier ou effacer du texte, on clique dans une zone de texte avec la souris. Puis, on utilise les touches du clavier.&nbsp; Voici les touches du clavier à retenir : </p><ul><li><strong>Les lettres</strong> pour taper des lettres.</li><li><strong>Espace </strong>pour ajouter un espace entre deux motsEntrée pour aller à la ligne.</li><li><strong>Effacer </strong>pour supprimer le caractère à gauche du curseur de texte.</li><li><strong>Les flèches directionnelles</strong> pour déplacer le curseur de texte.</li></ul><p><br>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-1/pix-fiche-revision-premieres-marches-clavier-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -584,7 +584,7 @@
           "element": {
             "id": "e51added-60dc-453b-98ed-b3230711155e",
             "type": "text",
-            "content": "<p>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://cloud.pix.fr/s/6TTTsJMJgJnqEjj\" target=\"_blank\">Ouvrir votre fiche de synthèse</a></p>"
+            "content": "<p>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-2/pix-fiche-revision-premieres-marches-clavier-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a></p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -639,7 +639,7 @@
           "element": {
             "id": "85ac9805-09f8-456b-8b5f-f26fe19ca618",
             "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://cloud.pix.fr/s/NAZZbo69Pg9rbtY\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+            "content": "<p><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-1/pix-fiche-revision-premieres-marches-souris-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -583,7 +583,7 @@
           "element": {
             "id": "3dbb4032-7150-447e-ac8c-00c1302bcc84",
             "type": "text",
-            "content": "<p>📌 Les points à retenir : <br>  </p><ul><li>▶️ Le bouton gauche permet de faire des clics gauche et des doubles-clics pour déclencher des actions (ouvrir, faire apparaître, sélectionner, etc).</li><li>📋 Le bouton droit permet d’afficher une liste d’actions possibles.</li><li>⬆️ La molette permet de monter ou de descendre dans une page.</li></ul><p><br><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://cloud.pix.fr/s/P2KogTyf3QzN9YE\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+            "content": "<p>📌 Les points à retenir : <br>  </p><ul><li>▶️ Le bouton gauche permet de faire des clics gauche et des doubles-clics pour déclencher des actions (ouvrir, faire apparaître, sélectionner, etc).</li><li>📋 Le bouton droit permet d’afficher une liste d’actions possibles.</li><li>⬆️ La molette permet de monter ou de descendre dans une page.</li></ul><p><br><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-2/pix-fiche-revision-premieres-marches-souris-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
           }
         }
       ]


### PR DESCRIPTION
## 🔆 Problème
Les liens Pix Cloud des fiches récap des modules premieres-marches ont sauté.

## ⛱️ Proposition
Les remplacer par des liens assets.pix.org.

## 🌊 Remarques
RAS

## 🏄 Pour tester

Vérifier que les liens des fiches récap des modules suivants fonctionnent : 
- https://app-pr12540.review.pix.fr/modules/utiliser-souris-ordinateur-1/passage
- https://app-pr12540.review.pix.fr/modules/utiliser-souris-ordinateur-2/passage
- https://app-pr12540.review.pix.fr/modules/bases-clavier-1/passage
- https://app-pr12540.review.pix.fr/modules/bases-clavier-2/passage