### PR TITLE
[TECH] Tenir compte des informations de pièce jointe, dans le cas où une configuration en gère une, lors du démarrage d'une conversation avec LLM (PIX-18332)

### DIFF
--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,3 +1,4 @@
+import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const create = async function (request, h, { usecases, passageSerializer }) {
@@ -50,13 +51,7 @@ const startEmbedLlmChat = async function (request, h, { usecases }) {
   const passageId = request.params.passageId;
   const startedChatDTO = await usecases.startEmbedLlmChat({ configId, userId, passageId });
 
-  return h
-    .response({
-      inputMaxChars: startedChatDTO.inputMaxChars,
-      inputMaxPrompts: startedChatDTO.inputMaxPrompts,
-      chatId: startedChatDTO.id,
-    })
-    .code(201);
+  return h.response(llmChatSerializer.serialize(startedChatDTO)).code(201);
 };
 
 const promptToLLMChat = async function (request, h, { usecases }) {

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -2,6 +2,7 @@ import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/in
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
 import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 
@@ -28,13 +29,7 @@ const startEmbedLlmChat = async function (request, h, { usecases } = { usecases:
   const userId = request.auth.credentials.userId;
   const assessmentId = request.params.assessmentId;
   const startedChatDTO = await usecases.startEmbedLlmChat({ configId, userId, assessmentId });
-  return h
-    .response({
-      inputMaxChars: startedChatDTO.inputMaxChars,
-      inputMaxPrompts: startedChatDTO.inputMaxPrompts,
-      chatId: startedChatDTO.id,
-    })
-    .code(201);
+  return h.response(llmChatSerializer.serialize(startedChatDTO)).code(201);
 };
 
 const promptToLLMChat = async function (request, h, { usecases } = { usecases: evaluationUsecases }) {

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -105,7 +105,8 @@ function getInputMaxCharsFromConfiguration(configuration) {
 }
 
 function getInputMaxPromptsFromConfiguration(configuration) {
-  return configuration.challenge.inputMaxPrompts;
+  const inputMaxPrompts = configuration.challenge.inputMaxPrompts;
+  return configuration.attachment?.name ? inputMaxPrompts - 1 : inputMaxPrompts;
 }
 
 function getAttachmentContextAndName(configuration) {

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -38,14 +38,18 @@ export async function startChat({ configId, userId }) {
   }
   const configuration = await configurationRepository.get(configId);
   const chatId = generateId(userId);
+  const { name: attachmentName, context: attachmentContext } = getAttachmentContextAndName(configuration);
   const newChat = new Chat({
     id: chatId,
     configurationId: configId,
+    attachmentName,
+    attachmentContext,
     messages: [],
   });
   await chatRepository.save(newChat);
   return new LLMChatDTO({
     id: newChat.id,
+    attachmentName,
     inputMaxChars: getInputMaxCharsFromConfiguration(configuration),
     inputMaxPrompts: getInputMaxPromptsFromConfiguration(configuration),
   });
@@ -102,6 +106,10 @@ function getInputMaxCharsFromConfiguration(configuration) {
 
 function getInputMaxPromptsFromConfiguration(configuration) {
   return configuration.challenge.inputMaxPrompts;
+}
+
+function getAttachmentContextAndName(configuration) {
+  return configuration.attachment ?? { name: null, context: null };
 }
 
 function addMessagesToChat(chat, prompt, chatRepository) {

--- a/api/src/llm/application/api/models/LLMChatDTO.js
+++ b/api/src/llm/application/api/models/LLMChatDTO.js
@@ -1,7 +1,8 @@
 export class LLMChatDTO {
-  constructor({ id, inputMaxChars, inputMaxPrompts }) {
+  constructor({ id, attachmentName, inputMaxChars, inputMaxPrompts }) {
     this.id = id;
     this.inputMaxChars = inputMaxChars;
     this.inputMaxPrompts = inputMaxPrompts;
+    this.attachmentName = attachmentName;
   }
 }

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -1,8 +1,10 @@
 export class Chat {
-  constructor({ id, configurationId, messages = [] }) {
+  constructor({ id, configurationId, attachmentName, attachmentContext, messages = [] }) {
     this.id = id;
     this.configurationId = configurationId;
     this.messages = messages;
+    this.attachmentName = attachmentName;
+    this.attachmentContext = attachmentContext;
   }
 
   addUserMessage(message) {
@@ -21,6 +23,8 @@ export class Chat {
     return {
       id: this.id,
       configurationId: this.configurationId,
+      attachmentName: this.attachmentName,
+      attachmentContext: this.attachmentContext,
       messages: this.messages.map((message) => message.toDTO()),
     };
   }

--- a/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
+++ b/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
@@ -3,6 +3,6 @@ export function serialize(llmChatDTO) {
     inputMaxChars: llmChatDTO.inputMaxChars,
     inputMaxPrompts: llmChatDTO.inputMaxPrompts,
     attachmentName: llmChatDTO.attachmentName,
-    chatId: llmChatDTO.id
-  }
+    chatId: llmChatDTO.id,
+  };
 }

--- a/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
+++ b/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
@@ -1,0 +1,8 @@
+export function serialize(llmChatDTO) {
+  return {
+    inputMaxChars: llmChatDTO.inputMaxChars,
+    inputMaxPrompts: llmChatDTO.inputMaxPrompts,
+    attachmentName: llmChatDTO.attachmentName,
+    chatId: llmChatDTO.id
+  }
+}

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -294,7 +294,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           expect(response.result).to.deep.equal({
             chatId: `${user.id}-${now.getMilliseconds()}`,
             inputMaxChars: 456,
-            inputMaxPrompts: 789,
+            inputMaxPrompts: 788,
             attachmentName: 'file.txt',
           });
           expect(llmApiScope.isDone()).to.be.true;

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -272,6 +272,10 @@ describe('Acceptance | Controller | passage-controller', function () {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
             },
+            attachment: {
+              name: 'file.txt',
+              context: 'context',
+            },
           };
           const llmApiScope = nock('https://llm-test.pix.fr/api')
             .get('/configurations/c1SuperConfig2Lespace')
@@ -291,6 +295,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             chatId: `${user.id}-${now.getMilliseconds()}`,
             inputMaxChars: 456,
             inputMaxPrompts: 789,
+            attachmentName: 'file.txt',
           });
           expect(llmApiScope.isDone()).to.be.true;
         });

--- a/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
@@ -1,6 +1,5 @@
 import { Passage } from '../../../../../src/devcomp/domain/models/Passage.js';
 import { startEmbedLlmChat } from '../../../../../src/devcomp/domain/usecases/start-embed-llm-chat.js';
-import { LLMChatDTO } from '../../../../../src/llm/application/api/models/LLMChatDTO.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
@@ -49,23 +48,14 @@ describe('Unit | Devcomp | Domain | UseCases | start-embed-llm-chat', function (
           userId,
         }),
       );
-      llmApi.startChat.withArgs({ configId, userId }).resolves(
-        new LLMChatDTO({
-          id: 'someChatId',
-          inputMaxChars: 123,
-          inputMaxPrompts: 456,
-        }),
-      );
+      const someLLMChatDTO = Symbol('LLMCHATDTO');
+      llmApi.startChat.withArgs({ configId, userId }).resolves(someLLMChatDTO);
 
       // when
       const chat = await startEmbedLlmChat({ configId, passageId, userId, llmApi, passageRepository });
 
       // then
-      expect(chat).to.deep.equal({
-        id: 'someChatId',
-        inputMaxChars: 123,
-        inputMaxPrompts: 456,
-      });
+      expect(chat).to.deep.equal(someLLMChatDTO);
     });
   });
 });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -818,7 +818,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           expect(response.result).to.deep.equal({
             chatId: `${user.id}-${now.getMilliseconds()}`,
             inputMaxChars: 456,
-            inputMaxPrompts: 789,
+            inputMaxPrompts: 788,
             attachmentName: 'file.txt',
           });
           expect(llmApiScope.isDone()).to.be.true;

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -796,6 +796,10 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
               inputMaxChars: 456,
               inputMaxPrompts: 789,
             },
+            attachment: {
+              name: 'file.txt',
+              context: 'context',
+            },
           };
           const llmApiScope = nock('https://llm-test.pix.fr/api')
             .get('/configurations/c1SuperConfig2Lespace')
@@ -815,6 +819,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
             chatId: `${user.id}-${now.getMilliseconds()}`,
             inputMaxChars: 456,
             inputMaxPrompts: 789,
+            attachmentName: 'file.txt',
           });
           expect(llmApiScope.isDone()).to.be.true;
         });

--- a/api/tests/evaluation/unit/domain/usecases/start-embed-llm-chat_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/start-embed-llm-chat_test.js
@@ -1,5 +1,4 @@
 import { startEmbedLlmChat } from '../../../../../src/evaluation/domain/usecases/start-embed-llm-chat.js';
-import { LLMChatDTO } from '../../../../../src/llm/application/api/models/LLMChatDTO.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/index.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
@@ -49,23 +48,14 @@ describe('Unit | Eval | Domain | UseCases | start-embed-llm-chat', function () {
           userId,
         }),
       );
-      llmApi.startChat.withArgs({ configId, userId }).resolves(
-        new LLMChatDTO({
-          id: 'someChatId',
-          inputMaxChars: 123,
-          inputMaxPrompts: 456,
-        }),
-      );
+      const someLLMChatDTO = Symbol('LLMCHATDTO');
+      llmApi.startChat.withArgs({ configId, userId }).resolves(someLLMChatDTO);
 
       // when
       const chat = await startEmbedLlmChat({ configId, assessmentId, userId, llmApi, assessmentRepository });
 
       // then
-      expect(chat).to.deep.equal({
-        id: 'someChatId',
-        inputMaxChars: 123,
-        inputMaxPrompts: 456,
-      });
+      expect(chat).to.deep.equal(someLLMChatDTO);
     });
   });
 });

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -83,7 +83,7 @@ describe('LLM | Integration | Application | API | llm', function () {
           llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
         });
 
-        it('should return the newly created chat with attachment info', async function () {
+        it('should return the newly created chat with attachment info, diminushing inputMaxPrompts by one', async function () {
           // when
           const chat = await startChat({ configId, userId });
 
@@ -92,7 +92,7 @@ describe('LLM | Integration | Application | API | llm', function () {
             id: `123456-${now.getMilliseconds()}`,
             attachmentName: 'file.txt',
             inputMaxChars: 456,
-            inputMaxPrompts: 789,
+            inputMaxPrompts: 788,
           });
           expect(llmApiScope.isDone()).to.be.true;
           expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -62,36 +62,84 @@ describe('LLM | Integration | Application | API | llm', function () {
 
     context('when config id and user id provided', function () {
       let configId, userId, llmApiScope, config;
-      beforeEach(function () {
-        configId = 'uneConfigQuiExist';
-        userId = 123456;
-        config = {
-          llm: {
-            historySize: 123,
-          },
-          challenge: {
+
+      context('when config has an attachment', function () {
+        beforeEach(function () {
+          configId = 'uneConfigQuiExist';
+          userId = 123456;
+          config = {
+            llm: {
+              historySize: 123,
+            },
+            challenge: {
+              inputMaxChars: 456,
+              inputMaxPrompts: 789,
+            },
+            attachment: {
+              name: 'file.txt',
+              context: '**coucou**',
+            },
+          };
+          llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
+        });
+
+        it('should return the newly created chat with attachment info', async function () {
+          // when
+          const chat = await startChat({ configId, userId });
+
+          // then
+          expect(chat).to.deep.equal({
+            id: `123456-${now.getMilliseconds()}`,
+            attachmentName: 'file.txt',
             inputMaxChars: 456,
             inputMaxPrompts: 789,
-          },
-        };
-        llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
+          });
+          expect(llmApiScope.isDone()).to.be.true;
+          expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({
+            id: `123456-${now.getMilliseconds()}`,
+            attachmentName: 'file.txt',
+            attachmentContext: '**coucou**',
+            configurationId: 'uneConfigQuiExist',
+            messages: [],
+          });
+        });
       });
 
-      it('should return the newly created chat', async function () {
-        // when
-        const chat = await startChat({ configId, userId });
-
-        // then
-        expect(chat).to.deep.equal({
-          id: `123456-${now.getMilliseconds()}`,
-          inputMaxChars: 456,
-          inputMaxPrompts: 789,
+      context('when config has no attachment', function () {
+        beforeEach(function () {
+          configId = 'uneConfigQuiExist';
+          userId = 123456;
+          config = {
+            llm: {
+              historySize: 123,
+            },
+            challenge: {
+              inputMaxChars: 456,
+              inputMaxPrompts: 789,
+            },
+          };
+          llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
         });
-        expect(llmApiScope.isDone()).to.be.true;
-        expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({
-          id: `123456-${now.getMilliseconds()}`,
-          configurationId: 'uneConfigQuiExist',
-          messages: [],
+
+        it('should return the newly created chat with attachment info', async function () {
+          // when
+          const chat = await startChat({ configId, userId });
+
+          // then
+          expect(chat).to.deep.equal({
+            id: `123456-${now.getMilliseconds()}`,
+            attachmentName: null,
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+          });
+          expect(llmApiScope.isDone()).to.be.true;
+          expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({
+            id: `123456-${now.getMilliseconds()}`,
+            attachmentName: null,
+            attachmentContext: null,
+            configurationId: 'uneConfigQuiExist',
+            messages: [],
+          });
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

On va devoir gérer des épreuves LLM avec usage de pièce jointe.

## ⛱️ Proposition

Dans un premier temps, il faut démarrer la conversation avec LLM en ajoutant les informations liées à l'attachment à la fois dans la conversation en cours côté PixApi mais aussi renvoyer le nom de l'attachment côté front (pour savoir si c'est une épreuve à pièce jointe)

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Jouer modulix et/ou éval avec une config avec pièce jointe et constater que l'affichage du prompt devient compliant LLM
