### PR TITLE
[FEATURE] Support des web-components Vue >=3.5.15 (PIX-18219)

### DIFF
--- a/junior/app/components/challenge/content/embedded-web-component.gjs
+++ b/junior/app/components/challenge/content/embedded-web-component.gjs
@@ -1,17 +1,25 @@
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { eq } from 'ember-truth-helpers';
+
+import didRender from '../../../modifiers/did-render';
 
 export default class EmbeddedWebComponent extends Component {
+  #customElement;
+  #handleAnswer = (event) => this.args.setAnswerValue(event.detail[0]);
+
   @action
-  handleAnswer(event) {
-    this.args.setAnswerValue(event.detail[0]);
+  mountCustomElement(container) {
+    this.#customElement = document.createElement(this.args.tagName);
+    Object.assign(this.#customElement, this.args.props);
+    this.#customElement.addEventListener('answer', this.#handleAnswer);
+    this.#customElement.dataset.testid = this.args.tagName;
+    container.append(this.#customElement);
   }
 
-  <template>
-    {{#if (eq @tagName "qcu-image")}}
-      <qcu-image props={{@props}} {{on "answer" this.handleAnswer}} data-testid={{@tagName}} />
-    {{/if}}
-  </template>
+  willDestroy(...args) {
+    super.willDestroy(...args);
+    this.#customElement.removeEventListener('answer', this.#handleAnswer);
+  }
+
+  <template><div {{didRender this.mountCustomElement}} /></template>
 }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.4.0",
+        "@1024pix/epreuves-components": "^0.4.1",
         "@1024pix/eslint-plugin": "^2.1.5",
         "@1024pix/pix-ui": "^55.21.1",
         "@1024pix/stylelint-config": "^5.1.32",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.0.tgz",
-      "integrity": "sha512-AYVUWuRCZ1v5h9sJhftedRam36GtuR7W+3HaLmenh+N8Q+T4ilejnoWiD5FfDjEqT9fhS4VKLGbrYuAoraxUfQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.1.tgz",
+      "integrity": "sha512-DkbQZavC0b8e/lBu12822NXReL5qgV6hNrza4qFGbq8tLugZhN8dKrjan47eNYL+UP5+2YWdfah9Gu0tHV0N5Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/junior/package.json
+++ b/junior/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.4.0",
+    "@1024pix/epreuves-components": "^0.4.1",
     "@1024pix/eslint-plugin": "^2.1.5",
     "@1024pix/pix-ui": "^55.21.1",
     "@1024pix/stylelint-config": "^5.1.32",

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -1,13 +1,15 @@
-import { element } from 'ember-element-helper';
+import { action } from '@ember/object';
+import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 import ModuleElement from './module-element';
 
 export default class ModulixCustomElement extends ModuleElement {
-  <template>
-    <div class="element-custom">
-      {{#let (element @component.tagName) as |Tag|}}
-        <Tag props={{@component.props}} />
-      {{/let}}
-    </div>
-  </template>
+  @action
+  mountCustomElement(container) {
+    const customElement = document.createElement(this.args.component.tagName);
+    Object.assign(customElement, this.args.component.props);
+    container.append(customElement);
+  }
+
+  <template><div class="element-custom" {{didInsert this.mountCustomElement}} /></template>
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.4.0",
+        "@1024pix/epreuves-components": "^0.4.1",
         "@1024pix/eslint-plugin": "^2.1.5",
         "@1024pix/pix-ui": "^55.21.1",
         "@1024pix/stylelint-config": "^5.1.32",
@@ -811,9 +811,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.0.tgz",
-      "integrity": "sha512-AYVUWuRCZ1v5h9sJhftedRam36GtuR7W+3HaLmenh+N8Q+T4ilejnoWiD5FfDjEqT9fhS4VKLGbrYuAoraxUfQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.1.tgz",
+      "integrity": "sha512-DkbQZavC0b8e/lBu12822NXReL5qgV6hNrza4qFGbq8tLugZhN8dKrjan47eNYL+UP5+2YWdfah9Gu0tHV0N5Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.4.0",
+    "@1024pix/epreuves-components": "^0.4.1",
     "@1024pix/eslint-plugin": "^2.1.5",
     "@1024pix/pix-ui": "^55.21.1",
     "@1024pix/stylelint-config": "^5.1.32",


### PR DESCRIPTION
## 🔆 Problème

À partir de Vue 3.5.15 il y a [une petite modification](https://github.com/vuejs/core/pull/12855) dans l’initialisation des web-components.
Cela empêche Ember d’alimenter les props du web-component correctement.

## ⛱️ Proposition

Instancier les web-components manuellement.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Vérifier que `message-conversation` fonctionne toujours dans Modulix : https://app-pr12554.review.pix.fr/modules/bien-ecrire-son-adresse-mail
Vérifier que `qcu-image` fonctionne toujours dans [junior](https://junior-pr12554.review.pix.fr/).