### PR TITLE
[FEATURE] ajouter une route PATCH users/{id} pour enrichir un utilisateur anonyme avec des données d'authentification (Pix-18022)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -197,6 +197,32 @@ buildUser.withoutPixAuthenticationMethod = function buildUserWithoutPixAuthentic
   return user;
 };
 
+buildUser.anonymous = function buildUserAnonymous({
+  id = databaseBuffer.getNextId(),
+  firstName = '',
+  lastName = '',
+  email = null,
+  username = null,
+  cgu = false,
+  hasSeenAssessmentInstructions = true,
+  isAnonymous = true,
+} = {}) {
+  const values = {
+    id,
+    firstName,
+    lastName,
+    email,
+    username,
+    cgu,
+    hasSeenAssessmentInstructions,
+    isAnonymous,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'users',
+    values,
+  });
+};
+
 buildUser.withRole = function buildUserWithRole({
   id = databaseBuffer.getNextId(),
   firstName = 'Billy',

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -129,6 +129,45 @@ export const userRoutes = [
   },
   {
     method: 'PATCH',
+    path: '/api/users/{id}',
+    config: {
+      pre: [
+        {
+          method: (request, h) => securityPreHandlers.checkRequestedUserIsAuthenticatedUser(request, h),
+          assign: 'requestedUserIsAuthenticatedUser',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          id: identifiersType.userId,
+        }),
+        payload: Joi.object({
+          data: Joi.object({
+            attributes: Joi.object({
+              'first-name': Joi.string().required(),
+              'last-name': Joi.string().required(),
+              email: Joi.string().required(),
+              password: Joi.string().required(),
+              cgu: Joi.boolean().required(),
+              'anonymous-user-token': Joi.string().required(),
+            }).required(),
+          }).required(),
+        }),
+        options: {
+          allowUnknown: true,
+        },
+      },
+      handler: (request, h) => userController.upgradeToRealUser(request, h),
+      notes: [
+        '- **Cette route est restreinte aux utilisateurs anonymes**\n' +
+          "- Crée un compte Pix en conservant les points et l'id de l'utilisateur anonyme" +
+          '- L’id demandé doit correspondre à celui de l’utilisateur à enrichir',
+      ],
+      tags: ['identity-access-management', 'api', 'user'],
+    },
+  },
+  {
+    method: 'PATCH',
     path: '/api/users/{id}/password-update',
     config: {
       auth: false,

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -161,6 +161,16 @@ class User {
     });
   }
 
+  convertAnonymousToRealUser(userAttributes) {
+    return new User({
+      ...this,
+      ...userAttributes,
+      isAnonymous: false,
+      lastTermsOfServiceValidatedAt: new Date(),
+      mustValidateTermsOfService: false,
+    });
+  }
+
   mapToDatabaseDto() {
     return {
       id: this.id,

--- a/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/upgrade-to-real-user.usecase.js
@@ -1,0 +1,62 @@
+import { AlreadyRegisteredEmailError } from '../../../../src/shared/domain/errors.js';
+import { UnauthorizedError } from '../../../shared/application/http-errors.js';
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import { createAccountCreationEmail } from '../emails/create-account-creation.email.js';
+import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+
+const upgradeToRealUser = withTransaction(async function ({
+  userId,
+  userAttributes,
+  password,
+  anonymousUserToken,
+  language,
+  anonymousUserTokenRepository,
+  userRepository,
+  authenticationMethodRepository,
+  emailValidationDemandRepository,
+  emailRepository,
+  cryptoService,
+}) {
+  const anonymousUser = await userRepository.getFullById(userId);
+  if (!anonymousUser.isAnonymous) {
+    throw new UnauthorizedError('User must be anonymous', 'NOT_ANONYMOUS_USER');
+  }
+
+  const existingUsersWithEmail = await userRepository.findAnotherUserByEmail(userId, userAttributes.email);
+  if (existingUsersWithEmail.length > 0) {
+    throw new AlreadyRegisteredEmailError();
+  }
+
+  const storedAnonymousUserToken = await anonymousUserTokenRepository.find(userId);
+  if (storedAnonymousUserToken !== anonymousUserToken) {
+    throw new UnauthorizedError('Anonymous token is invalid', 'INVALID_ANONYMOUS_TOKEN');
+  }
+
+  const realUser = anonymousUser.convertAnonymousToRealUser(userAttributes);
+  await userRepository.update(realUser.mapToDatabaseDto());
+
+  const hashedPassword = await cryptoService.hashPassword(password);
+  const authenticationMethod = new AuthenticationMethod({
+    userId,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
+      password: hashedPassword,
+      shouldChangePassword: false,
+    }),
+  });
+  await authenticationMethodRepository.create({ authenticationMethod });
+
+  const token = await emailValidationDemandRepository.save(realUser.id);
+  await emailRepository.sendEmailAsync(
+    createAccountCreationEmail({
+      locale: language,
+      email: realUser.email,
+      firstName: realUser.firstName,
+      token,
+    }),
+  );
+  return realUser;
+});
+
+export { upgradeToRealUser };

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -249,10 +249,12 @@ const getBySamlId = async function (samlId) {
   return user ? _toDomainFromDTO({ userDTO: user }) : null;
 };
 
-const update = async function (properties) {
-  const { id: userId, ...data } = properties;
-  data.updatedAt = new Date();
-  await knex('users').where({ id: userId }).update(data);
+const update = async function (user) {
+  const knexConn = DomainTransaction.getConnection();
+  const { id, ...data } = user;
+  await knexConn('users')
+    .where({ id })
+    .update({ ...data, updatedAt: new Date() });
 };
 
 const updateWithEmailConfirmed = function ({ id, userAttributes }) {

--- a/api/tests/identity-access-management/integration/domain/usecases/upgrade-to-real-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/upgrade-to-real-user.usecase.test.js
@@ -1,0 +1,138 @@
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { anonymousUserTokenRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/anonymous-user-token.repository.js';
+import { UnauthorizedError } from '../../../../../src/shared/application/http-errors.js';
+import { AlreadyRegisteredEmailError } from '../../../../../src/shared/domain/errors.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Identity Access Management | Domain | UseCase | upgradeToRealUser', function () {
+  let clock;
+
+  beforeEach(function () {
+    const now = new Date('2024-12-25');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('upgrades an anonymous user to a real user', async function () {
+    // given
+    const anonymousUser = databaseBuilder.factory.buildUser.anonymous();
+    await databaseBuilder.commit();
+    const anonymousUserToken = await anonymousUserTokenRepository.save(anonymousUser.id);
+
+    const password = 'P@ssW0rd';
+    const language = 'fr';
+    const userAttributes = {
+      firstName: 'First',
+      lastName: 'Last',
+      email: 'first.last@example.net',
+      cgu: true,
+      locale: 'fr-FR',
+    };
+
+    // when
+    const realUser = await usecases.upgradeToRealUser({
+      userId: anonymousUser.id,
+      userAttributes,
+      password,
+      anonymousUserToken,
+      language,
+    });
+
+    // then
+    expect(realUser).to.be.instanceOf(User);
+    expect(realUser).to.include(userAttributes);
+    expect(realUser.isAnonymous).to.be.false;
+    expect(realUser.lastTermsOfServiceValidatedAt).to.be.instanceOf(Date);
+    expect(realUser.mustValidateTermsOfService).to.be.false;
+
+    const authenticationMethod = await knex('authentication-methods').where({ userId: realUser.id }).first();
+    expect(authenticationMethod.identityProvider).to.equal(NON_OIDC_IDENTITY_PROVIDERS.PIX.code);
+
+    await expect('SendEmailJob').to.have.been.performed.withJobsCount(1);
+  });
+
+  context('when the user is not anonymous', function () {
+    it('throws an UnauthorizedError', async function () {
+      // given
+      const realUser = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const promise = usecases.upgradeToRealUser({
+        userId: realUser.id,
+        userAttributes: {
+          firstName: 'First',
+          lastName: 'Last',
+          email: 'first.last@example.net',
+          cgu: true,
+          locale: 'fr-FR',
+        },
+        password: 'P@ssW0rd',
+        anonymousUserToken: 'anonymous-token',
+        language: 'fr',
+      });
+
+      // then
+      await expect(promise).to.be.rejectedWith(UnauthorizedError, 'User must be anonymous');
+    });
+  });
+
+  context('when the email already exists', function () {
+    it('throws an AlreadyRegisteredEmailError', async function () {
+      // given
+      const existingEmail = 'first.last@example.net';
+      databaseBuilder.factory.buildUser({ email: existingEmail });
+      const anonymousUser = databaseBuilder.factory.buildUser.anonymous();
+      await databaseBuilder.commit();
+
+      // when
+      const promise = usecases.upgradeToRealUser({
+        userId: anonymousUser.id,
+        userAttributes: {
+          firstName: 'First',
+          lastName: 'Last',
+          email: existingEmail,
+          cgu: true,
+          locale: 'fr-FR',
+        },
+        password: 'P@ssW0rd',
+        anonymousUserToken: 'anonymous-token',
+        language: 'fr',
+      });
+
+      // then
+      await expect(promise).to.be.rejectedWith(AlreadyRegisteredEmailError);
+    });
+  });
+
+  context('when the user anonymous token is invalid', function () {
+    it('throws an UnauthorizedError', async function () {
+      // given
+      const anonymousUser = databaseBuilder.factory.buildUser.anonymous();
+      await databaseBuilder.commit();
+
+      // when
+      const promise = usecases.upgradeToRealUser({
+        userId: anonymousUser.id,
+        userAttributes: {
+          firstName: 'First',
+          lastName: 'Last',
+          email: 'first.last@example.net',
+          cgu: true,
+          locale: 'fr-FR',
+        },
+        password: 'P@ssW0rd',
+        anonymousUserToken: 'invalid-anonymous-token',
+        language: 'fr',
+      });
+
+      // then
+      await expect(promise).to.be.rejectedWith(UnauthorizedError, 'Anonymous token is invalid');
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Un utilisateur anonyme doit pouvoir s'inscrire en gardant ses acquis à la fin d'une campagne.

## ⛱️ Proposition

Faire une route PATCH users/{id} pour enrichir l'utilisateur anonyme de ses données d'authentification

## 🌊 Remarques

j'ai rajouté un commit de front uniquement pour les tests si vous ne voulez pas faire de curl

## 🏄 Pour tester

En local :
npm run toggles -- --key=upgradeToRealUserEnabled --value=true
Pour le mail, il faut lancer les jobs : 
`cd api/`
`npm run start:job`

Passer une campagne en anonyme, par exemple https://app.dev.pix.fr/campagnes/AUTOCOUR2
Récupérer l'`id`, le `Bearer Token`, l'`anonymousUserToken` de l'utilisateur sur la route `/me`
Modifier le fichier ci joint avec le `Bearer Token` et l'`anonymousUserToken`
Faire cette requête curl (avec le fichier [data.json](https://github.com/user-attachments/files/20881299/data.json)) :
```
curl \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H 'Accept: application/json' \
  -H "Content-Type: application/json" \
  -X PATCH \
  --data @data.json \
  https://app.dev.pix.fr/api/users/{id}
```

Vérifier que les informations de l'utilisateur ont été mises à jour : 
Dans la table `users` : les `nom`, `prénom`, `email`, `isAnonymous`, `locale`, `cgu`, `lastTermsOfServiceValidatedAt`, `mustValidateTermsOfService`, `updatedAt`
Dans la table `authentication-methods` : vérifier qu'une méthode de connexion PIX a été rajoutée pour cet utilisateur
Vérifier l'envoi du mail
