### PR TITLE
[FEATURE] Ajouter un feature flag pour l'envoi de résultats automatique (PIX-18452).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -65,4 +65,10 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'team-acces', 'pix-app'],
   },
+  isAutoShareEnabled: {
+    type: 'boolean',
+    description: 'Enable automatic campaign sharing.',
+    defaultValue: false,
+    tags: ['frontend', 'team-prescription', 'pix-app'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'dynamic-feature-toggle-system': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-async-quest-rewarding-calculation-enabled': false,
+            'is-auto-share-enabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,


### PR DESCRIPTION
# 🏗️ Rappel du contexte de l'epix
Cette epix vise à supprimer l'étape d’envoi des résultats de participation

# 🤔 Problème

Pour la feature de suppression de l'étape de partage, on souhaite pouvoir communiquer une fois que tout sera prêt. Pour cela nous avons besoin d’un feature flag `isAutoShareEnabled`

# ✨ Solution

Créer un feature flag isAutoSharedEnabled

# 🧪 Comment tester

- se connecter sur la RA
- lancer `npm run toggles`
- voir le feature toggle `isAutoShareEnabled` a false
