### PR TITLE
[FEATURE] Rendre les claims additionels optionels (PIX-18457)

### DIFF
--- a/api/src/identity-access-management/domain/models/ClaimManager.js
+++ b/api/src/identity-access-management/domain/models/ClaimManager.js
@@ -50,23 +50,19 @@ export class ClaimManager {
   /**
    * @param {Record<string, string>} userInfo
    *
-   * @returns {boolean} true if required claims are missing from userInfo
+   * @returns {boolean} true if some claims are missing from userInfo
    */
   hasMissingClaims(userInfo = {}) {
-    const missingClaims = this.getMissingClaims(userInfo);
+    const missingClaims = [...this.getMissingMandatoryClaims(userInfo), ...this.#getMissingAdditionalClaims(userInfo)];
     return missingClaims.length > 0;
   }
 
   /**
    * @param {Record<string, string>} userInfo
    *
-   * @returns {string[]} missing required claims from userInfo
+   * @returns {string[]} missing mandatory claims from userInfo
    */
-  getMissingClaims(userInfo = {}) {
-    return [...this.#getMissingClaimsToMap(userInfo), ...this.#getMissingAdditionalClaims(userInfo)];
-  }
-
-  #getMissingClaimsToMap(userInfo = {}) {
+  getMissingMandatoryClaims(userInfo = {}) {
     const requiredKeys = Object.keys(this.#claimMapping);
     const mappedKeys = Object.keys(this.mapClaims(userInfo));
     return flatten(

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -290,9 +290,9 @@ export class OidcAuthenticationService {
       throw new OidcError({ message: error.message });
     }
 
-    if (this.claimManager.hasMissingClaims(userInfo)) {
-      const missingClaims = this.claimManager.getMissingClaims(userInfo);
+    const missingClaims = this.claimManager.getMissingMandatoryClaims(userInfo);
 
+    if (missingClaims.length > 0) {
       const message = `Un ou des champs obligatoires (${missingClaims.join(
         ',',
       )}) n'ont pas été renvoyés par votre fournisseur d'identité ${this.organizationName}.`;

--- a/api/tests/identity-access-management/unit/domain/models/ClaimManager.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/ClaimManager.test.js
@@ -105,18 +105,18 @@ describe('Unit | Identity Access Management | Domain | Model | ClaimManager', fu
     });
   });
 
-  describe('#getMissingClaims', function () {
-    it('returns the missing claims from user info', async function () {
+  describe('#getMissingMandatoryClaims', function () {
+    it('returns the missing mandatory claims from user info', async function () {
       // given
       const claimMapping = { firstName: ['foo'], lastName: ['bar'], id: ['sub'] };
       const additionalClaims = ['aWantedClaim', 'anotherWantedClaim'];
 
       // when
       const claimManager = new ClaimManager({ claimMapping, additionalClaims });
-      const result = claimManager.getMissingClaims({ sub: '', foo: 'foofoo', anotherWantedClaim: '' });
+      const result = claimManager.getMissingMandatoryClaims({ sub: '', foo: 'foofoo', anotherWantedClaim: '' });
 
       // then
-      expect(result).to.deep.equal(['bar', 'sub', 'aWantedClaim', 'anotherWantedClaim']);
+      expect(result).to.deep.equal(['bar', 'sub']);
     });
 
     it('returns an empty array when all claims are present from user info', async function () {
@@ -125,7 +125,7 @@ describe('Unit | Identity Access Management | Domain | Model | ClaimManager', fu
 
       // when
       const claimManager = new ClaimManager({ claimMapping });
-      const result = claimManager.getMissingClaims({ foo: 'foofoo', bar: 'barbar' });
+      const result = claimManager.getMissingMandatoryClaims({ foo: 'foofoo', bar: 'barbar' });
 
       // then
       expect(result).to.deep.equal([]);

--- a/mon-pix/app/components/authentication/login-or-register-oidc.gjs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.gjs
@@ -182,9 +182,8 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
       Object.entries(rest).map(([key, value]) => {
         let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.information.${key}`)}`;
-        const translation = `${this.intl.t(`pages.login-or-register-oidc.register-form.information.${key}`)}`;
 
-        if (translation.includes('Missing translation')) {
+        if (label.includes('Missing translation')) {
           label = `${key} :`;
         }
 

--- a/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
+++ b/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
@@ -75,6 +75,7 @@
     }
 
     li {
+      overflow-wrap: anywhere;
       list-style: initial;
     }
   }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1367,14 +1367,14 @@
     },
     "evaluation-results": {
       "leave-without-signup-modal": {
-          "actions": {
-            "cancel": "Cancel",
-            "leave": "Yes, leave the course"
-          },
-          "content-information": "If you leave this course without registering, you will not be able to validate your progress.",
-          "content-instruction": "Would you like to continue?",
-          "title": "Leave and return to Pix?"
+        "actions": {
+          "cancel": "Cancel",
+          "leave": "Yes, leave the course"
         },
+        "content-information": "If you leave this course without registering, you will not be able to validate your progress.",
+        "content-instruction": "Would you like to continue?",
+        "title": "Leave and return to Pix?"
+      },
       "quit-results": {
         "send-result-modal": {
           "actions": {
@@ -1608,11 +1608,16 @@
         "button": "Create my account",
         "description": "An account will be created based on the information sent by the organisation",
         "information": {
-          "employeeNumber": "Employee number :",
+          "FrEduFonctAdm": "Administrative function:",
+          "FrEduNumenHash": "Numen (encrypted):",
+          "discipline": "School subject:",
+          "employeeNumber": "Employee number:",
           "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-          "firstName": "First name :",
-          "lastName": "Last name :",
-          "population": "Population :"
+          "firstName": "First name:",
+          "lastName": "Last name:",
+          "population": "Population:",
+          "rne": "Establishment of assignment:",
+          "title": "Title:"
         },
         "title": "Sign up"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1608,11 +1608,16 @@
         "button": "Je crée mon compte",
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
         "information": {
+          "FrEduFonctAdm": "Fonction Administrative :",
+          "FrEduNumenHash": "Numen (chiffré) :",
+          "discipline": "Discipline :",
           "employeeNumber": "Numéro d'employé :",
           "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
           "firstName": "Prénom :",
           "lastName": "Nom :",
-          "population": "Population :"
+          "population": "Population :",
+          "rne": "Etablissement d’affectation :",
+          "title": "Fonction :"
         },
         "title": "Je n’ai pas de compte Pix"
       },


### PR DESCRIPTION
## 🔆 Problème

1. Certains claims (du claimsToStore) sont optionnels côté SSO, or les claimsToStore sont obligatoires côté Pix
2. Les claims récupérées du SSO ne sont pas toutes traduites, il faut les traduire.
3. Corriger le pb d’affichage de la valeur de claims trop longs

## ⛱️ Proposition

1. Rendre les claimsToStore optionnels à la connexion OIDC, attention les claims mappés (first-name, last-name, sub) sont toujours obligatoires.
2. Traduire les claims
3. Corriger le problème de “wrapping” des claims trop long (voir capture d’écran)


## 🏄 Pour tester

**Test à réaliser en local et utiliser la dernière version de OIDC_PROVIDERS.json**

1. Aller sur https://app.dev.pix.fr
2. Se connecter avec un compte SSO Arena
3. Vérifier les claims récupérées
  - Les claims récupérées sont affichées (même si elles ne sont pas toutes renvoyées - tester avec différents comptes)
  - Les clés des claims sont traduites
  - La clé "Numen (chiffrée)" est correctement affichée sur plusieurs lignes
  
