### PR TITLE
[BUGFIX] Ne pas faire crasher l'api si l'id de la campagne n'existe pas (PIX-18062)

### DIFF
--- a/admin/app/routes/authenticated/organizations/get.js
+++ b/admin/app/routes/authenticated/organizations/get.js
@@ -4,12 +4,17 @@ import { service } from '@ember/service';
 export default class GetRoute extends Route {
   @service oidcIdentityProviders;
   @service store;
+  @service router;
 
   async beforeModel() {
     await this.oidcIdentityProviders.loadAllAvailableIdentityProviders();
   }
 
-  model(params) {
-    return this.store.findRecord('organization', params.organization_id, { reload: true });
+  async model(params) {
+    try {
+      return await this.store.findRecord('organization', params.organization_id, { reload: true });
+    } catch {
+      this.router.replaceWith('authenticated.organizations.list');
+    }
   }
 }

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-management.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-management.js
@@ -1,5 +1,11 @@
+import { NotFoundError } from '../../../../shared/application/http-errors.js';
+
 const getCampaignManagement = async function ({ campaignId, campaignManagementRepository }) {
-  return campaignManagementRepository.get(campaignId);
+  const campaign = await campaignManagementRepository.get(campaignId);
+  if (!campaign) {
+    throw new NotFoundError('campaign does not exist');
+  }
+  return campaign;
 };
 
 export { getCampaignManagement };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
@@ -40,6 +40,10 @@ const get = async function (campaignId) {
     .where('campaigns.id', campaignId)
     .first();
 
+  if (!campaign) {
+    return null;
+  }
+
   const externalIdFeature = await knex('campaign-features')
     .select('params')
     .join('features', 'features.id', 'featureId')

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-management_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-management_test.js
@@ -1,0 +1,29 @@
+import { CampaignManagement } from '../../../../../../src/prescription/campaign/domain/models/CampaignManagement.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../../src/shared/application/http-errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Domain | usecase | Get Campaign Management', function () {
+  it('should return campaign', async function () {
+    // given
+    const campaignId = databaseBuilder.factory.buildCampaign().id;
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getCampaignManagement({ campaignId });
+
+    // then
+    expect(result).to.be.instanceOf(CampaignManagement);
+  });
+
+  it('should throw an error if campaign is not found', async function () {
+    // given
+    const campaignId = 123;
+
+    // when
+    const result = await catchErr(usecases.getCampaignManagement)({ campaignId });
+
+    // then
+    expect(result).to.be.instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -274,6 +274,16 @@ describe('Integration | Repository | Campaign-Management', function () {
         });
       });
     });
+
+    context('when the campaign does not exist', function () {
+      it('should return null', async function () {
+        // when
+        const result = await campaignManagementRepository.get(123);
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
   });
 
   describe('#findPaginatedCampaignManagements', function () {


### PR DESCRIPTION
## 🔆 Problème

Dans Pix admin, si on modifie l'url à la main et qu'on met un id de campagne qui n'existe pas, on peut tenter de réaliser des actions et l'api plante.

## ⛱️ Proposition

Côté repository renvoyer null si l'id de la campagne n'existe pas et côté usecase, renvoyer une erreur notFoundError.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

- Aller dans Pix admin,
- Se connecter avec superadmin@example.net,
- Aller sur une campagne,
- Changer l'id dans l'url en mettant quelque chose comme 999999999999999,
- Constater qu'on n'a pas d'infos qui sont remontés et qu'on ne peut donc pas agir.
