### PR TITLE
[TECH] Permettre de spécifier quelle release récupérer côté PixApi lorsqu'un ID de release est renseigné dans une variable d'env

### DIFF
--- a/api/db/seeds/data/common/learningcontent-builder.js
+++ b/api/db/seeds/data/common/learningcontent-builder.js
@@ -3,7 +3,7 @@ import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js
 import { logger, SCOPES } from '../../../../src/shared/infrastructure/utils/logger.js';
 
 export async function learningContentBuilder({ databaseBuilder }) {
-  const learningContent = await lcmsClient.getLatestRelease();
+  const learningContent = await lcmsClient.getRelease();
 
   const totalCounts = Object.entries(learningContent).map(([model, entities]) => [model, entities.length]);
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -408,6 +408,16 @@ LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 # default: none
 LCMS_API_URL=https://lcms.minimal.pix.fr/api
 
+# ID of a release
+#
+# Useful when we need to not retrieve the latest release but a specific one
+# If not present, API will fetch the latest release
+#
+# presence: optional
+# type: number
+# default: null
+LCMS_API_RELEASE_ID=
+
 # =======
 # LLM CHAT
 # =======

--- a/api/src/learning-content/domain/usecases/refresh-learning-content-cache.js
+++ b/api/src/learning-content/domain/usecases/refresh-learning-content-cache.js
@@ -14,7 +14,7 @@ export async function refreshLearningContentCache({
   tutorialRepository,
   missionRepository,
 }) {
-  const learningContent = await lcmsClient.getLatestRelease();
+  const learningContent = await lcmsClient.getRelease();
 
   await DomainTransaction.execute(async () => {
     await frameworkRepository.saveMany(learningContent.frameworks);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -138,6 +138,7 @@ const schema = Joi.object({
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   LCMS_API_KEY: Joi.string().requiredForApi(),
   LCMS_API_URL: Joi.string().uri().requiredForApi(),
+  LCMS_API_RELEASE_ID: Joi.number().integer().min(1).optional(),
   LLM_API_GET_CONFIGURATIONS_URL: Joi.string().optional(),
   LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS: Joi.string().optional(),
   LOG_ENABLED: Joi.string().required().valid('true', 'false'),
@@ -324,6 +325,7 @@ const configuration = (function () {
     lcms: {
       url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL || ''),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
+      releaseId: _getNumber(process.env.LCMS_API_RELEASE_ID, null),
     },
     llm: {
       temporaryStorage: {

--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -3,7 +3,7 @@ import { httpAgent } from './http-agent.js';
 import { logger } from './utils/logger.js';
 
 const { lcms: lcmsConfig } = config;
-const getLatestRelease = async function () {
+const getRelease = async function () {
   let signature;
 
   if (process.env.APP) {
@@ -43,6 +43,6 @@ const createRelease = async function () {
   return response.data.content;
 };
 
-const lcmsClient = { getLatestRelease, createRelease };
+const lcmsClient = { getRelease, createRelease };
 
 export { lcmsClient };

--- a/api/src/shared/infrastructure/lcms-client.js
+++ b/api/src/shared/infrastructure/lcms-client.js
@@ -12,8 +12,9 @@ const getRelease = async function () {
     signature = 'pix-api';
   }
 
+  const url = lcmsConfig.url + '/releases/' + (lcmsConfig.releaseId ? lcmsConfig.releaseId.toString() : 'latest');
   const response = await httpAgent.get({
-    url: lcmsConfig.url + '/releases/latest',
+    url,
     headers: { Authorization: `Bearer ${lcmsConfig.apiKey}`, Referer: signature },
   });
 

--- a/api/tests/learning-content/unit/domain/usecases/refresh-learning-content-cache_test.js
+++ b/api/tests/learning-content/unit/domain/usecases/refresh-learning-content-cache_test.js
@@ -24,7 +24,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
       const missions = Symbol('missions');
 
       const lcmsClient = {
-        getLatestRelease: sinon.stub().resolves({
+        getRelease: sinon.stub().resolves({
           frameworks,
           areas,
           competences,
@@ -95,7 +95,7 @@ describe('Learning Content | Unit | Domain | Usecase | Refresh learning content 
       });
 
       // then
-      expect(lcmsClient.getLatestRelease).to.have.been.calledOnce;
+      expect(lcmsClient.getRelease).to.have.been.calledOnce;
 
       expect(frameworkRepository.saveMany).to.have.been.calledOnceWithExactly(frameworks);
       expect(areaRepository.saveMany).to.have.been.calledOnceWithExactly(areas);

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -1,6 +1,6 @@
+import { config } from '../../../../src/shared/config.js';
 import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js';
 import { catchErr, expect, mockLearningContent, nock } from '../../../test-helper.js';
-import { config } from '../../../../src/shared/config.js';
 
 describe('Integration | Infrastructure | LCMS Client', function () {
   describe('#getRelease', function () {

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -1,34 +1,91 @@
 import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js';
 import { catchErr, expect, mockLearningContent, nock } from '../../../test-helper.js';
+import { config } from '../../../../src/shared/config.js';
 
 describe('Integration | Infrastructure | LCMS Client', function () {
   describe('#getRelease', function () {
-    it('calls LCMS API to get learning content latest release', async function () {
-      // given
-      const learningContent = { models: [{ id: 'recId' }] };
-      const lcmsCall = await mockLearningContent(learningContent);
+    let originalEnvValue;
+    context('when no release id is specified', function () {
+      beforeEach(function () {
+        originalEnvValue = config.lcms.releaseId;
+        config.lcms.releaseId = null;
+      });
 
-      // when
-      const response = await lcmsClient.getRelease();
+      afterEach(function () {
+        config.lcms.releaseId = originalEnvValue;
+      });
 
-      // then
-      expect(response).to.deep.equal(learningContent);
-      expect(lcmsCall.isDone()).to.be.true;
+      it('calls LCMS API to get learning content latest release', async function () {
+        // given
+        const learningContent = { models: [{ id: 'fromLatestRelease' }] };
+        const lcmsCall = await mockLearningContent(learningContent);
+
+        // when
+        const response = await lcmsClient.getRelease();
+
+        // then
+        expect(response).to.deep.equal(learningContent);
+        expect(lcmsCall.isDone()).to.be.true;
+      });
+
+      it('rejects when learning content release failed to get', async function () {
+        // given
+        const lcmsCall = nock('https://lcms-test.pix.fr/api')
+          .get('/releases/latest')
+          .matchHeader('Authorization', 'Bearer test-api-key')
+          .reply(500);
+
+        // when
+        const error = await catchErr(lcmsClient.getRelease)();
+
+        // then
+        expect(error).to.be.instanceOf(Error);
+        expect(error.message).to.equal(`An error occurred while fetching https://lcms-test.pix.fr/api`);
+        expect(lcmsCall.isDone()).to.be.true;
+      });
     });
 
-    it('rejects when learning content release failed to get', async function () {
-      // given
-      nock('https://lcms-test.pix.fr/api')
-        .get('/releases/latest')
-        .matchHeader('Authorization', 'Bearer test-api-key')
-        .reply(500);
+    context('when a release id is specified', function () {
+      beforeEach(function () {
+        originalEnvValue = config.lcms.releaseId;
+        config.lcms.releaseId = 123;
+      });
 
-      // when
-      const error = await catchErr(lcmsClient.getRelease)();
+      afterEach(function () {
+        config.lcms.releaseId = originalEnvValue;
+      });
 
-      // then
-      expect(error).to.be.instanceOf(Error);
-      expect(error.message).to.equal(`An error occurred while fetching https://lcms-test.pix.fr/api`);
+      it('calls LCMS API to get learning content release of specified ID', async function () {
+        // given
+        const learningContent = { models: [{ id: 'fromRelease123' }] };
+        const lcmsCall = nock('https://lcms-test.pix.fr/api')
+          .get('/releases/123')
+          .matchHeader('Authorization', 'Bearer test-api-key')
+          .reply(200, { content: learningContent });
+
+        // when
+        const response = await lcmsClient.getRelease();
+
+        // then
+        expect(response).to.deep.equal(learningContent);
+        expect(lcmsCall.isDone()).to.be.true;
+      });
+
+      it('rejects when learning content release failed to get', async function () {
+        // given
+        const lcmsCall = nock('https://lcms-test.pix.fr/api')
+          .get('/releases/123')
+          .matchHeader('Authorization', 'Bearer test-api-key')
+          .reply(500);
+
+        // when
+        const error = await catchErr(lcmsClient.getRelease)();
+
+        // then
+        expect(error).to.be.instanceOf(Error);
+        expect(error.message).to.equal(`An error occurred while fetching https://lcms-test.pix.fr/api`);
+        expect(lcmsCall.isDone()).to.be.true;
+      });
     });
   });
 

--- a/api/tests/shared/integration/infrastructure/lcms-client_test.js
+++ b/api/tests/shared/integration/infrastructure/lcms-client_test.js
@@ -2,14 +2,14 @@ import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js
 import { catchErr, expect, mockLearningContent, nock } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | LCMS Client', function () {
-  describe('#getLatestRelease', function () {
+  describe('#getRelease', function () {
     it('calls LCMS API to get learning content latest release', async function () {
       // given
       const learningContent = { models: [{ id: 'recId' }] };
       const lcmsCall = await mockLearningContent(learningContent);
 
       // when
-      const response = await lcmsClient.getLatestRelease();
+      const response = await lcmsClient.getRelease();
 
       // then
       expect(response).to.deep.equal(learningContent);
@@ -24,7 +24,7 @@ describe('Integration | Infrastructure | LCMS Client', function () {
         .reply(500);
 
       // when
-      const error = await catchErr(lcmsClient.getLatestRelease)();
+      const error = await catchErr(lcmsClient.getRelease)();
 
       // then
       expect(error).to.be.instanceOf(Error);


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'on récupère la release sur une API, on récupère toujours la "latest", la plus récente.
Or, il existe des cas dans lesquels on voudrait pouvoir spécifier quelle release récupérer (cas de tests de non régression, cas de dernière release cassée, etc...).

## ⛱️ Proposition

Ajouter une variable d'env pour spécifier un ID de release. Si cette variable a une valeur, alors on récupère la release pointée par cette variable. Sinon, on fait "latest" comme avant.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
