### PR TITLE
[FEATURE] Ajouter l'animation des cartes vers la droite lorsque la réponse est incorrecte pour les QAB (PIX-18117)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-card.scss
@@ -2,6 +2,8 @@
 @use 'pix-design-tokens/typography';
 
 .qab-card {
+  --qab-card-content-border-color: var(--pix-primary-300);
+
   display: grid;
   grid-area: center;
   width: 100%;
@@ -43,14 +45,7 @@
     transform: scale(0.5) translateY(77%);
   }
 
-  &--removed {
-    translate: -100vw -10vh;
-    rotate: -20deg;
-  }
-
   &__container {
-    --qab-card-content-border-color: var(--pix-primary-300);
-
     display: flex;
     align-items: center;
     justify-content: center;
@@ -58,14 +53,24 @@
     padding: var(--pix-spacing-6x);
     border: var(--pix-spacing-2x) solid var(--qab-card-content-border-color);
     border-radius: var(--radius-s, 8px);
+  }
 
-    &--error {
-      --qab-card-content-border-color: var(--pix-error-500);
-    }
-
-    &--success {
+  &--success {
       --qab-card-content-border-color: var(--pix-success-300);
-    }
+  }
+
+  &--error {
+      --qab-card-content-border-color: var(--pix-error-500);
+  }
+
+  &--success.qab-card--removed {
+    translate: -100vw -10vh;
+    rotate: -20deg;
+  }
+
+  &--error.qab-card--removed {
+    translate: 100vw -10vh;
+    rotate: -20deg;
   }
 
   &--without-transition {

--- a/mon-pix/app/components/module/element/qab/qab-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-card.gjs
@@ -23,7 +23,9 @@ export default class QabCard extends Component {
     <div
       class="qab-card
         {{if @isRemoved 'qab-card--removed'}}
-        {{if this.userPrefersReducedMotion 'qab-card--without-transition'}}"
+        {{if this.userPrefersReducedMotion 'qab-card--without-transition'}}
+        {{if this.isSuccess 'qab-card--success'}}
+        {{if this.isError 'qab-card--error'}}"
     >
       {{#if this.isSuccess}}
         <p role="status" class="sr-only"> {{t "pages.modulix.qab.correct-answer"}} </p>
@@ -31,11 +33,7 @@ export default class QabCard extends Component {
       {{#if this.isError}}
         <p role="status" class="sr-only"> {{t "pages.modulix.qab.incorrect-answer"}} </p>
       {{/if}}
-      <div
-        class="qab-card__container
-          {{if this.isSuccess 'qab-card__container--success'}}
-          {{if this.isError 'qab-card__container--error'}}"
-      >
+      <div class="qab-card__container">
         <div class="qab-card-container-content {{if this.hasImage 'qab-card-container-content--with-image'}}">
           {{#if this.hasImage}}
             <img class="qab-card-container-content__image" src={{@card.image.url}} alt={{@card.image.altText}} />


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'animation des cartes de l'élément QAB va toujours dans le même sens même si l'utilisateur n'a pas choisi la bonne réponse.

## ⛱️ Proposition

Conditonner le sens selon si la réponse est correcte ou incorrecte : 
- Si c'est correcte, la carte va vers la gauche
- Si c'est incorrecte, la carte va vers la droite 

## 🌊 Remarques

On en profite pour gérer les modifiers `--success` et `--error` au premier niveau du composant QABCard.

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12580.review.pix.fr/modules/bac-a-sable)
- Sélectionner la réponse B pour la première carte
- Vérifier que l'animation se fait vers la droite car réponse incorrecte
- Sélectionner la réponse B sur la deuxième carte
- Vérifier que l'animation se fait vers la gauche car réponse correcte.
