### PR TITLE
[TECH] Suppression de la complementaryCertificationId au profit de complementaryCertificationKey dans la table certification-frameworks-challenges

### DIFF
--- a/api/db/database-builder/factory/build-certification-frameworks-challenge.js
+++ b/api/db/database-builder/factory/build-certification-frameworks-challenge.js
@@ -8,12 +8,12 @@ const buildCertificationFrameworksChallenge = function ({
   id = databaseBuffer.getNextId(),
   alpha = 2.2,
   delta = 3.5,
-  complementaryCertificationId,
+  complementaryCertificationKey,
   challengeId,
 } = {}) {
-  complementaryCertificationId = _.isUndefined(complementaryCertificationId)
-    ? buildComplementaryCertification().id
-    : complementaryCertificationId;
+  complementaryCertificationKey = _.isUndefined(complementaryCertificationKey)
+    ? buildComplementaryCertification().key
+    : complementaryCertificationKey;
 
   challengeId = _.isUndefined(challengeId) ? buildChallenge().id : challengeId;
 
@@ -21,7 +21,7 @@ const buildCertificationFrameworksChallenge = function ({
     id,
     alpha,
     delta,
-    complementaryCertificationId,
+    complementaryCertificationKey,
     challengeId,
   };
 

--- a/api/db/migrations/20250618150531_change-complementaryCertificationId-to-complementaryCertificationKey-in-certification-frameworks-challenges-table.js
+++ b/api/db/migrations/20250618150531_change-complementaryCertificationId-to-complementaryCertificationKey-in-certification-frameworks-challenges-table.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const OLD_COLUMN_NAME = 'complementaryCertificationId';
+const NEW_COLUMN_NAME = 'complementaryCertificationKey';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(NEW_COLUMN_NAME);
+    table.foreign(NEW_COLUMN_NAME).references('complementary-certifications.key');
+
+    table.dropColumn(OLD_COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(OLD_COLUMN_NAME).unsigned();
+    table.foreign(OLD_COLUMN_NAME).references('complementary-certifications.id');
+
+    table.dropColumn(NEW_COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -1,13 +1,10 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { complementaryCertificationRepository } from '../../../shared/infrastructure/repositories/complementary-certification-repository.js';
 
 export async function create({ complementaryCertificationKey, challenges }) {
   const knexConn = DomainTransaction.getConnection();
 
-  const complementaryCertification = await complementaryCertificationRepository.getByKey(complementaryCertificationKey);
-
   const challengesDTO = challenges.map((challenge) => ({
-    complementaryCertificationId: complementaryCertification.id,
+    complementaryCertificationKey,
     challengeId: challenge.id,
   }));
 

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -118,14 +118,14 @@ export async function findActiveFlashCompatible({
   locale,
   successProbabilityThreshold = config.features.successProbabilityThreshold,
   accessibilityAdjustmentNeeded = false,
-  complementaryCertificationId,
+  complementaryCertificationKey,
 } = {}) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
   let challengeDtos;
 
-  if (complementaryCertificationId) {
-    challengeDtos = await _findChallengesForComplementaryCertification({ complementaryCertificationId, cacheKey });
+  if (complementaryCertificationKey) {
+    challengeDtos = await _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey });
   } else {
     challengeDtos = await _findChallengesForCoreCertification({ locale, accessibilityAdjustmentNeeded, cacheKey });
   }
@@ -135,10 +135,10 @@ export async function findActiveFlashCompatible({
   );
 }
 
-async function _findChallengesForComplementaryCertification({ complementaryCertificationId, cacheKey }) {
+async function _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey }) {
   const complementaryCertificationChallenges = await knex
     .from('certification-frameworks-challenges')
-    .where({ complementaryCertificationId });
+    .where({ complementaryCertificationKey });
 
   const complementaryCertificationChallengesIds = complementaryCertificationChallenges.map(
     ({ challengeId }) => challengeId,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -288,16 +288,16 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       expect(response.result.data.id).to.exist;
 
       const consolidatedFramework = await knex('certification-frameworks-challenges')
-        .select('alpha', 'delta', 'challengeId', 'complementaryCertificationId')
+        .select('alpha', 'delta', 'challengeId', 'complementaryCertificationKey')
         .where({
-          complementaryCertificationId: complementaryCertification.id,
+          complementaryCertificationKey: complementaryCertification.key,
         });
       expect(consolidatedFramework).to.deep.equal([
         {
           alpha: null,
           delta: null,
           challengeId: challenge.id,
-          complementaryCertificationId: complementaryCertification.id,
+          complementaryCertificationKey: complementaryCertification.key,
         },
       ]);
     });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -29,7 +29,7 @@ describe('Certification | Configuration | Integration | Repository | consolidate
 
       // then
       const consolidatedFrameworkInDB = await knex('certification-frameworks-challenges').select(
-        'complementaryCertificationId',
+        'complementaryCertificationKey',
         'challengeId',
         'alpha',
         'delta',
@@ -38,13 +38,13 @@ describe('Certification | Configuration | Integration | Repository | consolidate
 
       expect(consolidatedFrameworkInDB).to.have.lengthOf(2);
       expect(_.omit(consolidatedFrameworkInDB[0], 'createdAt')).to.deep.equal({
-        complementaryCertificationId: complementaryCertification.id,
+        complementaryCertificationKey: complementaryCertification.key,
         challengeId: challenge1.id,
         alpha: null,
         delta: null,
       });
       expect(_.omit(consolidatedFrameworkInDB[1], 'createdAt')).to.deep.equal({
-        complementaryCertificationId: complementaryCertification.id,
+        complementaryCertificationKey: complementaryCertification.key,
         challengeId: challenge2.id,
         alpha: null,
         delta: null,

--- a/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
+++ b/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
@@ -34,7 +34,7 @@ describe('Integration | Scripts | Certification | target-profile-to-calibrated-f
     const frameworksChallenges = await knex('certification-frameworks-challenges');
     expect(frameworksChallenges).to.have.length(1);
     expect(frameworksChallenges[0].challengeId).to.equal(learningContent.challenges[0].id);
-    expect(frameworksChallenges[0].complementaryCertificationId).to.equal(complementaryCertification.id);
+    expect(frameworksChallenges[0].complementaryCertificationKey).to.equal(complementaryCertification.key);
     expect(frameworksChallenges[0].createdAt).to.be.instanceOf(Date);
     expect(frameworksChallenges[0].alpha).to.be.null;
     expect(frameworksChallenges[0].delta).to.be.null;

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1836,14 +1836,14 @@ describe('Integration | Repository | challenge-repository', function () {
         databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
         const certificationFrameworksChallenge = databaseBuilder.factory.buildCertificationFrameworksChallenge({
-          complementaryCertificationId: complementaryCertification.id,
+          complementaryCertificationKey: complementaryCertification.key,
           challengeId: challengesLC[0].id,
         });
 
         await databaseBuilder.commit();
 
         const flashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({
-          complementaryCertificationId: complementaryCertification.id,
+          complementaryCertificationKey: complementaryCertification.key,
           locale: 'fr',
         });
 


### PR DESCRIPTION
## 🔆 Problème

Nous faisons actuellement référence à l'id technique des certifications complémentaires dans la table `certification-frameworks-challenges`.
Cela n'apporte aucune valeur ajoutée par rapport à l'utilisation de la clé de ces mêmes certifications-complémentaires, elle aussi unique.

## ⛱️ Proposition

- Migration pour supprimer la colonne `complementaryCertificationId` et rajouter la colonne `complementaryCertificationKey`
- Mise à jour du code utilisant l'ancienne colonne

## 🌊 Remarques

Aucune risque lié à la suppression de l'ancienne colonne, qui ne contient pas encore de données sur les différents environnements.

## 🏄 Pour tester

- Tests vers ✅ 

- Création d'un référentiel cadre via une liste de tubes 

```bash
TOKEN=$(curl --insecure 'https://admin-pr12592.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr12592.review.pix.fr/api/admin/complementary-certifications/DROIT/consolidated-framework \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "data": { "attributes": { "tubeIds": ["rec1ahEQ4rwrml6Lo"] }}}'
```

- Création d'un référentiel cadre à partir du script dédié

```
scalingo -a "pix-api-review-pr12592" run "LOG_LEVEL=info node scripts/certification/target-profile-to-calibrated-framework.js --complementaryCertificationKey='DROIT' --targetProfileId=8000"
```