### PR TITLE
[BUGFIX] Afficher le compteur de participants (PIX-17755)

### DIFF
--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -417,7 +417,7 @@ export default class List extends Component {
 const Filters = <template>
   <InElement @destinationId={{@destinationId}}>
     <LearnerFilters
-      @learnersCount={{@participants.meta.rowCount}}
+      @learnersCount={{@learnersCount}}
       @fullName={{@fullName}}
       @customFilters={{@customFilters}}
       @customFiltersValues={{@customFiltersValues}}

--- a/orga/tests/integration/components/organization-participant/list-test.js
+++ b/orga/tests/integration/components/organization-participant/list-test.js
@@ -263,6 +263,40 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
   });
 
   module('filtering cases', function () {
+    test('it should display the students number', async function (assert) {
+      // given
+      this.set('participants', [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          id: 34,
+        },
+        {
+          lastName: 'Terreur',
+          firstName: 'Gi',
+          id: 33,
+        },
+      ]);
+      this.set('participants.meta', {
+        rowCount: 2,
+      });
+      this.set('certificabilityFilter', []);
+      this.set('fullNameFilter', null);
+
+      // when
+      const screen = await render(
+        hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`,
+      );
+
+      // then
+      assert.ok(screen.getByText(t('pages.organization-participants.filters.participations-count', { count: 2 })));
+    });
     test('it should display the filter labels', async function (assert) {
       // given
       this.set('participants', []);


### PR DESCRIPTION
## 🔆 Problème
le nombre d'élèves ne s'affiche pas
![image](https://github.com/user-attachments/assets/1feab093-d02d-4ec8-9865-1fbb9894fb5e)

## ⛱️ Proposition
Corriger
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- se connecter en tant qu'Admin à PixOrga

**1. Orga Pro classic** 
- se rendre sur l'orga Pro classic 
- se rendre sur la liste de participants
- vérifier la présence du compteur

**2. Orga Pro classic** 
- se rendre sur l'orga Pro Import Généric
-  importer des élèves
- se rendre sur la liste de participants
- vérifier la présence du compteur
- 🎉 