### PR TITLE
[POC] Permettre de prévisualiser des modules existants

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -92,6 +92,11 @@ export default class ModulixPreview extends Component {
   }
 
   get formattedModule() {
+    console.log(this.args.module);
+    if (this.args.module) {
+      return this.args.module;
+    }
+
     if (!this.module || this.module === '') {
       return { grains: [] };
     }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -101,6 +101,7 @@ Router.map(function () {
     this.route('existing-participation', { path: '/participation-existante' });
   });
 
+  this.route('module-preview-slug', { path: '/modules/preview/:slug' });
   this.route('module-preview', { path: '/modules/preview' });
   this.route('module', { path: '/modules/:slug' }, function () {
     this.route('details');

--- a/mon-pix/app/routes/module-preview-slug.js
+++ b/mon-pix/app/routes/module-preview-slug.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModulePreviewSlugRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const queryRecord = await this.store.queryRecord('module', { slug: params.slug });
+    console.log(params.slug);
+    return queryRecord;
+  }
+}

--- a/mon-pix/app/templates/module-preview-slug.gjs
+++ b/mon-pix/app/templates/module-preview-slug.gjs
@@ -1,0 +1,2 @@
+import Preview from 'mon-pix/components/module/preview';
+<template><Preview @module={{@model}} /></template>


### PR DESCRIPTION
## 🔆 Contexte

Aujourd’hui, l'équipe Contenu Modulix utilise principalement Google Docs pour collaborer sur la création d’un module, notamment pour faire de la revue et échanger des commentaires. Mais il serait beaucoup plus pratique de pouvoir le faire directement sur les modules dans leur navigateur.

## Problème

L’extension de navigateur [Hypothes.is](https://web.hypothes.is/) permet de faire des commentaires sur n’importe quel page web et a des fonctionnalités intéressantes comme la restriction de la visibilité des commentaires à un groupe privé.

L’extension ne peut pas être utilisée sur une page interactive de module, car tous les éléments se sont pas affichés au chargement de la page, et l’extension ne sait pas où placer les commentaires les concernant.

La preview Modulix qui affiche tout le contenu du module dès le chargement de la page permettrait de résoudre ce problème, mais elle est généré dynamiquement par Modulix Editor en passant un JSON à une page avec une url générique (/modules/preview). Or, [Hypothes.is](http://hypothes.is/) a besoin d’une url unique pour s’y retrouver.

## ⛱️ Proposition

Pouvoir prévisualiser un module existant (donc d’après le fichier JSON inclus dans l’API) en ajoutant son slug à la fin de l’url (ex : /modules/preview/bac-a-sable).

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier le bon affichage du module déplié :
https://app-pr12599.review.pix.fr/modules/preview/bac-a-sable
