### PR TITLE
[TECH] Ajoute la notion de "VerifiedCode" pour pouvoir distinguer les campagnes des parcours combinés.

### DIFF
--- a/api/src/quest/application/verified-code-controller.js
+++ b/api/src/quest/application/verified-code-controller.js
@@ -1,0 +1,16 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as verifiedCodeSerializer from '../infrastructure/serializers/verified-code-serializer.js';
+
+const get = async function (request, h, dependencies = { verifiedCodeSerializer }) {
+  const { code } = request.params;
+  const verifiedCode = await usecases.getVerifiedCode({ code });
+  const serializedVerifiedCode = dependencies.verifiedCodeSerializer.serialize(verifiedCode);
+
+  return h.response(serializedVerifiedCode);
+};
+
+const verifiedCodeController = {
+  get,
+};
+
+export { verifiedCodeController };

--- a/api/src/quest/application/verified-codes.js
+++ b/api/src/quest/application/verified-codes.js
@@ -1,0 +1,27 @@
+import Joi from 'joi';
+
+import { verifiedCodeController } from './verified-code-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/verified-codes/{code}',
+      config: {
+        auth: false,
+        handler: verifiedCodeController.get,
+        validate: {
+          params: Joi.object({
+            code: Joi.string()
+              .regex(/[^a-zA-Z0-9]/, { invert: true })
+              .required(),
+          }),
+        },
+        notes: ['- Récupère la campagne ou le parcours combiné correspondant à un code donné'],
+        tags: ['api', 'verified-codes'],
+      },
+    },
+  ]);
+};
+const name = 'verified-codes-api';
+export { name, register };

--- a/api/src/quest/domain/models/Campaign.js
+++ b/api/src/quest/domain/models/Campaign.js
@@ -1,0 +1,5 @@
+export class Campaign {
+  constructor({ code }) {
+    this.code = code;
+  }
+}

--- a/api/src/quest/domain/models/VerifiedCode.js
+++ b/api/src/quest/domain/models/VerifiedCode.js
@@ -1,0 +1,5 @@
+export class VerifiedCode {
+  constructor({ code }) {
+    this.id = code;
+  }
+}

--- a/api/src/quest/domain/usecases/get-verified-code.js
+++ b/api/src/quest/domain/usecases/get-verified-code.js
@@ -1,0 +1,7 @@
+import { VerifiedCode } from '../models/VerifiedCode.js';
+
+export const getVerifiedCode = async ({ code, campaignRepository }) => {
+  const campaign = await campaignRepository.getByCode({ code });
+
+  return new VerifiedCode({ code: campaign.code });
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
   questRepository: repositories.questRepository,
+  campaignRepository: repositories.campaignRepository,
   logger,
 };
 

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -1,0 +1,6 @@
+import { Campaign } from '../../domain/models/Campaign.js';
+
+export const getByCode = async function ({ code, campaignsApi }) {
+  const campaign = await campaignsApi.getByCode(code);
+  return new Campaign(campaign);
+};

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -7,6 +7,7 @@ import * as profileRewardApi from '../../../profile/application/api/profile-rewa
 import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import * as campaignRepository from './campaign-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';
@@ -19,6 +20,7 @@ const repositoriesWithoutInjectedDependencies = {
   successRepository,
   rewardRepository,
   questRepository,
+  campaignRepository,
 };
 
 const dependencies = {

--- a/api/src/quest/infrastructure/serializers/verified-code-serializer.js
+++ b/api/src/quest/infrastructure/serializers/verified-code-serializer.js
@@ -1,0 +1,21 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (verifiedCode) {
+  return new Serializer('verified-codes', {
+    attributes: ['campaign'],
+    campaign: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: {
+        related: function (record, current, verifiedCode) {
+          return `/api/campaigns?filter[code]=${verifiedCode.id}`;
+        },
+      },
+    },
+  }).serialize(verifiedCode);
+};
+
+export { serialize };

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,5 +1,6 @@
 import * as questRoute from './application/index.js';
+import * as verifiedCodeRoute from './application/verified-codes.js';
 
-const questRoutes = [questRoute];
+const questRoutes = [questRoute, verifiedCodeRoute];
 
 export { questRoutes };

--- a/api/tests/quest/acceptance/application/verified-code_test.js
+++ b/api/tests/quest/acceptance/application/verified-code_test.js
@@ -1,0 +1,43 @@
+import { createServer, databaseBuilder, expect } from '../../../test-helper.js';
+
+describe('Quest | Acceptance | Application | Verified Code Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/verified-codes/{id}', function () {
+    it('should return verified code with campaign link for given campaign', async function () {
+      // given
+      databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/verified-codes/${campaign.code}`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          type: 'verified-codes',
+          id: campaign.code,
+          attributes: {},
+          relationships: {
+            campaign: {
+              links: {
+                related: `/api/campaigns?filter[code]=${campaign.code}`,
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-verified-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-verified-code_test.js
@@ -1,0 +1,24 @@
+import { VerifiedCode } from '../../../../../src/quest/domain/models/VerifiedCode.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Domain | Usecases | getVerifiedCode', function () {
+  it('it returns verified code for a campaign', async function () {
+    const campaign = databaseBuilder.factory.buildCampaign();
+    await databaseBuilder.commit();
+
+    const verifiedCode = await usecases.getVerifiedCode({ code: campaign.code });
+
+    expect(verifiedCode).to.be.instanceOf(VerifiedCode);
+    expect(verifiedCode.id).to.equal(campaign.code);
+  });
+
+  it('it throws a NotFoundError when the provided code is not linked to a campaign', async function () {
+    const err = await catchErr(usecases.getVerifiedCode)({
+      code: 'NOCAMPAIGN',
+    });
+
+    expect(err).to.be.instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/verified-code-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/verified-code-serializer_test.js
@@ -1,0 +1,29 @@
+import { VerifiedCode } from '../../../../../src/quest/domain/models/VerifiedCode.js';
+import * as verifiedCodeSerializer from '../../../../../src/quest/infrastructure/serializers/verified-code-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | verified-code', function () {
+  it('#serialize', function () {
+    // given
+    const verifiedCode = new VerifiedCode({ code: 'ABCDEFGH' });
+
+    // when
+    const serializedVerifiedCode = verifiedCodeSerializer.serialize(verifiedCode);
+
+    // then
+    expect(serializedVerifiedCode).to.deep.equal({
+      data: {
+        attributes: {},
+        type: 'verified-codes',
+        id: 'ABCDEFGH',
+        relationships: {
+          campaign: {
+            links: {
+              related: '/api/campaigns?filter[code]=ABCDEFGH',
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -33,10 +33,10 @@ export default class FillInCampaignCodeController extends Controller {
   @action
   async startCampaign(campaignCode) {
     try {
-      this.campaign = await this.store.queryRecord('campaign', {
-        filter: { code: campaignCode },
-      });
-      const isGARCampaign = this.campaign.identityProvider === IDENTITY_PROVIDER_ID_GAR;
+      this.verifiedCode = await this.store.findRecord('verified-code', campaignCode);
+      this.campaign = await this.verifiedCode.campaign;
+      const organizationToJoin = await this.store.queryRecord('organization-to-join', { code: this.verifiedCode.id });
+      const isGARCampaign = organizationToJoin.identityProvider === IDENTITY_PROVIDER_ID_GAR;
       if (_shouldShowGARModal(isGARCampaign, this.isUserAuthenticatedByGAR, this.isUserAuthenticatedByPix)) {
         this.showGARModal = true;
         return;

--- a/mon-pix/app/models/verified-code.js
+++ b/mon-pix/app/models/verified-code.js
@@ -1,0 +1,5 @@
+import Model, { belongsTo } from '@ember-data/model';
+
+export default class VerifiedCode extends Model {
+  @belongsTo('campaign', { async: true, inverse: null }) campaign;
+}

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -27,6 +27,7 @@ import getQuestResults from './routes/get-quest-results';
 import getScorecard from './routes/get-scorecard';
 import getScorecardsTutorials from './routes/get-scorecards-tutorials';
 import loadUserTutorialsRoutes from './routes/get-user-tutorials';
+import getVerifiedCodes from './routes/get-verified-codes';
 import loadModuleRoutes from './routes/modules/index';
 import loadOrganizationLearnersRoutes from './routes/organization-learners/index';
 import loadPassageRoutes from './routes/passages/index';
@@ -128,4 +129,6 @@ function routes() {
   this.get('/information-banners/:target', getInformationBanners);
 
   this.get('/organizations-to-join/:code', getOrganizationsToJoin);
+
+  this.get('/verified-codes/:code', getVerifiedCodes);
 }

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -90,4 +90,13 @@ export default Factory.extend({
       });
     },
   }),
+
+  withVerifiedCode: trait({
+    afterCreate(campaign, server) {
+      server.create('verified-code', {
+        id: campaign.code,
+        campaign,
+      });
+    },
+  }),
 });

--- a/mon-pix/mirage/routes/get-verified-codes.js
+++ b/mon-pix/mirage/routes/get-verified-codes.js
@@ -1,0 +1,8 @@
+import { Response } from 'miragejs';
+
+export default function (schema, request) {
+  const { code } = request.params;
+  const verifiedCode = schema.verifiedCodes.find(code.toLowerCase());
+
+  return verifiedCode ? verifiedCode : new Response(404);
+}

--- a/mon-pix/mirage/serializers/verified-code.js
+++ b/mon-pix/mirage/serializers/verified-code.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  links(verifiedCode) {
+    return {
+      campaign: {
+        related: `/api/campaigns?filter[code]=${verifiedCode.id}`,
+      },
+    };
+  },
+});

--- a/mon-pix/tests/acceptance/authentication/signup-test.js
+++ b/mon-pix/tests/acceptance/authentication/signup-test.js
@@ -181,7 +181,7 @@ module('Acceptance | authentication | Signup', function (hooks) {
       const lastName = 'Doe';
       const email = 'john.doe@email.com';
       const password = 'JeMeLoggue1024';
-      const campaign = server.create('campaign', { isRestricted: false });
+      const campaign = server.create('campaign', 'withVerifiedCode', { isRestricted: false });
 
       // when
       const screen = await visit('/campagnes');

--- a/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code-test.js
@@ -39,11 +39,13 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
     module('and starts a campaign with GAR as identity provider', function () {
       test('should not redirect the user and display a modal', async function (assert) {
         // given
-        const campaign = server.create('campaign', {
+        const campaign = server.create('campaign', 'withVerifiedCode', {
+          organizationId: 1,
           identityProvider: 'GAR',
           targetProfileName: 'My Profile',
           organizationName: 'AWS',
         });
+        server.create('organization-to-join', { id: 1, code: campaign.code, identityProvider: 'GAR' });
 
         // when
         const screen = await visit(`/campagnes`);
@@ -58,11 +60,13 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
       module('and wants to continue', function () {
         test('should be redirected to the campaign entry page', async function (assert) {
           // given
-          const campaign = server.create('campaign', {
+          const campaign = server.create('campaign', 'withVerifiedCode', {
+            organizationId: 1,
             identityProvider: 'GAR',
             targetProfileName: 'My Profile',
             organizationName: 'AWS',
           });
+          server.create('organization-to-join', { id: 1, code: campaign.code, identityProvider: 'GAR' });
 
           // when
           const screen = await visit(`/campagnes`);
@@ -79,11 +83,14 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
       module('and wants to connect to his Mediacentre', function () {
         test('should stay on the same page after closing the modal', async function (assert) {
           // given
-          const campaign = server.create('campaign', {
+          const campaign = server.create('campaign', 'withVerifiedCode', {
+            organizationId: 1,
             identityProvider: 'GAR',
             targetProfileName: 'My Profile',
             organizationName: 'AWS',
           });
+
+          server.create('organization-to-join', { id: 1, code: campaign.code, identityProvider: 'GAR' });
 
           // when
           const screen = await visit(`/campagnes`);
@@ -101,7 +108,8 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
     module('and starts a campaign without GAR as identity provider', function () {
       test('should redirect the user to the campaign entry page', async function (assert) {
         // given
-        const campaign = server.create('campaign');
+        const campaign = server.create('campaign', 'withVerifiedCode');
+        server.create('organization-to-join', { id: 1, code: campaign.code, identityProvider: null });
 
         // when
         const screen = await visit(`/campagnes`);

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner-test.js
@@ -34,7 +34,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           }),
         );
 
-        campaign = server.create('campaign', { organizationId: 1 });
+        campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
         server.create('organization-to-join', { id: 1, identityProvider: 'OIDC_PARTNER', code: campaign.code });
       });
 
@@ -118,7 +118,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
             assign: assignLocationStub,
           }),
         );
-        campaign = server.create('campaign', { organizationId: 1 });
+        campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
         server.create('organization-to-join', { id: 1, identityProvider: 'OIDC_PARTNER', code: campaign.code });
       });
 

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -59,7 +59,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         module('When campaign is not restricted', function () {
           test('should display landing page', async function (assert) {
             // given
-            const campaign = server.create('campaign', { isRestricted: false, externalIdLabel: null });
+            const campaign = server.create('campaign', 'withVerifiedCode', {
+              isRestricted: false,
+              externalIdLabel: null,
+            });
             const screen = await visit('/campagnes');
 
             // when
@@ -94,7 +97,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               );
 
               // given
-              const campaign = server.create('campaign', { organizationId: 1 });
+              const campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
               server.create('organization-to-join', { id: 1, isRestricted: false, code: campaign.code });
               const screen = await visit('/campagnes');
               await fillIn(
@@ -136,7 +139,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
         module('When campaign is restricted and SCO', function (hooks) {
           hooks.beforeEach(function () {
-            campaign = server.create('campaign', { organizationId: 1 });
+            campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
             server.create('organization-to-join', {
               id: campaign.organizationId,
               isRestricted: true,
@@ -347,7 +350,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
         module('When campaign is restricted and SUP', function (hooks) {
           hooks.beforeEach(function () {
-            campaign = server.create('campaign', { organizationId: 1 });
+            campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
             server.create('organization-to-join', { id: 1, isRestricted: true, type: 'SUP', code: campaign.code });
           });
 
@@ -395,7 +398,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
         module('When is a simplified access campaign', function (hooks) {
           hooks.beforeEach(function () {
-            campaign = server.create('campaign', {
+            campaign = server.create('campaign', 'withVerifiedCode', {
               isSimplifiedAccess: true,
               externalIdLabel: 'Les anonymes',
               organizationId: 1,
@@ -446,7 +449,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       module('When the user has already seen the landing page', function () {
         test('should redirect to signin page', async function (assert) {
           // given & when
-          const campaign = server.create('campaign');
+          const campaign = server.create('campaign', 'withVerifiedCode');
           await startCampaignByCode(campaign.code);
 
           // then
@@ -467,7 +470,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         module('When campaign has custom text for the landing page', function () {
           test('should show the custom text on the landing page', async function (assert) {
             // given
-            const campaign = server.create('campaign', { customLandingPageText: 'SomeText' });
+            const campaign = server.create('campaign', 'withVerifiedCode', { customLandingPageText: 'SomeText' });
 
             // when
             const screen = await visit(`/campagnes/${campaign.code}`);
@@ -499,7 +502,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
       module('When campaign is restricted and SCO', function (hooks) {
         hooks.beforeEach(function () {
-          campaign = server.create('campaign', { organizationId: 1 });
+          campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
           server.create('organization-to-join', {
             id: 1,
             isRestricted: true,
@@ -610,7 +613,11 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
       module('When campaign is restricted and SUP', function (hooks) {
         hooks.beforeEach(function () {
-          campaign = server.create('campaign', { organizationId: 1, isRestricted: true, organizationType: 'SUP' });
+          campaign = server.create('campaign', 'withVerifiedCode', {
+            organizationId: 1,
+            isRestricted: true,
+            organizationType: 'SUP',
+          });
           server.create('organization-to-join', {
             id: 1,
             isRestricted: true,
@@ -668,7 +675,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         module('When participant external id is not set in the url', function () {
           test('should show the identifiant page after clicking on start button in landing page', async function (assert) {
             // given & when
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman' });
+            campaign = server.create('campaign', 'withVerifiedCode', { externalIdLabel: 'nom de naissance de maman' });
             await startCampaignByCode(campaign.code);
 
             // then
@@ -679,7 +686,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         module('When participant external id is set in the url', function () {
           test('should begin campaign participation', async function (assert) {
             // given & when
-            campaign = server.create('campaign', { externalIdLabel: 'nom de naissance de maman' });
+            campaign = server.create('campaign', 'withVerifiedCode', { externalIdLabel: 'nom de naissance de maman' });
             await startCampaignByCodeAndExternalId(campaign.code);
 
             // then
@@ -691,7 +698,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       module('When campaign does not have external id', function () {
         test('should begin campaign participation', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { externalIdLabel: null });
+          campaign = server.create('campaign', 'withVerifiedCode', { externalIdLabel: null });
           await startCampaignByCode(campaign.code);
 
           // then
@@ -702,7 +709,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       module('When campaign does not have external id but a participant external id is set in the url', function () {
         test('should begin campaign participation', async function (assert) {
           // given & when
-          campaign = server.create('campaign', { externalIdLabel: null });
+          campaign = server.create('campaign', 'withVerifiedCode', { externalIdLabel: null });
           await startCampaignByCodeAndExternalId(campaign.code);
 
           // then
@@ -746,7 +753,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
       module('When is a simplified access campaign', function (hooks) {
         hooks.beforeEach(function () {
-          campaign = server.create('campaign', { isSimplifiedAccess: true, externalIdLabel: 'Les anonymes' });
+          campaign = server.create('campaign', 'withVerifiedCode', {
+            isSimplifiedAccess: true,
+            externalIdLabel: 'Les anonymes',
+          });
         });
 
         test('should redirect to landing page', async function (assert) {
@@ -773,7 +783,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
     module('When user is logged as anonymous and campaign is simplified access', function () {
       test('should replace previous connected anonymous user', async function (assert) {
         // given
-        campaign = server.create('campaign', { isSimplifiedAccess: true, externalIdLabel: 'Les anonymes' });
+        campaign = server.create('campaign', 'withVerifiedCode', {
+          isSimplifiedAccess: true,
+          externalIdLabel: 'Les anonymes',
+        });
         await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
         const session = currentSession();
         const previousUserId = session.data.authenticated['user_id'];
@@ -798,7 +811,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
     module('When user is logged in an external platform', function () {
       module('When campaign is restricted and SCO', function (hooks) {
         hooks.beforeEach(function () {
-          campaign = server.create('campaign', { organizationId: 1 });
+          campaign = server.create('campaign', 'withVerifiedCode', { organizationId: 1 });
           server.create('organization-to-join', { id: 1, isRestricted: true, type: 'SCO', code: campaign.code });
         });
 

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
@@ -27,10 +27,17 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
         // given
         const campaignCode = 'LINKTOTHEPAST';
         const storeStub = {
+          findRecord: sinon
+            .stub()
+            .withArgs('verified-code', campaignCode)
+            .resolves({
+              id: campaignCode,
+              campaign: { id: 1, code: campaignCode },
+            }),
           queryRecord: sinon
             .stub()
-            .withArgs('campaign', { filter: { code: campaignCode } })
-            .resolves({ code: campaignCode, identityProvider: 'FRANCE DECONNECT' }),
+            .withArgs('organization-to-join', { code: campaignCode })
+            .resolves({ identityProvider: 'FRANCEDECONNECT' }),
         };
         controller.set('store', storeStub);
         controller.set('campaignCode', campaignCode);
@@ -50,10 +57,17 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
           // given
           const campaignCode = 'LINKTOTHEPAST';
           const storeStub = {
+            findRecord: sinon
+              .stub()
+              .withArgs('verified-code', campaignCode)
+              .resolves({
+                id: campaignCode,
+                campaign: { id: 1, code: campaignCode },
+              }),
             queryRecord: sinon
               .stub()
-              .withArgs('campaign', { filter: { code: campaignCode } })
-              .resolves({ code: campaignCode, identityProvider: 'GAR' }),
+              .withArgs('organization-to-join', { code: campaignCode })
+              .resolves({ identityProvider: 'GAR' }),
           };
           stubSessionService(this.owner, { isAuthenticatedByGar: true });
           controller.set('store', storeStub);
@@ -73,10 +87,17 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
             // given
             const campaignCode = 'LINKTOTHEPAST';
             const storeStub = {
+              findRecord: sinon
+                .stub()
+                .withArgs('verified-code', campaignCode)
+                .resolves({
+                  id: campaignCode,
+                  campaign: { id: 1, code: campaignCode },
+                }),
               queryRecord: sinon
                 .stub()
-                .withArgs('campaign', { filter: { code: campaignCode } })
-                .resolves({ code: campaignCode, identityProvider: 'GAR' }),
+                .withArgs('organization-to-join', { code: campaignCode })
+                .resolves({ identityProvider: 'GAR' }),
             };
             stubSessionService(this.owner, { isAuthenticated: true });
             controller.set('store', storeStub);
@@ -95,10 +116,17 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
             // given
             const campaignCode = 'LINKTOTHEPAST';
             const storeStub = {
+              findRecord: sinon
+                .stub()
+                .withArgs('verified-code', campaignCode)
+                .resolves({
+                  id: campaignCode,
+                  campaign: { id: 1, code: campaignCode },
+                }),
               queryRecord: sinon
                 .stub()
-                .withArgs('campaign', { filter: { code: campaignCode } })
-                .resolves({ code: campaignCode, identityProvider: 'GAR' }),
+                .withArgs('organization-to-join', { code: campaignCode })
+                .resolves({ identityProvider: 'GAR' }),
             };
             stubSessionService(this.owner, { isAuthenticated: false });
             controller.set('store', storeStub);
@@ -119,9 +147,9 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       const campaignCode = 'azerty1';
       controller.set('campaignCode', campaignCode);
       const storeStub = {
-        queryRecord: sinon
+        findRecord: sinon
           .stub()
-          .withArgs('campaign', { filter: { code: campaignCode } })
+          .withArgs('verified-code', campaignCode)
           .rejects({ errors: [{ status: '404' }] }),
       };
       controller.set('store', storeStub);
@@ -141,9 +169,9 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       const campaignCode = 'azerty1';
       controller.set('campaignCode', campaignCode);
       const storeStub = {
-        queryRecord: sinon
+        findRecord: sinon
           .stub()
-          .withArgs('campaign', { filter: { code: campaignCode } })
+          .withArgs('verified-code', campaignCode)
           .rejects({ errors: [{ status: '403' }] }),
       };
       controller.set('store', storeStub);


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

La saisie d'un code sous-entend qu'on commence une campagne.
Avec l'arrivée des parcours combinés, la saisie d'un code pourra également être le début d'un parcours combiné.


## ⛱️ Proposition

On ajoute la notion de "VerifiedCode" qui permet, pour un code donné, de retourner un objet lié à une campagne pour le moment (pour garder le fonctionnement actuel intact).
Par la suite ce VerifiedCode pourra être lié à un parcours combiné et ainsi permettre le début de celui-ci.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Lancer une campagne en mode connecté puis en mode non connecté via un code pour vérifier que le fonctionnement actuel ne comporte pas de régression.