### PR TITLE
[FEATURE] Ajouter un filtre sur l'api maddo pour remonter les dernières participations mise à jour (PIX-18288)

### DIFF
--- a/api/src/maddo/application/campaigns-controller.js
+++ b/api/src/maddo/application/campaigns-controller.js
@@ -5,11 +5,12 @@ export async function getCampaignParticipations(
   h,
   dependencies = { getCampaignParticipations: usecases.getCampaignParticipations },
 ) {
-  const { page } = request.query;
+  const { page, since } = request.query;
   const { models: campaignParticipations, meta } = await dependencies.getCampaignParticipations({
     campaignId: request.params.campaignId,
     clientId: request.auth.credentials.client_id,
     page,
+    since,
   });
   return h
     .response({ campaignParticipations, page: { number: meta.page, size: meta.pageSize, count: meta.pageCount } })

--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -17,6 +17,7 @@ const register = async function (server) {
             campaignId: identifiersType.campaignId,
           }),
           query: Joi.object({
+            since: Joi.date().iso(),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().max(200).empty('').allow(null).optional(),

--- a/api/src/maddo/domain/usecases/get-campaign-participations.js
+++ b/api/src/maddo/domain/usecases/get-campaign-participations.js
@@ -1,3 +1,9 @@
-export async function getCampaignParticipations({ campaignId, clientId, page, campaignParticipationRepository }) {
-  return campaignParticipationRepository.findByCampaignId(campaignId, clientId, page);
+export async function getCampaignParticipations({
+  campaignId,
+  clientId,
+  page,
+  since,
+  campaignParticipationRepository,
+}) {
+  return campaignParticipationRepository.findByCampaignId(campaignId, clientId, page, since);
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -2,8 +2,12 @@ import * as campaignsAPI from '../../../prescription/campaign/application/api/ca
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { TubeCoverage } from '../../domain/models/TubeCoverage.js';
 
-export async function findByCampaignId(campaignId, clientId, page) {
-  const { models: campaignParticipations, meta } = await campaignsAPI.getCampaignParticipations({ campaignId, page });
+export async function findByCampaignId(campaignId, clientId, page, since) {
+  const { models: campaignParticipations, meta } = await campaignsAPI.getCampaignParticipations({
+    campaignId,
+    page,
+    since,
+  });
   return { models: campaignParticipations.map((rawCampaign) => toDomain(rawCampaign, clientId, campaignId)), meta };
 }
 

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -1,4 +1,4 @@
-This doc has been generated on 18/06/2025 13:26:32 with `scripts/generate-api-documentation.js`. See package.json.
+This doc has been generated on 24/06/2025 11:31:47 with `scripts/generate-api-documentation.js`. See package.json.
 
 ---
 ## Modules
@@ -78,7 +78,7 @@ This doc has been generated on 18/06/2025 13:26:32 with `scripts/generate-api-do
     * [~update(payload)](#module_CampaignApi..update) ⇒ <code>Promise.&lt;Campaign&gt;</code>
     * [~findAllForOrganization(payload)](#module_CampaignApi..findAllForOrganization) ⇒ <code>Promise.&lt;CampaignListResponse&gt;</code>
     * [~findCampaignSkillIdsForCampaignParticipations(campaignParticipationIds)](#module_CampaignApi..findCampaignSkillIdsForCampaignParticipations) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
-    * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;(Array.&lt;AssessmentCampaignParticipationAPI&gt;\|Array.&lt;ProfilesCollectionCampaignParticipationAPI&gt;)&gt;</code>
+    * [~getCampaignParticipations(payload)](#module_CampaignApi..getCampaignParticipations) ⇒ <code>Promise.&lt;{models: (Array.&lt;AssessmentCampaignParticipationAPI&gt;\|Array.&lt;ProfilesCollectionCampaignParticipationAPI&gt;), meta: Pagination}&gt;</code>
     * [~deleteActiveCampaigns(payload)](#module_CampaignApi..deleteActiveCampaigns) ⇒ <code>Promise.&lt;void&gt;</code>
     * [~CampaignPayload](#module_CampaignApi..CampaignPayload) : <code>object</code>
     * [~UserNotAuthorizedToCreateCampaignError](#module_CampaignApi..UserNotAuthorizedToCreateCampaignError) : <code>object</code>
@@ -150,7 +150,7 @@ This doc has been generated on 18/06/2025 13:26:32 with `scripts/generate-api-do
 
 <a name="module_CampaignApi..getCampaignParticipations"></a>
 
-### CampaignApi~getCampaignParticipations(payload) ⇒ <code>Promise.&lt;(Array.&lt;AssessmentCampaignParticipationAPI&gt;\|Array.&lt;ProfilesCollectionCampaignParticipationAPI&gt;)&gt;</code>
+### CampaignApi~getCampaignParticipations(payload) ⇒ <code>Promise.&lt;{models: (Array.&lt;AssessmentCampaignParticipationAPI&gt;\|Array.&lt;ProfilesCollectionCampaignParticipationAPI&gt;), meta: Pagination}&gt;</code>
 **Kind**: inner method of [<code>CampaignApi</code>](#module_CampaignApi)  
 
 | Param | Type |
@@ -260,6 +260,8 @@ This doc has been generated on 18/06/2025 13:26:32 with `scripts/generate-api-do
 | Name | Type |
 | --- | --- |
 | campaignId | <code>number</code> | 
+| since | <code>string</code> | 
+| page | <code>PageDefinition</code> | 
 
 <a name="module_CampaignApi..DeleteActiveCampaignPayload"></a>
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -147,7 +147,7 @@ const remove = async function ({ id, attributes }) {
   return await knexConn('campaign-participations').where({ id }).update(attributes);
 };
 
-const findInfoByCampaignId = async function (campaignId, page) {
+const findInfoByCampaignId = async function ({ campaignId, page }) {
   const knexConn = DomainTransaction.getConnection();
   const query = knexConn('campaign-participations')
     .select([

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -147,7 +147,7 @@ const remove = async function ({ id, attributes }) {
   return await knexConn('campaign-participations').where({ id }).update(attributes);
 };
 
-const findInfoByCampaignId = async function ({ campaignId, page }) {
+const findInfoByCampaignId = async function ({ campaignId, page, since }) {
   const knexConn = DomainTransaction.getConnection();
   const query = knexConn('campaign-participations')
     .select([
@@ -168,6 +168,17 @@ const findInfoByCampaignId = async function ({ campaignId, page }) {
     .orderBy('lastName', 'ASC')
     .orderBy('firstName', 'ASC')
     .orderBy('createdAt', 'DESC');
+
+  if (since !== undefined) {
+    const sinceDate = new Date(since);
+    query.where(function () {
+      this.where('campaign-participations.sharedAt', '>', sinceDate).orWhere(
+        'campaign-participations.createdAt',
+        '>',
+        sinceDate,
+      );
+    });
+  }
 
   const { results, pagination } = await fetchPage(query, page);
 

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -174,8 +174,12 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
  * @param {CampaignParticipationsPayload} payload
  * @returns {Promise<{models: Array<AssessmentCampaignParticipationAPI>|Array<ProfilesCollectionCampaignParticipationAPI>, meta: Pagination}>}
  */
-export const getCampaignParticipations = async function ({ campaignId, page }) {
-  const { models: campaignParticipations, meta } = await usecases.getCampaignParticipations({ campaignId, page });
+export const getCampaignParticipations = async function ({ campaignId, page, since }) {
+  const { models: campaignParticipations, meta } = await usecases.getCampaignParticipations({
+    campaignId,
+    page,
+    since,
+  });
   return {
     models: campaignParticipations.map((campaignParticipation) =>
       campaignParticipation instanceof AssessmentCampaignParticipation

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -165,6 +165,8 @@ export const findCampaignSkillIdsForCampaignParticipations = async (campaignPart
  * @typedef CampaignParticipationsPayload
  * @type {object}
  * @property {number} campaignId
+ * @property {string} since
+ * @property {PageDefinition} page
  */
 
 /**

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -10,6 +10,7 @@ const getCampaignParticipations = async function ({
   campaignId,
   locale,
   page,
+  since,
   campaignRepository,
   campaignParticipationRepository,
   knowledgeElementSnapshotRepository,
@@ -19,6 +20,7 @@ const getCampaignParticipations = async function ({
   const { models: participations, meta } = await campaignParticipationRepository.findInfoByCampaignId({
     campaignId,
     page,
+    since,
   });
 
   if (campaign.isProfilesCollection) {

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -16,7 +16,10 @@ const getCampaignParticipations = async function ({
   learningContentRepository,
 }) {
   const campaign = await campaignRepository.get(campaignId);
-  const { models: participations, meta } = await campaignParticipationRepository.findInfoByCampaignId(campaignId, page);
+  const { models: participations, meta } = await campaignParticipationRepository.findInfoByCampaignId({
+    campaignId,
+    page,
+  });
 
   if (campaign.isProfilesCollection) {
     return {

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -36,7 +36,10 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
   const [allPixCompetences, organization, { models: campaignParticipationResultDatas }] = await Promise.all([
     competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),
     organizationRepository.get(campaign.organizationId),
-    campaignParticipationRepository.findInfoByCampaignId(campaign.id, { size: 1000000, number: 1 }),
+    campaignParticipationRepository.findInfoByCampaignId({
+      campaignId: campaign.id,
+      page: { size: 1000000, number: 1 },
+    }),
   ]);
 
   const campaignProfilesCollectionExport = new CampaignProfilesCollectionExport({

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -395,6 +395,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           campaignId: campaign.id,
           status: CampaignParticipationStatuses.STARTED,
           participantExternalId: 'started after 1',
+          masteryRate: null,
           createdAt: new Date('2025-01-03'),
         });
 
@@ -423,8 +424,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           masteryRate: 0.1,
           validatedSkillsCount: 10,
           participantExternalId: 'shared after 1',
-          createdAt: new Date('2025-01-01'),
-          sharedAt: new Date('2025-01-03'),
+          createdAt: new Date('2025-01-04'),
+          sharedAt: new Date('2025-01-05'),
         });
 
         databaseBuilder.factory.buildKnowledgeElementSnapshot({

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -352,5 +352,141 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         ]);
       });
     });
+    context('should handle filters', function () {
+      let campaign, clientId, tube, competenceId, skillId;
+
+      beforeEach(async function () {
+        const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
+        databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
+
+        const tag = databaseBuilder.factory.buildTag();
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: orgaInJurisdiction.id, tagId: tag.id });
+
+        clientId = 'client';
+        databaseBuilder.factory.buildClientApplication({
+          clientId: 'client',
+          jurisdiction: { rules: [{ name: 'tags', value: [tag.name] }] },
+        });
+
+        const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+        const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
+        competenceId = databaseBuilder.factory.learningContent.buildCompetence({ areaId }).id;
+        tube = databaseBuilder.factory.learningContent.buildTube({ competenceId });
+        skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+
+        campaign = databaseBuilder.factory.buildCampaign({
+          type: CampaignTypes.ASSESSMENT,
+          organizationId: orgaInJurisdiction.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should returns only participation created or updated after a given date', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.STARTED,
+          participantExternalId: 'started before 1',
+          createdAt: new Date('2025-01-01'),
+        });
+        const participationCreatedAfterDate = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.STARTED,
+          participantExternalId: 'started after 1',
+          createdAt: new Date('2025-01-03'),
+        });
+
+        const participationSharedBefore = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          masteryRate: 0.1,
+          validatedSkillsCount: 10,
+          participantExternalId: 'shared before 1',
+          createdAt: new Date('2025-01-01'),
+          sharedAt: new Date('2025-01-01'),
+        });
+        const ke = databaseBuilder.factory.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.VALIDATED,
+          skillId,
+          userId: participationSharedBefore.userId,
+        });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          campaignParticipationId: participationSharedBefore.id,
+          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+        });
+
+        const participationSharedAfterDate = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          masteryRate: 0.1,
+          validatedSkillsCount: 10,
+          participantExternalId: 'shared after 1',
+          createdAt: new Date('2025-01-01'),
+          sharedAt: new Date('2025-01-03'),
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          campaignParticipationId: participationSharedAfterDate.id,
+          snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          status: CampaignParticipationStatuses.SHARED,
+          masteryRate: 0.1,
+          validatedSkillsCount: 10,
+          participantExternalId: 'deleted external id 1',
+          createdAt: new Date('2024-01-02'),
+          sharedAt: new Date('2024-01-03'),
+          deletedAt: new Date('2025-01-04'),
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/participations?since=2025-01-02T01:01:01Z`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              clientId,
+              'pix-client',
+              'campaigns meta',
+            ),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.campaignParticipations).to.deep.members([
+          domainBuilder.maddo.buildCampaignParticipation({
+            ...participationSharedAfterDate,
+            clientId,
+            tubes: [
+              domainBuilder.maddo.buildTubeCoverage({
+                id: tube.id,
+                competenceId,
+                maxLevel: 2,
+                reachedLevel: 2,
+                practicalDescription: tube.practicalDescription_i18n['fr'],
+                practicalTitle: tube.practicalTitle_i18n['fr'],
+              }),
+            ],
+          }),
+          domainBuilder.maddo.buildCampaignParticipation({
+            ...participationCreatedAfterDate,
+            clientId,
+          }),
+        ]);
+        expect(response.result.page).to.deep.equal({
+          count: 1,
+          number: 1,
+          size: 10,
+        });
+      });
+    });
   });
 });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1058,10 +1058,12 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       it('should return the division of the school registration linked to the campaign', async function () {
+        // given & when
         const { models: campaignParticipationInfos } = await campaignParticipationRepository.findInfoByCampaignId({
           campaignId: campaign.id,
         });
 
+        // then
         expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].division).to.equal('3eme');
       });
@@ -1121,25 +1123,100 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
     });
 
-    context('pagination', function () {
-      it('should use given page and return pagination metadata', async function () {
-        // given
-        const campaignId = campaign1.id;
-        const page = { number: 2, size: 10 };
+    context('filters', function () {
+      context('pagination', function () {
+        it('should use given page and return pagination metadata', async function () {
+          // given
+          const campaignId = campaign1.id;
+          const page = { number: 2, size: 10 };
 
-        // when
-        const { models: participationResultDatas, meta } = await campaignParticipationRepository.findInfoByCampaignId({
-          campaignId,
-          page,
+          // when
+          const { models: participationResultDatas, meta } = await campaignParticipationRepository.findInfoByCampaignId(
+            {
+              campaignId,
+              page,
+            },
+          );
+
+          // then
+          expect(participationResultDatas).lengthOf(0);
+          expect(meta).to.deep.equal({
+            page: 2,
+            pageCount: 1,
+            pageSize: 10,
+            rowCount: 1,
+          });
         });
+      });
 
-        // then
-        expect(participationResultDatas).lengthOf(0);
-        expect(meta).to.deep.equal({
-          page: 2,
-          pageCount: 1,
-          pageSize: 10,
-          rowCount: 1,
+      context('since', function () {
+        it('should return created and updated campaign-participations after a given date', async function () {
+          // given
+          const campaignId = databaseBuilder.factory.buildCampaign().id;
+          const since = new Date('2025-01-02').getTime();
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: CampaignParticipationStatuses.STARTED,
+            participantExternalId: 'started before 1',
+            createdAt: new Date('2025-01-01'),
+          });
+          const participationCreatedAfterDate = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: CampaignParticipationStatuses.STARTED,
+            participantExternalId: 'started after 1',
+            createdAt: new Date('2025-01-03'),
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: CampaignParticipationStatuses.SHARED,
+            masteryRate: 0.1,
+            validatedSkillsCount: 10,
+            participantExternalId: 'shared before 1',
+            createdAt: new Date('2025-01-01'),
+            sharedAt: new Date('2025-01-01'),
+          });
+
+          const participationSharedAfterDate = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: CampaignParticipationStatuses.SHARED,
+            masteryRate: 0.1,
+            validatedSkillsCount: 10,
+            participantExternalId: 'shared after 1',
+            createdAt: new Date('2025-01-01'),
+            sharedAt: new Date('2025-01-03'),
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            status: CampaignParticipationStatuses.STARTED,
+            participantExternalId: 'started after 1 but in another campaign',
+            createdAt: new Date('2025-01-03'),
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: CampaignParticipationStatuses.SHARED,
+            masteryRate: 0.1,
+            validatedSkillsCount: 10,
+            participantExternalId: 'deleted external id 1',
+            createdAt: new Date('2024-01-02'),
+            sharedAt: new Date('2024-01-03'),
+            deletedAt: new Date('2025-01-04'),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: participationResultData } = await campaignParticipationRepository.findInfoByCampaignId({
+            campaignId,
+            since,
+          });
+
+          // then
+          expect(participationResultData).lengthOf(2);
+          expect(participationResultData.map(({ id }) => id)).to.deep.members([
+            participationCreatedAfterDate.id,
+            participationSharedAfterDate.id,
+          ]);
         });
       });
     });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -945,8 +945,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const { models: participationResultDatas } =
-        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+        campaignId,
+      });
 
       // then
       expect(participationResultDatas).lengthOf(1);
@@ -985,8 +986,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       await databaseBuilder.commit();
 
       // when
-      const { models: participationResultDatas } =
-        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+        campaignId,
+      });
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -1008,8 +1010,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignId = campaign1.id;
 
       // when
-      const { models: participationResultDatas } =
-        await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+      const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+        campaignId,
+      });
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
@@ -1055,9 +1058,9 @@ describe('Integration | Repository | Campaign Participation', function () {
       });
 
       it('should return the division of the school registration linked to the campaign', async function () {
-        const { models: campaignParticipationInfos } = await campaignParticipationRepository.findInfoByCampaignId(
-          campaign.id,
-        );
+        const { models: campaignParticipationInfos } = await campaignParticipationRepository.findInfoByCampaignId({
+          campaignId: campaign.id,
+        });
 
         expect(campaignParticipationInfos).to.have.lengthOf(1);
         expect(campaignParticipationInfos[0].division).to.equal('3eme');
@@ -1085,8 +1088,9 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const { models: participationResultDatas } =
-          await campaignParticipationRepository.findInfoByCampaignId(campaignId);
+        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+          campaignId,
+        });
 
         // then
         expect(participationResultDatas).to.lengthOf(2);
@@ -1108,9 +1112,9 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         // when
-        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId(
-          campaign.id,
-        );
+        const { models: participationResultDatas } = await campaignParticipationRepository.findInfoByCampaignId({
+          campaignId: campaign.id,
+        });
 
         // then
         expect(participationResultDatas[0].sharedAt).to.equal(null);
@@ -1124,10 +1128,10 @@ describe('Integration | Repository | Campaign Participation', function () {
         const page = { number: 2, size: 10 };
 
         // when
-        const { models: participationResultDatas, meta } = await campaignParticipationRepository.findInfoByCampaignId(
+        const { models: participationResultDatas, meta } = await campaignParticipationRepository.findInfoByCampaignId({
           campaignId,
           page,
-        );
+        });
 
         // then
         expect(participationResultDatas).lengthOf(0);

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -93,6 +93,21 @@ describe('Integration | Application | campaign-api', function () {
         status: CampaignParticipationStatuses.STARTED,
         organizationLearnerId: organizationLearner2.id,
         userId: organizationLearner2.userId,
+        createdAt: new Date('2025-01-02'),
+      });
+
+      const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organizationLearner1.organizationId,
+        lastName: 'zoé',
+      });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.STARTED,
+        organizationLearnerId: organizationLearner3.id,
+        userId: organizationLearner3.userId,
+        participantExternalId: 'participation before date filter',
+        createdAt: new Date('2024-12-03'),
       });
 
       await databaseBuilder.commit();
@@ -102,6 +117,7 @@ describe('Integration | Application | campaign-api', function () {
         campaignId: campaign.id,
         locale: 'fr',
         page: { size: 2, number: 1 },
+        since: new Date('2024-12-25'),
       });
 
       // then

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -23,7 +23,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId: competence.id });
       const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
 
-      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ lastName: 'Albert' });
       const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
       databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
       const participation1 = databaseBuilder.factory.buildCampaignParticipation({
@@ -33,6 +33,8 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         masteryRate: 0.1,
         pixScore: 42,
         validatedSkillsCount: 10,
+        createdAt: new Date('2020-01-03'),
+        sharedAt: new Date('2020-01-03'),
       });
       const ke = databaseBuilder.factory.buildKnowledgeElement({
         status: KnowledgeElement.StatusType.VALIDATED,
@@ -46,6 +48,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
       });
 
       const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        lastName: 'Michele',
         organizationId: organizationLearner1.organizationId,
       });
       databaseBuilder.factory.buildCampaignParticipation({
@@ -55,10 +58,18 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         masteryRate: null,
         pixScore: null,
         validatedSkillsCount: null,
+        createdAt: new Date('2020-01-03'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         status: CampaignParticipationStatuses.STARTED,
         masteryRate: 0.5,
+        createdAt: new Date('2020-01-04'),
+      });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        status: CampaignParticipationStatuses.STARTED,
+        masteryRate: 0.5,
+        createdAt: new Date('2020-01-01'),
       });
 
       await databaseBuilder.commit();
@@ -67,12 +78,13 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         size: 1,
         number: 1,
       };
-
+      const since = new Date('2020-01-02').getTime();
       // when
       const { models, meta } = await usecases.getCampaignParticipations({
         campaignId: campaign.id,
         locale: FRENCH_SPOKEN,
         page,
+        since,
       });
 
       // then

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -83,7 +83,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
     organizationRepository.get.withArgs(organization.id).resolves(organization);
     competenceRepository.listPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves(competences);
     campaignParticipationRepository.findInfoByCampaignId
-      .withArgs(campaign.id, { size: 1000000, number: 1 })
+      .withArgs({ campaignId: campaign.id, page: { size: 1000000, number: 1 } })
       .resolves({ models: campaignParticipationResultDatas });
     CampaignProfilesCollectionExport.prototype.export
       .withArgs(campaignParticipationResultDatas, placementProfileService)


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'api maddo pour récupérer les participations renvoie toutes les participations (de manière paginée) mais cela reste pénible pour les partenaires pour faire de la synchro. 

## ⛱️ Proposition

On souhaite que l'api maddo puisse remonter seulement les dernières participations mises à jour depuis une certaine date.

## 🌊 Remarques

On introduit un paramètre `since` qui prend un timestamp JS (nombre de milliseconde depuis 1 janv 1970)

On vu qu'il manquait des tests d'integ sur les couches repo / usecase / controller coté maddo (l'api reste couverte avec des tests en acceptance)

## 🏄 Pour tester

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12625.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns' | jq -r .access_token)
```

Appeler la route `/api/campaigns/:id/participations` avec le token et en remplaçant l'id de campagne par celui d'une campagne ayant des participations.

### Sans since

Campagne de collecte de profils : 

```
curl --get https://pix-api-maddo-review-pr12625.osc-fr1.scalingo.io/api/campaigns/105141/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

Campagne d'évaluation : 

```
curl https://pix-api-maddo-review-pr12625.osc-fr1.scalingo.io/api/campaigns/104906/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

### Avec since


Campagne de collecte de profils : 

```
curl --get --data-urlencode "since=2025-06-24" https://pix-api-maddo-review-pr12625.osc-fr1.scalingo.io/api/campaigns/105141/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

Campagne d'évaluation : 

```
 curl --get --data-urlencode "since=2025-06-24" https://pix-api-maddo-review-pr12625.osc-fr1.scalingo.io/api/campaigns/104906/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```
