### PR TITLE
[FEATURE] Partager automatiquement les résultats de campagne (PIX-18454)

### DIFF
--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,4 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isV3CertificationPageEnabled;
   @attr('boolean') upgradeToRealUserEnabled;
+  @attr('boolean') isAutoShareEnabled;
 }

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -48,7 +48,9 @@ export default class ResultsRoute extends Route {
     if (!this.featureToggles.featureToggles?.isAutoShareEnabled) {
       return;
     }
-
+    if (campaignParticipationResult.isShared) {
+      return;
+    }
     await this.store.adapterFor('campaign-participation-result').share(campaignParticipationResult.id);
     campaignParticipationResult.isShared = true;
     campaignParticipationResult.canImprove = false;

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -6,6 +6,7 @@ export default class ResultsRoute extends Route {
   @service session;
   @service store;
   @service router;
+  @service featureToggles;
 
   beforeModel(transition) {
     this.session.requireAuthenticationAndApprovedTermsOfService(transition);
@@ -41,5 +42,15 @@ export default class ResultsRoute extends Route {
         this.router.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
     }
+  }
+
+  async afterModel({ campaignParticipationResult }) {
+    if (!this.featureToggles.featureToggles?.isAutoShareEnabled) {
+      return;
+    }
+
+    await this.store.adapterFor('campaign-participation-result').share(campaignParticipationResult.id);
+    campaignParticipationResult.isShared = true;
+    campaignParticipationResult.canImprove = false;
   }
 }

--- a/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-results-test.js
@@ -129,6 +129,25 @@ module('Acceptance | Campaigns | Results', function (hooks) {
         assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/resultats`);
       });
 
+      module('when isAutoShareEnabled', function () {
+        test('should shared result automatically', async function (assert) {
+          // when
+          server.create('feature-toggle', {
+            id: 0,
+            isAutoShareEnabled: true,
+          });
+          server.create('campaign-participation-result', {
+            id: campaignParticipation.id,
+            isShared: false,
+          });
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/resultats`);
+
+          // then
+          assert.ok(await screen.findByRole('link', { name: t('navigation.back-to-homepage') }));
+        });
+      });
+
       test('should display evaluation results component', async function (assert) {
         // given
 

--- a/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
@@ -115,4 +115,35 @@ module('Unit | Route | Campaign | Assessment | Results', function (hooks) {
       });
     });
   });
+
+  module('afterModel', function () {
+    module('when isAutoshareEnable', function () {
+      test('should call share if campaign participation is not shared', async function (assert) {
+        // given
+        const featureToggleService = this.owner.lookup('service:feature-toggles');
+        sinon.stub(featureToggleService, 'featureToggles').value({ isAutoShareEnabled: true });
+        const store = this.owner.lookup('service:store');
+        const shareSpy = sinon.spy();
+        sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
+        // when
+        await route.afterModel({ campaignParticipationResult: { id: 123, isShared: false } });
+
+        // then
+        assert.ok(shareSpy.calledOnce);
+      });
+      test('should not call share if campaign participation is shared', async function (assert) {
+        // given
+        const featureToggleService = this.owner.lookup('service:feature-toggles');
+        sinon.stub(featureToggleService, 'featureToggles').value({ isAutoShareEnabled: true });
+        const store = this.owner.lookup('service:store');
+        const shareSpy = sinon.spy();
+        sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
+        // when
+        await route.afterModel({ campaignParticipationResult: { id: 123, isShared: true } });
+
+        // then
+        assert.ok(shareSpy.notCalled);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, un prescrit doit explicitement partager ses résultats au prescripteur. Cette étape est parfois oubliée.

## ⛱️ Proposition

On propose de partager automatiquement les résultats du prescrit lorsqu'il consulte la page de fin de parcours.

## 🌊 Remarques

ras

## 🏄 Pour tester
- passer le flag `isAutoShareEnabled` à `true`
- se connecter sur mon-pix
- participer à la campagne `PROASSMUL`
- voir le bouton `Retour à l'accueil` sur la page fin de campagne.
