### PR TITLE
[FEATURE] Ne pas afficher les méthodes de connexion SSO si l'utilisateur est anonyme (PIX-18320)

### DIFF
--- a/mon-pix/app/templates/inscription/inscription.gjs
+++ b/mon-pix/app/templates/inscription/inscription.gjs
@@ -21,7 +21,9 @@ import AuthenticationLayout from 'mon-pix/components/authentication-layout/index
     <:content>
       <h1 class="pix-title-m">{{t "pages.sign-up.first-title"}}</h1>
       <SignupForm @user={{@model}} />
-      <OtherAuthenticationProviders @isForSignup={{true}} />
+      {{#unless @model.isAnonymous}}
+        <OtherAuthenticationProviders @isForSignup={{true}} />
+      {{/unless}}
     </:content>
   </AuthenticationLayout>
 </template>

--- a/mon-pix/tests/acceptance/authentication/signup-test.js
+++ b/mon-pix/tests/acceptance/authentication/signup-test.js
@@ -45,6 +45,10 @@ module('Acceptance | authentication | Signup', function (hooks) {
     assert.dom(signupHeading).exists();
     const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
     assert.dom(loginButton).exists();
+    const otherAuthenticationProvidersTitle = screen.queryByText(
+      t('components.authentication.other-authentication-providers.signup.heading'),
+    );
+    assert.dom(otherAuthenticationProvidersTitle).exists();
 
     // when
     await fillByLabel(t(I18N_KEYS.firstNameInput), firstName);
@@ -101,6 +105,10 @@ module('Acceptance | authentication | Signup', function (hooks) {
         assert.dom(signupHeading).exists();
         const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
         assert.dom(loginButton).doesNotExist();
+        const otherAuthenticationProvidersTitle = screen.queryByText(
+          t('components.authentication.other-authentication-providers.signup.heading'),
+        );
+        assert.dom(otherAuthenticationProvidersTitle).doesNotExist();
       });
 
       test('then he signs up and is redirected to dashboard', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème
Lorsqu'un utilisateur anonyme a terminé sa campagne, on souhaite qu'il puisse se créer un compte et conserver les Pix gagnés. 
Il faut donc afficher une page d'inscription sans la partie "Autres moyens de connexion" pour que les utilisateurs issus d'un parcours simplifié s'inscrivent avec un login /mot de passe

## ⛱️ Proposition
Ne pas afficher la partie "Autres moyens de connexion" sur la page d'inscription si l'utilisateur est anonyme

## 🌊 Remarques


## 🏄 Pour tester
- Lancer un Parcours Autonome ([lien](https://app-pr12702.review.pix.fr/campagnes/AUTOCOUR2))
- Aller au bout de ce parcours autonome et cliquer sur "S'inscrire sur Pix"
- Constater qu'on arrive sur le formulaire d'inscription et que la partie basse de la page d'inscription (titre : "Autres moyens de connexion") n'est pas visible
