### PR TITLE
[TECH] Suppression de la colonne `calibration_id` de la table `active_calibrated_challenges` du datamart (PIX-18446).

### DIFF
--- a/api/datamart/migrations/20250625134123_remove-calibration-id-in-active-calibrated-challenges-table.js
+++ b/api/datamart/migrations/20250625134123_remove-calibration-id-in-active-calibrated-challenges-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'active_calibrated_challenges';
+const COLUMN_NAME = 'calibration_id';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).index();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous avons ajouté une colonne `calibration_id` dans la table du datamart `active_calibrated_challenges`.
Or cette colonne n'est pas disponible dans la table associée dans datawarehouse et ne sera pas remplie lors de la réplication.

## ⛱️ Proposition

Nous supprimons cette colonne de la table `active_calibrated_challenges` et récupèrerons le `calibration_id` là où il se trouve lorsque nous en aurons besoin.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

La colonne `calibration_id` a été supprimée de la table.
Exécuter `npm run datamart:rollback:latest` sur la RA et vérifier que la colonne est de nouveau disponible et indexée.
