### PR TITLE
[FEATURE] Remplir l'onglet profil cible dans la page des complémentaires sur Pix Admin (PIX-18187).

### DIFF
--- a/admin/app/components/complementary-certifications/item/target-profile.gjs
+++ b/admin/app/components/complementary-certifications/item/target-profile.gjs
@@ -1,0 +1,55 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import BadgesList from '../target-profiles/badges-list';
+import History from '../target-profiles/history';
+import Information from '../target-profiles/information';
+
+export default class TargetProfile extends Component {
+  @service router;
+  @service store;
+
+  @tracked complementaryCertification;
+  @tracked isToggleSwitched = true;
+  @tracked targetProfileId;
+
+  constructor() {
+    super(...arguments);
+    this.#onMount();
+  }
+
+  async #onMount() {
+    const currentComplementaryCertificationId = this.router.currentRoute.parent.params.complementary_certification_id;
+    this.complementaryCertification = await this.store.peekRecord(
+      'complementary-certification',
+      currentComplementaryCertificationId,
+    );
+
+    this.targetProfileId = this.complementaryCertification?.currentTargetProfiles?.[0].id;
+  }
+
+  get currentTargetProfile() {
+    return this.complementaryCertification?.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
+  }
+
+  @action
+  switchTargetProfile() {
+    this.isToggleSwitched = !this.isToggleSwitched;
+    this.targetProfileId = this.complementaryCertification.currentTargetProfiles?.find(
+      ({ id }) => id !== this.targetProfileId,
+    ).id;
+  }
+
+  <template>
+    <Information
+      @complementaryCertification={{this.complementaryCertification}}
+      @currentTargetProfile={{this.currentTargetProfile}}
+      @switchTargetProfile={{this.switchTargetProfile}}
+      @switchToggle={{this.isToggleSwitched}}
+    />
+    <BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
+    <History @targetProfilesHistory={{this.complementaryCertification.targetProfilesHistory}} />
+  </template>
+}

--- a/admin/app/components/complementary-certifications/target-profiles/information.gjs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.gjs
@@ -9,7 +9,7 @@ export default class Information extends Component {
   @service currentUser;
 
   get isMultipleCurrentTargetProfiles() {
-    return this.args.complementaryCertification.currentTargetProfiles?.length > 1;
+    return this.args.complementaryCertification?.currentTargetProfiles?.length > 1;
   }
 
   get hasAccessToAttachNewTargetProfile() {

--- a/admin/app/templates/authenticated/complementary-certifications/item/target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/target-profile.hbs
@@ -1,1 +1,1 @@
-<h2>Target profiles</h2>
+<ComplementaryCertifications::Item::TargetProfile />

--- a/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
@@ -2,7 +2,7 @@ import { render, within } from '@1024pix/ember-testing-library';
 import Header from 'pix-admin/components/complementary-certifications/item/header';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | complementary-certifications/item/header', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
@@ -1,0 +1,61 @@
+import { render } from '@1024pix/ember-testing-library';
+import TargetProfile from 'pix-admin/components/complementary-certifications/item/target-profile';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | complementary-certifications/item/target-profile', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display target profile information', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const serviceRouter = this.owner.lookup('service:router');
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
+    const complementaryCertification = store.createRecord('complementary-certification', {
+      id: 10,
+      key: 'DROIT',
+      label: 'Pix+Droit',
+      targetProfilesHistory: [
+        {
+          detachedAt: null,
+          name: 'ALEX TARGET',
+          id: 3,
+          badges: [
+            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
+            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
+          ],
+        },
+      ],
+    });
+
+    sinon
+      .stub(serviceRouter, 'currentRoute')
+      .value({ parent: { params: { complementary_certification_id: complementaryCertification.id } } });
+
+    // when
+    const screen = await render(<template><TargetProfile /></template>);
+
+    // then
+    assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+        }),
+      )
+      .exists();
+    assert.dom(screen.getByText('Badge Cascade')).exists();
+    assert.dom(screen.getByText('Badge Volcan')).exists();
+
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: t('components.complementary-certifications.target-profiles.history-list.title'),
+        }),
+      )
+      .exists();
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

De nouveaux onglets sont dispos sur la page des complémentaires sur Pix Admin. Mais ils sont vides.

## ⛱️ Proposition

Remplir l'onglet des profil cibles avec les composants existants

## 🏄 Pour tester

Constater que les tableaux, le bouton de rattachement et le lien du PC actuel s'affichent.
⚠️ le rattachement à un nouveau PC ne fonctionne pas pour le moment. Ce sera fixé lorsqu'on remplacera cette nouvelle page avec l'ancienne


https://admin-pr12541.review.pix.fr/complementary-certifications/item/53/target-profile