### PR TITLE
[FEATURE] anonymiser les campagnes et les prescrits à l'archivage d'une orga (PIX-18150)

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/index.js
+++ b/api/src/organizational-entities/infrastructure/repositories/index.js
@@ -1,8 +1,9 @@
+import * as campaignApi from '../../../prescription/campaign/application/api/campaigns-api.js';
+import * as learnerApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as organizationApi from '../../../team/application/api/organization.js';
 import { certificationCenterApiRepository } from './certification-center-api.repository.js';
 import { organizationForAdminRepository } from './organization-for-admin.repository.js';
-
 const repositoriesWithoutInjectedDependencies = {
   organizationForAdminRepository,
   certificationCenterApiRepository,
@@ -10,6 +11,8 @@ const repositoriesWithoutInjectedDependencies = {
 
 const dependencies = {
   organizationApi,
+  learnerApi,
+  campaignApi,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -1,4 +1,4 @@
-This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-documentation.js`. See package.json.
+This doc has been generated on 18/06/2025 13:26:32 with `scripts/generate-api-documentation.js`. See package.json.
 
 ---
 ## Modules
@@ -19,8 +19,6 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
 ## Classes
 
 <dl>
-<dt><a href="#CampaignTubeCoverage">CampaignTubeCoverage</a></dt>
-<dd></dd>
 <dt><a href="#CampaignParticipation">CampaignParticipation</a></dt>
 <dd></dd>
 <dt><a href="#AssessmentCampaignParticipation">AssessmentCampaignParticipation</a></dt>
@@ -40,6 +38,9 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
 <dt><a href="#deleteOrganizationLearnerBeforeImportFeature">deleteOrganizationLearnerBeforeImportFeature</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
 <dd><p>delete organization learner before adding import feature</p>
 </dd>
+<dt><a href="#anonymizeByUserId">anonymizeByUserId</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
+<dd><p>Anonymize an organizationLearner and their campaignParticipations</p>
+</dd>
 </dl>
 
 ## Functions
@@ -54,11 +55,15 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
 <dl>
 <dt><a href="#CampaignListItemArgs">CampaignListItemArgs</a> : <code>object</code></dt>
 <dd></dd>
+<dt><a href="#CampaignTubeCoverageArgs">CampaignTubeCoverageArgs</a> : <code>object</code></dt>
+<dd></dd>
 <dt><a href="#CampaignParticipationArgs">CampaignParticipationArgs</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#AssessmentCampaignParticipationArgs">AssessmentCampaignParticipationArgs</a> : <code>object</code></dt>
 <dd></dd>
 <dt><a href="#ProfilesCollectionCampaignParticipationArgs">ProfilesCollectionCampaignParticipationArgs</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#TubeCoverageArgs">TubeCoverageArgs</a> : <code>Object</code></dt>
 <dd></dd>
 </dl>
 
@@ -74,6 +79,7 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
     * [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
     * [~findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds)](#module_CampaignApi..findCampaignSkillIdsForCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
     * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;(Array.&lt;AssessmentCampaignParticipationAPI&gt;\|Array.&lt;ProfilesCollectionCampaignParticipationAPI&gt;)&gt;</code>
+    * [~deleteActiveCampaigns(payload)](#module_CampaignApi..deleteActiveCampaigns) ⇒ <code>Promise.&lt;void&gt;</code>
     * [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
     * [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
     * [~UpdateCampaignPayload](#module_CampaignApi..UpdateCampaignPayload) : <code>object</code>
@@ -82,6 +88,7 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
     * [~Pagination](#module_CampaignApi..Pagination) : <code>object</code>
     * [~CampaignListResponse](#module_CampaignApi..CampaignListResponse) : <code>object</code>
     * [~CampaignParticipationsPayload](#module_CampaignApi..CampaignParticipationsPayload) : <code>object</code>
+    * [~DeleteActiveCampaignPayload](#module_CampaignApi..DeleteActiveCampaignPayload) : <code>object</code>
 
 <a name="module_CampaignApi..save"></a>
 
@@ -149,6 +156,15 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
 | Param | Type |
 | --- | --- |
 | payload | <code>CampaignParticipationsPayload</code> | 
+
+<a name="module_CampaignApi..deleteActiveCampaigns"></a>
+
+### CampaignApi~deleteActiveCampaigns(payload) ⇒ <code>Promise.&lt;void&gt;</code>
+**Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
+
+| Param | Type |
+| --- | --- |
+| payload | <code>DeleteActiveCampaignPayload</code> | 
 
 <a name="module_CampaignApi..CampaignPayload"></a>
 
@@ -244,6 +260,19 @@ This doc has been generated on 30/04/2025 19:35:00 with `scripts/generate-api-do
 | Name | Type |
 | --- | --- |
 | campaignId | <code>number</code> | 
+
+<a name="module_CampaignApi..DeleteActiveCampaignPayload"></a>
+
+### CampaignApi~DeleteActiveCampaignPayload : <code>object</code>
+**Kind**: inner typedef of [<code>CampaignApi</code>](#module_CampaignApi)  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| organizationId | <code>number</code> | 
+| campaignIds | <code>Array.&lt;number&gt;</code> | 
+| userId | <code>number</code> | 
+| page | <code>PageDefinition</code> | 
 
 <a name="module_KnowledgeElementSnapshotAPI"></a>
 
@@ -559,30 +588,13 @@ Récupère les organizations-learners avec leurs participations à partir d'une 
 
 ## TubeCoverage
 **Kind**: global class  
-**Properties**
-
-| Name | Type |
-| --- | --- |
-| id | <code>string</code> | 
-| competenceId | <code>string</code> | 
-| practicalTitle | <code>string</code> | 
-| practicalDescription | <code>string</code> | 
-| maxLevel | <code>number</code> | 
-| reachedLevel | <code>number</code> | 
-
 <a name="new_TubeCoverage_new"></a>
 
 ### new TubeCoverage(args)
 
 | Param | Type |
 | --- | --- |
-| args | <code>object</code> | 
-| args.id | <code>string</code> | 
-| args.competenceId | <code>string</code> | 
-| args.practicalTitle | <code>string</code> | 
-| args.practicalDescription | <code>string</code> | 
-| args.maxLevel | <code>number</code> | 
-| args.reachedLevel | <code>number</code> | 
+| args | [<code>TubeCoverageArgs</code>](#TubeCoverageArgs) | 
 
 <a name="hasBeenLearner"></a>
 
@@ -617,6 +629,18 @@ delete organization learner before adding import feature
 | params.userId | <code>number</code> | The ID of the user wich request the action |
 | params.organizationId | <code>number</code> | The ID of the organizationId to find learner to delete |
 
+<a name="anonymizeByUserId"></a>
+
+## anonymizeByUserId ⇒ <code>Promise.&lt;void&gt;</code>
+Anonymize an organizationLearner and their campaignParticipations
+
+**Kind**: global constant  
+
+| Param | Type |
+| --- | --- |
+| params | <code>object</code> | 
+| params.userId | <code>number</code> | 
+
 <a name="hasCampaignParticipations"></a>
 
 ## hasCampaignParticipations(userId) ⇒ <code>Promise.&lt;boolean&gt;</code>
@@ -641,7 +665,22 @@ delete organization learner before adding import feature
 | type | <code>string</code> | 
 | code | <code>string</code> | 
 | targetProfileName | <code>string</code> | 
-| tubes | [<code>Array.&lt;CampaignTubeCoverage&gt;</code>](#CampaignTubeCoverage) | 
+| tubes | <code>Array.&lt;CampaignTubeCoverage&gt;</code> | 
+
+<a name="CampaignTubeCoverageArgs"></a>
+
+## CampaignTubeCoverageArgs : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| id | <code>string</code> | 
+| competenceId | <code>string</code> | 
+| practicalTitle | <code>string</code> | 
+| practicalDescription | <code>string</code> | 
+| maxLevel | <code>number</code> | 
+| reachedLevel | <code>number</code> | 
 
 <a name="CampaignParticipationArgs"></a>
 
@@ -682,5 +721,20 @@ delete organization learner before adding import feature
 | Name | Type |
 | --- | --- |
 | pixScore | <code>number</code> | 
+
+<a name="TubeCoverageArgs"></a>
+
+## TubeCoverageArgs : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| id | <code>string</code> | 
+| competenceId | <code>string</code> | 
+| title | <code>string</code> | 
+| description | <code>string</code> | 
+| maxLevel | <code>number</code> | 
+| reachedLevel | <code>number</code> | 
 
 

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -13,6 +13,7 @@ import * as organizationFeatureApi from '../../../../organizational-entities/app
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
+import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
@@ -45,6 +46,7 @@ import * as campaignUpdateValidator from '../validators/campaign-update-validato
 
 const dependencies = {
   assessmentRepository,
+  adminMemberRepository,
   badgeAcquisitionRepository,
   badgeRepository,
   campaignAdministrationRepository,

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignsDestructor_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignsDestructor_test.js
@@ -1,3 +1,4 @@
+import { PIX_ADMIN } from '../../../../../../src/authorization/domain/constants.js';
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { CampaignsDestructor } from '../../../../../../src/prescription/campaign/domain/models/CampaignsDestructor.js';
 import { OrganizationMembership } from '../../../../../../src/prescription/campaign/domain/read-models/OrganizationMembership.js';
@@ -6,6 +7,22 @@ import { ObjectValidationError } from '../../../../../../src/shared/domain/error
 import { expect } from '../../../../../test-helper.js';
 
 describe('CampaignsDestructor', function () {
+  describe('when user has an allowed PixAdmin Role', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [PIX_ADMIN.ROLES.SUPER_ADMIN, PIX_ADMIN.ROLES.SUPPORT, PIX_ADMIN.ROLES.METIER].forEach((role) => {
+      it(`should not throws for ${role} role`, function () {
+        expect(
+          () =>
+            new CampaignsDestructor({
+              userId: 1,
+              campaignsToDelete: [new Campaign({ ownerId: 2 })],
+              pixAdminRole: role,
+            }),
+        ).not.throws();
+      });
+    });
+  });
+
   describe('when datas are invalid', function () {
     it('throws an error when some campaigns does not belong to organization', function () {
       try {
@@ -25,6 +42,19 @@ describe('CampaignsDestructor', function () {
           membership: new OrganizationMembership({ isAdmin: false }),
           userId: 1,
           campaignsToDelete: [new Campaign({ ownerId: 2 })],
+        });
+      } catch (error) {
+        expect(error).to.be.instanceOf(ObjectValidationError);
+        expect(error.message).to.equal('User does not have right to delete some campaigns.');
+      }
+    });
+
+    it('throws an error when user is CERTIF AdminMember', function () {
+      try {
+        new CampaignsDestructor({
+          userId: 3,
+          campaignsToDelete: [new Campaign({ ownerId: 2 })],
+          adminMemberRole: PIX_ADMIN.ROLES.CERTIF,
         });
       } catch (error) {
         expect(error).to.be.instanceOf(ObjectValidationError);


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre de notre chantier sur l'anonymisation, on s'est rendu compte que lorsqu'une orga est archivée, on archive les campagnes. Or aucune données n'est traitées.


## ⛱️ Proposition
On supprime les prescrits (et leur participations) ainsi que et les campagnes de l'organization et on anonymise tout ça.
Ce comportement est sous feature toggle. 
Pour cela, on va utiliser l'api qui permet de supprimer des prescrits d'une orga lorsqu'on souhaite rajouter un import à format et on mettra en place une nouvelle api pour supprimer les campagnes afin de pouvoir réutiliser la logique des usecases existants. 


## 🌊 Remarques
On a dû modifier l'import du repo `organization-for-admin-repository.js` car on n'utilisait par la version "injecté" du repo.

## 🏄 Pour tester
```sh
scalingo -a pix-api-review-pr12581 run "npm run toggles -- -k isAnonymizationWithDeletionEnabled -v true"
```
- supprimer une orga PRO_CLASSIC
- se connecter avec pgsql 
```sh
scalingo -a pix-api-review-pr12581 pgsql-console 
```

et verifier que les données sont bien anonymisé (userId /  info perso à null)
```sql
select * from campaigns where "organizationId"=1005;
select * from "organization-learners" where "organizationId"=1005;
select “campaign-participations".* from "campaign-participations" join campaigns on campaigns.id = "campaign-participations"."campaignId" where "organizationId"=1005;
```