### PR TITLE
[DOC] Consolidation de la documentation concernant l’architecture, notamment sur les nommage des tables en BDD

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,6 +1,7 @@
 # Conventions
 
-Ces conventions sont vérifiées dans la tâche de `lint` de l'API.
+Ces conventions sont vérifiées autant que possible dans la tâche de `lint` de l'API.
+
 
 ## Nommage
 
@@ -9,11 +10,35 @@ Ces conventions sont vérifiées dans la tâche de `lint` de l'API.
 Le nom d'une table :
 
 - est au pluriel : `users` et pas `user`
+- est en minuscules et peut contenir des soulignés (underscore), c’est à dire
+  `_`, mais pas des tirets (dash), c’est à dire `-`,
+  suivant la [préconisation de PostgreSQL](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names)
+
+Les bases de données ne servent pas uniquement à l’API et lorsqu’on doit faire
+des tests, du debug ou tout simplement des requêtes pour chercher des
+informations mettre des guillemets (double quotes) impacte énormément la
+productivité.
+
+Bon :
+```
+client_applications
+lti_platform_registrations
+```
+
+Pas bon :
+```
+wonder-assets
+wonder_asset
+wonderAssets
+```
+
 
 #### Exceptions
 
 Les exceptions possibles sont :
 
+- les anciennes tables déjà existantes (`organization-learners`,
+  `certification-centers`, `user-logins`, etc.)
 - les tables utilisées par les librairies, par exemple la table `knex_migrations_lock` utilisée par la librairie `knex`;
 - les tables ne contenant qu'un seul enregistrement (aucun exemple connu).
 
@@ -26,3 +51,10 @@ du [fichier de configuration](../api/tests/acceptance/database/configuration.js)
   {identifierPattern: 'public\\.badge-criteria', rulePattern: 'name-inflection'},
 ]
 ```
+
+##### Historique
+
+Aux débuts de Pix les développeurs ont voulu être disruptifs en utilisant des
+tirets (dash), c’est à dire `-`, et pendant longtemps personne n’a remis en
+cause cette décision
+

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -21,21 +21,41 @@ il n'y a qu'un type d'erreur et pas de mapping.
 
 ## Pratiques à suivre
 
-Il faut privilégier :
+### Ce qu’il faut privilégier
+
 * l'ajout d'une propriété `code` et le traitement côté client, par `code` en
   priorité par rapport à la propriété `status`. Il faut
   réserver les status pour les couches HTTP/réseau hors de l'application.
 * l'ajout d'une propriété `meta` pour ajouter des informations supplémentaires lorsque nécessaire
 * un nom finissant par `Error` pour standardiser
 
-Il ne faut pas :
-* mettre un texte traduit
-* mettre un code dans le constructeur qui incite à le changer
-* mal utiliser les codes HTTP pour faire de la discrimination entre erreur
-* mettre des informations dans le `meta` qui divulgueraient des informations
-  menaçant la sécurité des applications (stacktrace de l'erreur indiquant des
-  chemins de fichiers sur le conteneur permettant des attaques, des IP de
-  conteneurs, des informations sur les utilisateurs trouvés ou non, etc.)
+### Ce qu’il faut éviter
+
+* Il ne faut pas mettre de texte traduit dans une erreur.
+
+* Il ne faut pas mettre un argument `code` dans les constructeurs des erreurs,
+  mais plutôt créer des classes d’erreur dédiées chacune porteuse d’un `code`
+  unique.
+
+  L’objectif est de standardiser et d’unifier les `code` des erreurs pour
+  pouvoir les traiter de manière efficace et le plus possible standardisée dans
+  les Fronts, sans avoir à gérer autant de cas de `code` qu’il y a de usecase
+  dans le Back.
+
+  En effet donner la possibilité de spécifier un `code` dans le constructeur
+  laisserait penser que, plutôt que d’hériter du `code` de la classe, changer le
+  `code` d’une erreur à son instanciation est une bonne pratique. Or lorsque les
+  erreurs du Back sont propagées aux Fronts le type de la classe est perdu et
+  seul le `code` est préservé.
+
+* Il ne faut pas mal utiliser les codes HTTP pour faire de la discrimination
+  entre erreur.
+
+* Il ne faut pas mettre des informations dans le `meta` qui divulgueraient des
+  informations menaçant la sécurité des applications (stacktrace de l'erreur
+  indiquant des chemins de fichiers sur le conteneur permettant des attaques,
+  des IP de conteneurs, des informations sur les utilisateurs trouvés ou non,
+  etc.).
 
 
 Bon :

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,7 +32,7 @@ Il ne faut pas :
 * mettre un texte traduit
 * mettre un code dans le constructeur qui incite à le changer
 * mal utiliser les codes HTTP pour faire de la discrimination entre erreur
-* mettre des informations dans le `meta` qui divilgueraient des informations
+* mettre des informations dans le `meta` qui divulgueraient des informations
   menaçant la sécurité des applications (stacktrace de l'erreur indiquant des
   chemins de fichiers sur le conteneur permettant des attaques, des IP de
   conteneurs, des informations sur les utilisateurs trouvés ou non, etc.)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -67,6 +67,16 @@ class AuthenticationKeyExpiredError extends DomainError {
 }
 ```
 
+Bon :
+```javascript
+class TagNotFoundError extends DomainError {
+  constructor(meta) {
+    super('Tag does not exist', 'TAG_NOT_FOUND');
+    if (meta) this.meta = meta;
+  }
+}
+```
+
 Pas bon :
 ```javascript
 class UncancellableCertificationCenterInvitation extends DomainError {

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -1,0 +1,35 @@
+
+# Repository
+
+
+## En résumé
+
+* Un repository est une couche d’abstraction au-dessus de la persistance de
+  données
+* Un repository doit contenir le moins de logique métier possible (être le plus
+  « dumb » possible)
+* Un repository ne doit pas faire de vérifications de sécurité
+
+
+## Détails
+
+Le design pattern Repository permet de masquer le choix de persistances. Le code
+qui utilise le repository ne doit pas savoir si on utilise une base
+relationnelle ou un cache par exemple. L’objectif est de permettre de changer
+les choix de persistance sans devoir faire changer le code qui dépend des
+repositories. Pour atteindre cet objectif, l’interface d’un repository doit être
+indépendante de la couche technique.
+
+Les repositories sont une abstraction pour masquer les problématiques et les
+choix lié à la persistance des données. Un représentation simple qui montre
+l’intention d’un repository est celle d’une collection. On peut y ajouter des
+éléments, en supprimer ou en récupérer.  L’idée c’est qu’on va récupérer un
+objet a partir du repository, modifier cet objet et ensuite enregistrer ces
+modifications.
+
+Si l’utilisation d’un repository existant ne répond pas complètement au besoin
+métier, il est préférable de créer un reposiory à part plutôt que d’injecter un
+repository existant.
+
+Un repository n'a pas vocation à faire des vérifications de sécurité.
+

--- a/docs/service.md
+++ b/docs/service.md
@@ -1,0 +1,32 @@
+
+# Service
+
+
+## En résumé
+
+* Créer un service est légitime si la logique implique plusieurs modèles et que
+  la logique n'a pas à être positionnée dans un modèle
+* Un service est stateless
+
+
+## Détails
+
+On utilise un service quand on veut partager une fonctionnalité entre plusieurs
+usecases et/ou que la fonctionnalité ne doit pas être implémentée dans un objet
+métier (domaine) plutôt que dans un autre (exemple de la fonction de virement
+d'un compte en banque vers un autre qui doit être implémentée dans un service et
+non pas dans un compte en banque car notamment un compte en banque A n'a pas de
+raison d'avoir les droits pour manipuler un compte en banque B).
+
+Un service est stateless.
+
+
+## Rérérences
+
+DDD Chapter 7: Services
+Often the best indication that you should create a Service in the domain
+model is when the operation you need to perform feels out of place as a method
+on an Aggregate or a Value Object.
+
+
+


### PR DESCRIPTION
## 🔆 Problème

Nous souhaitons faire avancer la standardisation des pratiques.

## ⛱️ Proposition

Avec cette PR on propose de faire avancer de manière très incrémentale la standardisation de quelques pratiques de base en terme de code, principalement de nommage et notamment sur le nommage des tables en BDD.

Cette PR est exprès minimaliste et a priori sur des points où tout le monde est déjà d’accord.

Cette PR est une héritière de #11637.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Lire les fichiers texte et dire ce que vous en pensez.
