### PR TITLE
[BUGFIX] Corriger les niveaux des tags dans la page analyse et statistiques (PIX-18322)

### DIFF
--- a/orga/app/components/statistics/tag-level.gjs
+++ b/orga/app/components/statistics/tag-level.gjs
@@ -10,11 +10,13 @@ const MAX_LEVEL = {
 
 export default class TagLevel extends Component {
   get category() {
-    const parsedLevel = Math.ceil(parseFloat(this.args.level));
-    if (parsedLevel < MAX_LEVEL.novice) return 'pages.statistics.level.novice';
-    if (parsedLevel < MAX_LEVEL.independent) return 'pages.statistics.level.independent';
-    if (parsedLevel < MAX_LEVEL.advanced) return 'pages.statistics.level.advanced';
-    return 'pages.statistics.level.expert';
+    const parsedLevel = Number(this.args.level);
+
+    const intlKey = 'pages.statistics.level.';
+    if (parsedLevel < MAX_LEVEL.novice) return intlKey + 'novice';
+    if (parsedLevel < MAX_LEVEL.independent) return intlKey + 'independent';
+    if (parsedLevel < MAX_LEVEL.advanced) return intlKey + 'advanced';
+    return intlKey + 'expert';
   }
 
   <template>

--- a/orga/tests/integration/components/statistics/tag-level-test.gjs
+++ b/orga/tests/integration/components/statistics/tag-level-test.gjs
@@ -9,45 +9,31 @@ module('Integration | Component | Statistics | TagLevel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('#get category', function () {
-    test('when level is lower than 3 it should return novice', async function (assert) {
-      //given
-      const level = 2;
+    const intlKey = 'pages.statistics.level.';
 
-      //when
-      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+    const testData = [
+      { level: 0.1, expectedText: intlKey + 'novice' },
+      { level: 2, expectedText: intlKey + 'novice' },
+      { level: 3.4, expectedText: intlKey + 'independent' },
+      { level: 4, expectedText: intlKey + 'independent' },
+      { level: 4.1, expectedText: intlKey + 'independent' },
+      { level: 5, expectedText: intlKey + 'advanced' },
+      { level: 6, expectedText: intlKey + 'advanced' },
+      { level: 6.5, expectedText: intlKey + 'advanced' },
+      { level: 7, expectedText: intlKey + 'expert' },
+    ];
 
-      //then
-      assert.ok(screen.getByText(t('pages.statistics.level.novice')));
-    });
-    test('when level is lower than 5 it should return independent', async function (assert) {
-      //given
-      const level = 4;
+    testData.forEach((item) => {
+      test(`when level is ${item.level} it should return ${item.expectedText}`, async function (assert) {
+        //given
+        const level = item.level;
 
-      //when
-      const screen = await render(<template><TagLevel @level={{level}} /></template>);
+        //when
+        const screen = await render(<template><TagLevel @level={{level}} /></template>);
 
-      //then
-      assert.ok(screen.getByText(t('pages.statistics.level.independent')));
-    });
-    test('when level is lower than 7 it should return advanced', async function (assert) {
-      //given
-      const level = 6;
-
-      //when
-      const screen = await render(<template><TagLevel @level={{level}} /></template>);
-
-      //then
-      assert.ok(screen.getByText(t('pages.statistics.level.advanced')));
-    });
-    test('when level is upper or equal 7 it should return expert', async function (assert) {
-      //given
-      const level = 7;
-
-      //when
-      const screen = await render(<template><TagLevel @level={{level}} /></template>);
-
-      //then
-      assert.ok(screen.getByText(t('pages.statistics.level.expert')));
+        //then
+        assert.ok(screen.getByText(t(item.expectedText)));
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Les niveaux dans les tags ne correspondent pas a ce qu'on attend. En effet on retourne le plus petit entier supérieur ou égal au nombre donné. Ce qui nous donne par exemple un niveau avance pour un niveau de 4,1. 

## ⛱️ Proposition

Supprimer l'arrondi.

## 🏄 Pour tester

Acceder a la page d'analyse, jouer avec la console ember pour modifier les valeurs et s'assurer que le tag correspond a ce qui est attendu.
