### PR TITLE
[TECH] Création de la table `calibrations` dans le datamart. (PIX-18447).

### DIFF
--- a/api/datamart/migrations/20250625144056_create-calibrations-table-in-datamart.js
+++ b/api/datamart/migrations/20250625144056_create-calibrations-table-in-datamart.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'calibrations';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.integer('id').notNullable().comment('Calibration ID');
+    table.dateTime('calibration_date').notNullable().comment('Date of calibration');
+    table.string('status').notNullable().comment('Validation status of the calibration');
+    table.string('scope').notNullable().comment('Calibration scope');
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Pour identifier une calibration, il nous faut nous baser sur le `calibration_id` de celle-ci.
Cet ID est disponible côté datawarehouse dans la table `data_calibrations`

## ⛱️ Proposition

Nous créons donc une nouvelle table dans le datamart sur laquelle nous allons nous appuyer pour récupérer l'ID là où nous en aurons besoin.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Vérifier la présence de la table dans le datamart.
Executer la commande `npm run datamart:rollback:latest` sur la RA pour attester de l'effacement de la table.
