### PR TITLE
[BUGFIX] Corriger des clés de traduction du bouton "s'inscrire" en nl, es, en (PIX-18326)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1885,7 +1885,7 @@
     "sign-up": {
       "actions": {
         "login": "Log in",
-        "sign-up-on-Pix": "Sign up for Pix",
+        "sign-up-on-pix": "Sign up for Pix",
         "submit": "Sign up"
       },
       "errors": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1878,7 +1878,7 @@
       "actions": {
         "login": "Iniciar sesión",
         "submit": "Crear cuenta",
-        "sign-up-on-Pix": "Crear cuenta en Pix"
+        "sign-up-on-pix": "Crear cuenta en Pix"
       },
       "errors": {
         "invalid-locale-format": "Tu configuración local «{invalidLocale}» tiene un formato incorrecto.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1881,7 +1881,7 @@
       "actions": {
         "login": "Inloggen",
         "submit": "Registreren",
-        "sign-up-on-Pix": "Inschrijven bij Pix"
+        "sign-up-on-pix": "Inschrijven bij Pix"
       },
       "errors": {
         "invalid-locale-format": "Uw locale \"{invalidLocale}\" heeft de verkeerde indeling.",


### PR DESCRIPTION
## 🔆 Problème

La clé de traduction ` pages.sign-up.actions.sign-up-on-Pix` des fichiers de traduction nl, es, en doit être corrigée en `pages.sign-up.actions.sign-up-on-pix` 

## ⛱️ Proposition

Faire cette correction

## 🌊 Remarques

ras

## 🏄 Pour tester

Refaire le "Pour tester" de https://github.com/1024pix/pix/pull/12499 en anglais sur https://app-pr12578.review.pix.org/campagnes/AUTOCOURS2
