### PR TITLE
[TECH] Récupérer la réponse à une épreuve uniquement lorsqu'on affiche une épreuve déjà répondue

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -16,9 +16,11 @@ export default class ChallengeRoute extends Route {
     let challenge;
     const currentChallengeNumber = parseInt(params.challenge_number);
     const isBackToPreviousChallenge = currentChallengeNumber < assessment.orderedChallengeIdsAnswered.length;
+    let answer = null;
     if (isBackToPreviousChallenge) {
       const challengeId = assessment.orderedChallengeIdsAnswered.at(currentChallengeNumber);
       challenge = await this.store.findRecord('challenge', challengeId);
+      answer = await this.store.queryRecord('answer', { assessmentId: assessment.id, challengeId: challenge.id });
     } else {
       if (assessment.isPreview && params.challengeId) {
         challenge = await this.store.findRecord('challenge', params.challengeId);
@@ -43,7 +45,7 @@ export default class ChallengeRoute extends Route {
     return RSVP.hash({
       assessment,
       challenge,
-      answer: this.store.queryRecord('answer', { assessmentId: assessment.id, challengeId: challenge.id }),
+      answer,
       currentChallengeNumber,
     }).catch((err) => {
       const meta = 'errors' in err ? err.errors[0].meta : null;


### PR DESCRIPTION
## 🔆 Problème
Quelle que soit la prochaine épreuve, déjà répondue ou nouvelle, on lance un appel API :
GET /answers?challengeId=<chal_id>&assessmentId=<ass_id>

Or cet appel sert, en cas d'affichage d'une épreuve déjà répondue, de réafficher la réponse apportée par l'utilisateur sous un overlay qui indique que la modification de la réponse n'est pas possible.

## ⛱️ Proposition

Eviter de déclencher cet appel lorsqu'on s'apprête à afficher une épreuve à laquelle l'utilisateur n'a pas encore répondu

Scénario :
- Je réponds à une épreuve
- Je réponds à la suivante
- J'appuie sur le bouton navigateur "précédent" pour réafficher l'épreuve précédente

Appels réseaux avant :
![avant](https://github.com/user-attachments/assets/c73e6a3a-8cf1-425a-86e9-33276bd2033b)

Appels réseaux après :
![apres](https://github.com/user-attachments/assets/fbf82a7a-2eae-410c-91f4-70fe0b921585)



## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
