### PR TITLE
[FEATURE] Anonymiser les pix label lors la suppresion d'une campagne (PIX-18286)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -60,6 +60,10 @@ const deleteCampaigns = async ({
       assessment.detachCampaignParticipation();
       await assessmentRepository.updateCampaignParticipationId(assessment);
     }
+
+    const campaignIdsToDelete = campaignDestructor.campaigns.map(({ id }) => id);
+
+    await campaignAdministrationRepository.deleteExternalIdLabelFromCampaigns(campaignIdsToDelete);
   }
 
   await campaignAdministrationRepository.remove(campaignsToDelete);

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -188,6 +188,22 @@ const archiveCampaigns = function (campaignIds, userId) {
   });
 };
 
+/**
+ * Deletes the external ID label from campaigns features.
+ *
+ * @param {number[]} campaignIds - The IDs of the campaigns to update.
+ * @returns {Promise<void>}
+ */
+export const deleteExternalIdLabelFromCampaigns = (campaignIds) => {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('campaign-features')
+    .update('params', knex.raw("params - 'label'"))
+    .updateFrom('features')
+    .where('features.id', '=', knex.raw('??', ['campaign-features.featureId']))
+    .where('features.key', '=', CAMPAIGN_FEATURES.EXTERNAL_ID.key)
+    .whereIn('campaign-features.campaignId', campaignIds);
+};
+
 export {
   archiveCampaigns,
   get,


### PR DESCRIPTION
## 🔆 Problème

Lors de la suppression d'une campagne, nous souhaitons supprimer le label dans la table `campaign-features` pour éviter de garder des données personnelles.

## ⛱️ Proposition

Dans le usecase de suppression, supprimer les labels concernés en base. 

## 🏄 Pour tester

isAnonymizationWithDeletion : false
Supprimer une campagne avec identifiant externe : vérifier que le label est toujours présent en BDD dans la table campaign-features .

isAnonymizationWithDeletion : true
Supprimer une campagne avec identifiant externe : vérifier que le label n'est plus présent en BDD dans la table campaign-features . Mais que la feature est conservée.