### PR TITLE
[TECH] Unification de la date de création des challenges d'un référentiel cadre (PIX-18284).

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -11,7 +11,5 @@ export async function create({ complementaryCertificationKey, challenges }) {
     challengeId: challenge.id,
   }));
 
-  for (const challengeDTO of challengesDTO) {
-    await knexConn('certification-frameworks-challenges').insert({ ...challengeDTO });
-  }
+  await knexConn('certification-frameworks-challenges').insert(challengesDTO);
 }

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import * as consolidatedFrameworkRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
@@ -31,21 +33,23 @@ describe('Certification | Configuration | Integration | Repository | consolidate
         'challengeId',
         'alpha',
         'delta',
+        'createdAt',
       );
-      expect(consolidatedFrameworkInDB).to.deep.equal([
-        {
-          complementaryCertificationId: complementaryCertification.id,
-          challengeId: challenge1.id,
-          alpha: null,
-          delta: null,
-        },
-        {
-          complementaryCertificationId: complementaryCertification.id,
-          challengeId: challenge2.id,
-          alpha: null,
-          delta: null,
-        },
-      ]);
+
+      expect(consolidatedFrameworkInDB).to.have.lengthOf(2);
+      expect(_.omit(consolidatedFrameworkInDB[0], 'createdAt')).to.deep.equal({
+        complementaryCertificationId: complementaryCertification.id,
+        challengeId: challenge1.id,
+        alpha: null,
+        delta: null,
+      });
+      expect(_.omit(consolidatedFrameworkInDB[1], 'createdAt')).to.deep.equal({
+        complementaryCertificationId: complementaryCertification.id,
+        challengeId: challenge2.id,
+        alpha: null,
+        delta: null,
+      });
+      expect(consolidatedFrameworkInDB[0].createdAt).to.deep.equal(consolidatedFrameworkInDB[1].createdAt);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Lors de la création d'un référentiel cadre, les challenges le constituant sont enregistrés les uns à la suite des autres, donc leur date de création diffère, ce qui pose problème pour réussir à différencier les référentiels en fonction de leur date de création.

## ⛱️ Proposition

On unifie la date de création des challenges d'un référentiel via une fonction de knex, passée à l'entièreté des challenges d'un référentiel

## 🌊 Remarques

Lors d'une première itération, nous voulions forcer la date d'insertion des challenges au travers d'une fonction (SQL ou JS)

`knex.fn.now()` ne retourne pas une date fixe mais une fonction SQL (ici NOW()) qui sera évaluée au moment de l'éxecution de la requête d'insertion, créant des dates variant d'une ou plusieurs millisecondes entre chaque insert puisque les challenges sont insérés un par un.

Pour rester cohérent avec l'ensemble des données de dates enregistrées chez Pix et ne pas tronquer les millisecondes lors de l'enregistrement avec une approximation qu'il est possible d'utiliser dans `knex.fn.now()`, nous avons recouru à la création d'une date en Javascript et non via `knex.fn.now()`

Lors d'une seconde itération, nous sommes cependant partis via une insertion des challenges en batch en SQL.

## 🏄 Pour tester

- Trouver une liste de tubes.

- Exécuter la requête curl suivante : 

```bash
TOKEN=$(curl --insecure 'https://admin-pr12543.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr12543.review.pix.fr/api/admin/complementary-certifications/DROIT/consolidated-framework \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "data": { "attributes": { "tubeIds": ["rec1ahEQ4rwrml6Lo"] }}}'
```

Vérifier que des challenges ont bien été enregistrés dans la table `consolidated-framework-challenges` avec : 

- un createdAt identique pour tous les challenges
