### PR TITLE
[TECH] Ajout d'un log en cas de différence entre le sub récupéré et le précédent (externalIdentifier) (PIX-18360)

### DIFF
--- a/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
@@ -47,20 +47,22 @@ const findUserForOidcReconciliation = async function ({
       (authenticationMethod) => authenticationMethod.identityProvider === identityProvider,
     );
 
-    const isSameExternalIdentifier =
-      oidcAuthenticationMethod?.externalIdentifier === sessionContentAndUserInfo.userInfo.externalIdentityId;
-    if (oidcAuthenticationMethod && !isSameExternalIdentifier) {
-      monitoringTools.logErrorWithCorrelationIds({
-        message: 'Different externalIdentifier (sub)',
-        context: 'oidc',
-        data: {
-          externalIdentifier: sessionContentAndUserInfo.userInfo.externalIdentityId,
-          previousExternalIdentifier: oidcAuthenticationMethod.externalIdentifier,
-        },
-        team: 'acces',
-      });
+    if (oidcAuthenticationMethod) {
+      const isDifferentFromPreviousExternalIdentifier =
+        sessionContentAndUserInfo.userInfo.externalIdentityId != oidcAuthenticationMethod.externalIdentifier;
+      if (isDifferentFromPreviousExternalIdentifier) {
+        monitoringTools.logErrorWithCorrelationIds({
+          message: 'Different externalIdentifier (sub)',
+          context: 'oidc',
+          data: {
+            externalIdentifier: sessionContentAndUserInfo.userInfo.externalIdentityId,
+            previousExternalIdentifier: oidcAuthenticationMethod.externalIdentifier,
+          },
+          team: 'acces',
+        });
 
-      throw new DifferentExternalIdentifierError();
+        throw new DifferentExternalIdentifierError();
+      }
     }
 
     sessionContentAndUserInfo.userInfo.userId = foundUser.id;

--- a/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
@@ -1,4 +1,5 @@
 import { UserNotFoundError } from '../../../shared/domain/errors.js';
+import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
@@ -49,6 +50,16 @@ const findUserForOidcReconciliation = async function ({
     const isSameExternalIdentifier =
       oidcAuthenticationMethod?.externalIdentifier === sessionContentAndUserInfo.userInfo.externalIdentityId;
     if (oidcAuthenticationMethod && !isSameExternalIdentifier) {
+      monitoringTools.logErrorWithCorrelationIds({
+        message: 'Different externalIdentifier (sub)',
+        context: 'oidc',
+        data: {
+          externalIdentifier: sessionContentAndUserInfo.userInfo.externalIdentityId,
+          previousExternalIdentifier: oidcAuthenticationMethod.externalIdentifier,
+        },
+        team: 'acces',
+      });
+
       throw new DifferentExternalIdentifierError();
     }
 


### PR DESCRIPTION
## 🔆 Problème

Il semble que pour certains comptes utilisateurs identifiés par OIDC le `sub` change dans le temps. Nous avons besoin de suivre ce type d’erreur très précisément pour les quantifier.

## ⛱️ Proposition

Ajouter un log dédié `Different externalIdentifier (sub)` en utilisant `logErrorWithCorrelationIds` avec la valeur du `sub` récupéré et la précédente valeur du `sub` (`externalIdentifier`) précédent.

## 🌊 Remarques

Un 2ème commit rend la gestion de cette erreur un peu plus claire et plus facile à identifier et retrouver.

## 🏄 Pour tester

Pour tester en _local_ : 

1. S’authentifier avec un SSO OIDC (n’importe lequel)
2. Associer cette identité avec un utilisateur existant en BDD (par exemple `james-paledroits@example.net`)
3. Se déconnecter
4. Modifier l’`externalIdentifier` de l’`authenticationMethod de ce user : 
```sql
update "authentication-methods" set "externalIdentifier"='THIS_IS_THE_PREVIOUS_VALUE' where "identityProvider"='SOME_IDENTITY_PROVIDER' and "userId" in (select "userId" from users where email='james-paledroits@example.net');
```
5. Se ré-authentifier avec le même SSO OIDC
6. Constater la présence du log donnant les infos supplémentaires allant avec le message qui s’affiche pour l’utilisateur : `Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.`

![Screenshot_2025-06-19_at_20-22-35_Créez_votre_compte_Pix_Pix](https://github.com/user-attachments/assets/ad07e39e-b272-4373-b111-a027e3fce9a0)

