### PR TITLE
[FEATURE] Migrer les événements ANSWERED en Passage Events (PIX-18444)

### DIFF
--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -30,6 +30,12 @@ class PassageEventWithElementInstantiationError extends TypeError {
   }
 }
 
+class PassageEventWithElementAnsweredInstantiationError extends TypeError {
+  constructor(message = 'A passage element answered event cannot be instantiated directly') {
+    super(message);
+  }
+}
+
 class PassageDoesNotExistError extends DomainError {
   constructor(message = 'The passage does not exist') {
     super(message);
@@ -54,6 +60,7 @@ export {
   ModuleInstantiationError,
   PassageDoesNotExistError,
   PassageEventInstantiationError,
+  PassageEventWithElementAnsweredInstantiationError,
   PassageEventWithElementInstantiationError,
   PassageTerminatedError,
   UserNotAuthorizedToFindTrainings,

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -4,6 +4,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
@@ -43,6 +44,8 @@ class PassageEventFactory {
         return new QABCardAnsweredEvent(eventData);
       case 'QAB_CARD_RETRIED':
         return new QABCardRetriedEvent(eventData);
+      case 'QROCM_ANSWERED':
+        return new QROCMAnsweredEvent(eventData);
       case 'QCM_ANSWERED':
         return new QCMAnsweredEvent(eventData);
       case 'QCU_ANSWERED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,6 +1,7 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import {
   EmbedAnsweredEvent,
+  QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
@@ -42,6 +43,8 @@ class PassageEventFactory {
         return new QABCardAnsweredEvent(eventData);
       case 'QAB_CARD_RETRIED':
         return new QABCardRetriedEvent(eventData);
+      case 'QCM_ANSWERED':
+        return new QCMAnsweredEvent(eventData);
       case 'QCU_ANSWERED':
         return new QCUAnsweredEvent(eventData);
       case 'QCU_DECLARATIVE_ANSWERED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,5 +1,9 @@
 import { DomainError } from '../../../shared/domain/errors.js';
-import { EmbedAnsweredEvent, QCUDeclarativeAnsweredEvent } from '../models/passage-events/answerable-element-events.js';
+import {
+  EmbedAnsweredEvent,
+  QCUAnsweredEvent,
+  QCUDeclarativeAnsweredEvent,
+} from '../models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -38,6 +42,8 @@ class PassageEventFactory {
         return new QABCardAnsweredEvent(eventData);
       case 'QAB_CARD_RETRIED':
         return new QABCardRetriedEvent(eventData);
+      case 'QCU_ANSWERED':
+        return new QCUAnsweredEvent(eventData);
       case 'QCU_DECLARATIVE_ANSWERED':
         return new QCUDeclarativeAnsweredEvent(eventData);
       default:

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -1,5 +1,5 @@
 import { DomainError } from '../../../shared/domain/errors.js';
-import { QCUDeclarativeAnsweredEvent } from '../models/passage-events/answerable-element-events.js';
+import { EmbedAnsweredEvent, QCUDeclarativeAnsweredEvent } from '../models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -14,6 +14,8 @@ import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-eve
 class PassageEventFactory {
   static build(eventData) {
     switch (eventData.type) {
+      case 'EMBED_ANSWERED':
+        return new EmbedAnsweredEvent(eventData);
       case 'FLASHCARDS_CARD_AUTO_ASSESSED':
         return new FlashcardsCardAutoAssessedEvent(eventData);
       case 'FLASHCARDS_RECTO_REVIEWED':

--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -14,30 +14,30 @@ import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-eve
 class PassageEventFactory {
   static build(eventData) {
     switch (eventData.type) {
-      case 'PASSAGE_STARTED':
-        return new PassageStartedEvent(eventData);
-      case 'PASSAGE_TERMINATED':
-        return new PassageTerminatedEvent(eventData);
-      case 'FLASHCARDS_STARTED':
-        return new FlashcardsStartedEvent(eventData);
-      case 'FLASHCARDS_VERSO_SEEN':
-        return new FlashcardsVersoSeenEvent(eventData);
       case 'FLASHCARDS_CARD_AUTO_ASSESSED':
         return new FlashcardsCardAutoAssessedEvent(eventData);
       case 'FLASHCARDS_RECTO_REVIEWED':
         return new FlashcardsRectoReviewedEvent(eventData);
       case 'FLASHCARDS_RETRIED':
         return new FlashcardsRetriedEvent(eventData);
-      case 'QCU_DECLARATIVE_ANSWERED':
-        return new QCUDeclarativeAnsweredEvent(eventData);
-      case 'QAB_CARD_ANSWERED':
-        return new QABCardAnsweredEvent(eventData);
-      case 'QAB_CARD_RETRIED':
-        return new QABCardRetriedEvent(eventData);
+      case 'FLASHCARDS_STARTED':
+        return new FlashcardsStartedEvent(eventData);
+      case 'FLASHCARDS_VERSO_SEEN':
+        return new FlashcardsVersoSeenEvent(eventData);
       case 'GRAIN_CONTINUED':
         return new GrainContinuedEvent(eventData);
       case 'GRAIN_SKIPPED':
         return new GrainSkippedEvent(eventData);
+      case 'PASSAGE_STARTED':
+        return new PassageStartedEvent(eventData);
+      case 'PASSAGE_TERMINATED':
+        return new PassageTerminatedEvent(eventData);
+      case 'QAB_CARD_ANSWERED':
+        return new QABCardAnsweredEvent(eventData);
+      case 'QAB_CARD_RETRIED':
+        return new QABCardRetriedEvent(eventData);
+      case 'QCU_DECLARATIVE_ANSWERED':
+        return new QCUDeclarativeAnsweredEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/PassageEventWithElementAnswered.js
+++ b/api/src/devcomp/domain/models/passage-events/PassageEventWithElementAnswered.js
@@ -1,0 +1,33 @@
+import { assertEnumValue, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { PassageEventWithElementAnsweredInstantiationError } from '../../errors.js';
+import { PassageEventWithElement } from './PassageEventWithElement.js';
+
+const StatusEnumValues = Object.freeze({
+  OK: 'ok',
+  KO: 'ko',
+});
+
+/**
+ * @abstract PassageEventWithElementAnswered
+ * See PassageEventWithElement for more info.
+ *
+ * This is the base class for all PassageEventWithElementAnswered.
+ * It's syntaxic sugar for a `PassageEvent` that contains an element answerable which send an event with the answer
+ * It exists because we have a lot of answerable element and that we store its answer and status in the `data` key...
+ * Subclasses should be named in past tense.
+ */
+class PassageEventWithElementAnswered extends PassageEventWithElement {
+  constructor({ id, type, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status, data } = {}) {
+    super({ id, type, occurredAt, createdAt, passageId, sequenceNumber, elementId, data: { ...data, answer, status } });
+
+    if (this.constructor === PassageEventWithElementAnswered) {
+      throw new PassageEventWithElementAnsweredInstantiationError();
+    }
+
+    assertNotNullOrUndefined(answer, 'The answer property is required for a PassageEventWithElementAnswered');
+    assertNotNullOrUndefined(status, 'The status property is required for a PassageEventWithElementAnswered');
+    assertEnumValue(StatusEnumValues, status, 'The status value must be one of these : [‘ok‘, ‘ko‘]');
+  }
+}
+
+export { PassageEventWithElementAnswered };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -1,5 +1,22 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageEventWithElement } from './PassageEventWithElement.js';
+import { PassageEventWithElementAnswered } from './PassageEventWithElementAnswered.js';
+
+class EmbedAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
+    super({
+      type: 'EMBED_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      answer,
+      status,
+    });
+  }
+}
 
 class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
@@ -18,4 +35,4 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   }
 }
 
-export { QCUDeclarativeAnsweredEvent };
+export { EmbedAnsweredEvent, QCUDeclarativeAnsweredEvent };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -18,8 +18,8 @@ class EmbedAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
-class QCMAnsweredEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
+class QCMAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
     super({
       type: 'QCM_ANSWERED',
       id,
@@ -28,10 +28,9 @@ class QCMAnsweredEvent extends PassageEventWithElement {
       passageId,
       sequenceNumber,
       elementId,
-      data: { answer },
+      answer,
+      status,
     });
-
-    assertNotNullOrUndefined(answer, 'The answer is required for a QCMAnsweredEvent');
   }
 }
 
@@ -68,4 +67,4 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   }
 }
 
-export { EmbedAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent };
+export { EmbedAnsweredEvent, QCMAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -15,9 +15,6 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
     });
 
     assertNotNullOrUndefined(answer, 'The answer is required for a QCUDeclarativeAnsweredEvent');
-
-    this.elementId = elementId;
-    this.answer = answer;
   }
 }
 

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -67,4 +67,20 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   }
 }
 
-export { EmbedAnsweredEvent, QCMAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent };
+class QROCMAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
+    super({
+      type: 'QROCM_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      answer,
+      status,
+    });
+  }
+}
+
+export { EmbedAnsweredEvent, QCMAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent, QROCMAnsweredEvent };

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -18,6 +18,39 @@ class EmbedAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
+class QCMAnsweredEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
+    super({
+      type: 'QCM_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { answer },
+    });
+
+    assertNotNullOrUndefined(answer, 'The answer is required for a QCMAnsweredEvent');
+  }
+}
+
+class QCUAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
+    super({
+      type: 'QCU_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      answer,
+      status,
+    });
+  }
+}
+
 class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer }) {
     super({
@@ -35,4 +68,4 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   }
 }
 
-export { EmbedAnsweredEvent, QCUDeclarativeAnsweredEvent };
+export { EmbedAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent };

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -32,8 +32,6 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(qcuDeclarativeAnsweredEvent.createdAt).to.equal(createdAt);
       expect(qcuDeclarativeAnsweredEvent.passageId).to.equal(passageId);
       expect(qcuDeclarativeAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
-      expect(qcuDeclarativeAnsweredEvent.elementId).to.equal(elementId);
-      expect(qcuDeclarativeAnsweredEvent.answer).to.equal(answer);
       expect(qcuDeclarativeAnsweredEvent.data).to.deep.equal({ elementId, answer });
     });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,5 +1,6 @@
 import {
   EmbedAnsweredEvent,
+  QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
@@ -39,6 +40,41 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(embedAnsweredEvent.passageId).to.equal(passageId);
       expect(embedAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(embedAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
+  describe('#QCMAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = ['2', '3', '4'];
+      const status = 'ok';
+
+      // when
+      const qcmAnsweredEvent = new QCMAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(qcmAnsweredEvent.id).to.equal(id);
+      expect(qcmAnsweredEvent.type).to.equal('QCM_ANSWERED');
+      expect(qcmAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qcmAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qcmAnsweredEvent.passageId).to.equal(passageId);
+      expect(qcmAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcmAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
     });
   });
 

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,8 +1,46 @@
-import { QCUDeclarativeAnsweredEvent } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
+import {
+  EmbedAnsweredEvent,
+  QCUDeclarativeAnsweredEvent,
+} from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Devcomp | Domain | Models | passage-events | answerable-element-events', function () {
+  describe('#EmbedAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = 'Courgette';
+      const status = 'ok';
+
+      // when
+      const embedAnsweredEvent = new EmbedAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(embedAnsweredEvent.id).to.equal(id);
+      expect(embedAnsweredEvent.type).to.equal('EMBED_ANSWERED');
+      expect(embedAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(embedAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(embedAnsweredEvent.passageId).to.equal(passageId);
+      expect(embedAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(embedAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
   describe('#QCUDeclarativeAnsweredEvent', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -3,6 +3,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QROCMAnsweredEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -174,6 +175,41 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The answer is required for a QCUDeclarativeAnsweredEvent');
       });
+    });
+  });
+
+  describe('#QROCMAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = 'Framboise';
+      const status = 'ok';
+
+      // when
+      const qrocmAnsweredEvent = new QROCMAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(qrocmAnsweredEvent.id).to.equal(id);
+      expect(qrocmAnsweredEvent.type).to.equal('QROCM_ANSWERED');
+      expect(qrocmAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qrocmAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qrocmAnsweredEvent.passageId).to.equal(passageId);
+      expect(qrocmAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qrocmAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
     });
   });
 });

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -1,5 +1,6 @@
 import {
   EmbedAnsweredEvent,
+  QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
@@ -38,6 +39,41 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
       expect(embedAnsweredEvent.passageId).to.equal(passageId);
       expect(embedAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
       expect(embedAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
+    });
+  });
+
+  describe('#QCUAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = 'Poire';
+      const status = 'ok';
+
+      // when
+      const qcuAnsweredEvent = new QCUAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(qcuAnsweredEvent.id).to.equal(id);
+      expect(qcuAnsweredEvent.type).to.equal('QCU_ANSWERED');
+      expect(qcuAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qcuAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qcuAnsweredEvent.passageId).to.equal(passageId);
+      expect(qcuAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcuAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
     });
   });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
 import {
   EmbedAnsweredEvent,
+  QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
@@ -275,6 +276,26 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QABCardRetriedEvent);
+      });
+    });
+
+    describe('when given a QCM_ANSWERED event', function () {
+      it('should return a QCMAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCM_ANSWERED',
+          answer: ['2', '3', '4'],
+          status: 'ok',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCMAnsweredEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
 import {
   EmbedAnsweredEvent,
+  QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
@@ -274,6 +275,26 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QABCardRetriedEvent);
+      });
+    });
+
+    describe('when given a QCU_ANSWERED event', function () {
+      it('should return a QCUAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCU_ANSWERED',
+          answer: 'Poire',
+          status: 'ok',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCUAnsweredEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -6,6 +6,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
@@ -316,6 +317,26 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCUAnsweredEvent);
+      });
+    });
+
+    describe('when given a QROCM_ANSWERED event', function () {
+      it('should return a QCUAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QROCM_ANSWERED',
+          answer: 'Framboise',
+          status: 'ok',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QROCMAnsweredEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -46,83 +46,6 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
       });
     });
 
-    describe('when given a PASSAGE_STARTED event', function () {
-      it('should return a PassageStartedEvent instance', function () {
-        // given
-        const rawEvent = {
-          occurredAt: new Date(),
-          passageId: 2,
-          sequenceNumber: 1,
-          contentHash: 'module-version',
-          type: 'PASSAGE_STARTED',
-        };
-
-        // when
-        const builtEvent = PassageEventFactory.build(rawEvent);
-
-        // then
-        expect(builtEvent).to.be.instanceOf(PassageStartedEvent);
-      });
-    });
-
-    describe('when given a PASSAGE_TERMINATED event', function () {
-      it('should return a PassageTerminatedEvent instance', function () {
-        // given
-        const rawEvent = {
-          occurredAt: new Date(),
-          passageId: 2,
-          sequenceNumber: 1,
-          contentHash: 'module-version',
-          type: 'PASSAGE_TERMINATED',
-        };
-
-        // when
-        const builtEvent = PassageEventFactory.build(rawEvent);
-
-        // then
-        expect(builtEvent).to.be.instanceOf(PassageTerminatedEvent);
-      });
-    });
-
-    describe('when given a FLASHCARDS_STARTED event', function () {
-      it('should return a FlashcardsStartedEvent instance', function () {
-        // given
-        const rawEvent = {
-          occurredAt: new Date(),
-          passageId: 2,
-          sequenceNumber: 1,
-          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-          type: 'FLASHCARDS_STARTED',
-        };
-
-        // when
-        const builtEvent = PassageEventFactory.build(rawEvent);
-
-        // then
-        expect(builtEvent).to.be.instanceOf(FlashcardsStartedEvent);
-      });
-    });
-
-    describe('when given a FLASHCARDS_VERSO_SEEN event', function () {
-      it('should return a FlashcardsVersoSeenEvent instance', function () {
-        // given
-        const rawEvent = {
-          occurredAt: new Date(),
-          passageId: 2,
-          sequenceNumber: 1,
-          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
-          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
-          type: 'FLASHCARDS_VERSO_SEEN',
-        };
-
-        // when
-        const builtEvent = PassageEventFactory.build(rawEvent);
-
-        // then
-        expect(builtEvent).to.be.instanceOf(FlashcardsVersoSeenEvent);
-      });
-    });
-
     describe('when given a FLASHCARDS_AUTO_ASSESSED event', function () {
       it('should return a FlashcardsAutoAssessedEvent instance', function () {
         // given
@@ -180,22 +103,116 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
       });
     });
 
-    describe('when given a QCU_DECLARATIVE_ANSWERED event', function () {
-      it('should return a QCUDeclarativeAnsweredEvent instance', function () {
+    describe('when given a FLASHCARDS_STARTED event', function () {
+      it('should return a FlashcardsStartedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          type: 'FLASHCARDS_STARTED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsStartedEvent);
+      });
+    });
+
+    describe('when given a FLASHCARDS_VERSO_SEEN event', function () {
+      it('should return a FlashcardsVersoSeenEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+          cardId: 'c4675f66-97f1-4202-8aeb-0388edf102d5',
+          type: 'FLASHCARDS_VERSO_SEEN',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FlashcardsVersoSeenEvent);
+      });
+    });
+
+    describe('when given a GRAIN_CONTINUED event', function () {
+      it('should return a GrainContinuedEvent instance', function () {
         // given
         const rawEvent = {
           occurredAt: new Date(),
           passageId: 2,
           sequenceNumber: 3,
-          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
-          type: 'QCU_DECLARATIVE_ANSWERED',
-          answer: 'Tous les mercredis',
+          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'GRAIN_CONTINUED',
         };
         // when
         const builtEvent = PassageEventFactory.build(rawEvent);
 
         // then
-        expect(builtEvent).to.be.instanceOf(QCUDeclarativeAnsweredEvent);
+        expect(builtEvent).to.be.instanceOf(GrainContinuedEvent);
+      });
+    });
+
+    describe('when given a GRAIN_SKIPPED event', function () {
+      it('should return a GrainContinuedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'GRAIN_SKIPPED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(GrainSkippedEvent);
+      });
+    });
+
+    describe('when given a PASSAGE_STARTED event', function () {
+      it('should return a PassageStartedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          contentHash: 'module-version',
+          type: 'PASSAGE_STARTED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(PassageStartedEvent);
+      });
+    });
+
+    describe('when given a PASSAGE_TERMINATED event', function () {
+      it('should return a PassageTerminatedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 1,
+          contentHash: 'module-version',
+          type: 'PASSAGE_TERMINATED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(PassageTerminatedEvent);
       });
     });
 
@@ -237,39 +254,22 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
       });
     });
 
-    describe('when given a GRAIN_CONTINUED event', function () {
-      it('should return a GrainContinuedEvent instance', function () {
+    describe('when given a QCU_DECLARATIVE_ANSWERED event', function () {
+      it('should return a QCUDeclarativeAnsweredEvent instance', function () {
         // given
         const rawEvent = {
           occurredAt: new Date(),
           passageId: 2,
           sequenceNumber: 3,
-          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
-          type: 'GRAIN_CONTINUED',
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCU_DECLARATIVE_ANSWERED',
+          answer: 'Tous les mercredis',
         };
         // when
         const builtEvent = PassageEventFactory.build(rawEvent);
 
         // then
-        expect(builtEvent).to.be.instanceOf(GrainContinuedEvent);
-      });
-    });
-
-    describe('when given a GRAIN_SKIPPED event', function () {
-      it('should return a GrainContinuedEvent instance', function () {
-        // given
-        const rawEvent = {
-          occurredAt: new Date(),
-          passageId: 2,
-          sequenceNumber: 3,
-          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
-          type: 'GRAIN_SKIPPED',
-        };
-        // when
-        const builtEvent = PassageEventFactory.build(rawEvent);
-
-        // then
-        expect(builtEvent).to.be.instanceOf(GrainSkippedEvent);
+        expect(builtEvent).to.be.instanceOf(QCUDeclarativeAnsweredEvent);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 
 import { PassageEventFactory } from '../../../../../src/devcomp/domain/factories/passage-event-factory.js';
-import { QCUDeclarativeAnsweredEvent } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
+import {
+  EmbedAnsweredEvent,
+  QCUDeclarativeAnsweredEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -43,6 +46,26 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
         // then
         expect(error).to.be.instanceof(DomainError);
         expect(error.message).to.equal('Passage event with type UNKNOWN does not exist');
+      });
+    });
+
+    describe('when given an EMBED_ANSWERED event', function () {
+      it('should return a EmbedAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'EMBED_ANSWERED',
+          answer: 'Courgette',
+          status: 'ok',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(EmbedAnsweredEvent);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/models/module/PassageEventWithElementAnswered_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/PassageEventWithElementAnswered_test.js
@@ -1,0 +1,150 @@
+import { PassageEventWithElementAnsweredInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { PassageEventWithElementAnswered } from '../../../../../../src/devcomp/domain/models/passage-events/PassageEventWithElementAnswered.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | PassageEventWithElementAnswered', function () {
+  describe('#constructor', function () {
+    it('should not be able to create a PassageEventWithElementAnswered directly', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = Symbol('date');
+      const passageId = 3;
+      const sequenceNumber = 1;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = '1';
+      const status = 'ok';
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new PassageEventWithElementAnswered({
+            id,
+            type: 'PassageEventWithElementAnswered',
+            elementId,
+            occurredAt,
+            createdAt,
+            passageId,
+            sequenceNumber,
+            answer,
+            status,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(PassageEventWithElementAnsweredInstantiationError);
+    });
+
+    it('should init and keep attributes', function () {
+      // given
+      class FakePassageEventWithElementAnswered extends PassageEventWithElementAnswered {}
+
+      const id = Symbol('id');
+      const type = 'FakePassageEventWithElementAnswered';
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 123;
+      const sequenceNumber = 2;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = '1';
+      const status = 'ok';
+
+      // when
+      const event = new FakePassageEventWithElementAnswered({
+        id,
+        type,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(event.id).to.equal(id);
+      expect(event.type).to.equal(type);
+      expect(event.occurredAt).to.equal(occurredAt);
+      expect(event.createdAt).to.equal(createdAt);
+      expect(event.passageId).to.equal(passageId);
+      expect(event.sequenceNumber).to.equal(sequenceNumber);
+      expect(event.data).to.deep.equal({ elementId, answer, status });
+    });
+
+    it('should throw an error if answer is not present', function () {
+      // given
+      class FakePassageEventWithElementAnswered extends PassageEventWithElementAnswered {}
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new FakePassageEventWithElementAnswered({
+            id: Symbol('id'),
+            type: 'FakePassageElementWithEventAnswered',
+            occurredAt: new Date(),
+            createdAt: new Date(),
+            passageId: 123,
+            sequenceNumber: 2,
+            elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+            status: 'ok',
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The answer property is required for a PassageEventWithElementAnswered');
+    });
+
+    it('should throw an error if status is not present', function () {
+      // given
+      class FakePassageEventWithElement extends PassageEventWithElementAnswered {}
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new FakePassageEventWithElement({
+            id: Symbol('id'),
+            type: 'FakePassageElementWithEventAnswered',
+            occurredAt: new Date(),
+            createdAt: new Date(),
+            passageId: 123,
+            sequenceNumber: 2,
+            elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+            answer: '1',
+            status: undefined,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The status property is required for a PassageEventWithElementAnswered');
+    });
+
+    it('should throw an error if status is invalid', function () {
+      // given
+      class FakePassageEventWithElement extends PassageEventWithElementAnswered {}
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new FakePassageEventWithElement({
+            id: Symbol('id'),
+            type: 'FakePassageElementWithEventAnswered',
+            occurredAt: new Date(),
+            createdAt: new Date(),
+            passageId: 123,
+            sequenceNumber: 2,
+            elementId: '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095',
+            answer: '1',
+            status: 'not_valid_status',
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(TypeError);
+      expect(error.message).to.equal('The status value must be one of these : [‘ok‘, ‘ko‘]');
+    });
+  });
+});

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -24,6 +24,9 @@ export default class ModulixEmbed extends ModuleElement {
   @service
   modulixPreviewMode;
 
+  @service
+  passageEvents;
+
   @tracked
   isSimulatorLaunched = false;
 
@@ -107,6 +110,15 @@ export default class ModulixEmbed extends ModuleElement {
     this.args.onAnswer({
       userResponse: [message.answer],
       element: this.args.embed,
+    });
+
+    this.passageEvents.record({
+      type: 'EMBED_ANSWERED',
+      data: {
+        answer: message.answer,
+        elementId: this.args.embed.id,
+        status: 'ok',
+      },
     });
   }
 

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -4,6 +4,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
@@ -11,6 +12,8 @@ import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import ModuleElement from './module-element';
 
 export default class ModuleQcm extends ModuleElement {
+  @service passageEvents;
+
   selectedAnswerIds = new Set();
 
   get canValidateElement() {
@@ -49,6 +52,17 @@ export default class ModuleQcm extends ModuleElement {
     }
 
     return this.correction.solution.includes(proposalId) ? 'success' : 'error';
+  }
+
+  @action
+  async onAnswer(event) {
+    await super.onAnswer(event);
+
+    const status = this.answerIsValid ? 'ok' : 'ko';
+    this.passageEvents.record({
+      type: 'QCM_ANSWERED',
+      data: { answer: this.userResponse, elementId: this.element.id, status },
+    });
   }
 
   <template>

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -4,6 +4,7 @@ import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
@@ -13,6 +14,8 @@ import ModuleElement from './module-element';
 
 export default class ModuleQcu extends ModuleElement {
   @tracked selectedAnswerId = null;
+
+  @service passageEvents;
 
   @action
   radioClicked(proposalId) {
@@ -50,6 +53,17 @@ export default class ModuleQcu extends ModuleElement {
     }
 
     return this.correction?.isOk ? 'success' : 'error';
+  }
+
+  @action
+  async onAnswer(event) {
+    await super.onAnswer(event);
+
+    const status = this.answerIsValid ? 'ok' : 'ko';
+    this.passageEvents.record({
+      type: 'QCU_ANSWERED',
+      data: { answer: this.selectedAnswerId, elementId: this.element.id, status },
+    });
   }
 
   <template>

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -5,6 +5,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
@@ -14,6 +15,8 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModuleQrocm extends ModuleElement {
   @tracked selectedValues = {};
+
+  @service passageEvents;
 
   constructor() {
     super(...arguments);
@@ -70,6 +73,17 @@ export default class ModuleQrocm extends ModuleElement {
   @action
   onSelectChanged(block, value) {
     this.#updateSelectedValues(block, value);
+  }
+
+  @action
+  async onAnswer(event) {
+    await super.onAnswer(event);
+
+    const status = this.answerIsValid ? 'ok' : 'ko';
+    this.passageEvents.record({
+      type: 'QROCM_ANSWERED',
+      data: { answer: this.userResponse, elementId: this.element.id, status },
+    });
   }
 
   #updateSelectedValues(block, value) {

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -46,7 +46,7 @@ export default class ModuleQrocm extends ModuleElement {
   }
 
   resetAnswers() {
-    this.selectedValues = undefined;
+    this.selectedValues = {};
   }
 
   get formattedProposals() {

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -127,13 +127,6 @@ export default class ModulePassage extends Component {
       .save({
         adapterOptions: { passageId: this.args.passage.id },
       });
-
-    this.metrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.element.id}`,
-    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -13,6 +13,17 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Embed', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let passageEventService, passageEventRecordStub;
+
+  hooks.beforeEach(function () {
+    passageEventService = this.owner.lookup('service:passageEvents');
+    passageEventRecordStub = sinon.stub(passageEventService, 'record');
+  });
+
+  hooks.afterEach(function () {
+    passageEventRecordStub.restore();
+  });
+
   test('should display an embed with instruction', async function (assert) {
     // given
     const embed = {
@@ -97,7 +108,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
     module('when a message is received', function () {
       module('when message data has no type property', function () {
         module('when embed requires completion', function () {
-          test('should call the onAnswer method', async function (assert) {
+          test('should call the onAnswer method and send an event', async function (assert) {
             // given
             const embed = {
               id: 'id',
@@ -123,6 +134,14 @@ module('Integration | Component | Module | Embed', function (hooks) {
 
             // then
             sinon.assert.called(onElementAnswerStub);
+            sinon.assert.calledWithExactly(passageEventRecordStub, {
+              type: 'EMBED_ANSWERED',
+              data: {
+                answer: event.data.answer,
+                elementId: embed.id,
+                status: 'ok',
+              },
+            });
             assert.ok(true);
           });
         });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -717,6 +717,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         ];
         function getLastCorrectionForElementStub() {}
         const onElementAnswerStub = sinon.stub();
+        const passageEventService = this.owner.lookup('service:passage-events');
+        sinon.stub(passageEventService, 'record');
         const store = this.owner.lookup('service:store');
         const grain = store.createRecord('grain', {
           components: [

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -492,52 +492,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       sinon.assert.calledWith(saveStub, { adapterOptions: { passageId: passage.id } });
       assert.ok(true);
     });
-
-    test('should push metrics event', async function (assert) {
-      // given
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.trackEvent = sinon.stub();
-
-      const store = this.owner.lookup('service:store');
-      const qcuElement = {
-        id: 'element-id',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'radio1' },
-          { id: '2', content: 'radio2' },
-        ],
-        type: 'qcu',
-        isAnswerable: true,
-      };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-
-      const module = store.createRecord('module', {
-        id: 'module-id',
-        slug: 'module-slug',
-        title: 'Module title',
-        grains: [grain1],
-      });
-      const passage = store.createRecord('passage');
-
-      const createRecordMock = sinon.mock();
-      createRecordMock.returns({ save: function () {} });
-      store.createRecord = createRecordMock;
-
-      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-
-      // when
-      await clickByName(qcuElement.proposals[0].content);
-      await clickByName(t('pages.modulix.buttons.activity.verify'));
-
-      // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton vérifier de l'élément : ${qcuElement.id}`,
-      });
-      assert.ok(true);
-    });
   });
 
   module('when user clicks on an answerable element retry button', function () {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -126,7 +126,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               ],
             },
           ];
-          function getLastCorrectionForElementStub() {}
+          const passageEventService = this.owner.lookup('service:passage-events');
+          sinon.stub(passageEventService, 'record');
+          const getLastCorrectionForElementStub = sinon.stub();
           const onElementAnswerStub = sinon.stub();
           const store = this.owner.lookup('service:store');
           const passage = store.createRecord('passage');


### PR DESCRIPTION
## 🔆 Problème

Plusieurs éléments répondables font des appels au service `metrics` lorsque l’utilisateur appuie sur le bouton `vérifier` ou répond

C’est le cas des : 
- Embed 
- QCU
- QCM
- QROCM

## ⛱️ Proposition

Les migrer en Passage Event avec les types suivants : 
- EMBED_ANSWERED
- QCU_ANSWERED
- QCM_ANSWERED
- QROCM_ANSWERED

avec 2 champs dans data : `elementId` et `answer` qui sont les mêmes que ceux de `QCUDeclarativeAnsweredEvent`


## 🌊 Remarques

- Il faudrait aussi passer un champ status avec les valeurs 'ok' ou 'ko' pour savoir c'est une bonne ou mauvaise réponse. 
- Certains éléments envoie dans le champ answer un tableau (QCM, QROCM) d'autre non (Embed et QCU). Veut-on uniformiser cela ?

## 🏄 Pour tester
- Ouvrir la console navigateur -> onglet Network

### Embed
- Aller sur le module [controle-parental](https://app-pr12648.review.pix.fr/modules/controle-parental/passage)
- Passer / cliquer sur le bouton continuer jusqu'à arriver sur l'étape 8 du module avec le simulateur affiché
- Jouer le simulateur "Contrôle Parental" en cliquant sur Paramètres -> Contrôle Parental -> Ce téléphone est à mon enfant -> Activer le contrôle parental
- Constater qu'un appel POST /passage-events est bien fait avec le type `EMBED_ANSWERED` les champs `answer` et `elementId` bien renseigné.

### QCU
- Aller sur le module [chatgpt-vraiment-neutre](https://app-pr12648.review.pix.fr/modules/chatgpt-vraiment-neutre/passage)
- Cliquer sur Continuer
- Répondre au QCU et cliquer sur vérifier
- Constater qu'un appel POST /passage-events est bien fait avec le type `QCU_ANSWERED` et les champs `answer` et `elementId` bien renseigné.

### QCM
- Aller sur le module [controle-parental](https://app-pr12648.review.pix.fr/modules/controle-parental/passage)
- Passer / cliquer sur le bouton continuer jusqu'à arriver sur l'étape 11 du module avec le QCM affiché avec la question 
`Où Nina peut-elle activer des options de contrôle parental pour accompagner Max ?`
- Répondre au QCM et cliquer sur Vérifier
- Constater qu'un appel POST /passage-events est bien fait avec le type `QCM_ANSWERED` et les champs `answer` et `elementId` bien renseigné.

### QROCM
- Aller sur le module [mots-de-passe-securises](https://app-pr12648.review.pix.fr/modules/mots-de-passe-securises/passage)
- Cliquer sur Continuer
- Répondre au QROCM et cliquer sur Vérifier
- Constater qu'un appel POST /passage-events est bien fait avec le type `QROCM_ANSWERED` et les champs `answer` et `elementId` bien renseigné.