### PR TITLE
[BUGFIX] Corriger la largeur des colonnes en cas de mots longs sur Pix Certif (PIX-18501).

### DIFF
--- a/certif/app/styles/components/issue-report-modal.scss
+++ b/certif/app/styles/components/issue-report-modal.scss
@@ -1,13 +1,10 @@
 /* stylelint-disable no-descending-specificity */
 
 .issue-report-modal {
-  min-width: 650px;
-  max-width: 650px;
-  margin: 100px auto;
+  min-width: 800px;
 
-  /* to fix in pix UI */
-  h2 {
-    font-size: 0.875rem;
+  h1 {
+    word-break: break-all;
   }
 
   &__frame {

--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -21,4 +21,14 @@
   }
 }
 
+// temporary fix: to do on Pix UI
+table {
+  tbody {
+    tr {
+      td {
+        word-break: break-word;
+      }
+    }
+  }
+}
 


### PR DESCRIPTION
## 🔆 Problème

Les données affichées dans les tableaux, composées de mot sans espaces (ou avec _ etc) étendent les colonnes qui casse l'affichage des tableaux.

## ⛱️ Proposition

Corriger ça temporairement. Il faudrait pouvoir avoir ça par défaut sur Pix UI mais ça nécessite une discussion avec les utilisateurs du composant du PixTable pour voir si ça ne va pas créer d'effet de bord

## 🌊 Remarques

On fixe aussi la modale du signalement

## 🏄 Pour tester

checker les tableaux pour voir les comportements avec des longs mots

https://certif-pr12694.review.pix.fr/connexion
https://certif-pr12694.review.pix.fr/sessions
https://certif-pr12694.review.pix.fr/sessions/7403/candidats