### PR TITLE
[FEATURE] Masquer le sélecteur de niveau lors de la création du référentiel cadre d'un Pix+ sur Admin (PIX-18189).

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -262,7 +262,11 @@ export default class Badge extends Component {
             </h2>
             {{#each this.cappedTubesCriteria as |criterion|}}
               <div class="card">
-                <CappedTubesCriterion @criterion={{criterion}} @targetProfile={{@targetProfile}} />
+                <CappedTubesCriterion
+                  @criterion={{criterion}}
+                  @targetProfile={{@targetProfile}}
+                  @displaySkillDifficultySelection={{false}}
+                />
               </div>
             {{/each}}
           {{/if}}

--- a/admin/app/components/common/tubes-selection.gjs
+++ b/admin/app/components/common/tubes-selection.gjs
@@ -61,6 +61,10 @@ export default class TubesSelection extends Component {
     });
   }
 
+  get displaySkillDifficultySelection() {
+    return this.args.displaySkillDifficultySelection ?? true;
+  }
+
   get selectedFrameworks() {
     return this.args.frameworks.filter((framework) => this.selectedFrameworkIds.includes(framework.id));
   }
@@ -265,6 +269,7 @@ export default class TubesSelection extends Component {
           @tubeLevels={{this.tubeLevels}}
           @displayDeviceCompatibility={{@displayDeviceCompatibility}}
           @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
+          @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
         />
       {{/if}}
     </div>

--- a/admin/app/components/common/tubes-selection/areas.gjs
+++ b/admin/app/components/common/tubes-selection/areas.gjs
@@ -19,6 +19,7 @@ import Competence from './competence';
               @tubeLevels={{@tubeLevels}}
               @displayDeviceCompatibility={{@displayDeviceCompatibility}}
               @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
+              @displaySkillDifficultySelection={{@displaySkillDifficultySelection}}
             />
           {{/each}}
         </:content>

--- a/admin/app/components/common/tubes-selection/competence.gjs
+++ b/admin/app/components/common/tubes-selection/competence.gjs
@@ -102,6 +102,7 @@ export default class Competence extends Component {
                         @tubeLevels={{@tubeLevels}}
                         @displayDeviceCompatibility={{@displayDeviceCompatibility}}
                         @displaySkillDifficultyAvailability={{@displaySkillDifficultyAvailability}}
+                        @displaySkillDifficultySelection={{@displaySkillDifficultySelection}}
                       />
                     </tr>
                   {{/each}}

--- a/admin/app/components/common/tubes-selection/tube.gjs
+++ b/admin/app/components/common/tubes-selection/tube.gjs
@@ -85,17 +85,19 @@ export default class Tube extends Component {
     </td>
     <td class="table__column--center">
       <div class="level-selection">
-        <PixSelect
-          @screenReaderOnly={{true}}
-          @options={{this.levelOptions}}
-          @value={{this.selectedLevel}}
-          @onChange={{this.setLevelTube}}
-          @placeholder="À sélectionner"
-          @hideDefaultOption={{true}}
-          class="tubes-selection__level-select"
-        >
-          <:label>Sélection du niveau du sujet suivant : {{@tube.practicalTitle}}</:label>
-        </PixSelect>
+        {{#if @displaySkillDifficultySelection}}
+          <PixSelect
+            @screenReaderOnly={{true}}
+            @options={{this.levelOptions}}
+            @value={{this.selectedLevel}}
+            @onChange={{this.setLevelTube}}
+            @placeholder="À sélectionner"
+            @hideDefaultOption={{true}}
+            class="tubes-selection__level-select"
+          >
+            <:label>Sélection du niveau du sujet suivant : {{@tube.practicalTitle}}</:label>
+          </PixSelect>
+        {{/if}}
         {{#if @displaySkillDifficultyAvailability}}
           <div class="skill-availability">
             {{#each this.skillAvailabilityMap as |skillAvailability|}}

--- a/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
@@ -72,7 +72,12 @@ export default class CreationForm extends Component {
     <form>
       <section>
         {{#if this.frameworks.length}}
-          <TubesSelection @frameworks={{this.frameworks}} @onChange={{this.onTubesSelectionChange}} />
+          <TubesSelection
+            @frameworks={{this.frameworks}}
+            @onChange={{this.onTubesSelectionChange}}
+            @displaySkillDifficultyAvailability={{true}}
+            @displaySkillDifficultySelection={{false}}
+          />
           <ul class="framework-creation-form__buttons">
             <li>
               <PixButton @triggerAction={{this.onSubmit}} @isDisabled={{if this.selectedTubes.length false true}}>

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.gjs
@@ -22,6 +22,10 @@ export default class CappedTubesCriterion extends Component {
     });
   }
 
+  get displaySkillDifficultySelection() {
+    return this.args.displaySkillDifficultySelection ?? true;
+  }
+
   get areas() {
     return sortBy(this.areasList, 'code');
   }
@@ -113,6 +117,7 @@ export default class CappedTubesCriterion extends Component {
           @uncheckTube={{this.uncheckTube}}
           @setLevelTube={{this.setLevelTube}}
           @displayDeviceCompatibility={{true}}
+          @displaySkillDifficultySelection={{this.displaySkillDifficultySelection}}
         />
       </main>
     </section>

--- a/admin/tests/unit/components/common/tubes-selection-test.js
+++ b/admin/tests/unit/components/common/tubes-selection-test.js
@@ -8,11 +8,11 @@ import createComponent from '../../../helpers/create-glimmer-component';
 module('Unit | Component | common/tubes-selection', function (hooks) {
   setupTest(hooks);
 
-  let component;
+  let component, frameworks;
 
   hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
-    const frameworks = [
+    frameworks = [
       store.createRecord('framework', { name: 'Pix', id: 'id1' }),
       store.createRecord('framework', { name: 'framework2', id: 'id2' }),
     ];
@@ -252,6 +252,58 @@ module('Unit | Component | common/tubes-selection', function (hooks) {
           level: 8,
         },
       ]);
+    });
+  });
+
+  module('#displaySkillDifficultySelection', function () {
+    module('when skill difficulty selection param is true', function () {
+      test('it should return true', async function (assert) {
+        // given
+        const component = createComponent('component:common/tubes-selection', {
+          displaySkillDifficultySelection: true,
+          frameworks,
+          onChange: sinon.stub(),
+        });
+
+        // when
+        const result = component.displaySkillDifficultySelection;
+
+        // then
+        assert.true(result);
+      });
+    });
+
+    module('when skill difficulty selection param is false', function () {
+      test('it should return false', async function (assert) {
+        // given
+        const component = createComponent('component:common/tubes-selection', {
+          displaySkillDifficultySelection: false,
+          frameworks,
+          onChange: sinon.stub(),
+        });
+
+        // when
+        const result = component.displaySkillDifficultySelection;
+
+        // then
+        assert.false(result);
+      });
+    });
+
+    module('when skill difficulty selection param is not defined', function () {
+      test('it should return true', async function (assert) {
+        // given
+        const component = createComponent('component:common/tubes-selection', {
+          frameworks,
+          onChange: sinon.stub(),
+        });
+
+        // when
+        const result = component.displaySkillDifficultySelection;
+
+        // then
+        assert.true(result);
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Sur Pix Admin, lorsque l'on souhaite créer un nouveau référentiel cadre pour une Pix+, on ne souhaite pas modifier le niveau d'un sujet lorsqu'on le sélectionne.
Problème, le composant que l'on utilise est partagé par d'autres features (la création ou modif d'un profil cible pour n'en citer qu'un) et ces derniers souhaitent garder cette sélection

## ⛱️ Proposition

Conditionner le sélecteur de niveau sur le composant `TubesSelection` pour ne pas l'afficher coté référentiel cadre Pix+

## 🌊 Remarques

On en profite aussi pour afficher petites cartes verte et rouge indiquant les niveaux dispo pour chaque sujet (il fallait simplement renseigner le paramètre `displaySkillDifficultyAvailability`)

## 🏄 Pour tester

Vérifier que les sélecteurs s'affichent toujours dans les features utilisant ce composant
Vérifier que le formulaire du ref cadre affiche les dispos de niveau mais pas le sélecteur
