### PR TITLE
[FEATURE] Migration BDD ajouter une colonne "code" et une colonne "organizationId" à la table "quests" (PIX-18466)

### DIFF
--- a/api/db/migrations/20250627084010_add-code-column-to-quests.js
+++ b/api/db/migrations/20250627084010_add-code-column-to-quests.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'quests';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('code').defaultTo(null).comment('Adds code on quests to use a quest object in a course');
+    table.integer('organizationId').defaultTo(null).unsigned().comment('Links a quest to an organization');
+    table.foreign('organizationId').references('organizations.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('code');
+    table.dropColumn('organizationId');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème
Pour accéder au parcours combiné, on a besoin de deux colonnes optionnelles : "code" et "organizationId" sur la table "quests".

## ⛱️ Proposition
RAS

## 🌊 Remarques
Pas de contrainte "not null" pour ne pas casser l'existant.

## 🏄 Pour tester
Se connecter sur le scalingo de la RA, pgsl-console.
Faire une requête SELECT sur la table "quests" et vérifier qu'elle contient bien une colonne code et une colonne organizationId.