### PR TITLE
[TECH] Retirer la mention d'équipe dans le message Slack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-            text: "Coucou 👋, je lance la mise en recette de la version ${{ env.new_release_version }}. <!subteam^${{ secrets.PO_ID }}>\nMettez vos messages en :thread:"
+            text: "Coucou 🙃, je lance la mise en recette de la v${{ env.NEW_RELEASE_VERSION }} !"


### PR DESCRIPTION
## 🔆 Problème

On va inviter à mettre les message dans le thread de discussion de fin de mise en recette sur Pix bot. Il n'est donc plus nécessaire de le faire ici.

## ⛱️ Proposition

Retirer la mension.

## Remarque
Ajouter les variables:
- SLACK_TEAM_PO_ID pour mensionner les PO,
- SLACK_RELEASE_CHANNEL_COMMUNICATION pour mensionner actu-pix.