### PR TITLE
[FEATURE] Enregistrer les traces d'apprentissages pour les Questions A/B (QAB) (PIX-18001)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,7 @@ import {
   FlashcardsVersoSeenEvent,
 } from '../models/passage-events/flashcard-events.js';
 import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
+import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-events/qab-events.js';
 
 class PassageEventFactory {
   static build(eventData) {
@@ -28,6 +29,10 @@ class PassageEventFactory {
         return new FlashcardsRetriedEvent(eventData);
       case 'QCU_DECLARATIVE_ANSWERED':
         return new QCUDeclarativeAnsweredEvent(eventData);
+      case 'QAB_CARD_ANSWERED':
+        return new QABCardAnsweredEvent(eventData);
+      case 'QAB_CARD_RETRIED':
+        return new QABCardRetriedEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/qab-events.js
+++ b/api/src/devcomp/domain/models/passage-events/qab-events.js
@@ -1,0 +1,22 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEventWithElement } from './PassageEventWithElement.js';
+
+class QABCardAnsweredEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId, chosenProposal }) {
+    super({
+      type: 'QAB_CARD_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { cardId, chosenProposal },
+    });
+
+    assertNotNullOrUndefined(cardId, 'The cardId is required for a QABCardAnsweredEvent');
+    assertNotNullOrUndefined(chosenProposal, 'The chosenProposal is required for a QABCardAnsweredEvent');
+  }
+}
+
+export { QABCardAnsweredEvent };

--- a/api/src/devcomp/domain/models/passage-events/qab-events.js
+++ b/api/src/devcomp/domain/models/passage-events/qab-events.js
@@ -19,4 +19,10 @@ class QABCardAnsweredEvent extends PassageEventWithElement {
   }
 }
 
-export { QABCardAnsweredEvent };
+class QABCardRetriedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({ id, type: 'QAB_CARD_RETRIED', occurredAt, createdAt, passageId, sequenceNumber, elementId });
+  }
+}
+
+export { QABCardAnsweredEvent, QABCardRetriedEvent };

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -1,4 +1,7 @@
-import { QABCardAnsweredEvent } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
+import {
+  QABCardAnsweredEvent,
+  QABCardRetriedEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -97,6 +100,37 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The chosenProposal is required for a QABCardAnsweredEvent');
       });
+    });
+  });
+
+  describe('#QABCardRetriedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const qabCardAnsweredEvent = new QABCardRetriedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(qabCardAnsweredEvent.id).to.equal(id);
+      expect(qabCardAnsweredEvent.type).to.equal('QAB_CARD_RETRIED');
+      expect(qabCardAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qabCardAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qabCardAnsweredEvent.passageId).to.equal(passageId);
+      expect(qabCardAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qabCardAnsweredEvent.data).to.deep.equal({ elementId });
     });
   });
 });

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -1,0 +1,102 @@
+import { QABCardAnsweredEvent } from '../../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | qab-events', function () {
+  describe('#QABCardAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+      const cardId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
+      const chosenProposal = 'A';
+
+      // when
+      const qabCardAnsweredEvent = new QABCardAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        cardId,
+        chosenProposal,
+      });
+
+      // then
+      expect(qabCardAnsweredEvent.id).to.equal(id);
+      expect(qabCardAnsweredEvent.type).to.equal('QAB_CARD_ANSWERED');
+      expect(qabCardAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qabCardAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qabCardAnsweredEvent.passageId).to.equal(passageId);
+      expect(qabCardAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qabCardAnsweredEvent.data).to.deep.equal({ cardId, chosenProposal, elementId });
+    });
+
+    describe('when cardId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+        const chosenProposal = 'A';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new QABCardAnsweredEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              elementId,
+              chosenProposal,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The cardId is required for a QABCardAnsweredEvent');
+      });
+    });
+
+    describe('when chosenProposal is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+        const cardId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new QABCardAnsweredEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              elementId,
+              cardId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The chosenProposal is required for a QABCardAnsweredEvent');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -13,6 +13,10 @@ import {
   PassageStartedEvent,
   PassageTerminatedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/passage-events.js';
+import {
+  QABCardAnsweredEvent,
+  QABCardRetriedEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync } from '../../../../test-helper.js';
 
@@ -188,6 +192,44 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCUDeclarativeAnsweredEvent);
+      });
+    });
+
+    describe('when given a QAB_CARD_ANSWERED event', function () {
+      it('should return a QabCardAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QAB_CARD_ANSWERED',
+          cardId: '34b916b9-9103-4060-818d-98b2dc67111d',
+          chosenProposal: 'A',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QABCardAnsweredEvent);
+      });
+    });
+
+    describe('when given a QAB_CARD_RETRIED event', function () {
+      it('should return a QabCardAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QAB_CARD_RETRIED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QABCardRetriedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -102,6 +102,13 @@ export default class ModuleQab extends ModuleElement {
     this.cardStatuses.clear();
     this.displayedCards = new TrackedArray(this.element.cards);
     this.score = 0;
+
+    this.passageEvents.record({
+      type: 'QAB_CARD_RETRIED',
+      data: {
+        elementId: this.element.id,
+      },
+    });
   }
 
   get shouldDisplayCards() {

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import QabCard from 'mon-pix/components/module/element/qab/qab-card';
@@ -21,6 +22,8 @@ export default class ModuleQab extends ModuleElement {
   @tracked displayedCards;
   @tracked cardStatuses = new TrackedMap();
   @tracked removedCards = new TrackedMap();
+
+  @service passageEvents;
 
   constructor() {
     super(...arguments);
@@ -82,6 +85,14 @@ export default class ModuleQab extends ModuleElement {
 
     this.cardStatuses.set(this.currentCard.id, this.currentCardStatus);
     window.setTimeout(async () => await this.goToNextCard(), NEXT_CARD_TRANSITION_DELAY);
+    this.passageEvents.record({
+      type: 'QAB_CARD_ANSWERED',
+      data: {
+        cardId: this.currentCard.id,
+        chosenProposal: event.submitter.value,
+        elementId: this.element.id,
+      },
+    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -154,7 +154,7 @@ module('Integration | Component | Module | QAB', function (hooks) {
       });
 
       module('when user clicks the retry button', function () {
-        test('should reset the component and display the first card', async function (assert) {
+        test('should reset the component, display the first card and send an event', async function (assert) {
           // given
           const qabElement = _getQabElement();
           const onAnswerStub = sinon.stub();
@@ -170,8 +170,20 @@ module('Integration | Component | Module | QAB', function (hooks) {
           await click(screen.getByRole('button', { name: 'Réessayer' }));
 
           // then
+
+          assert.dom(screen.getByText('Les chiens ne transpirent pas.')).exists();
           assert.dom(screen.getByText('Maintenant, entraînez-vous sur des exemples concrets !')).exists();
           assert.dom(screen.getByText('Les boules de pétanques sont creuses.')).exists();
+
+          const recordQabCardRetriedCall = passageEventRecordStub.getCall(2);
+          assert.deepEqual(recordQabCardRetriedCall.args, [
+            {
+              type: 'QAB_CARD_RETRIED',
+              data: {
+                elementId: qabElement.id,
+              },
+            },
+          ]);
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Il n'y a actuellement pas d'enregistrement de traces d'apprentissages pour l'élément QAB.

## ⛱️ Proposition
Ajouter cette gestion avec l'enregistrement de 2 événements : 
- QAB_CARD_ANSWERED : envoyé lorsque l'utilisateur a répondu à la carte
- QAB_RETRIED : envoyé lorsque l'utilisateur a cliqué sur le bouton `Réessayer`

## 🌊 Remarques

- Les propriétés de la classe (elementId...) provenant de l'attribut data n'étaient pas utilisé dans le projet (voir [repository](https://github.com/1024pix/pix/blob/dev/api/src/devcomp/infrastructure/repositories/passage-event-repository.js#L10-L14)) mais uniquement pour les tests. Nous ne faisons donc plus l'affectation.

## 🏄 Pour tester

- Aller sur le module bac-a-sable
- Ouvrir la console navigateur => onglet réseau 
- Répondre à la 1ère carte. Vérifier que l'appel à POST /passage-events est fait avec un type `QAB_CARD_ANSWERED`
- Continuer à répondre jusqu'à arriver à la carte de fin avec le score.
- Cliquer sur le bouton `Réessayer`
- Vérifier que l'appel à POST /passage-events est fait avec un type `QAB_CARD_RETRIED`