### PR TITLE
[BUGFIX] Corriger le numéro de version dans le workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-            text: "Coucou 🙃, je lance la mise en recette de la v${{ env.NEW_RELEASE_VERSION }} !"
+            text: "Coucou 🙃, je lance la mise en recette de la v${{ env.new_release_version }} !"


### PR DESCRIPTION
## 🔆 Problème

On utilisait pas la bonne variable pour récupérer le numéro de version et le ppublier dans slack.

## ⛱️ Proposition

Utiliser new_release_version plutôt que NEW_RELEASE_VERSION.

## 🌊 Remarques

J'y touche plus!

## 🏄 Pour tester

Vérifier dans l'historique qu'on utilisait bien new_release_version.
Changer de tag avec:
```shell
git checkout v5.135.0
```
Retour sur la branche principale avec:
```shell
git checkout dev
```