### PR TITLE
[FEATURE] Traiter les retours design sur l'élément QAB (PIX-18160)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_proposal-button.scss
+++ b/mon-pix/app/components/module/element/qab/_proposal-button.scss
@@ -28,7 +28,7 @@
     --qab-proposal-border-color: var(--pix-primary-100);
 
     background: var(--pix-neutral-20);
-    cursor: not-allowed;
+    cursor: wait;
   }
 
   &--selected.qab-proposal-button--success {

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -33,6 +33,10 @@
 
 @include breakpoints.device-is('tablet') {
   .element-qab {
+    &__cards {
+      justify-content: normal;
+    }
+
     &__proposals {
       gap: calc(var(--pix-spacing-10x) * 2);
       max-width: none;

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -14,7 +14,6 @@
     display: grid;
     grid-template-areas: 'center';
     justify-content: center;
-    margin-bottom: var(--pix-spacing-12x);
   }
 
   &__proposals {
@@ -23,7 +22,15 @@
     gap: var(--pix-spacing-3x);
     justify-content: center;
     max-width: 240px;
+    height: 106px;
     margin: auto;
+    margin-top: var(--pix-spacing-12x);
+    transition: height 400ms;
+
+    &--empty {
+      height: 0;
+      margin-top: 0;
+    }
   }
 }
 
@@ -40,6 +47,11 @@
     &__proposals {
       gap: calc(var(--pix-spacing-10x) * 2);
       max-width: none;
+      height: 75px;
+
+      &--empty {
+        height: 0;
+      }
     }
   }
 }

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -145,8 +145,8 @@ export default class ModuleQab extends ModuleElement {
             <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}} @onRetry={{this.onRetry}} />
           {{/if}}
         </div>
-        {{#if this.shouldDisplayCards}}
-          <div class="element-qab__proposals">
+        <div class="element-qab__proposals {{unless this.shouldDisplayCards 'element-qab__proposals--empty'}}">
+          {{#if this.shouldDisplayCards}}
             <QabProposalButton
               @text={{this.currentCard.proposalA}}
               @option="A"
@@ -161,8 +161,8 @@ export default class ModuleQab extends ModuleElement {
               @isSelected={{this.isProposalSelected "B"}}
               @isDisabled={{this.isAnswered}}
             />
-          </div>
-        {{/if}}
+          {{/if}}
+        </div>
       </fieldset>
     </form>
   </template>

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -8,7 +8,7 @@
   --modulix-radius-s: 8px;
   --modulix-radius: 16px;
   --modulix-radius-l: 24px;
-  --modulix-z-index-above-all: 2;
+  --modulix-z-index-above-all: 10;
 
   flex-grow: 1;
   color: var(--pix-neutral-900);
@@ -16,7 +16,7 @@
 }
 
 .modulix-beta-banner {
-  --modulix-z-index-above-all: 2;
+  --modulix-z-index-above-all: 10;
 
   z-index: var(--modulix-z-index-above-all);
 }


### PR DESCRIPTION
## 🔆 Problème

Suite à la PR https://github.com/1024pix/pix/pull/12447, Il y avait des retours qui n'étaient pas traités.

## ⛱️ Proposition

Implémenter les changements demandés en incluant les retours design :
- carte de score n'ayant pas la même taille que les autres
- même transition que sur les flashcards lors du passage sur la carte de score qui est sur la hauteur

## 🌊 Remarques

Autres changements effectués : 
- Ajout d'un `cursor:wait` lorsque la carte est à l'état `disabled`
- Augmentation de la valeur du z-index `--modulix-z-index-above-all` à 10 car elle était inférieure au QAB.
- Ajout d'une hauteur fixe sur les boutons du QAB pour la transition

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12598.review.pix.fr/modules/bac-a-sable/passage)
- Répondre à la 1ère carte. Vérifier que le curseur a bien été modifié (`cursor: wait`)
- Continuer à répondre jusqu'à arriver à la dernière carte (avant la carte de score).
- Répondre et constater la transition sur les boutons.
- Vérifier que la carte de score a bien la même taille que les autres cartes.
