### PR TITLE
[FEATURE] Migrer l'événement GRAIN_SKIPPED en traces d'apprentissage (PIX-18364)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -7,7 +7,7 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../models/passage-events/flashcard-events.js';
-import { GrainContinuedEvent } from '../models/passage-events/grain-events.js';
+import { GrainContinuedEvent, GrainSkippedEvent } from '../models/passage-events/grain-events.js';
 import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-events/qab-events.js';
 
@@ -36,6 +36,8 @@ class PassageEventFactory {
         return new QABCardRetriedEvent(eventData);
       case 'GRAIN_CONTINUED':
         return new GrainContinuedEvent(eventData);
+      case 'GRAIN_SKIPPED':
+        return new GrainSkippedEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/grain-events.js
+++ b/api/src/devcomp/domain/models/passage-events/grain-events.js
@@ -18,4 +18,21 @@ class GrainContinuedEvent extends PassageEvent {
   }
 }
 
-export { GrainContinuedEvent };
+class GrainSkippedEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, grainId }) {
+    super({
+      type: 'GRAIN_SKIPPED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      data: { grainId },
+    });
+
+    assertNotNullOrUndefined(grainId, 'The grainId property is required for a GrainSkippedEvent');
+    assertHasUuidLength(grainId, 'The grainId property should be exactly 36 characters long');
+  }
+}
+
+export { GrainContinuedEvent, GrainSkippedEvent };

--- a/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
@@ -1,4 +1,7 @@
-import { GrainContinuedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
+import {
+  GrainContinuedEvent,
+  GrainSkippedEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -74,6 +77,93 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
         const error = catchErrSync(
           () =>
             new GrainContinuedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              grainId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property should be exactly 36 characters long');
+      });
+    });
+  });
+
+  describe('#GrainSkippedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const grainId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+      // when
+      const grainSkippedEvent = new GrainSkippedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        grainId,
+      });
+
+      // then
+      expect(grainSkippedEvent.id).to.equal(id);
+      expect(grainSkippedEvent.type).to.equal('GRAIN_SKIPPED');
+      expect(grainSkippedEvent.occurredAt).to.equal(occurredAt);
+      expect(grainSkippedEvent.createdAt).to.equal(createdAt);
+      expect(grainSkippedEvent.passageId).to.equal(passageId);
+      expect(grainSkippedEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(grainSkippedEvent.data).to.deep.equal({ grainId });
+    });
+
+    describe('when grainId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new GrainSkippedEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property is required for a GrainSkippedEvent');
+      });
+    });
+
+    describe('when grainId is invalid', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const grainId = 'invalidGrainId';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new GrainSkippedEvent({
               id,
               occurredAt,
               createdAt,

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -9,7 +9,10 @@ import {
   FlashcardsStartedEvent,
   FlashcardsVersoSeenEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/flashcard-events.js';
-import { GrainContinuedEvent } from '../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
+import {
+  GrainContinuedEvent,
+  GrainSkippedEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/grain-events.js';
 import {
   PassageStartedEvent,
   PassageTerminatedEvent,
@@ -249,6 +252,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(GrainContinuedEvent);
+      });
+    });
+
+    describe('when given a GRAIN_SKIPPED event', function () {
+      it('should return a GrainContinuedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'GRAIN_SKIPPED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(GrainSkippedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -47,11 +47,11 @@ export default class ModulePassage extends Component {
 
     this.addNextGrainToDisplay();
 
-    this.metrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton passer du grain : ${currentGrain.id}`,
+    this.passageEvents.record({
+      type: 'GRAIN_SKIPPED',
+      data: {
+        grainId: currentGrain.id,
+      },
     });
   }
 

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -281,7 +281,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.strictEqual(findAll('.element-text').length, 1);
     });
 
-    test('should push event', async function (assert) {
+    test('should send an event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const textElement = { content: 'content', type: 'text' };
@@ -310,11 +310,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.grain.skip'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'GRAIN_SKIPPED',
+        data: {
+          grainId: grain1.id,
+        },
       });
       assert.ok(true);
     });


### PR DESCRIPTION
## 🔆 Problème

L'événement envoyé lorsque l'utilisateur clique sur le bouton passer n'est pas une trace d'apprentissage.

## ⛱️ Proposition

Créer la trace correspondante avec un type `GRAIN_SKIPPED`.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Aller sur le module [chatgpt-vraiment-neutre](https://app-pr12622.review.pix.fr/modules/chatgpt-vraiment-neutre/passage)
- Ouvrir la console développeur -> onglet Network
- Vérifier que l'appel POST /passage-events contient bien un type `GRAIN_SKIPPED` et un champ `grainId`.
