### PR TITLE
[BUGFIX] Afficher les bonnes urls dans la documentation OpenAPI (PIX-18396)

### DIFF
--- a/api/src/shared/swaggers.js
+++ b/api/src/shared/swaggers.js
@@ -116,7 +116,13 @@ class ApiManagerAccess extends PixOpenApiBaseDefinition {
     this.swaggerConfiguration.uiOptions.url = `${this.endpoint}${this.swaggerConfiguration.jsonPath}`;
 
     // UI won't display the internal api base path externally
-    this.swaggerConfiguration.basePath = '/api/application';
+    this.swaggerConfiguration.pathReplacements = [
+      {
+        replaceIn: 'all',
+        pattern: /api\/(?:application\/)?/,
+        replacement: '',
+      },
+    ];
     this.#addExternalPartnersAccess();
   }
 


### PR DESCRIPTION
## 🔆 Problème

On a actuellement `/api` dans les routes du swagger cependant nous ne les exposons pas de cette manière dans notre gateway.


## ⛱️ Proposition

Retirer `/api`.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se rendre sur [`/documentation/maddo`](https://pix-api-maddo-review-pr12612.osc-fr1.scalingo.io/documentation/maddo)