### PR TITLE
[BUGFIX] Restreindre les URLs d’API disponibles pour les Embeds (PIX-18327)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.gjs
+++ b/mon-pix/app/components/challenge-embed-simulator.gjs
@@ -119,7 +119,7 @@ export default class ChallengeEmbedSimulator extends Component {
         if (data.enableFetchFromApi) {
           const [requestsPort] = ports;
 
-          this.embedApiProxy.forward(this, requestsPort, `/api/assessments/${this.args.assessmentId}/embed/`);
+          this.embedApiProxy.forward(this, requestsPort, this.args.assessmentId, 'assessment');
         }
 
         if (data.autoLaunch || thisComponent.isSimulatorLaunched) {

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -73,7 +73,7 @@ export default class ModulixEmbed extends ModuleElement {
 
         const [requestsPort] = event.ports;
 
-        this.embedApiProxy.forward(this, requestsPort, `/api/passages/${this.args.passageId}/embed/`);
+        this.embedApiProxy.forward(this, requestsPort, this.args.passageId, 'passage');
       }
     }
 

--- a/mon-pix/app/services/embed-api-proxy.js
+++ b/mon-pix/app/services/embed-api-proxy.js
@@ -3,8 +3,8 @@ import { getOwner } from '@ember/owner';
 import Service from '@ember/service';
 
 export default class EmbedApiProxyService extends Service {
-  forward(context, requestsPort, urlPrefix) {
-    requestsPort.addEventListener('message', (event) => this.handleMessageEvent(event, { urlPrefix }));
+  forward(context, requestsPort, id, modelName) {
+    requestsPort.addEventListener('message', (event) => this.handleMessageEvent(event, { id, modelName }));
 
     requestsPort.start();
 
@@ -13,10 +13,13 @@ export default class EmbedApiProxyService extends Service {
     });
   }
 
-  async handleMessageEvent(event, { fetch = window.fetch, urlPrefix }) {
+  async handleMessageEvent(event, { fetch = window.fetch, modelName, id }) {
+    const adapter = getOwner(this).lookup(`adapter:${modelName}`);
+
     let { url } = event.data;
-    if (url.startsWith('/')) url = url.slice(1);
-    url = urlPrefix + url;
+
+    const urlPrefix = `${adapter.urlForFindRecord(id, modelName)}/embed/`;
+    url = EmbedApiProxyService.buildURL(url, urlPrefix);
 
     const { init } = event.data;
 
@@ -27,7 +30,7 @@ export default class EmbedApiProxyService extends Service {
         ...init,
         headers: {
           ...init.headers,
-          ...this.headers,
+          ...adapter.headers,
         },
       });
 
@@ -52,7 +55,7 @@ export default class EmbedApiProxyService extends Service {
    * @param {string} url
    * @param {string} urlPrefix
    */
-  buildURL(url, urlPrefix) {
+  static buildURL(url, urlPrefix) {
     url = url.trim();
     if (/^https?:\/\//.test(url)) throw new Error('invalid URL');
 
@@ -63,10 +66,6 @@ export default class EmbedApiProxyService extends Service {
     if (!urlPath.startsWith(urlPrefixPath)) throw new Error('invalid URL');
 
     return url;
-  }
-
-  get headers() {
-    return getOwner(this).lookup('adapter:application').headers;
   }
 }
 

--- a/mon-pix/app/services/embed-api-proxy.js
+++ b/mon-pix/app/services/embed-api-proxy.js
@@ -48,7 +48,31 @@ export default class EmbedApiProxyService extends Service {
     }
   }
 
+  /**
+   * @param {string} url
+   * @param {string} urlPrefix
+   */
+  buildURL(url, urlPrefix) {
+    url = url.trim();
+    if (/^https?:\/\//.test(url)) throw new Error('invalid URL');
+
+    url = urlPrefix + trimLeadingSlashes(url);
+
+    const { pathname: urlPath } = new URL(url, window.location);
+    const { pathname: urlPrefixPath } = new URL(urlPrefix, window.location);
+    if (!urlPath.startsWith(urlPrefixPath)) throw new Error('invalid URL');
+
+    return url;
+  }
+
   get headers() {
     return getOwner(this).lookup('adapter:application').headers;
   }
+}
+
+function trimLeadingSlashes(path) {
+  while (path.startsWith('/')) {
+    path = path.slice(1);
+  }
+  return path;
 }

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -199,7 +199,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
           window.dispatchEvent(event);
 
           // then
-          sinon.assert.calledWith(forwardStub, sinon.match.object, requestsPort, `/api/assessments/123/embed/`);
+          sinon.assert.calledWith(forwardStub, sinon.match.object, requestsPort, '123', 'assessment');
           assert.ok(true);
         });
       });

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -227,7 +227,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
             window.dispatchEvent(event);
 
             // then
-            sinon.assert.calledWith(forwardStub, sinon.match.object, requestsPort, `/api/passages/${passageId}/embed/`);
+            sinon.assert.calledWith(forwardStub, sinon.match.object, requestsPort, passageId, 'passage');
             assert.ok(true);
           });
 

--- a/mon-pix/tests/unit/services/embed-api-proxy-test.js
+++ b/mon-pix/tests/unit/services/embed-api-proxy-test.js
@@ -151,4 +151,74 @@ module('Unit | Services | embed api proxy', function (hooks) {
       });
     });
   });
+
+  module('#buildURL', function () {
+    test('it should prefix URL with prefix', function (assert) {
+      // given
+      const url = 'chat/456';
+      const urlPrefix = '/api/passages/123/embed/';
+
+      // when
+      const actualURL = embedApiProxy.buildURL(url, urlPrefix);
+
+      // then
+      assert.strictEqual(actualURL, '/api/passages/123/embed/chat/456');
+    });
+
+    module('when URL has leading slashes', function () {
+      test('it should trim leading slashes', function (assert) {
+        // given
+        const url = '///chat/456';
+        const urlPrefix = '/api/passages/123/embed/';
+
+        // when
+        const actualURL = embedApiProxy.buildURL(url, urlPrefix);
+
+        // then
+        assert.strictEqual(actualURL, '/api/passages/123/embed/chat/456');
+      });
+    });
+
+    module('when URL prefix includes host', function () {
+      test('it should keep host', function (assert) {
+        // given
+        const url = 'chat/456';
+        const urlPrefix = 'https://api.example.com/api/passages/123/embed/';
+
+        // when
+        const actualURL = embedApiProxy.buildURL(url, urlPrefix);
+
+        // then
+        assert.strictEqual(actualURL, 'https://api.example.com/api/passages/123/embed/chat/456');
+      });
+    });
+
+    module('when URL goes out of prefix', function () {
+      test('it should throw an error', function (assert) {
+        // given
+        const url = '../chat/456';
+        const urlPrefix = '/api/passages/123/embed/';
+
+        // when
+        const call = () => embedApiProxy.buildURL(url, urlPrefix);
+
+        // then
+        assert.throws(call, new Error('invalid URL'));
+      });
+    });
+
+    module('when URL includes host', function () {
+      test('it should throw an error', function (assert) {
+        // given
+        const url = 'https://example.com/should/not/work';
+        const urlPrefix = '/api/passages/123/embed/';
+
+        // when
+        const call = () => embedApiProxy.buildURL(url, urlPrefix);
+
+        // then
+        assert.throws(call, new Error('invalid URL'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement il existe 2 failles dans la mise à disposition de l’API pour les Embeds :
 - L’embed peut utiliser `../` dans l’URL pour sortir du préfixe d’URL imposé par Pix App
 - L’embed peut mettre un host dans l’URL et requêter un autre site

D’autre part si la variable d’environnement `API_HOST` est utilisée (certes c’est rarissime), celle-ci ne s’applique pas aux requêtes de l’Embed.

## ⛱️ Proposition

 - S’appuyer sur les adapters pour construire le préfixe d’URL
 - Ajouter des vérifications sur l’URL finale pour être sûr qu’elle respecte le préfixe

## 🌊 Remarques

N/A

## 🏄 Pour tester

Vérifier que le LLM fonctionne toujours dans Modulix et en Eval.