### PR TITLE
[BUGFIX] Réparer la récupération des données de campagnes volumineuses (PIX-18335)

### DIFF
--- a/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
+++ b/api/src/prescription/campaign/domain/models/CampaignResultLevelsPerTubesAndCompetences.js
@@ -3,22 +3,25 @@ import { TubeResultForKnowledgeElementSnapshots } from './TubeResultForKnowledge
 
 class CampaignResultLevelsPerTubesAndCompetences {
   #tubesWithLevels;
+  #competencesWithLevels;
 
-  constructor({ campaignId, learningContent, knowledgeElementsByParticipation } = {}) {
+  constructor({ campaignId, learningContent } = {}) {
     this.id = campaignId;
     this.learningContent = learningContent;
-    this.knowledgeElementSnapshots = Object.values(knowledgeElementsByParticipation);
-    this.#tubesWithLevels = this.#getTubesWithLevels(learningContent.tubes);
-  }
 
-  #getTubesWithLevels(tubes) {
-    return tubes.map((tube) => {
+    this.#tubesWithLevels = learningContent.tubes.map((tube) => {
       return new TubeResultForKnowledgeElementSnapshots({
         tube,
         competence: this.learningContent.competences.find((competence) => competence.id === tube.competenceId),
-        knowledgeElementSnapshots: this.knowledgeElementSnapshots,
       });
     });
+
+    this.#competencesWithLevels = this.learningContent.competences.map(
+      (competence) =>
+        new CompetenceResultForKnowledgeElementSnapshots({
+          competence,
+        }),
+    );
   }
 
   get levelsPerTube() {
@@ -26,12 +29,7 @@ class CampaignResultLevelsPerTubesAndCompetences {
   }
 
   get levelsPerCompetence() {
-    return this.learningContent.competences.map((competence) => {
-      return new CompetenceResultForKnowledgeElementSnapshots({
-        competence,
-        knowledgeElementSnapshots: this.knowledgeElementSnapshots,
-      });
-    });
+    return this.#competencesWithLevels;
   }
 
   get maxReachableLevel() {
@@ -40,6 +38,15 @@ class CampaignResultLevelsPerTubesAndCompetences {
 
   get meanReachedLevel() {
     return averageBy(this.levelsPerTube, 'meanLevel');
+  }
+
+  addKnowledgeElementSnapshots(knowledgeElementSnapshots) {
+    this.#competencesWithLevels.forEach((competenceResult) =>
+      competenceResult.addKnowledgeElementSnapshots(Object.values(knowledgeElementSnapshots)),
+    );
+    this.#tubesWithLevels.forEach((tubesWithLevel) =>
+      tubesWithLevel.addKnowledgeElementSnapshots(Object.values(knowledgeElementSnapshots)),
+    );
   }
 }
 

--- a/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
@@ -1,6 +1,8 @@
 import { TubeResultForKnowledgeElementSnapshots } from './TubeResultForKnowledgeElementSnapshots.js';
 
 class CompetenceResultForKnowledgeElementSnapshots {
+  #tubeResults;
+
   id;
   index;
   name;
@@ -8,17 +10,23 @@ class CompetenceResultForKnowledgeElementSnapshots {
   meanLevel;
   maxLevel;
 
-  constructor({ competence, knowledgeElementSnapshots } = {}) {
-    const tubeResults = competence.tubes.map(
-      (tube) => new TubeResultForKnowledgeElementSnapshots({ tube, knowledgeElementSnapshots, competence }),
+  constructor({ competence } = {}) {
+    this.#tubeResults = competence.tubes.map(
+      (tube) => new TubeResultForKnowledgeElementSnapshots({ tube, competence }),
     );
 
     this.id = competence.id;
     this.index = competence.index;
     this.name = competence.name;
     this.description = competence.description;
-    this.maxLevel = averageBy(tubeResults, 'maxLevel');
-    this.meanLevel = averageBy(tubeResults, 'meanLevel');
+  }
+
+  addKnowledgeElementSnapshots(knowledgeElementSnapshots) {
+    this.#tubeResults.forEach((tubesWithLevel) =>
+      tubesWithLevel.addKnowledgeElementSnapshots(knowledgeElementSnapshots),
+    );
+    this.maxLevel = averageBy(this.#tubeResults, 'maxLevel');
+    this.meanLevel = averageBy(this.#tubeResults, 'meanLevel');
   }
 }
 

--- a/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/TubeResultForKnowledgeElementSnapshots.js
@@ -1,16 +1,36 @@
 import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 
 class TubeResultForKnowledgeElementSnapshots {
+  #tube;
+  #competence;
   id;
   competenceId;
   competenceName;
   title;
   description;
-  meanLevel;
-  maxLevel;
+  maxLevel = 0;
+  meanLevel = 0;
+  #sum = 0;
+  #count = 0;
 
-  constructor({ tube, knowledgeElementSnapshots, competence } = {}) {
-    const skillIds = tube.skills.map((skill) => skill.id);
+  constructor({ tube, competence } = {}) {
+    this.#tube = tube;
+    this.#competence = competence;
+    this.id = tube.id;
+    this.competenceId = competence.id;
+    this.competenceName = competence.name;
+    this.title = tube.practicalTitle;
+    this.description = tube.practicalDescription;
+    this.maxLevel = tube.getHardestSkill().difficulty;
+  }
+
+  addKnowledgeElementSnapshots(knowledgeElementSnapshots) {
+    const skillIds = this.#tube.skills.map((skill) => skill.id);
+    // TODO: vérifier si on peut utiliser ceux du tubes,
+    const difficultyBySkillId = this.#competence.skills.reduce(
+      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
+      {},
+    );
 
     const tubeValidatedKnowledgeElementSnapshots = knowledgeElementSnapshots.map((knowledgeElementSnapshot) =>
       knowledgeElementSnapshot
@@ -18,36 +38,24 @@ class TubeResultForKnowledgeElementSnapshots {
         .filter((ke) => skillIds.includes(ke.skillId)),
     );
 
-    const difficultyBySkillId = competence.skills.reduce(
-      (acc, skill) => ({ ...acc, [skill.id]: skill.difficulty }),
-      {},
+    const knowledgeElementSnapshotReachedLevels = tubeValidatedKnowledgeElementSnapshots.map(
+      (knowledgeElementSnapshot) => {
+        if (knowledgeElementSnapshot.length === 0) {
+          return 0;
+        }
+        return Math.max(
+          ...knowledgeElementSnapshot.map((knowledgeElement) => difficultyBySkillId[knowledgeElement.skillId]),
+        );
+      },
     );
 
-    this.id = tube.id;
-    this.competenceId = competence.id;
-    this.competenceName = competence.name;
-    this.title = tube.practicalTitle;
-    this.description = tube.practicalDescription;
-    this.maxLevel = tube.getHardestSkill().difficulty;
-    this.meanLevel = this.#computeMeanLevel(difficultyBySkillId, tubeValidatedKnowledgeElementSnapshots);
-  }
+    const sum = knowledgeElementSnapshotReachedLevels.reduce((acc, value) => acc + value, 0);
+    const count = knowledgeElementSnapshotReachedLevels.length;
 
-  #computeMeanLevel(difficultyBySkillId, knowledgeElementSnapshots) {
-    const knowledgeElementSnapshotReachedLevels = knowledgeElementSnapshots.map((knowledgeElementSnapshot) => {
-      if (knowledgeElementSnapshot.length === 0) {
-        return 0;
-      }
-      return Math.max(
-        ...knowledgeElementSnapshot.map((knowledgeElement) => difficultyBySkillId[knowledgeElement.skillId]),
-      );
-    });
-    if (knowledgeElementSnapshotReachedLevels.length === 0) {
-      return 0;
-    }
-    return average(knowledgeElementSnapshotReachedLevels);
+    this.#sum += sum;
+    this.#count += count;
+    this.meanLevel = this.#count === 0 ? 0 : this.#sum / this.#count;
   }
 }
-
-const average = (collection) => collection.reduce((acc, value) => acc + value, 0) / collection.length;
 
 export { TubeResultForKnowledgeElementSnapshots };

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -50,8 +50,8 @@ function computeTubes(campaignId, campaignParticipation, learningContent, knowle
   const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
     campaignId,
     learningContent,
-    knowledgeElementsByParticipation,
   });
+  campaignResultLevelPerTubesAndCompetences.addKnowledgeElementSnapshots(knowledgeElementsByParticipation);
   return campaignResultLevelPerTubesAndCompetences.levelsPerTube.map(
     ({ id, competenceId, competenceName, title, description, meanLevel, maxLevel }) => {
       return new TubeCoverage({

--- a/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
+++ b/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js
@@ -14,11 +14,12 @@ const getResultLevelsPerTubesAndCompetences = async ({
 
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
 
-  return new CampaignResultLevelsPerTubesAndCompetences({
+  const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
     campaignId,
     learningContent,
-    knowledgeElementsByParticipation,
   });
+  campaignResult.addKnowledgeElementSnapshots(knowledgeElementsByParticipation);
+  return campaignResult;
 };
 
 export { getResultLevelsPerTubesAndCompetences };

--- a/api/src/shared/domain/read-models/CampaignReport.js
+++ b/api/src/shared/domain/read-models/CampaignReport.js
@@ -92,19 +92,17 @@ class CampaignReport {
   }
 
   setCoverRate(campaignResultLevelsPerTubesAndCompetences) {
-    this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube.map(
-      ({ id, competenceId, competenceName, title, description, meanLevel, maxLevel }) => {
-        return new TubeCoverage({
-          id,
-          competenceId,
-          competenceName,
-          title,
-          description,
-          maxLevel,
-          reachedLevel: meanLevel,
-        });
-      },
-    );
+    this.tubes = campaignResultLevelsPerTubesAndCompetences.levelsPerTube.map((tube) => {
+      return new TubeCoverage({
+        id: tube.id,
+        competenceId: tube.competenceId,
+        competenceName: tube.competenceName,
+        title: tube.title,
+        description: tube.description,
+        maxLevel: tube.maxLevel,
+        reachedLevel: tube.meanLevel,
+      });
+    });
   }
 
   /**

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignResultLevelsPerTubesAndCompetences_test.js
@@ -111,8 +111,8 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
       const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
         campaignId: 1,
         learningContent,
-        knowledgeElementsByParticipation: keData,
       });
+      campaignResult.addKnowledgeElementSnapshots(keData);
 
       expect(campaignResult.levelsPerTube).to.deep.equal([
         {
@@ -140,8 +140,8 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
       const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
         campaignId: 1,
         learningContent,
-        knowledgeElementsByParticipation: keData,
       });
+      campaignResult.addKnowledgeElementSnapshots(keData);
 
       expect(campaignResult.levelsPerCompetence[0].id).to.deep.equal('competence1');
       expect(campaignResult.levelsPerCompetence[0].index).to.deep.equal('1.1');
@@ -162,8 +162,9 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
       const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
         campaignId: 1,
         learningContent,
-        knowledgeElementsByParticipation: keData,
       });
+      campaignResult.addKnowledgeElementSnapshots(Object.values(keData));
+
       expect(campaignResult.maxReachableLevel).equal(3);
     });
 
@@ -171,8 +172,9 @@ describe('Unit | Domain | Models | CampaignResultLevelPerTubesAndCompetences', f
       const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
         campaignId: 1,
         learningContent,
-        knowledgeElementsByParticipation: keData,
       });
+      campaignResult.addKnowledgeElementSnapshots(Object.values(keData));
+
       expect(campaignResult.meanReachedLevel).equal(1.25);
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/TubeResultForKnowledgeElementSnapshots_test.js
@@ -82,9 +82,9 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         const tubeResult = new TubeResultForKnowledgeElementSnapshots({
           tube,
           competence,
-          knowledgeElementSnapshots,
         });
 
+        tubeResult.addKnowledgeElementSnapshots(knowledgeElementSnapshots);
         //then
         expect(tubeResult.id).equal(tube.id);
         expect(tubeResult.competenceId).equal(tube.competenceId);
@@ -103,7 +103,6 @@ describe('Unit | Domain | Models | TubeResultForKnowledgeElementSnapshots', func
         const tubeResult = new TubeResultForKnowledgeElementSnapshots({
           tube,
           competence,
-          knowledgeElementSnapshots: [],
         });
 
         //then

--- a/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/campaign/build-campaign-result-levels-per-tubes-and-competences.js
@@ -62,10 +62,11 @@ function buildCampaignResultLevelsPerTubesAndCompetences() {
     participationId1: new KnowledgeElementCollection([user1ke1]).latestUniqNonResetKnowledgeElements,
     participationId2: new KnowledgeElementCollection([user2ke1]).latestUniqNonResetKnowledgeElements,
   };
-  return new CampaignResultLevelsPerTubesAndCompetences({
+  const campaignResult = new CampaignResultLevelsPerTubesAndCompetences({
     campaignId: 1,
     learningContent,
-    knowledgeElementsByParticipation: keData,
   });
+  campaignResult.addKnowledgeElementSnapshots(keData);
+  return campaignResult;
 }
 export { buildCampaignResultLevelsPerTubesAndCompetences };


### PR DESCRIPTION
## 🔆 Problème

La mise à dispo des données de participations aux campagnes via l'api fait crasher les conteneurs lorsque les volumes sont trop importants. 

Ce qui cloche dans notre cas, c'est que nous ramenons un gros nombre de participations (environ 23 000 dans notre cas de bug) et pour toutes ces participations, nous ramenons tous les KEsnapshot associés. Cela commence à faire beaucoup de monde. 
 
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

Notre proposition est de découper la récupération des KEsnapshots en découpant en chunk les participations et leur usage, en stockant le résultat temporaire.

On devrait donc avoir une consommation mémoire raisonnable après ce refacto. 
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Ça alors, comme c'est curieux :)

Plus sérieusement, nous 

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Pour cette recette rapide, en 1 min top chrono. 

**Liste des ingrédients** 

1. Un access token 

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12586.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns' | jq -r .access_token)
```
2. Un cerveau 


**étapes :**

1. Chercher les campagnes

```
curl --get https://pix-api-maddo-review-pr12586.osc-fr1.scalingo.io/api/organizations/1000/campaigns -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```
2. Voilà votre pâté de campagne est prêt, bon appétit