### PR TITLE
[TECH] Rend disponible les routes LSU/LSL via maddo.

### DIFF
--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -5,6 +5,7 @@ import { parse } from 'neoqs';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 import { databaseConnections } from './db/database-connections.js';
 import { knex } from './db/knex-database-connection.js';
+import * as livretScolaireRoutes from './src/certification/results/application/livret-scolaire-route.js';
 import * as parcoursupRoutes from './src/certification/results/application/parcoursup-route.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
@@ -184,6 +185,7 @@ const setupRoutesAndPlugins = async function (server) {
     organizationsRoutes,
     replicationsRoutes,
     parcoursupRoutes,
+    livretScolaireRoutes,
   ];
   const routesWithOptions = routes.map((route) => ({
     plugin: route,

--- a/api/server.maddo.js
+++ b/api/server.maddo.js
@@ -13,6 +13,7 @@ import * as campaignsRoutes from './src/maddo/application/campaigns-routes.js';
 import * as organizationsRoutes from './src/maddo/application/organizations-routes.js';
 import * as replicationsRoutes from './src/maddo/application/replications-routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
+import * as franceTravailRoutes from './src/prescription/campaign-participation/application/pole-emploi-route.js';
 import * as healthcheckRoutes from './src/shared/application/healthcheck/index.js';
 import { config } from './src/shared/config.js';
 import { installHapiHook } from './src/shared/infrastructure/async-local-storage.js';
@@ -185,6 +186,7 @@ const setupRoutesAndPlugins = async function (server) {
     organizationsRoutes,
     replicationsRoutes,
     parcoursupRoutes,
+    franceTravailRoutes,
     livretScolaireRoutes,
   ];
   const routesWithOptions = routes.map((route) => ({


### PR DESCRIPTION
## 🔆 Problème

Les appels LSU/LSL sont trop impactants sur la prod. A chaque appel le conteneur est immobilisé pendant longtemps et pendant ce temps là il se met à accepter pleins de requêtes http (effet du réactif await /async), ce qui fait qu'il n'a plus la capacité à gérer et génère une centaine d'erreurs de timeout sur l'app.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

Ajouter la route `/api/organizations/{uai}/certifications` au serveur maddo.
On en profite pour ajouter également les routes France Travail.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

Il faudra sans doute un jour rendre cohérents les résultats de certifications exposées aux partenaires.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Créer un client application dont le scope est `organizations-certifications-result` avec le script

```
node ./scripts/identity-access-management/client-applications.js add --name maddo-client --clientId maddo-client --scope=meta --scope=organizations-certifications-result --clientSecret=maddo-secret
```

Créer un token avec le scope `organizations-certifications-result`

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12593.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=organizations-certifications-result' | jq -r .access_token)
```

Appeler la route livret scolaire avec le token :

```
curl -X GET https://pix-api-maddo-review-pr12593.osc-fr1.scalingo.io/api/organizations/1000/certifications -H "Authorization: Bearer $ACCESS_TOKEN"
```

Refaire la même chose avec un token dont le scope est `pole-emploi-participants-result` et la route `GET /api/pole-emploi/envois`.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
