### PR TITLE
[FEATURE] Supporter plus d'options de configuration d'embed par le message init dans un module (PIX-18197)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -225,8 +225,12 @@
           "type": "element",
           "element": {
             "id": "ccaefecd-db35-40ea-a6f9-8d42fb907e63",
-            "type": "text",
-            "content": "<iframe title=\"carteagratter\" src=\"https://epreuves.pix.fr/fr/puzzle/example.html\" height=\"445\"></iframe>"
+            "type": "embed",
+            "isCompletionRequired": false,
+            "title": "Carte à gratter",
+            "url": "https://epreuves.pix.fr/fr/puzzle/example.html",
+            "instruction": "<p>Instruction</p>",
+            "height": 445
           }
         }
       ]

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -87,6 +87,10 @@ export default class ModulixEmbed extends ModuleElement {
       if (!message.rebootable) {
         this.isSimulatorRebootable = false;
       }
+
+      if (message.autoLaunch) {
+        this.startSimulator();
+      }
     }
 
     if (!this.args.embed.isCompletionRequired) return;

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -25,6 +25,10 @@ export default class ModulixEmbed extends ModuleElement {
 
   @tracked
   isSimulatorLaunched = false;
+
+  @tracked
+  isSimulatorRebootable = true;
+
   embedHeight = this.args.embed.height;
   iframe;
   messageHandler = null;
@@ -42,6 +46,10 @@ export default class ModulixEmbed extends ModuleElement {
 
   get heightStyle() {
     return htmlUnsafe(`height: ${this.embedHeight}px`);
+  }
+
+  get resetButtonDisplayed() {
+    return this.isSimulatorLaunched && this.isSimulatorRebootable;
   }
 
   @action
@@ -74,6 +82,10 @@ export default class ModulixEmbed extends ModuleElement {
         const [requestsPort] = event.ports;
 
         this.embedApiProxy.forward(this, requestsPort, this.args.passageId, 'passage');
+      }
+
+      if (!message.rebootable) {
+        this.isSimulatorRebootable = false;
       }
     }
 
@@ -135,7 +147,7 @@ export default class ModulixEmbed extends ModuleElement {
         {{/unless}}
       </div>
 
-      {{#if this.isSimulatorLaunched}}
+      {{#if this.resetButtonDisplayed}}
         <div class="element-embed__reset">
           <PixButton
             @iconBefore="refresh"

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -14,6 +14,7 @@ export default class ModulixEmbed extends ModuleElement {
     super(...args);
 
     this.messageHandler = this._receiveEmbedMessage.bind(this);
+    this.embedHeight = this.args.embed.height;
     window.addEventListener('message', this.messageHandler);
   }
 
@@ -29,7 +30,9 @@ export default class ModulixEmbed extends ModuleElement {
   @tracked
   isSimulatorRebootable = true;
 
-  embedHeight = this.args.embed.height;
+  @tracked
+  embedHeight;
+
   iframe;
   messageHandler = null;
 
@@ -72,6 +75,10 @@ export default class ModulixEmbed extends ModuleElement {
     const message = this._getMessageFromEventData(event);
 
     if (message?.from !== 'pix') return;
+
+    if (message.type === 'height') {
+      this.embedHeight = message.height;
+    }
 
     if (message.type === 'init') {
       if (message.enableFetchFromApi) {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -470,6 +470,38 @@ module('Integration | Component | Module | Embed', function (hooks) {
         .dom(await screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.start.ariaLabel') }))
         .doesNotExist();
     });
+  });
+
+  module('when embed send its height', function () {
+    test('should set embed with value of height attribute', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'Simulateur',
+        isCompletionRequired: true,
+        url: 'https://example.org',
+        height: 800,
+      };
+      const passageId = '5729837548';
+      const screen = await render(<template><ModulixEmbed @embed={{embed}} @passageId={{passageId}} /></template>);
+      await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // when
+      const iframe = screen.getByTitle('Simulateur');
+      const event = new MessageEvent('message', {
+        data: { type: 'height', from: 'pix', height: 400 },
+        origin: 'https://epreuves.pix.fr',
+        source: iframe.contentWindow,
+      });
+
+      window.dispatchEvent(event);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // then
+      assert.strictEqual(iframe.style.getPropertyValue('height'), '400px');
+    });
+  });
 
   module('when user clicks on reset button', function () {
     test('should focus on the iframe', async function (assert) {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -442,6 +442,35 @@ module('Integration | Component | Module | Embed', function (hooks) {
     });
   });
 
+  module('when embed send autolaunch configuration with a true value', function () {
+    test('should hide the start button', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'Simulateur',
+        isCompletionRequired: true,
+        url: 'https://example.org',
+        height: 800,
+      };
+      const passageId = '5729837548';
+      const screen = await render(<template><ModulixEmbed @embed={{embed}} @passageId={{passageId}} /></template>);
+
+      // when
+      const iframe = screen.getByTitle('Simulateur');
+      const event = new MessageEvent('message', {
+        data: { type: 'init', from: 'pix', autoLaunch: true },
+        origin: 'https://epreuves.pix.fr',
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(event);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // then
+      assert
+        .dom(await screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.start.ariaLabel') }))
+        .doesNotExist();
+    });
+
   module('when user clicks on reset button', function () {
     test('should focus on the iframe', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -313,6 +313,39 @@ module('Integration | Component | Module | Embed', function (hooks) {
             assert.ok(true);
           });
         });
+
+        module('when message data has rebootable=false', function () {
+          test('should not display reset button', async function (assert) {
+            // given
+            const embed = {
+              id: 'id',
+              title: 'Simulateur',
+              isCompletionRequired: true,
+              url: 'https://example.org',
+              height: 800,
+            };
+            const passageId = '5729837548';
+            const screen = await render(
+              <template><ModulixEmbed @embed={{embed}} @passageId={{passageId}} /></template>,
+            );
+
+            // when
+            const iframe = screen.getByTitle('Simulateur');
+            const event = new MessageEvent('message', {
+              data: { type: 'init', from: 'pix', rebootable: false },
+              origin: 'https://epreuves.pix.fr',
+              source: iframe.contentWindow,
+            });
+            window.dispatchEvent(event);
+
+            await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
       });
 
       module('when message is not from pix', function () {


### PR DESCRIPTION
## 🔆 Problème

Certains embeds envoient un message d'`'init'` pour annoncer comment elles seront affichées. Cela n'est pas pris en compte actuellement.

## ⛱️ Proposition

Prendre en compte ces options. Cela concerne : 
- la hauteur envoyé par l'embed avec le message de type `height`
- le bouton réinitialiser optionnel avec le champ `rebootable`
- le bouton commencer optionnel avec le champ `autoLaunch`

## 🌊 Remarques

- On en profite pour mettre à jour le simulateur carte à gratter dans le module utiliser-souris-ordinateur-1.

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12594.review.pix.fr/modules/bac-a-sable/passage) et commencer le module
- Vérifier que le simulateur affiché a bien : 
  - les boutons réessayer et commencer caché
  - une hauteur différente de celle passée dans la configuration donc supérieure à 5px 😄 
