### PR TITLE
[FEATURE] Permettre à un utilisateur anonyme d'être redirigé vers son dashboard après inscription (PIX-18445)

### DIFF
--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -19,6 +19,7 @@ export default class User extends Model {
   @attr('string') lang;
   @attr('string') locale;
   @attr('boolean') isAnonymous;
+  @attr('string') anonymousUserToken;
   @attr('boolean') shouldSeeDataProtectionPolicyInformationBanner;
   @attr('boolean') emailConfirmed;
   @attr() lastDataProtectionPolicySeenAt;


### PR DESCRIPTION
## 🔆 Problème
Lorsqu'un utilisateur anonyme a terminé sa campagne, on souhaite qu'il puisse se créer un compte et conserver les Pix gagnés. 

## ⛱️ Proposition
Quand l'utilisateur anonyme remplit le formulaire d'inscription et clique sur "Je m'inscris", il  doit être redirigé vers son dashboard avec une session `authenticated:oauth2`

## 🌊 Remarques
ras 

## 🏄 Pour tester
- En local, ne pas oublier de mettre le feature toggle upgradeToRealUser à true 
- Lancer un Parcours Autonome ([lien](https://app-pr12693.review.pix.fr/campagnes/AUTOCOURS1))
- Aller au bout de ce parcours autonome , cliquer sur "S'inscrire sur Pix", compléter le formulaire d'inscription, et cliquer sur "Je m'inscris"
- Constater qu'on arrive sur le dashboard de l'utilisateur inscrit.
- Reprendre les tests de https://github.com/1024pix/pix/pull/12626 pour vérifier que l'utilisateur anonyme a bien été enrichi