### PR TITLE
[BUGFIX] Éviter d'appeller le LLM en mode preview (PIX-18295)

### DIFF
--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -20,6 +20,9 @@ export default class ModulixEmbed extends ModuleElement {
   @service
   embedApiProxy;
 
+  @service
+  modulixPreviewMode;
+
   @tracked
   isSimulatorLaunched = false;
   embedHeight = this.args.embed.height;
@@ -64,6 +67,10 @@ export default class ModulixEmbed extends ModuleElement {
 
     if (message.type === 'init') {
       if (message.enableFetchFromApi) {
+        if (this.modulixPreviewMode.isEnabled) {
+          return;
+        }
+
         const [requestsPort] = event.ports;
 
         this.embedApiProxy.forward(this, requestsPort, `/api/passages/${this.args.passageId}/embed/`);


### PR DESCRIPTION
## 🔆 Problème
En [mode preview de module](https://app-pr12547.review.pix.fr/modules/preview) (utilisé pour construire son module avec [Modulix Editor](https://1024pix.github.io/modulix-editor/)) on n'instancie pas de passage. De ce fait, le POST `/api/passages/<id>/embed/llm/chats` avec un `id` `null` renvoie une 400.

## ⛱️ Proposition
Pour éviter ces 400, on propose dans un premier temps de ne pas requêter cet endpoint en mode preview.

## 🌊 Remarques
Pas bien certain du test...

## 🏄 Pour tester
En [mode preview](https://app-pr12547.review.pix.fr/modules/preview), s'assurer que le LLM est bien inaccessible.