### PR TITLE
[FEATURE] Afficher une modale avant de quitter la page de fin de parcours (PIX-18023)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
@@ -23,11 +23,11 @@ export default class QuitResults extends Component {
   <template>
     {{#if this.shouldShareCampaignResults}}
       <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleModal}}>
-        {{t "common.actions.quit"}}
+        {{t "pages.skill-review.actions.back-to-pix"}}
       </button>
     {{else}}
       <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
-        {{t "common.actions.quit"}}
+        {{t "pages.skill-review.actions.back-to-pix"}}
       </LinkTo>
     {{/if}}
     <PixModal

--- a/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
@@ -4,20 +4,42 @@ import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class QuitResults extends Component {
+  @service currentUser;
+  @service router;
+  @service session;
+
   @tracked showSendResultModal = false;
+  @tracked showLeaveWithoutSignupModal = false;
 
   get shouldShareCampaignResults() {
     return this.args.isSharableCampaign && !this.args.isCampaignShared;
   }
 
+  get isUserAnonymous() {
+    return Boolean(this.currentUser.user?.isAnonymous);
+  }
+
   @action
   toggleSendResultModal() {
     this.showSendResultModal = !this.showSendResultModal;
+  }
+
+  @action
+  toggleSignUpModal() {
+    this.showLeaveWithoutSignupModal = !this.showLeaveWithoutSignupModal;
+  }
+
+  @action
+  async goToSignup() {
+    await this.session.invalidate();
+
+    return this.router.transitionTo('authentication');
   }
 
   <template>
@@ -26,31 +48,64 @@ export default class QuitResults extends Component {
         {{t "pages.skill-review.actions.back-to-pix"}}
       </button>
     {{else}}
-      <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
-        {{t "pages.skill-review.actions.back-to-pix"}}
-      </LinkTo>
+      {{#if this.isUserAnonymous}}
+        <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleSignUpModal}}>
+          {{t "pages.skill-review.actions.back-to-pix"}}
+        </button>
+      {{else}}
+        <LinkTo @route="authenticated" class="evaluation-results-header__back-link">
+          {{t "pages.skill-review.actions.back-to-pix"}}
+        </LinkTo>
+      {{/if}}
     {{/if}}
     <PixModal
-      @title={{t "pages.evaluation-results.quit-results.modal.title"}}
+      @title={{t "pages.evaluation-results.quit-results.send-result-modal.title"}}
       @onCloseButtonClick={{this.toggleSendResultModal}}
       @showModal={{this.showSendResultModal}}
     >
       <:content>
         <p class="quit-results__first-paragraph">{{t
-            "pages.evaluation-results.quit-results.modal.content-information"
+            "pages.evaluation-results.quit-results.send-result-modal.content-information"
           }}</p>
-        <p><strong>{{t "pages.evaluation-results.quit-results.modal.content-instruction"}}</strong></p>
+        <p><strong>{{t "pages.evaluation-results.quit-results.send-result-modal.content-instruction"}}</strong></p>
       </:content>
 
       <:footer>
         <div class="quit-results__footer">
           <PixButton @variant="secondary" @triggerAction={{this.toggleSendResultModal}}>
-            {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
+            {{t "pages.evaluation-results.quit-results.send-result-modal.actions.cancel-to-share"}}
           </PixButton>
 
-          <PixButtonLink @href="authenticated" @variant="primary">
-            {{t "pages.evaluation-results.quit-results.modal.actions.quit-without-sharing"}}
+          <PixButtonLink @route="authenticated" @variant="primary">
+            {{t "pages.evaluation-results.quit-results.send-result-modal.actions.quit-without-sharing"}}
           </PixButtonLink>
+        </div>
+      </:footer>
+    </PixModal>
+
+    <PixModal
+      @title={{t "pages.evaluation-results.quit-results.leave-without-signup-modal.title"}}
+      @onCloseButtonClick={{this.toggleSignUpModal}}
+      @showModal={{this.showLeaveWithoutSignupModal}}
+    >
+      <:content>
+        <p class="quit-results__first-paragraph">{{t
+            "pages.evaluation-results.quit-results.leave-without-signup-modal.content-information"
+          }}</p>
+        <p><strong>{{t
+              "pages.evaluation-results.quit-results.leave-without-signup-modal.content-instruction"
+            }}</strong></p>
+      </:content>
+
+      <:footer>
+        <div class="quit-results__footer">
+          <PixButton @variant="secondary" @triggerAction={{this.toggleSignUpModal}}>
+            {{t "pages.evaluation-results.quit-results.leave-without-signup-modal.actions.cancel"}}
+          </PixButton>
+
+          <PixButton @triggerAction={{this.goToSignup}} @variant="primary">
+            {{t "pages.evaluation-results.quit-results.leave-without-signup-modal.actions.leave"}}
+          </PixButton>
         </div>
       </:footer>
     </PixModal>

--- a/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/quit-results.gjs
@@ -9,20 +9,20 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class QuitResults extends Component {
-  @tracked showModal = false;
+  @tracked showSendResultModal = false;
 
   get shouldShareCampaignResults() {
     return this.args.isSharableCampaign && !this.args.isCampaignShared;
   }
 
   @action
-  toggleModal() {
-    this.showModal = !this.showModal;
+  toggleSendResultModal() {
+    this.showSendResultModal = !this.showSendResultModal;
   }
 
   <template>
     {{#if this.shouldShareCampaignResults}}
-      <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleModal}}>
+      <button class="evaluation-results-header__back-link" type="button" {{on "click" this.toggleSendResultModal}}>
         {{t "pages.skill-review.actions.back-to-pix"}}
       </button>
     {{else}}
@@ -32,8 +32,8 @@ export default class QuitResults extends Component {
     {{/if}}
     <PixModal
       @title={{t "pages.evaluation-results.quit-results.modal.title"}}
-      @onCloseButtonClick={{this.toggleModal}}
-      @showModal={{this.showModal}}
+      @onCloseButtonClick={{this.toggleSendResultModal}}
+      @showModal={{this.showSendResultModal}}
     >
       <:content>
         <p class="quit-results__first-paragraph">{{t
@@ -44,7 +44,7 @@ export default class QuitResults extends Component {
 
       <:footer>
         <div class="quit-results__footer">
-          <PixButton @variant="secondary" @triggerAction={{this.toggleModal}}>
+          <PixButton @variant="secondary" @triggerAction={{this.toggleSendResultModal}}>
             {{t "pages.evaluation-results.quit-results.modal.actions.cancel-to-share"}}
           </PixButton>
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
@@ -36,6 +36,74 @@ module('Acceptance | Campaigns | Results', function (hooks) {
       });
     });
 
+    module('when user is anonymous', function (hooks) {
+      const competenceResultName = 'Competence Nom';
+
+      hooks.beforeEach(async function () {
+        // given
+        const anonymousUser = server.create('user', 'withEmail', {
+          isAnonymous: true,
+        });
+
+        await authenticate(anonymousUser);
+        const competenceResult = server.create('competence-result', {
+          name: competenceResultName,
+          masteryPercentage: 85,
+        });
+        server.create('campaign-participation-result', {
+          id: campaignParticipation.id,
+          competenceResults: [competenceResult],
+          masteryPercentage: 85,
+        });
+      });
+
+      test('should access to the result page', async function (assert) {
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+        // then
+        assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/resultats`);
+      });
+
+      module('when the evaluation results have been shared', function () {
+        test('should open a confirm modal', async function (assert) {
+          // given
+          server.create('campaign-participation-result', {
+            id: campaignParticipation.id,
+            isShared: true,
+          });
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+          // when
+          await click(await screen.findByRole('button', { name: 'Quitter et revenir sur Pix' }));
+
+          // then
+          const modalTitle = await screen.findByRole('heading', {
+            name: 'Quitter et revenir sur pix.fr ?',
+          });
+          assert.ok(screen.findByRole('dialog'));
+          assert.ok(modalTitle);
+        });
+
+        test('should redirect to home page when confirm button is clicked', async function (assert) {
+          // given
+          server.create('campaign-participation-result', {
+            id: campaignParticipation.id,
+            isShared: true,
+          });
+
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+
+          // when
+          await click(await screen.findByRole('button', { name: 'Quitter et revenir sur Pix' }));
+          await click(await screen.findByRole('button', { name: 'Oui, quitter le parcours' }));
+
+          // then
+          assert.strictEqual(currentURL(), '/connexion');
+        });
+      });
+    });
+
     module('When user is logged in', function (hooks) {
       const competenceResultName = 'Competence Nom';
 

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
@@ -84,7 +84,7 @@ module('Acceptance | Campaigns | Results', function (hooks) {
           const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
           // when
-          await click(await screen.findByRole('link', { name: 'Quitter' }));
+          await click(await screen.findByRole('link', { name: 'Quitter et revenir sur Pix' }));
 
           // then
           assert.strictEqual(currentURL(), '/accueil');
@@ -101,7 +101,7 @@ module('Acceptance | Campaigns | Results', function (hooks) {
           const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
           // when
-          await click(await screen.findByRole('button', { name: 'Quitter' }));
+          await click(await screen.findByRole('button', { name: 'Quitter et revenir sur Pix' }));
 
           // then
           const modalTitle = await screen.findByRole('heading', {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
@@ -20,7 +20,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
       assert.ok(
         screen
           .getByRole('link', {
-            name: 'Quitter',
+            name: t('pages.skill-review.actions.back-to-pix'),
           })
           .getAttribute('href')
           .includes('/'),
@@ -39,7 +39,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
       assert.ok(
         screen
           .getByRole('link', {
-            name: 'Quitter',
+            name: t('pages.skill-review.actions.back-to-pix'),
           })
           .getAttribute('href')
           .includes('/'),
@@ -55,7 +55,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
       );
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Quitter' })).exists();
+      assert.dom(screen.getByRole('button', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
     });
 
     module('when the quit button is clicked', function () {
@@ -66,7 +66,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
         );
 
         // when
-        await click(screen.getByRole('button', { name: 'Quitter' }));
+        await click(screen.getByRole('button', { name: t('pages.skill-review.actions.back-to-pix') }));
 
         // then
         const modalTitle = await screen.findByRole('heading', {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/quit-results-test.js
@@ -4,10 +4,15 @@ import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
+import { stubCurrentUserService } from '../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Components | Campaigns | Assessment | Results | Quit Results', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    stubCurrentUserService(this.owner, { firstName: 'Alain', isAnonymous: false });
+  });
 
   module('when the campaign results are not sharable', function () {
     test('it should display a quit button link', async function (assert) {
@@ -73,20 +78,28 @@ module('Integration | Components | Campaigns | Assessment | Results | Quit Resul
           name: 'Oups, vous n’avez pas encore envoyé vos résultats !',
         });
         assert.dom(modalTitle).exists();
-        assert.dom(screen.getByText(t('pages.evaluation-results.quit-results.modal.content-information')));
-        assert.dom(screen.getByText(t('pages.evaluation-results.quit-results.modal.content-instruction')));
-        assert.dom(
-          screen.getByRole('button', {
-            name: t('pages.evaluation-results.quit-results.modal.actions.cancel-to-share'),
-          }),
-        );
+        assert
+          .dom(screen.getByText(t('pages.evaluation-results.quit-results.send-result-modal.content-information')))
+          .exists();
+        assert
+          .dom(screen.getByText(t('pages.evaluation-results.quit-results.send-result-modal.content-instruction')))
+          .exists();
+
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: t('pages.evaluation-results.quit-results.send-result-modal.actions.cancel-to-share'),
+            }),
+          )
+          .exists();
+
         assert.ok(
           screen
             .getByRole('link', {
-              name: t('pages.evaluation-results.quit-results.modal.actions.quit-without-sharing'),
+              name: t('pages.evaluation-results.quit-results.send-result-modal.actions.quit-without-sharing'),
             })
             .getAttribute('href')
-            .includes('authenticated'),
+            .includes('/'),
         );
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1366,8 +1366,17 @@
       "first-title": "Oops, an error occurred!"
     },
     "evaluation-results": {
+      "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Cancel",
+            "leave": "Yes, leave the course"
+          },
+          "content-information": "If you leave this course without registering, you will not be able to validate your progress.",
+          "content-instruction": "Would you like to continue?",
+          "title": "Leave and return to Pix?"
+        },
       "quit-results": {
-        "modal": {
+        "send-result-modal": {
           "actions": {
             "cancel-to-share": "Rester pour envoyer",
             "quit-without-sharing": "Quitter sans envoyer"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1917,6 +1917,7 @@
       "abstract": "You have mastered '<strong>'{rate, number, ::percent}'</strong><br>' of the competences tested.",
       "abstract-title": "Your result for this customised test",
       "actions": {
+        "back-to-pix": "Leave and return to Pix",
         "continue": "Continue my Pix experience",
         "improve": "Try again",
         "send": "Submit my results"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1909,6 +1909,7 @@
       "abstract": "Has dominado el '<strong>'{rate, number, ::percent}'</strong><br>'de las competencias evaluadas.",
       "abstract-title": "Tu resultado para este test",
       "actions": {
+        "back-to-pix": "Salir y volver a Pix",
         "continue": "Continúa tu experiencia Pix",
         "improve": "Lo vuelvo a intentar",
         "send": "Envío mis resultados"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1362,7 +1362,16 @@
     },
     "evaluation-results": {
       "quit-results": {
-        "modal": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Cancelar",
+            "leave": "Sí, dejar el curso"
+          },
+          "content-information": "Si abandona este curso sin inscribirse, no podrá validar su progreso.",
+          "content-instruction": "¿Quiere continuar?",
+          "title": "¿Salir y volver a Pix?"
+        },
+        "send-result-modal": {
           "actions": {
             "cancel-to-share": "Permanecer para enviar",
             "quit-without-sharing": "Salir sin enviar"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1917,6 +1917,7 @@
       "abstract": "Vous maîtrisez '<strong>'{rate, number, ::percent}'</strong><br>'des compétences testées.",
       "abstract-title": "Votre résultat pour ce parcours",
       "actions": {
+        "back-to-pix": "Quitter et revenir sur Pix",
         "continue": "Continuez votre expérience Pix",
         "improve": "Je retente",
         "send": "J'envoie mes résultats"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1367,7 +1367,16 @@
     },
     "evaluation-results": {
       "quit-results": {
-        "modal": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Annuler",
+            "leave": "Oui, quitter le parcours"
+          },
+          "content-information": "En quittant ce parcours sans vous inscrire, vous ne pourrez pas valider votre progression.",
+          "content-instruction": "Voulez-vous continuer ?",
+          "title": "Quitter et revenir sur pix.fr ?"
+        },
+        "send-result-modal": {
           "actions": {
             "cancel-to-share": "Rester pour envoyer",
             "quit-without-sharing": "Quitter sans envoyer"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1365,7 +1365,16 @@
     },
     "evaluation-results": {
       "quit-results": {
-        "modal": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Annuleren",
+            "leave": "Ja, verlaat de cursus"
+          },
+          "content-information": "Als je deze cursus verlaat zonder je te registreren, kun je je voortgang niet valideren.",
+          "content-instruction": "Wil je doorgaan?",
+          "title": "Vertrekken en terugkeren naar Pix?"
+        },
+        "send-result-modal": {
           "actions": {
             "cancel-to-share": "Blijf om te verzenden",
             "quit-without-sharing": "Stoppen zonder te verzenden"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1912,6 +1912,7 @@
       "abstract": "Je beheerst '<strong>'{rate, number, ::percent}'</strong><br>'van de getoetste vaardigheden.",
       "abstract-title": "Je resultaat voor deze route",
       "actions": {
+        "back-to-pix": "Vertrekken en terugkeren naar Pix",
         "continue": "Zet je Pix-ervaring voort",
         "improve": "Ik zal het nog eens proberen",
         "send": "Ik stuur mijn resultaten"


### PR DESCRIPTION
## 🔆 Problème

On souhaite afficher une modale pour les utilisateurs anonymes en fin de parcours pour les inciter à s’inscrire sur Pix. 

## ⛱️ Proposition
Modifier le texte du bouton Quitter de la page de fin de parcours en “Quitter et revenir sur Pix”

- Si l’utilisateur est anonyme et qu’il clique sur le bouton “Quitter et revenir sur Pix” & **qu’il a déjà envoyé ses résultats** :

  - Afficher une modale dont le texte est “en quittant ce parcours sans vous inscrire, vous ne pourrez pas valider votre progression
Voulez-vous continuer ?”

  - En-tête : “Quitter et revenir sur [pix.fr](http://pix.fr/) ?”

  - Les boutons sont : “Annuler” et “Oui quitter le parcours”

  - [Maquette Figma](https://www.figma.com/design/wDdAJwtswAllBk0ZtMLu4Y/Acc%C3%A8s?node-id=3709-14010)

- S’il valide sur la modale : invalider la session courante et retour sur page de login. Ceci corrige le comportement actuel qui n’est pas correct : quand on clique sur le bouton “quitter”après avoir envoyé ou refusé d’envoyer ses résultats, on arrive sur la page d’accueil tout en étant un utilisateur anonyme => Donc empêcher ce comportement par la solution proposée.

- Si l’utilisateur n’est pas anonyme, le comportement actuel est à conserver

  - quand l’utilisateur clique sur “Quitter et revenir sur Pix”,

  - une modale apparaît s’il n’a pas envoyé ses résultats (comportement à conserver)

  - et s’il confirme qu’il veut quitter il est redirigé vers /accueil en tant qu’utilisateur connecté

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Attention: si vous testez en local il faut

- modifier en base la valeur isSimplifiedAccess de la campagne EVALSTAG1
Pour cela, récupérer l'id de la campagne (table campaigns) pour le rechercher dans la table target-profile, et passer la valeur de isSimplifiedAccess à true.
Ensuite passez les campagnes et faites les mêmes vérifications que pour la RA.


- En RA :

- parcours autonome sur une campagne à envoi de résultats : https://app-pr12604.review.pix.fr/campagnes/EVALSTAG1/presentation
  - passez la campagne
  - [NON REGRESSION] sans envoyer les résultats, cliquer sur "Quitter et revenir sur Pix" et vérifier que la modale qui s'affiche est bien "Oups, vous n'avez pas encore envoyé vos résultats !"
  - partagez les résultats
  - Cliquez sur "Quitter et revenir sur Pix"
  - Constater que la modale avec le titre "Quitter et revenir sur pix.fr ?" s'ouvre bien


- parcours autonome sur une campagne sans envoi de résultats : https://app-pr12604.review.pix.fr/campagnes/AUTOCOURS1
  - passez la campagne
  - Cliquez sur "Quitter et revenir sur Pix"
  - Constater que la modale avec le titre "Quitter et revenir sur pix.fr ?" s'ouvre bien

- [NON REGRESSION] passer une campagne en utilisateur connecté ("real user"), par exemple sur le compte "James Paledroits", puis "J"ai un code":  EVALSTAG6
    - à la fin de la campagne , sans envoyer les résultats, quitter sur "Quitter et revenir sur Pix"
    - Constater que la modale "Oups, vous n'avez pas encore envoyé vos résultats !"s'affiche bien
    - partagez les résultats
    - cliquez à nouveau sur "Quitter et revenir sur Pix"
    - constatez que vous arrivez sur votre homepage d'utilisateur connecté
