### PR TITLE
[FEATURE] Migrer l'événement GRAIN_CONTINUED en traces d'apprentissage (PIX-18363)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -7,6 +7,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../models/passage-events/flashcard-events.js';
+import { GrainContinuedEvent } from '../models/passage-events/grain-events.js';
 import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-events/qab-events.js';
 
@@ -33,6 +34,8 @@ class PassageEventFactory {
         return new QABCardAnsweredEvent(eventData);
       case 'QAB_CARD_RETRIED':
         return new QABCardRetriedEvent(eventData);
+      case 'GRAIN_CONTINUED':
+        return new GrainContinuedEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/grain-events.js
+++ b/api/src/devcomp/domain/models/passage-events/grain-events.js
@@ -1,0 +1,21 @@
+import { assertHasUuidLength, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEvent } from './PassageEvent.js';
+
+class GrainContinuedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, grainId }) {
+    super({
+      type: 'GRAIN_CONTINUED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      data: { grainId },
+    });
+
+    assertNotNullOrUndefined(grainId, 'The grainId property is required for a GrainContinuedEvent');
+    assertHasUuidLength(grainId, 'The grainId property should be exactly 36 characters long');
+  }
+}
+
+export { GrainContinuedEvent };

--- a/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
@@ -1,0 +1,92 @@
+import { GrainContinuedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | qab-events', function () {
+  describe('#GrainContinuedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const grainId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const grainContinuedEvent = new GrainContinuedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        grainId,
+      });
+
+      // then
+      expect(grainContinuedEvent.id).to.equal(id);
+      expect(grainContinuedEvent.type).to.equal('GRAIN_CONTINUED');
+      expect(grainContinuedEvent.occurredAt).to.equal(occurredAt);
+      expect(grainContinuedEvent.createdAt).to.equal(createdAt);
+      expect(grainContinuedEvent.passageId).to.equal(passageId);
+      expect(grainContinuedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(grainContinuedEvent.data).to.deep.equal({ grainId });
+    });
+
+    describe('when grainId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new GrainContinuedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property is required for a GrainContinuedEvent');
+      });
+    });
+
+    describe('when grainId is invalid', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const grainId = 'invalidGrainId';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new GrainContinuedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              grainId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property should be exactly 36 characters long');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -9,6 +9,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
+import { GrainContinuedEvent } from '../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
 import {
   PassageStartedEvent,
   PassageTerminatedEvent,
@@ -230,6 +231,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QABCardRetriedEvent);
+      });
+    });
+
+    describe('when given a GRAIN_CONTINUED event', function () {
+      it('should return a GrainContinuedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'GRAIN_CONTINUED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(GrainContinuedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -61,11 +61,11 @@ export default class ModulePassage extends Component {
 
     this.addNextGrainToDisplay();
 
-    this.metrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton continuer du grain : ${currentGrain.id}`,
+    this.passageEvents.record({
+      type: 'GRAIN_CONTINUED',
+      data: {
+        grainId: currentGrain.id,
+      },
     });
   }
 


### PR DESCRIPTION
## 🔆 Problème

L'événement envoyé lorsque l'utilisateur clique sur le bouton continuer n'est pas une trace d'apprentissage.

## ⛱️ Proposition

Créer la trace correspondante avec un type GRAIN_CONTINUED

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Aller sur le module [chatgpt-vraiment-neutre](https://app-pr12620.review.pix.fr/modules/chatgpt-vraiment-neutre/passage)
- Ouvrir la console developpeur -> onglet network
- Vérifier que l'appel POST /passage-events contient bien un type `GRAIN_CONTINUED` et un champ `grainId`.
