### PR TITLE
[TECH] :truck: Déplace le repository Learning Content utilisé par prescription vers `/src/prescription`

### DIFF
--- a/api/src/certification/evaluation/domain/services/certification-challenges-service.js
+++ b/api/src/certification/evaluation/domain/services/certification-challenges-service.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../prescription/shared/infrastructure/repositories/learning-content-repository.js';
 import {
   MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS,
   MAX_CHALLENGES_PER_COMPETENCE_FOR_CERTIFICATION,

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../../src/prescription/shared/infrastructure/repositories/learning-content-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as compareStagesAndAcquiredStages from '../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
+import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import { CampaignAssessmentParticipationResult } from '../../domain/models/CampaignAssessmentParticipationResult.js';
 
 const getByCampaignIdAndCampaignParticipationId = async function ({ campaignId, campaignParticipationId, locale }) {

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
@@ -24,6 +23,7 @@ import * as membershipRepository from '../../../../team/infrastructure/repositor
 import * as campaignAnalysisRepository from '../../../campaign-participation/infrastructure/repositories/campaign-analysis-repository.js';
 import * as campaignParticipationRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import * as organizationLearnerImportFormatRepository from '../../../learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
+import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as campaignAdministrationRepository from '../../infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignAssessmentParticipationResultListRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
 import * as campaignCollectiveResultRepository from '../../infrastructure/repositories/campaign-collective-result-repository.js';

--- a/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/prescription/shared/infrastructure/repositories/learning-content-repository.js
@@ -1,17 +1,17 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
-import * as campaignRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
-import { NoSkillsInCampaignError, NotFoundError } from '../../../src/shared/domain/errors.js';
-import { CampaignLearningContent } from '../../../src/shared/domain/models/CampaignLearningContent.js';
-import { LearningContent } from '../../../src/shared/domain/models/LearningContent.js';
-import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
-import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as frameworkRepository from '../../../src/shared/infrastructure/repositories/framework-repository.js';
-import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
-import * as thematicRepository from '../../../src/shared/infrastructure/repositories/thematic-repository.js';
-import * as tubeRepository from '../../../src/shared/infrastructure/repositories/tube-repository.js';
-import * as learningContentConversionService from '../../domain/services/learning-content/learning-content-conversion-service.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
+import * as campaignRepository from '../../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
+import { NoSkillsInCampaignError, NotFoundError } from '../../../../shared/domain/errors.js';
+import { CampaignLearningContent } from '../../../../shared/domain/models/CampaignLearningContent.js';
+import { LearningContent } from '../../../../shared/domain/models/LearningContent.js';
+import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
+import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import * as frameworkRepository from '../../../../shared/infrastructure/repositories/framework-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
+import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
+import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 
 async function findByCampaignId(campaignId, locale) {
   const skills = await campaignRepository.findSkills({ campaignId });

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -2,11 +2,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
-import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
 import * as targetProfileAdministrationRepository from '../../infrastructure/repositories/target-profile-administration-repository.js';

--- a/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/prescription/shared/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -1,6 +1,6 @@
-import * as learningContentRepository from '../../../../lib/infrastructure/repositories/learning-content-repository.js';
-import { NoSkillsInCampaignError, NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import * as learningContentRepository from '../../../../../../src/prescription/shared/infrastructure/repositories/learning-content-repository.js';
+import { NoSkillsInCampaignError, NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | learning-content', function () {
   let framework1Fr, framework1En, framework2Fr, framework2En;


### PR DESCRIPTION
## 🔆 Problème

Le repository Learning Content restant dans `lib/` est principalement utilisé par prescription.

## ⛱️ Proposition

Déplacer le repository Learning Content utilisé par prescription vers `/src/prescription`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Effectuer un téléchargement de résultats de campagne d'évaluation sur PixOrga. vérifier les affichages des écrans de campagne d'évaluation sur PixOrga
