### PR TITLE
[BUGFIX] afficher la popup des formations, la première fois qu'on affiche les résultats de participation. (PIX-18498)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -12,8 +12,8 @@ import QuitResults from '../../../campaigns/assessment/results/quit-results';
 
 export default class EvaluationResults extends Component {
   @service tabManager;
-
-  @tracked showEvaluationResultsModal = false;
+  // eslint-disable-next-line ember/no-tracked-properties-from-args
+  @tracked showEvaluationResultsModal = this.args.model.showTrainings;
 
   get isResultsSharedModalEnabled() {
     return this.hasTrainings;

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -36,7 +36,7 @@ export default class ResultsRoute extends Route {
         await this.currentUser.load();
       }
 
-      return { campaign, campaignParticipationResult, trainings, questResults };
+      return { campaign, campaignParticipationResult, showTrainings: false, trainings, questResults };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
         this.router.transitionTo('campaigns.entry-point', campaign.code);
@@ -44,15 +44,16 @@ export default class ResultsRoute extends Route {
     }
   }
 
-  async afterModel({ campaignParticipationResult }) {
+  async afterModel(model) {
     if (!this.featureToggles.featureToggles?.isAutoShareEnabled) {
       return;
     }
-    if (campaignParticipationResult.isShared) {
+    if (model.campaignParticipationResult.isShared) {
       return;
     }
-    await this.store.adapterFor('campaign-participation-result').share(campaignParticipationResult.id);
-    campaignParticipationResult.isShared = true;
-    campaignParticipationResult.canImprove = false;
+    await this.store.adapterFor('campaign-participation-result').share(model.campaignParticipationResult.id);
+    model.campaignParticipationResult.isShared = true;
+    model.campaignParticipationResult.canImprove = false;
+    model.showTrainings = true;
   }
 }

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -60,25 +60,41 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
   module('when the campaign is shared and has trainings', function (hooks) {
     hooks.beforeEach(async function () {
       // given
+      this.model.showTrainings = true;
       this.model.trainings = [{ duration: { days: 1, hours: 1, minutes: 1 } }];
       this.model.campaignParticipationResult.isShared = true;
       this.model.campaignParticipationResult.competenceResults = [Symbol('competences')];
     });
 
+    test('it should display modal before show assessment result', async function (assert) {
+      screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+
+      assert.ok(
+        screen.getByRole('dialog', { name: t('pages.skill-review.tabs.trainings.shared-results-modal.title') }),
+      );
+    });
+
     test('it should display the training button', async function (assert) {
       // when
+      this.model.showTrainings = false;
+
       screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
 
       // then
-      assert.dom(screen.getByRole('button', { name: /Voir les formations/ })).isVisible();
+      assert.notOk(
+        screen.queryByRole('dialog', { name: t('pages.skill-review.tabs.trainings.shared-results-modal.title') }),
+      );
+      assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).isVisible();
     });
 
     test('when the training button is clicked, it should set trainings tab active', async function (assert) {
+      this.model.showTrainings = false;
+
       // when
       screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
 
       // then
-      await click(screen.getByRole('button', { name: /Voir les formations/ }));
+      await click(screen.getByRole('button', { name: t('pages.skill-review.hero.see-trainings') }));
       assert
         .dom(screen.getByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }))
         .hasAttribute('aria-selected', 'true');


### PR DESCRIPTION
## 🤔 Problème

on affiche plus la popup des formations

## ✨ Solution

on affiche la popup des formations

## 🧪 Comment tester

- se connecter avec [kat-alloguicks@example.net](mailto:kat-alloguicks@example.net)
- finir un parcours 
- voir les recommandations de formation