### PR TITLE
[FEATURE] Permettre de placer des embeds dans un stepper (PIX-18198)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -16,6 +16,25 @@ import { textElementSchema } from './element/text-schema.js';
 import { videoElementSchema } from './element/video-schema.js';
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from './utils.js';
 
+const ALLOWED_ELEMENTS_SCHEMA = [
+  { is: 'custom', then: customElementSchema },
+  { is: 'download', then: downloadElementSchema },
+  { is: 'embed', then: embedElementSchema },
+  { is: 'expand', then: expandElementSchema },
+  { is: 'flashcards', then: flashcardsElementSchema },
+  { is: 'image', then: imageElementSchema },
+  { is: 'qab', then: qabElementSchema },
+  { is: 'qcu', then: qcuElementSchema },
+  { is: 'qcu-declarative', then: qcuDeclarativeElementSchema },
+  { is: 'qcm', then: qcmElementSchema },
+  { is: 'qrocm', then: qrocmElementSchema },
+  { is: 'separator', then: separatorElementSchema },
+  { is: 'text', then: textElementSchema },
+  { is: 'video', then: videoElementSchema },
+];
+
+const ELEMENTS_FORBIDDEN_IN_STEPPER = ['embed', 'flashcards', 'qab'];
+
 const moduleDetailsSchema = Joi.object({
   image: Joi.string().uri().required(),
   description: htmlSchema.required(),
@@ -26,38 +45,11 @@ const moduleDetailsSchema = Joi.object({
 });
 
 const elementSchema = Joi.alternatives().conditional('.type', {
-  switch: [
-    { is: 'custom', then: customElementSchema },
-    { is: 'download', then: downloadElementSchema },
-    { is: 'embed', then: embedElementSchema },
-    { is: 'expand', then: expandElementSchema },
-    { is: 'flashcards', then: flashcardsElementSchema },
-    { is: 'image', then: imageElementSchema },
-    { is: 'qab', then: qabElementSchema },
-    { is: 'qcu', then: qcuElementSchema },
-    { is: 'qcu-declarative', then: qcuDeclarativeElementSchema },
-    { is: 'qcm', then: qcmElementSchema },
-    { is: 'qrocm', then: qrocmElementSchema },
-    { is: 'separator', then: separatorElementSchema },
-    { is: 'text', then: textElementSchema },
-    { is: 'video', then: videoElementSchema },
-  ],
+  switch: ALLOWED_ELEMENTS_SCHEMA,
 });
 
 const stepperElementSchema = Joi.alternatives().conditional('.type', {
-  switch: [
-    { is: 'custom', then: customElementSchema },
-    { is: 'download', then: downloadElementSchema },
-    { is: 'expand', then: expandElementSchema },
-    { is: 'image', then: imageElementSchema },
-    { is: 'qcu', then: qcuElementSchema },
-    { is: 'qcu-declarative', then: qcuDeclarativeElementSchema },
-    { is: 'qcm', then: qcmElementSchema },
-    { is: 'qrocm', then: qrocmElementSchema },
-    { is: 'separator', then: separatorElementSchema },
-    { is: 'text', then: textElementSchema },
-    { is: 'video', then: videoElementSchema },
-  ],
+  switch: ALLOWED_ELEMENTS_SCHEMA.filter((elementSchema) => !ELEMENTS_FORBIDDEN_IN_STEPPER.includes(elementSchema.is)),
 });
 
 const componentElementSchema = Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -33,7 +33,7 @@ const ALLOWED_ELEMENTS_SCHEMA = [
   { is: 'video', then: videoElementSchema },
 ];
 
-const ELEMENTS_FORBIDDEN_IN_STEPPER = ['embed', 'flashcards', 'qab'];
+const ELEMENTS_FORBIDDEN_IN_STEPPER = ['flashcards', 'qab'];
 
 const moduleDetailsSchema = Joi.object({
   image: Joi.string().uri().required(),


### PR DESCRIPTION
## 🔆 Problème

Actuellement il n'est pas possible d'utiliser des embed dans un stepper.

## ⛱️ Proposition

L'autoriser.

## 🌊 Remarques

Nous avons simplifié le code pour savoir quels éléments peuvent être mis ou non dans un stepper

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12611.review.pix.fr/modules/bac-a-sable/details)
- Jouer le simulateur "Contrôle Parental" en cliquant sur Paramètres -> Contrôle Parental -> Ce téléphone est à mon enfant -> Activer le contrôle parental
- Vérifier que le bouton `Suivant` apparaît bien 😄 
