### PR TITLE
[TECH] :card_file_box: Ajoute la colonne `calibrationId` dans la table `certification-frameworks-challenges` (PIX-18435)

### DIFF
--- a/api/db/migrations/20250624144832_add-calibration_id-to-certification-frameworks-challenges.js
+++ b/api/db/migrations/20250624144832_add-calibration_id-to-certification-frameworks-challenges.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'calibrationId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).defaultTo(null).comment('calibration id used in calibrated challenges in datamart');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous ne pouvons plus faire le lien avec la calibration sélectionné une fois mise à jour dans notre table `certification-frameworks-challenges`

## ⛱️ Proposition

Ajouter la colonne `CalibrationId` pour y stocker l'ID de calibration qui aura été sélectionné.

## 🌊 Remarques

⚠️  Nous faisons ici référence à une PK de la future table `data_calibrations` du datamart.
Il nous est donc possible d'ajouter une contrainte d'unicité sur cette valeur, à voir si l'on veut le faire ou non.

## 🏄 Pour tester

La migration se passe bien.
