### PR TITLE
[FEATURE] Lister par défaut les feature-toggles. 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -196,7 +196,7 @@
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint",
     "test:api:git-modified": "git ls-files -m -- '*test.js' | xargs npm run test:api:path -- $1",
-    "toggles": "node src/shared/infrastructure/feature-toggles/feature-toggles-script.js",
+    "toggles": "LOG_FOR_HUMANS_FORMAT=compact node src/shared/infrastructure/feature-toggles/feature-toggles-script.js",
     "monitoring:arborescence": "node scripts/arborescence-monitoring/arborescence-monitoring.js",
     "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js",
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/integration/repositories/module-repository_test.js'"

--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-script.js
@@ -31,7 +31,7 @@ export class FeatureToggleScript extends Script {
     const { list, key, value } = options;
 
     // List all feature toggles
-    if (list) {
+    if (list || (!key && !value)) {
       const all = await featureTogglesClient.all();
       for (const [key, value] of Object.entries(all)) {
         logger.warn(`Feature toggle "${key}" is set to "${value}"`);


### PR DESCRIPTION
## 🔆 Problème

La commande `npm run toggles` ne liste pas par défaut ce qui fait perdre du temps. 

## ⛱️ Proposition
Lancer par défaut le liste des toggles.

## 🌊 Remarques

Au passage, cette commande est à destination des devs qui sont encore tous des humains, du coup je force la variable d'environnement `LOG_FOR_HUMANS_FORMAT=compact`

## 🏄 Pour tester
### 1. Cas sans list

1. Lancer la commande sans l'option list 
```
npm run toggles
```
2. Constater que ça liste 

### 2. Cas avec list

1. Lancer la commande avec l'option list 
```
npm run toggles -- --list
```
2. Constater que ça liste 

### 3. Cas avec seulement la clé ou la valeur

1. Lancer la commande avec l'option --k uniquement ou key uniquement
```
npm run toggles -- -k toto
```
2. Constater que ça liste 

### 3. Cas avec clé et valeur

1. Lancer la commande pour set une valeur
```
npm run toggles -- -k isQuestEnabled -v false
```
2. Constater que ça set
