### PR TITLE
[TECH] :truck: Déplacer un serializer vers le contexte `team`

### DIFF
--- a/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
@@ -1,6 +1,6 @@
 import { BadRequestError } from '../../../shared/application/http-errors.js';
-import * as certificationCenterMembershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const findCertificationCenterMembershipsByCertificationCenter = async function (

--- a/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
@@ -1,6 +1,6 @@
 import { ForbiddenError } from '../../../shared/application/http-errors.js';
-import * as certificationCenterMembershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
 

--- a/api/src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js
@@ -1,6 +1,6 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-import { CertificationCenterMembership } from '../../../domain/models/index.js';
+import { CertificationCenterMembership } from '../../../../shared/domain/models/index.js';
 
 const { Serializer } = jsonapiSerializer;
 

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-membership.serializer.test.js
@@ -1,6 +1,6 @@
-import { CertificationCenterMembership } from '../../../../../src/shared/domain/models/CertificationCenterMembership.js';
-import * as certificationCenterMembershipSerializer from '../../../../../src/shared/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { CertificationCenterMembership } from '../../../../../../src/shared/domain/models/CertificationCenterMembership.js';
+import * as certificationCenterMembershipSerializer from '../../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | certification-center-membership-serializer', function () {
   describe('#deserialize', function () {


### PR DESCRIPTION
## 🔆 Problème

Un serializer est dans le répertoire `src/shared/` alors qu'il ne concerne qu'un contexte `team`

## ⛱️ Proposition

Déplacer le serializer vers le contexte `team`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
