### PR TITLE
[BUGFIX] Réparer la position des boutons d'action liés au candidat dans l'espace de certif (PIX-18458).

### DIFF
--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -2,15 +2,12 @@
 @use 'pix-design-tokens/typography';
 
 .session-supervising-candidate-in-list {
+  position: relative;
   margin-bottom: var(--pix-spacing-3x);
   border-radius: 4px;
   display: flex;
   @extend %pix-body-s;
   color: var(--pix-neutral-0);
-
-  @include breakpoints.device-is('tablet') {
-    position: relative;
-  }
 
   &__candidate-data {
     width: calc(100% - var(--pix-spacing-8x));

--- a/certif/app/styles/components/session-supervising/handle-live-alert-modal.scss
+++ b/certif/app/styles/components/session-supervising/handle-live-alert-modal.scss
@@ -1,6 +1,4 @@
 .handle-live-alert-modal {
-  width: 800px;
-
   &__footer {
     width: 100%;
   }
@@ -8,7 +6,8 @@
   &__actions-list {
     display: flex;
     justify-content: flex-end;
-    column-gap: 16px;
+    flex-wrap: wrap;
+    gap: var(--pix-spacing-3x);
     margin-top: 16px;
   }
 }


### PR DESCRIPTION
## 🔆 Problème

Lorsque le surveillant se connecte via un téléphone mobile à l’Espace surveillant, au clic sur le bouton concerné, le menu “Autoriser la reprise de test/Terminer le test” s'affiche mais tout en haut de l'écran, pas là où il y a le prénom/nom du candidat…

## ⛱️ Proposition

Repositionner les boutons d'action au bon endroit sur mobile.

## 🏄 Pour tester

Tester sur [PixCertif en RA](https://certif-pr12675.review.pix.fr/) avec `certif-prescriptor@example.net`
(Session 7402)

<img width="416" alt="image" src="https://github.com/user-attachments/assets/8ee0ec0e-fbe3-430f-b73a-050372b31ee7" />


