### PR TITLE
[FEATURE] Retourner les participations de campagnes par page (PIX-18218).

### DIFF
--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -5,9 +5,13 @@ export async function getCampaignParticipations(
   h,
   dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
 ) {
-  const campaignParticipations = await dependencies.getCampaignParticipations({
+  const { page } = request.query;
+  const { models: campaignParticipations, meta } = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
     clientId: request.auth.credentials.client_id,
+    page,
   });
-  return h.response(campaignParticipations).code(200);
+  return h
+    .response({ campaignParticipations, page: { number: meta.page, size: meta.pageSize, count: meta.pageCount } })
+    .code(200);
 }

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -16,6 +16,12 @@ const register = async function (server) {
           params: Joi.object({
             campaignId: identifiersType.campaignId,
           }),
+          query: Joi.object({
+            page: Joi.object({
+              number: Joi.number().integer().empty('').allow(null).optional(),
+              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
+            }).default({}),
+          }),
         },
         pre: [organizationPreHandler, isCampaignInJurisdictionPreHandler],
         handler: getCampaignParticipations,
@@ -28,43 +34,50 @@ const register = async function (server) {
         response: {
           failAction: 'log',
           status: {
-            200: Joi.array()
-              .items(
-                Joi.object({
-                  id: Joi.number().description('ID de la participation à la campagne'),
-                  createdAt: Joi.date().description('Date de début de participation'),
-                  participantExternalId: Joi.string().description(
-                    'Identifiant Externe rempli en début de participation',
-                  ),
-                  status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
-                  sharedAt: Joi.date().description('Date de participation'),
-                  campaignId: Joi.number().description('ID de la campagne liée à la participation'),
-                  userId: Joi.number().description('ID utilisateur du participant'),
-                  organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
-                  pixScore: Joi.number().description(
-                    'Score en pix pour une participation à une campagne de collecte de profil',
-                  ),
-                  masteryRate: Joi.number().description(
-                    "Taux de réussite, i.e. pourcentage d'acquis validés dans la campagne",
-                  ),
-                  tubes: Joi.array()
-                    .items(
-                      Joi.object({
-                        competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
-                        id: Joi.string().description('ID du sujet'),
-                        maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
-                        reachedLevel: Joi.number().description('Niveau obtenu dans cette campagne'),
-                        practicalDescription: Joi.string().description('Description du sujet'),
-                        practicalTitle: Joi.string().description('Titre du sujet'),
-                      }).label('CampaignParticipationTube'),
-                    )
-                    .description(
-                      'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
-                    )
-                    .label('CampaignParticipationTubes'),
-                }).label('CampaignParticipation'),
-              )
-              .label('CampaignParticipations'),
+            200: Joi.object({
+              campaignParticipations: Joi.array()
+                .items(
+                  Joi.object({
+                    id: Joi.number().description('ID de la participation à la campagne'),
+                    createdAt: Joi.date().description('Date de début de participation'),
+                    participantExternalId: Joi.string().description(
+                      'Identifiant Externe rempli en début de participation',
+                    ),
+                    status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
+                    sharedAt: Joi.date().description('Date de participation'),
+                    campaignId: Joi.number().description('ID de la campagne liée à la participation'),
+                    userId: Joi.number().description('ID utilisateur du participant'),
+                    organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
+                    pixScore: Joi.number().description(
+                      'Score en pix pour une participation à une campagne de collecte de profil',
+                    ),
+                    masteryRate: Joi.number().description(
+                      "Taux de réussite, i.e. pourcentage d'acquis validés dans la campagne",
+                    ),
+                    tubes: Joi.array()
+                      .items(
+                        Joi.object({
+                          competenceId: Joi.string().description('ID de la compétence auquel appartient le sujet'),
+                          id: Joi.string().description('ID du sujet'),
+                          maxLevel: Joi.number().description('Niveau maximum atteignable dans cette campagne'),
+                          reachedLevel: Joi.number().description('Niveau obtenu dans cette campagne'),
+                          practicalDescription: Joi.string().description('Description du sujet'),
+                          practicalTitle: Joi.string().description('Titre du sujet'),
+                        }).label('CampaignParticipationTube'),
+                      )
+                      .description(
+                        'Sujets évalués dans la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                      )
+                      .label('CampaignParticipationTubes'),
+                  }).label('CampaignParticipation'),
+                )
+                .label('CampaignParticipations'),
+              page: Joi.object({
+                number: Joi.number().description('Numéro de la page courante'),
+                size: Joi.number().description('Taille de la page courante'),
+                count: Joi.number().description('Nombre total de page'),
+              }).description('Information de pagination'),
+            }).label('CampaignParticipationsResult'),
             401: responseObjectErrorDoc,
             403: responseObjectErrorDoc,
           },

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -1,3 +1,3 @@
-export async function getCampaignParticipations({ campaignId, clientId, campaignParticipationRepository }) {
-  return campaignParticipationRepository.findByCampaignId(campaignId, clientId);
+export async function getCampaignParticipations({ campaignId, clientId, page, campaignParticipationRepository }) {
+  return campaignParticipationRepository.findByCampaignId(campaignId, clientId, page);
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -2,9 +2,9 @@ import * as campaignsAPI from '../../../prescription/campaign/application/api/ca
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { TubeCoverage } from '../../domain/models/TubeCoverage.js';
 
-export async function findByCampaignId(campaignId, clientId) {
-  const { models: campaignParticipations } = await campaignsAPI.getCampaignParticipations({ campaignId });
-  return campaignParticipations.map((rawCampaign) => toDomain(rawCampaign, clientId, campaignId));
+export async function findByCampaignId(campaignId, clientId, page) {
+  const { models: campaignParticipations, meta } = await campaignsAPI.getCampaignParticipations({ campaignId, page });
+  return { models: campaignParticipations.map((rawCampaign) => toDomain(rawCampaign, clientId, campaignId)), meta };
 }
 
 function toDomain(rawCampaignParticipation, clientId, campaignId) {

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -3,7 +3,7 @@ import { CampaignParticipation } from '../../domain/models/CampaignParticipation
 import { TubeCoverage } from '../../domain/models/TubeCoverage.js';
 
 export async function findByCampaignId(campaignId, clientId) {
-  const campaignParticipations = await campaignsAPI.getCampaignParticipations({ campaignId });
+  const { models: campaignParticipations } = await campaignsAPI.getCampaignParticipations({ campaignId });
   return campaignParticipations.map((rawCampaign) => toDomain(rawCampaign, clientId, campaignId));
 }
 

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -170,13 +170,16 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
  * @name getCampaignParticipations
  *
  * @param {CampaignParticipationsPayload} payload
- * @returns {Promise<Array<AssessmentCampaignParticipationAPI>|Array<ProfilesCollectionCampaignParticipationAPI>>}
+ * @returns {Promise<{models: Array<AssessmentCampaignParticipationAPI>|Array<ProfilesCollectionCampaignParticipationAPI>, meta: Pagination}>}
  */
-export const getCampaignParticipations = async function ({ campaignId }) {
-  const campaignParticipations = await usecases.getCampaignParticipations({ campaignId });
-  return campaignParticipations.map((campaignParticipation) =>
-    campaignParticipation instanceof AssessmentCampaignParticipation
-      ? new AssessmentCampaignParticipationAPI(campaignParticipation)
-      : new ProfilesCollectionCampaignParticipationAPI(campaignParticipation),
-  );
+export const getCampaignParticipations = async function ({ campaignId, page }) {
+  const { models: campaignParticipations, meta } = await usecases.getCampaignParticipations({ campaignId, page });
+  return {
+    models: campaignParticipations.map((campaignParticipation) =>
+      campaignParticipation instanceof AssessmentCampaignParticipation
+        ? new AssessmentCampaignParticipationAPI(campaignParticipation)
+        : new ProfilesCollectionCampaignParticipationAPI(campaignParticipation),
+    ),
+    meta,
+  };
 };

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -33,10 +33,10 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
     additionalHeaders = importFormat.exportableColumns;
   }
 
-  const [allPixCompetences, organization, campaignParticipationResultDatas] = await Promise.all([
+  const [allPixCompetences, organization, { models: campaignParticipationResultDatas }] = await Promise.all([
     competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),
     organizationRepository.get(campaign.organizationId),
-    campaignParticipationRepository.findInfoByCampaignId(campaign.id),
+    campaignParticipationRepository.findInfoByCampaignId(campaign.id, { size: 1000000, number: 1 }),
   ]);
 
   const campaignProfilesCollectionExport = new CampaignProfilesCollectionExport({

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -105,7 +105,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.members([
+        expect(response.result.campaignParticipations).to.deep.members([
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation1,
             clientId,
@@ -125,11 +125,16 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
             clientId,
           }),
         ]);
+        expect(response.result.page).to.deep.equal({
+          count: 1,
+          number: 1,
+          size: 10,
+        });
       });
     });
 
     context('when campaign type is PROFILES_COLLECTION', function () {
-      it('returns the list of all participations of campaign with  with an HTTP status code 200', async function () {
+      it('returns the list of all participations of campaign with an HTTP status code 200', async function () {
         // given
         const organization = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
 
@@ -175,11 +180,175 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.members([
+        expect(response.result.campaignParticipations).to.deep.members([
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation,
             clientId,
           }),
+        ]);
+        expect(response.result.page).to.deep.equal({
+          count: 1,
+          number: 1,
+          size: 10,
+        });
+      });
+    });
+
+    context('should handle pagination ', function () {
+      it('returns the list of all participations for given page', async function () {
+        // given
+        const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+        databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
+
+        const tag = databaseBuilder.factory.buildTag();
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+
+        const clientId = 'client';
+        databaseBuilder.factory.buildClientApplication({
+          clientId: 'client',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+        });
+
+        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+        const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+        const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+        const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+        const { id: userId } = databaseBuilder.factory.buildUser({
+          firstName: 'user firstname 1',
+          lastName: 'user lastname 1',
+        });
+        const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: orgaInJurisdiction.id,
+          userId,
+          firstName: 'firstname 1',
+          lastName: 'lastname 1',
+        });
+        const campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orgaInJurisdiction.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+        const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          organizationLearnerId: organizationLearner1.id,
+          masteryRate: 0.1,
+          validatedSkillsCount: 10,
+          userId,
+          participantExternalId: 'external id 1',
+          createdAt: new Date('2025-01-02'),
+          sharedAt: new Date('2025-01-03'),
+        });
+        const ke = databaseBuilder.factory.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.VALIDATED,
+          skillId,
+          userId: participation1.userId,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          campaignParticipationId: participation1.id,
+          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+        });
+
+        const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organizationLearner1.organizationId,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.STARTED,
+          organizationLearnerId: organizationLearner2.id,
+          userId: organizationLearner2.userId,
+          masteryRate: null,
+        });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations?page[size]=1&page[number]=2`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.campaignParticipations).to.deep.members([
+          domainBuilder.maddo.buildCampaignParticipation({
+            ...participation1,
+            clientId,
+            tubes: [
+              domainBuilder.maddo.buildTubeCoverage({
+                id: tube.id,
+                competenceId,
+                maxLevel: 2,
+                reachedLevel: 2,
+                practicalDescription: tube.practicalDescription_i18n['fr'],
+                practicalTitle: tube.practicalTitle_i18n['fr'],
+              }),
+            ],
+          }),
+        ]);
+        expect(response.result.page).to.deep.equal({
+          count: 2,
+          number: 2,
+          size: 1,
+        });
+      });
+
+      it('should return 400, when size exceed 200', async function () {
+        // given
+        const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+
+        const tag = databaseBuilder.factory.buildTag();
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+
+        const campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orgaInJurisdiction.id,
+        });
+
+        const clientId = 'client';
+        databaseBuilder.factory.buildClientApplication({
+          clientId: 'client',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations?page[size]=401&page[number]=2`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        expect(response.result.errors).to.deep.equal([
+          {
+            status: '400',
+            title: 'Bad Request',
+            detail: '"page.size" must be less than or equal to 200',
+          },
         ]);
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -945,7 +945,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } =
+        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       expect(participationResultDatas).lengthOf(1);
@@ -984,7 +985,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       await databaseBuilder.commit();
 
       // when
-      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } =
+        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -1006,7 +1008,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } =
+        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -1052,7 +1055,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       it('should return the division of the school registration linked to the campaign', async function () {
-        const campaignParticipationInfos = await campaignParticipationRepository.findInfoByCampaignId(campaign.id);
+        const { models: campaignParticipationInfos } = await campaignParticipationRepository.findInfoByCampaignId(
+          campaign.id,
+        );
 
         expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].division).to.equal('3eme');
@@ -1080,7 +1085,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+        const { models: participationResultDatas } =
+          await campaignParticipationRepository.findInfoByCampaignId(campaignId);
 
         // then
         expect(participationResultDatas).to.lengthOf(2);
@@ -1102,10 +1108,35 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const participationResultDatas = await campaignParticipationRepository.findInfoByCampaignId(campaign.id);
+        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId(
+          campaign.id,
+        );
 
         // then
         expect(participationResultDatas[0].sharedAt).to.equal(null);
+      });
+    });
+
+    context('pagination', function () {
+      it('should use given page and return pagination metadata', async function () {
+        // given
+        const campaignId = campaign1.id;
+        const page = { number: 2, size: 10 };
+
+        // when
+        const { models: participationResultDatas, meta } = await campaignParticipationRepository.findInfoByCampaignId(
+          campaignId,
+          page,
+        );
+
+        // then
+        expect(participationResultDatas).lengthOf(0);
+        expect(meta).to.deep.equal({
+          page: 2,
+          pageCount: 1,
+          pageSize: 10,
+          rowCount: 1,
+        });
       });
     });
   });

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -100,12 +100,13 @@ describe('Integration | Application | campaign-api', function () {
       const result = await campaignApi.getCampaignParticipations({
         campaignId: campaign.id,
         locale: 'fr',
+        page: { size: 2, number: 1 },
       });
 
       // then
-      expect(result[0]).instanceOf(CampaignParticipation);
-      expect(result[1]).instanceOf(CampaignParticipation);
-      expect(result).to.deep.equal([
+      expect(result.models[0]).instanceOf(CampaignParticipation);
+      expect(result.models[1]).instanceOf(CampaignParticipation);
+      expect(result.models).to.deep.equal([
         {
           campaignParticipationId: participation2.id,
           participantFirstName: organizationLearner2.firstName,
@@ -140,6 +141,12 @@ describe('Integration | Application | campaign-api', function () {
           ],
         },
       ]);
+      expect(result.meta).to.deep.equal({
+        page: 1,
+        pageCount: 1,
+        pageSize: 2,
+        rowCount: 2,
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -48,7 +48,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
         organizationId: organizationLearner1.organizationId,
       });
-      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+      databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.STARTED,
         organizationLearnerId: organizationLearner2.id,
@@ -63,15 +63,21 @@ describe('Integration | UseCase | get-campaign-participations', function () {
 
       await databaseBuilder.commit();
 
+      const page = {
+        size: 1,
+        number: 1,
+      };
+
       // when
-      const participations = await usecases.getCampaignParticipations({
+      const { models, meta } = await usecases.getCampaignParticipations({
         campaignId: campaign.id,
         locale: FRENCH_SPOKEN,
+        page,
       });
 
       // then
-      expect(participations).to.have.lengthOf(2);
-      expect(participations).to.deep.members([
+      expect(models).to.have.lengthOf(1);
+      expect(models).to.deep.members([
         new AssessmentCampaignParticipation({
           campaignParticipationId: participation1.id,
           userId: participation1.userId,
@@ -94,19 +100,13 @@ describe('Integration | UseCase | get-campaign-participations', function () {
             },
           ],
         }),
-        new AssessmentCampaignParticipation({
-          campaignParticipationId: participation2.id,
-          userId: participation2.userId,
-          participantExternalId: participation2.participantExternalId,
-          status: participation2.status,
-          masteryRate: participation2.masteryRate,
-          createdAt: participation2.createdAt,
-          sharedAt: participation2.sharedAt,
-          participantFirstName: organizationLearner2.firstName,
-          participantLastName: organizationLearner2.lastName,
-          tubes: undefined,
-        }),
       ]);
+      expect(meta).to.deep.equal({
+        page: 1,
+        pageCount: 2,
+        pageSize: 1,
+        rowCount: 2,
+      });
     });
   });
   context('when campaign type is profile collection', function () {
@@ -141,16 +141,16 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       await databaseBuilder.commit();
 
       // when
-      const participations = await usecases.getCampaignParticipations({
+      const { models, meta } = await usecases.getCampaignParticipations({
         campaignId: campaign.id,
         locale: FRENCH_SPOKEN,
       });
 
       //then
-      expect(participations).to.have.lengthOf(2);
-      expect(participations[0]).instanceOf(ProfilesCollectionCampaignParticipation);
-      expect(participations[1]).instanceOf(ProfilesCollectionCampaignParticipation);
-      expect(participations).to.deep.members([
+      expect(models).to.have.lengthOf(2);
+      expect(models[0]).instanceOf(ProfilesCollectionCampaignParticipation);
+      expect(models[1]).instanceOf(ProfilesCollectionCampaignParticipation);
+      expect(models).to.deep.members([
         {
           campaignParticipationId: participation1.id,
           userId: participation1.userId,
@@ -174,6 +174,12 @@ describe('Integration | UseCase | get-campaign-participations', function () {
           participantLastName: organizationLearner2.lastName,
         },
       ]);
+      expect(meta).to.deep.equal({
+        page: 1,
+        pageCount: 1,
+        pageSize: 10,
+        rowCount: 2,
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -83,8 +83,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
     organizationRepository.get.withArgs(organization.id).resolves(organization);
     competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
     campaignParticipationRepository.findInfoByCampaignId
-      .withArgs(campaign.id)
-      .resolves(campaignParticipationResultDatas);
+      .withArgs(campaign.id, { size: 1000000, number: 1 })
+      .resolves({ models: campaignParticipationResultDatas });
     CampaignProfilesCollectionExport.prototype.export
       .withArgs(campaignParticipationResultDatas, placementProfileService)
       .callsFake(async () => {


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'API Maddo, qui permet de récupérer les `campaign-participations` d'une campagne donnée, peut retourner un gros volume de données (+ de 20 000 participations pour un de nos partenaires). Cela peut créer des lenteurs dans notre API et engendrer des problèmes.  

## ⛱️ Proposition

Nous mettons en place une pagination, pour récupérer uniquement des pages et le non le retour complet. 
Pour cela nous utilisons notre utilitaire knex `fetchPage` auquel nous fournissons notre query qui doit être paginée. Et nous transmettons la pagination dans toutes les couches, et nous remontons le retour avec la pagination dans l'autre sens. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12558.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=campaigns' | jq -r .access_token)
```

Appeler la route `/api/campaigns/:id/participations` avec le token et en remplaçant l'id de campagne par celui d'une campagne ayant des participations.

### Sans pagination 

Campagne de collecte de profils : 

```
curl --get https://pix-api-maddo-review-pr12558.osc-fr1.scalingo.io/api/campaigns/105141/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

Campagne d'évaluation : 

```
 curl https://pix-api-maddo-review-pr12558.osc-fr1.scalingo.io/api/campaigns/104906/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

### Avec pagination 


Campagne de collecte de profils : 

```
curl --get --data-urlencode "page[size]=1" https://pix-api-maddo-review-pr12558.osc-fr1.scalingo.io/api/campaigns/105141/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

Campagne d'évaluation : 

```
 curl --get --data-urlencode "page[size]=1" https://pix-api-maddo-review-pr12558.osc-fr1.scalingo.io/api/campaigns/104906/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```


