### PR TITLE
[BUGFIX] Réparer l'affichage du nombre de tentatives de connexions restantes (PIX-18405)

### DIFF
--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -44,7 +44,7 @@ class MissingOrInvalidCredentialsError extends DomainError {
     this.meta = {};
     this.meta.isLoginFailureWithUsername = meta?.isLoginFailureWithUsername ?? false;
     if (meta?.remainingAttempts) {
-      this.meta = meta.remainingAttempts;
+      this.meta.remainingAttempts = meta.remainingAttempts;
     }
   }
 }

--- a/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/identity-access-management/unit/application/http-error-mapper-configuration_test.js
@@ -40,61 +40,101 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
 
   context('when mapping "DifferentExternalIdentifierError"', function () {
     it('returns an ConflictError Http Error', function () {
-      //given
+      // given
       const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
         (httpErrorMapper) => httpErrorMapper.name === DifferentExternalIdentifierError.name,
       );
 
-      //when
+      // when
       const error = httpErrorMapper.httpErrorFn(new DifferentExternalIdentifierError());
 
-      //then
+      // then
       expect(error).to.be.instanceOf(HttpErrors.ConflictError);
     });
   });
 
   context('when mapping "MissingOrInvalidCredentialsError"', function () {
-    it('returns an UnauthorizedError Http Error', function () {
-      //given
-      const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
-        (httpErrorMapper) => httpErrorMapper.name === MissingOrInvalidCredentialsError.name,
-      );
+    context('when isLoginFailureWithUsername is true', function () {
+      it('returns a UnauthorizedError with isLoginFailureWithUsername set to true', function () {
+        // given
+        const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+          (httpErrorMapper) => httpErrorMapper.name === MissingOrInvalidCredentialsError.name,
+        );
 
-      //when
-      const error = httpErrorMapper.httpErrorFn(new MissingOrInvalidCredentialsError());
+        // when
+        const error = httpErrorMapper.httpErrorFn(
+          new MissingOrInvalidCredentialsError({ isLoginFailureWithUsername: true }),
+        );
 
-      //then
-      expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        // then
+        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error.meta.isLoginFailureWithUsername).to.be.true;
+      });
+    });
+
+    context('when isLoginFailureWithUsername is false', function () {
+      it('returns a UnauthorizedError with isLoginFailureWithUsername set to false', function () {
+        // given
+        const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+          (httpErrorMapper) => httpErrorMapper.name === MissingOrInvalidCredentialsError.name,
+        );
+
+        // when
+        const error = httpErrorMapper.httpErrorFn(
+          new MissingOrInvalidCredentialsError({ isLoginFailureWithUsername: false }),
+        );
+
+        // then
+        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error.meta.isLoginFailureWithUsername).to.be.false;
+      });
+    });
+
+    context('when remainingAttempts is provided', function () {
+      it('returns a UnauthorizedError with remainingAttempts set', function () {
+        // given
+        const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
+          (httpErrorMapper) => httpErrorMapper.name === MissingOrInvalidCredentialsError.name,
+        );
+        const remainingAttempts = 3;
+
+        // when
+        const error = httpErrorMapper.httpErrorFn(new MissingOrInvalidCredentialsError({ remainingAttempts }));
+
+        // then
+        expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
+        expect(error.meta.remainingAttempts).to.equal(remainingAttempts);
+      });
     });
   });
 
   context('when mapping "MissingUserAccountError"', function () {
     it('returns an BadRequestError Http Error', function () {
-      //given
+      // given
       const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
         (httpErrorMapper) => httpErrorMapper.name === MissingUserAccountError.name,
       );
 
-      //when
+      // when
       const error = httpErrorMapper.httpErrorFn(new MissingUserAccountError());
 
-      //then
+      // then
       expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
     });
   });
 
   context('when mapping "PasswordResetDemandNotFoundError"', function () {
     it('returns a NotFoundError Http Error', function () {
-      //given
+      // given
       const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
         (httpErrorMapper) => httpErrorMapper.name === PasswordResetDemandNotFoundError.name,
       );
       const message = 'Test message error';
 
-      //when
+      // when
       const error = httpErrorMapper.httpErrorFn(new PasswordResetDemandNotFoundError(message));
 
-      //then
+      // then
       expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
       expect(error.message).to.equal(message);
     });
@@ -102,16 +142,16 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
 
   context('when mapping "UserCantBeCreatedError"', function () {
     it('returns an UnauthorizedError Http Error', function () {
-      //given
+      // given
       const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
         (httpErrorMapper) => httpErrorMapper.name === UserCantBeCreatedError.name,
       );
       const message = 'Test message error';
 
-      //when
+      // when
       const error = httpErrorMapper.httpErrorFn(new UserCantBeCreatedError(message));
 
-      //then
+      // then
       expect(error).to.be.instanceOf(HttpErrors.UnauthorizedError);
       expect(error.message).to.equal(message);
     });
@@ -119,17 +159,17 @@ describe('Unit | Identity Access Management | Application | HttpErrorMapperConfi
 
   context('when mapping "UserShouldChangePasswordError"', function () {
     it('returns an PasswordShouldChangeError Http Error', function () {
-      //given
+      // given
       const httpErrorMapper = authenticationDomainErrorMappingConfiguration.find(
         (httpErrorMapper) => httpErrorMapper.name === UserShouldChangePasswordError.name,
       );
       const message = 'Test message error';
       const meta = 'Test meta';
 
-      //when
+      // when
       const error = httpErrorMapper.httpErrorFn(new UserShouldChangePasswordError(message, meta));
 
-      //then
+      // then
       expect(error).to.be.instanceOf(HttpErrors.PasswordShouldChangeError);
       expect(error.message).to.equal(message);
       expect(error.meta).to.equal(meta);


### PR DESCRIPTION
## 🔆 Problème

La PR #12387 permet d’afficher à l’utilisateur le nombre de tentatives restantes avant que son compte soit bloqué définitivement. Ce message s’affiche après le blocage temporaire de 4 minutes qui se produit à la 20ème tentatives. Or le mécanisme ne fonctionne pas.

## ⛱️ Proposition

Réparer l'affichage


## 🏄 Pour tester

**Tentatives de connexion avec email sur Pix App, utiliser un `email` et un mauvais mot de passe:**

- **10 premières tentatives :** _L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects._
- **À la 11ᵉ tentative :** _Vous avez effectué trop de tentatives de connexion, votre compte Pix est bloqué temporairement pendant 2 minutes. Réessayez plus tard ou cliquez sur [mot de passe oublié](https://app.recette.pix.fr/mot-de-passe-oublie) pour le réinitialiser._
- **10 tentatives suivantes :** _L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects._
- **À la 21ᵉ tentative :** _Vous avez effectué trop de tentatives de connexion, votre compte Pix est bloqué temporairement pendant 4 minutes. Réessayez plus tard ou cliquez sur [mot de passe oublié](https://app.recette.pix.fr/mot-de-passe-oublie) pour le réinitialiser._
- **10 tentatives suivantes :** _Attention : il vous reste <X> tentatives avant le blocage définitif de votre compte Pix._
- **À la 31ᵉ tentative :** _Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, [contactez-nous](https://support.pix.org/support/tickets/new)._


**Tentatives de connexion avec email sur Pix App, utiliser un `username` et un mauvais mot de passe:**

- **10 premières tentatives :** _L'identifiant et/ou le mot de passe saisis sont incorrects. En cas d’oubli, **contactez votre enseignant** pour récupérer votre identifiant et/ou réinitialiser votre mot de passe._
- **À la 11ᵉ tentative :** _Vous avez effectué trop de tentatives de connexion, votre compte Pix est bloqué temporairement pendant 2 minutes. En cas d’oubli, **contactez votre enseignant** pour récupérer votre identifiant et/ou réinitialiser votre mot de passe._
- **10 tentatives suivantes :**_L'identifiant et/ou le mot de passe saisis sont incorrects. En cas d’oubli, **contactez votre enseignant** pour récupérer votre identifiant et/ou réinitialiser votre mot de passe._
- **À la 21ᵉ tentative :** _Vous avez effectué trop de tentatives de connexion, votre compte Pix est bloqué temporairement pendant 4 minutes. En cas d’oubli, **contactez votre enseignant** pour récupérer votre identifiant et/ou réinitialiser votre mot de passe._
- **10 tentatives suivantes :**  _Attention : il vous reste <X> tentatives avant le blocage définitif de votre compte Pix. En cas d’oubli, **contactez votre enseignant** pour récupérer votre identifiant et/ou réinitialiser votre mot de passe._
- **À la 31ᵉ tentative :**  _Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, [contactez-nous](https://support.pix.org/support/tickets/new)._

**Tester de la même manière pour le cas d’une authentification OIDC et pour le cas d’une authentification SAML**

**Se connecter avec un `email` et mot de passe corrects** pour vérifier la non régression.

**Se connecter avec un `username` et mot de passe corrects** pour vérifier la non régression.
