### PR TITLE
[TECH] `shouldDisplayNewAnalysisPage` actif par défaut  (PIX-18306)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -44,7 +44,7 @@ export default {
   shouldDisplayNewAnalysisPage: {
     description: 'Display the new page for campaign analysis',
     type: 'boolean',
-    defaultValue: false,
+    defaultValue: true,
     tags: ['frontend', 'pix-orga', 'team-prescription'],
   },
   isV3CertificationPageEnabled: {


### PR DESCRIPTION
## 🔆 Problème

Nous souhaitons que `shouldDisplayNewAnalysisPage` soit actif par défaut.

## ⛱️ Proposition

`shouldDisplayNewAnalysisPage` actif par défaut.

## 🏄 Pour tester

NA
