### PR TITLE
[FEATURE] Rediriger un utilisateur anonyme vers le formulaire d'inscription après sa campagne (PIX-18026)

### DIFF
--- a/mon-pix/app/routes/inscription/inscription.js
+++ b/mon-pix/app/routes/inscription/inscription.js
@@ -4,12 +4,25 @@ import { service } from '@ember/service';
 export default class InscriptionRoute extends Route {
   @service session;
   @service store;
+  @service featureToggles;
+  @service router;
+  @service currentUser;
+
+  get isAnonymous() {
+    return this.currentUser?.user?.isAnonymous || false;
+  }
 
   beforeModel() {
+    if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.isAnonymous) {
+      return;
+    }
     this.session.prohibitAuthentication('authenticated.user-dashboard');
   }
 
   model() {
+    if (this.isAnonymous) {
+      return this.currentUser.user;
+    }
     // XXX: Model needs to be initialize with empty to handle validations on all fields from Api
     return this.store.createRecord('user', {
       lastName: '',

--- a/mon-pix/app/templates/inscription/inscription.gjs
+++ b/mon-pix/app/templates/inscription/inscription.gjs
@@ -4,14 +4,18 @@ import pageTitle from 'ember-page-title/helpers/page-title';
 import OtherAuthenticationProviders from 'mon-pix/components/authentication/other-authentication-providers';
 import SignupForm from 'mon-pix/components/authentication/signup-form/index';
 import AuthenticationLayout from 'mon-pix/components/authentication-layout/index';
+
 <template>
   {{pageTitle (t "pages.sign-up.title")}}
 
   <AuthenticationLayout class="signup-page-layout">
+
     <:header>
-      <PixButtonLink @variant="secondary" @route="authentication.login">
-        {{t "pages.sign-up.actions.login"}}
-      </PixButtonLink>
+      {{#unless @model.isAnonymous}}
+        <PixButtonLink @variant="secondary" @route="authentication.login">
+          {{t "pages.sign-up.actions.login"}}
+        </PixButtonLink>
+      {{/unless}}
     </:header>
 
     <:content>

--- a/mon-pix/tests/acceptance/authentication/signup-test.js
+++ b/mon-pix/tests/acceptance/authentication/signup-test.js
@@ -6,6 +6,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { authenticate } from '../../helpers/authentication';
 import setupIntl from '../../helpers/setup-intl';
 
 const I18N_KEYS = {
@@ -36,7 +37,14 @@ module('Acceptance | authentication | Signup', function (hooks) {
     const email = 'john.doe@email.com';
     const password = 'JeMeLoggue1024';
 
+    // when
     const screen = await visit('/inscription');
+
+    //then
+    const signupHeading = screen.getByRole('heading', { name: t('pages.sign-up.first-title') });
+    assert.dom(signupHeading).exists();
+    const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
+    assert.dom(loginButton).exists();
 
     // when
     await fillByLabel(t(I18N_KEYS.firstNameInput), firstName);
@@ -49,6 +57,88 @@ module('Acceptance | authentication | Signup', function (hooks) {
     // then
     const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
     assert.dom(homepageHeading).exists();
+  });
+
+  module('when feature toggle upgradeToRealUserEnabled is true', function (hooks) {
+    hooks.beforeEach(async function () {
+      server.create('feature-toggle', { id: '0', upgradeToRealUserEnabled: true });
+    });
+
+    module('when real user is authenticated', function () {
+      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
+        // given
+        const firstName = 'John';
+        const lastName = 'Doe';
+        const email = 'john.doe@email.com';
+
+        const user = server.create('user', { firstName, lastName, email, isAnonymous: false });
+        await authenticate(user);
+
+        // when
+        const screen = await visit('/inscription');
+
+        // then
+        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
+        assert.dom(homepageHeading).exists();
+      });
+    });
+
+    module('when anonymous user is authenticated', function () {
+      test('he can access the sign up page', async function (assert) {
+        // given
+        const user = server.create('user', { isAnonymous: true });
+        await authenticate(user);
+
+        // when
+        const screen = await visit('/inscription');
+
+        // then
+        const signupHeading = screen.getByRole('heading', { name: t('pages.sign-up.first-title') });
+        assert.dom(signupHeading).exists();
+        const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
+        assert.dom(loginButton).doesNotExist();
+      });
+    });
+  });
+
+  module('when feature toggle upgradeToRealUserEnabled is false', function (hooks) {
+    hooks.beforeEach(async function () {
+      server.create('feature-toggle', { id: '0', upgradeToRealUserEnabled: false });
+    });
+
+    module('when real user is authenticated', function () {
+      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
+        // given
+        const firstName = 'John';
+        const lastName = 'Doe';
+        const email = 'john.doe@email.com';
+
+        const user = server.create('user', { firstName, lastName, email, isAnonymous: false });
+        await authenticate(user);
+
+        // when
+        const screen = await visit('/inscription');
+
+        // then
+        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
+        assert.dom(homepageHeading).exists();
+      });
+    });
+
+    module('when anonymous user is authenticated', function () {
+      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
+        // given
+        const user = server.create('user', { isAnonymous: true });
+        await authenticate(user);
+
+        // when
+        const screen = await visit('/inscription');
+
+        // then
+        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
+        assert.dom(homepageHeading).exists();
+      });
+    });
   });
 
   module('when a new user join a campaign', function () {


### PR DESCRIPTION
## 🔆 Problème
Lorsqu'un utilisateur anonyme a terminé sa campagne, on souhaite qu'il puisse se créer un compte et conserver les Pix gagnés. 

## ⛱️ Proposition
Rediriger l'utilisateur anonyme vers la page de création de compte au clic sur le bouton "S'inscrire sur Pix" 

## 🌊 Remarques
Il existait une brèche qui permettait déjà à un utilisateur anonyme d'accéder au dashboard. On se prémunit désormais de cette brèche. 

## 🏄 Pour tester
- Lancer un Parcours Autonome (lien)
- Aller au bout de ce parcours autonome et cliquer sur "S'inscrire sur Pix"
- Constater qu'on arrive sur le formulaire d'inscription et que le bouton "Se connecter" en haut à droite n'est pas visible
