### PR TITLE
[TECH] Mettre à jour le message Slack pour indiquer seulement que la mise en recette est lancée

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-            text: "Coucou :wave:\nLa v${{ env.new_release_version }} est en recette <!subteam^S074J8W3Q77>\nMettez vos messages en :thread:"
+            text: "Coucou, Je lance la mise en recette de la version ${{ env.new_release_version }}. <@${{ secrets.PO_ID }}> mettez vos messages en :thread:"


### PR DESCRIPTION
## 🔆 Problème

On indique dans le message slack envoyé lors de la release, que la mise en recette est faite, ce qui est faux. Sur pix-bot, on a implémenté un webhook qui va notifier sur Slack lorsque toutes les applications seront déployées.

## ⛱️ Proposition

Modifier le message Slack de la release pour indiquer seulement que la MER est lancée, pas qu'elle est terminée.

## 🌊 Remarques

RAS.