### PR TITLE
[BUGFIX] Pouvoir cliquer sur le bouton télécharger des attestations même si le dropdown est ouvert (PIX-17864)

### DIFF
--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -69,10 +69,10 @@ class OtherAttestations extends Component {
   }
 
   @action
-  onSubmit(event) {
+  async onSubmit(event) {
     event.preventDefault();
 
-    this.args.onSubmit(this.selectedAttestation, []);
+    await this.args.onSubmit(this.selectedAttestation, []);
     this.selectedAttestation = null;
   }
 

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -114,12 +114,13 @@ class OtherAttestations extends Component {
 
 class SixthGrade extends Component {
   @tracked selectedDivisions = [];
+  @tracked isLoading = false;
 
   @action
-  onSubmit(event) {
-    event.preventDefault();
-
-    this.args.onSubmit(SIXTH_GRADE_ATTESTATION_KEY, this.selectedDivisions);
+  async onSubmit() {
+    this.isLoading = true;
+    await this.args.onSubmit(SIXTH_GRADE_ATTESTATION_KEY, this.selectedDivisions);
+    this.isLoading = false;
   }
 
   @action
@@ -128,15 +129,14 @@ class SixthGrade extends Component {
   }
 
   get isDisabled() {
-    return !this.selectedDivisions.length;
+    return !this.selectedDivisions.length || this.isLoading;
   }
 
   <template>
     <p class="attestations-page__text">
       {{t "pages.attestations.divisions-description"}}
     </p>
-
-    <form class="attestations-page__action" {{on "submit" this.onSubmit}}>
+    <div class="attestations-page__action">
       <PixMultiSelect
         @isSearchable={{true}}
         @options={{@divisions}}
@@ -147,9 +147,9 @@ class SixthGrade extends Component {
         <:label>{{t "pages.attestations.select-divisions-label"}}</:label>
         <:default as |option|>{{option.label}}</:default>
       </PixMultiSelect>
-      <PixButton @type="submit" @size="small" @isDisabled={{this.isDisabled}}>
+      <PixButton @triggerAction={{this.onSubmit}} @size="small" @isDisabled={{this.isDisabled}}>
         {{t "pages.attestations.download-attestations-button"}}
       </PixButton>
-    </form>
+    </div>
   </template>
 }

--- a/orga/tests/integration/components/attestations_test.gjs
+++ b/orga/tests/integration/components/attestations_test.gjs
@@ -98,8 +98,6 @@ module('Integration | Component | Attestations', function (hooks) {
         name: t('pages.attestations.download-attestations-button'),
       });
 
-      // we need to get out of input choice to click on download button, so we have to click again on the multiselect to close it
-      await click(multiSelect);
       await click(downloadButton);
 
       // then


### PR DESCRIPTION
## 🔆 Problème
Lorsqu’on sélectionne des classes pour télécharger les attestations de 6eme, on doit d'abord cliquer ailleurs pour fermer le dropdown puis appuyer sur le bouton.
Comme le bouton est toujours visuellement accessible, les gens cliquent dessus mais il ne se passe rien.
On ne comprend pas forcément non plus lorsque le le téléchargement est en cours. 

## ⛱️ Proposition
Changer le comportement du composant pour pouvoir cliquer sur le bouton des lors qu'une classe est selectionnée même si la dropdown est encore ouverte.
On ajoute également l'état chargement sur le bouton pendant que le zip se télécharge

## 🌊 Remarques
On en profite pour faire de même (concernant le chargement) sur le bouton de téléchargement des autres attestations.   
🤔  J'ai essayé mais pas réussi a tester le comportement du bouton pendant le téléchargement, c'est a dire vérifier qu'il soit bien dans l'état disabled. J'ai pas non plus trouvé d'autres exemple ressemblant .. Du coup est-ce pertinent ? 🤷‍♂️  Je vous laisse juger 🙏 

## 🏄 Pour tester

### 1er test : 
- Se connecter a PixOrga
- Aller sur l'orga Attestation et sur l'onglet Attestation
- Sélectionner une classe
- Cliquer sur le bouton télécharger pendant que le dropdown est encore ouvert
- Constater que le téléchargement se lance au premier clic sur le bouton
### 2nd test : 
- Se mettre en "Slow 3G" pour simuler un téléchargement + lent
- Refaire la même manip qu'au dessus
- Constater que pendant le téléchargement le bouton est en état "chargement"
### 3eme test : 
- Faire la même chose que le 2eme test mais sur l'orga "SCO CLASSIC"
- Constater que pendant le téléchargement le bouton est également en état "chargement" 
