### PR TITLE
[FEATURE] Ajouter une route récupérant le référentiel cadre en cours d'une complémentaire (PIX-18344).

### DIFF
--- a/api/db/database-builder/factory/build-certification-frameworks-challenge.js
+++ b/api/db/database-builder/factory/build-certification-frameworks-challenge.js
@@ -10,6 +10,7 @@ const buildCertificationFrameworksChallenge = function ({
   delta = 3.5,
   complementaryCertificationKey,
   challengeId,
+  createdAt,
 } = {}) {
   complementaryCertificationKey = _.isUndefined(complementaryCertificationKey)
     ? buildComplementaryCertification().key
@@ -23,6 +24,7 @@ const buildCertificationFrameworksChallenge = function ({
     delta,
     complementaryCertificationKey,
     challengeId,
+    createdAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/src/certification/configuration/application/complementary-certification-controller.js
+++ b/api/src/certification/configuration/application/complementary-certification-controller.js
@@ -1,6 +1,7 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as attachableTargetProfilesSerializer from '../infrastructure/serializers/attachable-target-profiles-serializer.js';
 import * as complementaryCertificationSerializer from '../infrastructure/serializers/complementary-certification-serializer.js';
+import * as certificationConsolidatedFrameworkSerializer from '../infrastructure/serializers/consolidated-framework-serializer.js';
 
 const findComplementaryCertifications = async function () {
   const complementaryCertifications = await usecases.findComplementaryCertifications();
@@ -29,9 +30,20 @@ const createConsolidatedFramework = async function (request, h) {
     .code(201);
 };
 
+const getCurrentConsolidatedFramework = async function (request) {
+  const { complementaryCertificationKey } = request.params;
+
+  const currentConsolidatedFramework = await usecases.getCurrentConsolidatedFramework({
+    complementaryCertificationKey,
+  });
+
+  return certificationConsolidatedFrameworkSerializer.serialize(currentConsolidatedFramework);
+};
+
 const complementaryCertificationController = {
   findComplementaryCertifications,
   searchAttachableTargetProfilesForComplementaryCertifications,
   createConsolidatedFramework,
+  getCurrentConsolidatedFramework,
 };
 export { complementaryCertificationController };

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -93,6 +93,33 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/complementary-certifications/{complementaryCertificationKey}/current-consolidated-framework',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            complementaryCertificationKey: Joi.string().valid(...Object.values(ComplementaryCertificationKeys)),
+          }),
+        },
+        handler: complementaryCertificationController.getCurrentConsolidatedFramework,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          'Elle permet de récupérer le référentiel cadre courant pour une complémentaire',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/configuration/domain/models/ConsolidatedFramework.js
+++ b/api/src/certification/configuration/domain/models/ConsolidatedFramework.js
@@ -1,0 +1,9 @@
+class ConsolidatedFramework {
+  constructor({ complementaryCertificationKey, createdAt, tubeIds } = {}) {
+    this.complementaryCertificationKey = complementaryCertificationKey;
+    this.createdAt = createdAt;
+    this.tubeIds = tubeIds;
+  }
+}
+
+export { ConsolidatedFramework };

--- a/api/src/certification/configuration/domain/usecases/get-current-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/get-current-consolidated-framework.js
@@ -1,0 +1,18 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
+ * @typedef {import ('./index.js').ConsolidatedFrameworkRepository} ConsolidatedFrameworkRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
+ * @param {ConsolidatedFrameworkRepository} params.consolidatedFrameworkRepository
+ */
+export const getCurrentConsolidatedFramework = async ({
+  complementaryCertificationKey,
+  consolidatedFrameworkRepository,
+}) => {
+  return consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey({
+    complementaryCertificationKey,
+  });
+};

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -1,4 +1,8 @@
+import { LOCALE } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
+import { ConsolidatedFramework } from '../../domain/models/ConsolidatedFramework.js';
 
 export async function create({ complementaryCertificationKey, challenges }) {
   const knexConn = DomainTransaction.getConnection();
@@ -9,4 +13,35 @@ export async function create({ complementaryCertificationKey, challenges }) {
   }));
 
   await knexConn('certification-frameworks-challenges').insert(challengesDTO);
+}
+
+export async function getCurrentFrameworkByComplementaryCertificationKey({ complementaryCertificationKey }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const currentFrameworkChallenges = await knexConn('certification-frameworks-challenges')
+    .where({
+      createdAt: knexConn('certification-frameworks-challenges')
+        .select('createdAt')
+        .orderBy('createdAt', 'desc')
+        .first(),
+    })
+    .select('*');
+
+  const currentChallengeIds = currentFrameworkChallenges.map((challenge) => challenge.challengeId);
+  const currentChallenges = await challengeRepository.getMany(currentChallengeIds, LOCALE.FRENCH_SPOKEN);
+
+  const currentSkillIds = currentChallenges.map((challenge) => challenge.skill.id);
+  const currentSkills = await skillRepository.findByRecordIds(currentSkillIds);
+
+  const currentTubeIds = currentSkills.map((skill) => skill.tubeId);
+
+  return _toDomain({
+    complementaryCertificationKey,
+    createdAt: currentFrameworkChallenges[0].createdAt,
+    tubeIds: currentTubeIds,
+  });
+}
+
+function _toDomain({ complementaryCertificationKey, createdAt, tubeIds }) {
+  return new ConsolidatedFramework({ complementaryCertificationKey, createdAt, tubeIds });
 }

--- a/api/src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (consolidatedFramework) {
+  return new Serializer('certification-consolidated-framework', {
+    attributes: ['complementaryCertificationKey', 'createdAt', 'tubeIds'],
+  }).serialize(consolidatedFramework);
+};
+
+export { serialize };

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -302,4 +302,52 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       ]);
     });
   });
+
+  describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/current-consolidated-framework', function () {
+    it('should return the current consolidated framework for given complementaryCertificationKey', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+      const tubeId = 'myTubeId';
+      const skill = databaseBuilder.factory.learningContent.buildSkill({
+        tubeId,
+        status: 'actif',
+      });
+      const tube = databaseBuilder.factory.learningContent.buildTube({ id: tubeId, skillIds: [skill.id] });
+      const challenge = databaseBuilder.factory.learningContent.buildChallenge({
+        skillId: skill.id,
+        alpha: 2.1,
+        delta: 3.4,
+        status: 'validé',
+      });
+      const certificationFrameworksChallenge = databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: challenge.id,
+        createdAt: new Date('2023-01-11'),
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/complementary-certifications/${complementaryCertification.key}/current-consolidated-framework`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal({
+        type: 'certification-consolidated-frameworks',
+        attributes: {
+          'complementary-certification-key': complementaryCertification.key,
+          'created-at': certificationFrameworksChallenge.createdAt,
+          'tube-ids': [tube.id],
+        },
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -52,4 +52,67 @@ describe('Certification | Configuration | Integration | Repository | consolidate
       expect(consolidatedFrameworkInDB[0].createdAt).to.deep.equal(consolidatedFrameworkInDB[1].createdAt);
     });
   });
+
+  describe('#getCurrentFrameworkByComplementaryCertificationKey', function () {
+    it('should get the current complementary certification framework', async function () {
+      // given
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+      const olderTube = databaseBuilder.factory.learningContent.buildTube({ id: 'olderTube' });
+      const olderSkill = databaseBuilder.factory.learningContent.buildSkill({ tubeId: olderTube.id });
+      const olderChallenge = databaseBuilder.factory.learningContent.buildChallenge({ skillId: olderSkill.id });
+
+      const expectedTube1 = databaseBuilder.factory.learningContent.buildTube({ id: 'expectedTube1' });
+      const expectedTube2 = databaseBuilder.factory.learningContent.buildTube({ id: 'expectedTube2' });
+      const expectedSkill1 = databaseBuilder.factory.learningContent.buildSkill({
+        id: 'skillId1',
+        tubeId: expectedTube1.id,
+      });
+      const expectedSkill2 = databaseBuilder.factory.learningContent.buildSkill({
+        id: 'skillId2',
+        tubeId: expectedTube2.id,
+      });
+
+      const expectedChallenge1 = databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'challengeId1',
+        skillId: expectedSkill1.id,
+      });
+      const expectedChallenge2 = databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'challengeId2',
+        skillId: expectedSkill2.id,
+      });
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: olderChallenge.id,
+        createdAt: new Date('2023-01-11'),
+      });
+
+      const currentDate = new Date('2025-10-21');
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: expectedChallenge1.id,
+        createdAt: currentDate,
+      });
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: expectedChallenge2.id,
+        createdAt: currentDate,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const currentConsolidatedFramework =
+        await consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey({
+          complementaryCertificationKey: complementaryCertification.key,
+        });
+
+      // then
+      expect(currentConsolidatedFramework).to.deep.equal({
+        complementaryCertificationKey: complementaryCertification.key,
+        createdAt: currentDate,
+        tubeIds: [expectedTube1.id, expectedTube2.id],
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
@@ -102,4 +102,28 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
       });
     });
   });
+
+  describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/current-consolidated-framework', function () {
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(complementaryCertificationController, 'getCurrentConsolidatedFramework').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/current-consolidated-framework`,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(complementaryCertificationController.getCurrentConsolidatedFramework);
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/get-current-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-current-consolidated-framework_test.js
@@ -1,0 +1,32 @@
+import { getCurrentConsolidatedFramework } from '../../../../../../src/certification/configuration/domain/usecases/get-current-consolidated-framework.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | UseCase | get-current-consolidated-framework', function () {
+  it('should return the current consolidated framework', async function () {
+    // given
+    const complementaryCertificationKey = Symbol('complementaryCertificationKey');
+
+    const consolidatedFrameworkRepository = {
+      getCurrentFrameworkByComplementaryCertificationKey: sinon.stub(),
+    };
+
+    const currentConsolidatedFramework = domainBuilder.certification.configuration.buildConsolidatedFramework();
+    consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey.resolves(
+      currentConsolidatedFramework,
+    );
+
+    // when
+    const results = await getCurrentConsolidatedFramework({
+      complementaryCertificationKey,
+      consolidatedFrameworkRepository,
+    });
+
+    // then
+    expect(
+      consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey,
+    ).to.have.been.calledOnceWith({
+      complementaryCertificationKey,
+    });
+    expect(results).to.deep.equal(currentConsolidatedFramework);
+  });
+});

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/consolidated-framework-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/consolidated-framework-serializer_test.js
@@ -1,0 +1,29 @@
+import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Configuration | Unit | Serializer | consolidated-framework-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize attachable a consolidated framework to JSONAPI', function () {
+      // given
+      const consolidatedFramework = domainBuilder.certification.configuration.buildConsolidatedFramework();
+
+      // when
+      const serializedConsolidatedFramework = serializer.serialize([consolidatedFramework]);
+
+      // then
+      expect(serializedConsolidatedFramework).to.deep.equal({
+        data: [
+          {
+            type: 'certification-consolidated-frameworks',
+            attributes: {
+              'complementary-certification-key': consolidatedFramework.complementaryCertificationKey,
+              'created-at': consolidatedFramework.createdAt,
+              'tube-ids': consolidatedFramework.tubeIds,
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-consolidated-framework.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-consolidated-framework.js
@@ -1,0 +1,16 @@
+import { ConsolidatedFramework } from '../../../../../../src/certification/configuration/domain/models/ConsolidatedFramework.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+
+export const buildConsolidatedFramework = function ({
+  id = 1,
+  complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+  createdAt = new Date(),
+  tubeIds = ['tube1'],
+} = {}) {
+  return new ConsolidatedFramework({
+    id,
+    complementaryCertificationKey,
+    createdAt,
+    tubeIds,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -169,6 +169,7 @@ import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
 import { buildCenter as buildConfigurationCenter } from './certification/configuration/build-center.js';
 import { buildCenterPilotFeatures } from './certification/configuration/build-center-pilot-features.js';
+import { buildConsolidatedFramework } from './certification/configuration/build-consolidated-framework.js';
 import { buildCandidate } from './certification/enrolment/build-candidate.js';
 import { buildCertificationEligibilityEnrolment } from './certification/enrolment/build-certification-eligibility.js';
 import { buildComplementaryCertificationBadgeWithOffsetVersion as buildComplementaryCertificationBadgeForEnrolment } from './certification/enrolment/build-complementary-certification-badge.js';
@@ -229,6 +230,7 @@ const certification = {
   configuration: {
     buildCenter: buildConfigurationCenter,
     buildCenterPilotFeatures,
+    buildConsolidatedFramework,
   },
   complementary: {
     buildComplementaryCertificationBadge: buildComplementaryCertificationBadge,


### PR DESCRIPTION
## 🔆 Problème

Nous n'avons aujourd'hui pas de moyen de récupérer la liste des sujets du référentiel cadre en cours d'une complémentaire spécifique.

## ⛱️ Proposition

Ajouter une route `/api/admin/complementary-certifications/{complementaryCertificationKey}/current-consolidated-framework`.

## 🏄 Pour tester

• Création d'un référentiel cadre

```
scalingo -a "pix-api-review-pr12629" run "LOG_LEVEL=info node scripts/certification/target-profile-to-calibrated-framework.js --complementaryCertificationKey='DROIT' --targetProfileId=8000"
```

✅ Lancer ce curl en local
```
TOKEN=$(curl --insecure 'https://admin-pr12629.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123' -X POST | jq -r .access_token)
curl https://admin-pr12629.review.pix.fr/api/admin/complementary-certifications/DROIT/current-consolidated-framework \
    -H "Authorization: Bearer $TOKEN"
```

Vous devriez obtenir [cette liste de tubes](https://github.com/1024pix/pix/pull/12629#issuecomment-3000510141).

✅ Vérifier les tests
