### PR TITLE
[TECH] Suppression de la colonne `scope` et ré-ajout de `calibration_id` dans `active_calibrated_challenges`

### DIFF
--- a/api/datamart/migrations/20250626144833_remove-scope-column-and-add-calibration-id-in-active-calibrated-challenges.js
+++ b/api/datamart/migrations/20250626144833_remove-scope-column-and-add-calibration-id-in-active-calibrated-challenges.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'active_calibrated_challenges';
+const SCOPE_COLUMN = 'scope';
+const CALIBRATION_ID_COLUMN = 'calibration_id';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(SCOPE_COLUMN);
+    table.string(CALIBRATION_ID_COLUMN).index();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(SCOPE_COLUMN).index();
+    table.dropColumn(CALIBRATION_ID_COLUMN);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Suite à une erreur d'interprétation, la colonne `calibration_id` a été supprimée dans la PR alors qu'il ne le fallait pas.
La colonne à supprimer de la table `active_calibrated_challenges` était en fait `scope`

## ⛱️ Proposition

Ré-ajout de la colonne `calibration_id`
Suppression de la colonne `scope`

## 🌊 Remarques

Aucune donnée sur les différents environnements pour l'instant, RAS.

## 🏄 Pour tester

La table `active_calibrated_challenges` ne contient plus la colonne `scope` mais contient `calibration_id`
Exécuter la commande `npm run datamart:rollback:latest` sur la RA pour attester du bon fonctionnement du rollback
Tests verts
