### PR TITLE
[TECH]] Renommage de la table active_calibrated_challenges du datamart (PIX-18438).

### DIFF
--- a/api/datamart/migrations/20250625065129_rename-active-calibrated-challenges-table-to-calibrated-challenges.js
+++ b/api/datamart/migrations/20250625065129_rename-active-calibrated-challenges-table-to-calibrated-challenges.js
@@ -1,0 +1,12 @@
+const OLD_TABLE_NAME = 'active_calibrated_challenges';
+const NEW_TABLE_NAME = 'calibrated_challenges';
+
+const up = async function (knex) {
+  await knex.schema.renameTable(OLD_TABLE_NAME, NEW_TABLE_NAME);
+};
+
+const down = async function (knex) {
+  await knex.schema.renameTable(NEW_TABLE_NAME, OLD_TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Le nom de la table `active_calibrated_challenges` du datamart est erroné puisque celle-ci ne vas finalement pas incorporer que des challenges calibrés au statut `actif`

## ⛱️ Proposition

Renommage de la tabke en `calibrated_challenges`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Vérifier que le nom de la table a bien été changé.
Effectuer un `npm run datamart:rollback:latest` pour tester le down et revenir à l'ancien nom de table.