### PR TITLE
[FEATURE] Ajout du formulaire de création de référentiel cadre (PIX-18188).

### DIFF
--- a/admin/app/adapters/certification-consolidated-framework.js
+++ b/admin/app/adapters/certification-consolidated-framework.js
@@ -1,0 +1,22 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationConsolidatedFrameworkAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  createRecord(store, type, snapshot) {
+    const complementaryCertification = snapshot.record.get('complementaryCertification');
+
+    const url = `${this.buildURL('complementary-certifications', complementaryCertification.get('key'))}/consolidated-framework`;
+    const payload = {
+      data: {
+        data: {
+          attributes: {
+            tubeIds: snapshot.hasMany('tubes').map((tube) => tube.id),
+          },
+        },
+      },
+    };
+
+    return this.ajax(url, 'POST', payload);
+  }
+}

--- a/admin/app/components/complementary-certifications/item/framework.gjs
+++ b/admin/app/components/complementary-certifications/item/framework.gjs
@@ -1,0 +1,11 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { t } from 'ember-intl';
+
+<template>
+  <PixButtonLink
+    class="framework__creation-button"
+    @route="authenticated.complementary-certifications.item.framework.new"
+  >
+    {{t "components.complementary-certifications.item.framework.create-button"}}
+  </PixButtonLink>
+</template>

--- a/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
@@ -1,0 +1,92 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+import TubesSelection from '../../../common/tubes-selection';
+
+export default class CreationForm extends Component {
+  @service intl;
+  @service pixToast;
+  @service router;
+  @service store;
+
+  @tracked complementaryCertification = [];
+  @tracked frameworks = [];
+  @tracked selectedTubes = [];
+
+  constructor() {
+    super(...arguments);
+
+    this.#onMount();
+  }
+
+  async #onMount() {
+    const foundFrameworks = await this.store.findAll('framework');
+    this.frameworks = foundFrameworks.map((framework) => framework);
+
+    const routeParams = this.router.currentRoute.parent.parent.params;
+    this.complementaryCertification = await this.store.peekRecord(
+      'complementary-certification',
+      routeParams.complementary_certification_id,
+    );
+  }
+
+  @action
+  onTubesSelectionChange(selectedTubes) {
+    this.selectedTubes = selectedTubes.map((tube) => this.store.peekRecord('tube', tube.id));
+  }
+
+  @action
+  async onSubmit() {
+    const consolidatedFramework = this.store.createRecord('certification-consolidated-framework', {
+      complementaryCertification: this.complementaryCertification,
+      tubes: this.selectedTubes,
+    });
+
+    try {
+      await consolidatedFramework.save();
+
+      this.router.transitionTo('authenticated.complementary-certifications.item.framework');
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
+          'components.complementary-certifications.item.framework.creation-form.success-notification',
+        ),
+      });
+    } catch (error) {
+      this.pixToast.sendErrorNotification({ message: error.errors?.[0].detail });
+    }
+  }
+
+  <template>
+    <h2 class="framework-creation-form__title">
+      {{t
+        "components.complementary-certifications.item.framework.creation-form.title"
+        complementaryCertificationLabel=this.complementaryCertification.label
+      }}
+    </h2>
+
+    <form>
+      <section>
+        {{#if this.frameworks.length}}
+          <TubesSelection @frameworks={{this.frameworks}} @onChange={{this.onTubesSelectionChange}} />
+          <ul class="framework-creation-form__buttons">
+            <li>
+              <PixButton @triggerAction={{this.onSubmit}} @isDisabled={{if this.selectedTubes.length false true}}>
+                {{t "components.complementary-certifications.item.framework.creation-form.submit-button"}}
+              </PixButton>
+            </li>
+            <li>
+              <PixButtonLink @route="authenticated.complementary-certifications.item.framework" @variant="secondary">
+                {{t "common.actions.cancel"}}
+              </PixButtonLink>
+            </li>
+          </ul>
+        {{/if}}
+      </section>
+    </form>
+  </template>
+}

--- a/admin/app/models/certification-consolidated-framework.js
+++ b/admin/app/models/certification-consolidated-framework.js
@@ -1,0 +1,6 @@
+import Model, { belongsTo, hasMany } from '@ember-data/model';
+
+export default class CertificationConsolidatedFramework extends Model {
+  @belongsTo('complementary-certification', { async: false, inverse: null }) complementaryCertification;
+  @hasMany('tubes', { async: false, inverse: null }) tubes;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -109,7 +109,9 @@ Router.map(function () {
     this.route('complementary-certifications', function () {
       this.route('list');
       this.route('item', { path: '/item/:complementary_certification_id' }, function () {
-        this.route('framework');
+        this.route('framework', function () {
+          this.route('new');
+        });
         this.route('target-profile');
       });
       this.route('complementary-certification', { path: '/:complementary_certification_id' }, function () {

--- a/admin/app/routes/authenticated/complementary-certifications/item/framework/new.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item/framework/new.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class FrameworkNewRoute extends Route {}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -57,6 +57,7 @@
 @use 'components/complementary-certifications/details' as *;
 @use 'components/complementary-certifications/header' as *;
 @use 'components/complementary-certifications/item' as *;
+@use 'components/complementary-certifications/item/framework' as *;
 @use 'components/complementary-certifications/link-to-current-target-profile' as *;
 @use 'components/complementary-certifications/search-bar' as *;
 @use 'components/complementary-certifications/selected-target-profile' as *;

--- a/admin/app/styles/components/complementary-certifications/item/framework.scss
+++ b/admin/app/styles/components/complementary-certifications/item/framework.scss
@@ -1,0 +1,19 @@
+@use 'pix-design-tokens/typography';
+
+.framework__creation-button {
+  display: inline-flex;
+  margin-top: var(--pix-spacing-6x);
+}
+
+.framework-creation-form__title {
+  @extend %pix-title-s;
+
+  margin-top: var(--pix-spacing-6x);
+  margin-bottom: var(--pix-spacing-4x);
+  color: var(--pix-neutral-800);
+}
+
+.framework-creation-form__buttons {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+}

--- a/admin/app/templates/authenticated/complementary-certifications/item.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item.hbs
@@ -7,7 +7,7 @@
   @ariaLabel={{t "components.complementary-certifications.item.navigation.aria-label"}}
 >
   <LinkTo @route="authenticated.complementary-certifications.item.framework">
-    {{t "components.complementary-certifications.item.framework"}}
+    {{t "components.complementary-certifications.item.framework.tab"}}
   </LinkTo>
   <LinkTo @route="authenticated.complementary-certifications.item.target-profile">
     {{t "components.complementary-certifications.item.target-profile"}}

--- a/admin/app/templates/authenticated/complementary-certifications/item/framework.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/framework.hbs
@@ -1,1 +1,1 @@
-<h2>Framework</h2>
+{{outlet}}

--- a/admin/app/templates/authenticated/complementary-certifications/item/framework/index.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/framework/index.hbs
@@ -1,0 +1,1 @@
+<ComplementaryCertifications::Item::Framework />

--- a/admin/app/templates/authenticated/complementary-certifications/item/framework/new.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/framework/new.hbs
@@ -1,0 +1,1 @@
+<ComplementaryCertifications::Item::Framework::CreationForm />

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
 
-module('Acceptance | Complementary certifications | Complementary certification | item ', function (hooks) {
+module('Acceptance | Complementary certifications | Complementary certification | Item', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -27,7 +27,7 @@ module('Acceptance | Complementary certifications | Complementary certification 
       name: t('components.complementary-certifications.item.navigation.aria-label'),
     });
     assert.ok(
-      within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.framework') }),
+      within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.framework.tab') }),
     );
     assert.ok(
       within(navigation).getByRole('link', { name: t('components.complementary-certifications.item.target-profile') }),

--- a/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
@@ -1,0 +1,131 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import CreationForm from 'pix-admin/components/complementary-certifications/item/framework/creation-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | complementary-certifications/item/framework/creation-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display framework creation form', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const frameworks = _createFrameworks(store);
+    sinon.stub(store, 'findAll').withArgs('framework').resolves(frameworks);
+
+    const complementaryCertification = store.createRecord('complementary-certification', {
+      id: 0,
+      key: 'DROIT',
+      label: 'Pix+Droit',
+    });
+
+    const serviceRouter = this.owner.lookup('service:router');
+    sinon
+      .stub(serviceRouter, 'currentRoute')
+      .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
+
+    // when
+    const screen = await render(<template><CreationForm /></template>);
+
+    assert
+      .dom(
+        screen.getByRole('button', {
+          name: t('components.complementary-certifications.item.framework.creation-form.submit-button'),
+        }),
+      )
+      .isDisabled();
+
+    await click(screen.getByText('1 · Titre domaine'));
+    await click(screen.getByText('1 Titre competence'));
+    await click(screen.getByLabelText('@tubeName1 : Tube 1'));
+
+    // then
+    assert.ok(
+      screen.getByRole('heading', {
+        name: t('components.complementary-certifications.item.framework.creation-form.title', {
+          complementaryCertificationLabel: complementaryCertification.label,
+        }),
+        level: 2,
+      }),
+    );
+    assert
+      .dom(
+        screen.getByRole('button', {
+          name: t('components.complementary-certifications.item.framework.creation-form.submit-button'),
+        }),
+      )
+      .isNotDisabled();
+    assert.ok(screen.getByText(t('common.actions.cancel')));
+  });
+});
+
+function _createFrameworks(store) {
+  const tubes1 = [
+    store.createRecord('tube', {
+      id: 'tubeId1',
+      name: '@tubeName1',
+      practicalTitle: 'Tube 1',
+      skills: [],
+      level: 8,
+    }),
+    store.createRecord('tube', {
+      id: 'tubeId2',
+      name: '@tubeName2',
+      practicalTitle: 'Tube 2',
+      skills: [],
+      level: 8,
+    }),
+  ];
+
+  const tubes2 = [
+    store.createRecord('tube', {
+      id: 'tubeId3',
+      name: '@tubeName3',
+      practicalTitle: 'Tube 3',
+      skills: [],
+      level: 8,
+    }),
+  ];
+
+  const thematics = [
+    store.createRecord('thematic', { id: 'thematicId1', name: 'Thématique 1', tubes: tubes1 }),
+    store.createRecord('thematic', { id: 'thematicId2', name: 'Thématique 2', tubes: tubes2 }),
+  ];
+
+  const competences = [
+    store.createRecord('competence', {
+      id: 'competenceId',
+      index: '1',
+      name: 'Titre competence',
+      thematics,
+    }),
+  ];
+
+  const areas = [
+    store.createRecord('area', {
+      id: 'areaId',
+      title: 'Titre domaine',
+      code: 1,
+      competences,
+    }),
+  ];
+
+  const framework = store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas });
+  const framework2 = store.createRecord('framework', {
+    id: 'pixPlusFrameworkId',
+    name: 'Pix plus',
+    areas: [
+      store.createRecord('area', {
+        id: 'pixPlusAreaId',
+        title: 'Area pix plus',
+        code: 2,
+        competences,
+      }),
+    ],
+  });
+
+  return [framework, framework2];
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -387,7 +387,15 @@
     "complementary-certifications": {
       "item": {
         "complementary-certification": "Complementary certification",
-        "framework": "Consolidated framework",
+        "framework": {
+          "create-button": "Create a new consolidated framework",
+          "creation-form": {
+            "submit-button": "Submit the new consolidated framework",
+            "success-notification": "The new framework has been successfully created.",
+            "title": "Creating a new consolidated framework for {complementaryCertificationLabel}"
+          },
+          "tab": "Consolidated framework"
+        },
         "navigation": {
           "aria-label": "Navigation of the complementary certification section"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -387,7 +387,15 @@
     "complementary-certifications": {
       "item": {
         "complementary-certification": "Certification complémentaire",
-        "framework": "Référentiel cadre",
+        "framework": {
+          "create-button": "Créer un nouveau référentiel cadre",
+          "creation-form": {
+            "submit-button": "Créer le nouveau référentiel cadre",
+            "success-notification": "Le nouveau référentiel cadre a été créé avec succès",
+            "title": "Créer un nouveau référentiel cadre pour {complementaryCertificationLabel}"
+          },
+          "tab": "Référentiel cadre"
+        },
         "navigation": {
           "aria-label": "Navigation de la section certification complémentaire"
         },

--- a/api/src/certification/complementary-certification/domain/models/ComplementaryCertificationForTargetProfileAttachment.js
+++ b/api/src/certification/complementary-certification/domain/models/ComplementaryCertificationForTargetProfileAttachment.js
@@ -1,6 +1,7 @@
 class ComplementaryCertificationForTargetProfileAttachment {
-  constructor({ id, label, hasExternalJury }) {
+  constructor({ id, key, label, hasExternalJury }) {
     this.id = id;
+    this.key = key;
     this.label = label;
     this.hasExternalJury = hasExternalJury;
   }

--- a/api/src/certification/complementary-certification/domain/models/ComplementaryCertificationTargetProfileHistory.js
+++ b/api/src/certification/complementary-certification/domain/models/ComplementaryCertificationTargetProfileHistory.js
@@ -6,12 +6,14 @@ class ComplementaryCertificationTargetProfileHistory {
   /**
    * @param {Object} params
    * @param {number} params.id - identifier of the complementary certification
+   * @param {string} params.key
    * @param {string} params.label
    * @param {boolean} params.hasExternalJury
    * @param {Array<TargetProfileHistoryForAdmin>} params.targetProfilesHistory
    */
-  constructor({ id, label, hasExternalJury, targetProfilesHistory }) {
+  constructor({ id, key, label, hasExternalJury, targetProfilesHistory }) {
     this.id = id;
+    this.key = key;
     this.label = label;
     this.hasExternalJury = hasExternalJury;
     this.targetProfilesHistory = targetProfilesHistory;

--- a/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -8,6 +8,7 @@ const serializeForAdmin = function (complementaryCertification) {
       const targetProfilesHistory = complementaryCertification.targetProfilesHistory ?? [];
       return {
         id: complementaryCertification.id,
+        key: complementaryCertification.key,
         label: complementaryCertification.label,
         hasExternalJury: complementaryCertification.hasExternalJury,
         targetProfilesHistory: targetProfilesHistory.map((targetProfile) => ({
@@ -25,7 +26,7 @@ const serializeForAdmin = function (complementaryCertification) {
         })),
       };
     },
-    attributes: ['label', 'hasExternalJury', 'targetProfilesHistory'],
+    attributes: ['key', 'label', 'hasExternalJury', 'targetProfilesHistory'],
   }).serialize(complementaryCertification);
 };
 

--- a/api/src/certification/configuration/application/complementary-certification-controller.js
+++ b/api/src/certification/configuration/application/complementary-certification-controller.js
@@ -16,9 +16,17 @@ const searchAttachableTargetProfilesForComplementaryCertifications = async funct
 const createConsolidatedFramework = async function (request, h) {
   const { complementaryCertificationKey } = request.params;
   const { tubeIds } = request.payload.data.attributes;
+
   await usecases.createConsolidatedFramework({ complementaryCertificationKey, tubeIds });
 
-  return h.response().code(201);
+  return h
+    .response({
+      data: {
+        id: complementaryCertificationKey,
+        type: 'certification-consolidated-framework',
+      },
+    })
+    .code(201);
 };
 
 const complementaryCertificationController = {

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-for-target-profile-attachment-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-for-target-profile-attachment-repository_test.js
@@ -6,9 +6,7 @@ describe('Integration | Repository | complementary-certification-for-target-prof
   describe('#getById', function () {
     it('should return the complementary certification by its id', async function () {
       // given
-      const complementaryCertificationId = 1;
-      databaseBuilder.factory.buildComplementaryCertification({
-        id: complementaryCertificationId,
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         label: 'Pix+ Édu 1er degré',
         hasExternalJury: true,
       });
@@ -16,18 +14,17 @@ describe('Integration | Repository | complementary-certification-for-target-prof
       await databaseBuilder.commit();
 
       // when
-      const complementaryCertification = await complementaryCertificationForTargetProfileAttachmentRepository.getById({
-        complementaryCertificationId,
-      });
+      const retrievedComplementaryCertification =
+        await complementaryCertificationForTargetProfileAttachmentRepository.getById({
+          complementaryCertificationId: complementaryCertification.id,
+        });
 
       // then
       const expectedComplementaryCertification =
         domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
-          id: 1,
-          label: 'Pix+ Édu 1er degré',
-          hasExternalJury: true,
+          ...complementaryCertification,
         });
-      expect(complementaryCertification).to.deepEqualInstance(expectedComplementaryCertification);
+      expect(retrievedComplementaryCertification).to.deepEqualInstance(expectedComplementaryCertification);
     });
 
     describe('when complementary certification does not exist', function () {

--- a/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
+++ b/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
@@ -56,8 +56,9 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
           type: 'complementary-certifications',
           id: '11',
           attributes: {
-            label: 'Pix+Edu',
-            'has-external-jury': true,
+            key: complementaryCertificationTargetProfileHistory.key,
+            label: complementaryCertificationTargetProfileHistory.label,
+            'has-external-jury': complementaryCertificationTargetProfileHistory.hasExternalJury,
             'target-profiles-history': [
               {
                 id: 999,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -213,6 +213,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
           id: '1',
           attributes: {
             label: 'Pix+ Édu 2nd degré',
+            key: 'EDU_2ND_DEGRE',
             'has-external-jury': true,
             'target-profiles-history': [
               {
@@ -283,6 +284,8 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
 
       // then
       expect(response.statusCode).to.equal(201);
+      expect(response.result.data.type).to.equal('certification-consolidated-framework');
+      expect(response.result.data.id).to.exist;
 
       const consolidatedFramework = await knex('certification-frameworks-challenges')
         .select('alpha', 'delta', 'challengeId', 'complementaryCertificationId')

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-target-profile-attachment.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-target-profile-attachment.js
@@ -2,11 +2,13 @@ import { ComplementaryCertificationForTargetProfileAttachment } from '../../../.
 
 const buildComplementaryCertificationForTargetProfileAttachment = function ({
   id = 1,
+  key = 'Complementary certification key',
   label = 'Complementary certification name',
   hasExternalJury = true,
 } = {}) {
   return new ComplementaryCertificationForTargetProfileAttachment({
     id,
+    key,
     label,
     hasExternalJury,
   });

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-target-profile-history-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-target-profile-history-for-admin.js
@@ -2,12 +2,14 @@ import { ComplementaryCertificationTargetProfileHistory } from '../../../../src/
 
 const buildComplementaryCertificationTargetProfileHistory = function ({
   id = 1,
+  key = 'Complementary certification key',
   label = 'Complementary certification name',
   hasExternalJury = false,
   targetProfilesHistory = [],
 } = {}) {
   return new ComplementaryCertificationTargetProfileHistory({
     id,
+    key,
     label,
     hasExternalJury,
     targetProfilesHistory,


### PR DESCRIPTION
## 🔆 Problème

Pour les nouvelles pages dédiés aux référentiels cadres des certifs complémentaires, nous n'avons pas encore de contenu.

## ⛱️ Proposition

- Ajouter un bouton permettant de créer un référentiel cadre
- Ce dernier redirige vers un form de création de ref cadre (choix des sujets, comme dans un profil cible)
- À la soumission, rediriger vers la page du bouton

## 🌊 Remarques

À l'heure actuelle, le choix des sujets se fait via un composant utilisé pour les profils cibles.
Il y a donc une possibilité de choix de niveau, qui n'est pas utile pour nous.

Certains changements viendront donc dans une PR future.

## 🏄 Pour tester

- Se connecter sur PixAdmin
- Choisir une complémentaire et aller [à cette URL](https://admin-pr12546.review.pix.fr/complementary-certifications/item/52/framework)
- Créer un nouveau ref cadre
