### PR TITLE
[BUGFIX] Rendre transactionnel le scoring V3 (PIX-18354).

### DIFF
--- a/api/db/seeds/data/common/complementary-certification-builder.js
+++ b/api/db/seeds/data/common/complementary-certification-builder.js
@@ -241,13 +241,13 @@ function _createComplementaryWithoutReferential(databaseBuilder) {
     complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
     level: 1,
     imageUrl: 'https://images.pix.fr/badges/CleA_Num_certif.svg',
-    label: 'CléA Numérique V2',
+    label: 'CléA Numérique',
     certificateMessage: null,
     temporaryCertificateMessage: null,
     stickerUrl: 'https://images.pix.fr/stickers/macaron_clea.pdf',
     createdAt: new Date('2021-01-01'),
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
-    minimumEarnedPix: 70,
+    minimumEarnedPix: 256,
   });
 }
 

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -12,7 +12,6 @@
  * @typedef {import('../index.js').ChallengeRepository} ChallengeRepository
  * @typedef {import('../index.js').ScoringDegradationService} ScoringDegradationService
  */
-import Debug from 'debug';
 
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
 import { config } from '../../../../../shared/config.js';
@@ -21,8 +20,6 @@ import { FlashAssessmentAlgorithm } from '../../../../flash-certification/domain
 import { CertificationAssessmentHistory } from '../../../../scoring/domain/models/CertificationAssessmentHistory.js';
 import { CertificationAssessmentScoreV3 } from '../../../../scoring/domain/models/CertificationAssessmentScoreV3.js';
 import { AssessmentResultFactory } from '../../../../scoring/domain/models/factories/AssessmentResultFactory.js';
-
-const debugScoringForV3Certification = Debug('pix:certif:v3:scoring');
 
 /**
  * @param {Object} params
@@ -54,9 +51,7 @@ export const handleV3CertificationScoring = async ({
   dependencies,
 }) => {
   const { certificationCourseId, id: assessmentId } = certificationAssessment;
-
   const candidateAnswers = await answerRepository.findByAssessment(assessmentId);
-  debugScoringForV3Certification(`CandidateAnswers count: ${candidateAnswers.length}`);
 
   const toBeCancelled = event instanceof CertificationCancelled;
 

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -48,7 +48,6 @@ import pickChallengeService from '../services/pick-challenge-service.js';
  * @typedef {scoringCertificationService} ScoringCertificationService
  * @typedef {services} Services
  */
-
 const dependencies = {
   ...sessionRepositories,
   evaluationSessionRepository,

--- a/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
@@ -112,4 +112,6 @@ async function _handleV3CertificationScoring({
   if (certificationCourse.isCancelled()) {
     await certificationCourseRepository.update({ certificationCourse });
   }
+
+  return services.scoreDoubleCertificationV3({ certificationCourseId: certificationCourse.getId() });
 }

--- a/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
+++ b/api/src/certification/evaluation/domain/usecases/rescore-v3-certification.js
@@ -5,6 +5,7 @@
  * @typedef {import('./index.js').EvaluationSessionRepository} EvaluationSessionRepository
  * @typedef {import('./index.js').Services} Services
  */
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
 import CertificationCancelled from '../../../../shared/domain/events/CertificationCancelled.js';
 import { CertificationCourseUnrejected } from '../../../../shared/domain/events/CertificationCourseUnrejected.js';
@@ -24,48 +25,49 @@ const eventTypes = [
   CertificationUncancelled,
 ];
 
-/**
- * @param {Object} params
- * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
- * @param {CertificationCourseRepository} params.certificationCourseRepository
- * @param {CertificationCourseRepository} params.certificationCourseRepository
- * @param {EvaluationSessionRepository} params.evaluationSessionRepository
- * @param {Services} services
- *
- * @returns {Promise<void>}
- * @throws {Error} unrecognized event
- * @throws {NotFinalizedSessionError}
- * @throws {SessionAlreadyPublishedError}
- */
-export const rescoreV3Certification = async ({
-  event,
-  certificationAssessmentRepository,
-  certificationCourseRepository,
-  evaluationSessionRepository,
-  services,
-}) => {
-  checkEventTypes(event, eventTypes);
-
-  const certificationCourseId = event.certificationCourseId;
-
-  await _verifySessionIsPublishable({ certificationCourseId, evaluationSessionRepository });
-
-  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
-    certificationCourseId,
-  });
-
-  if (certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges) {
-    return;
-  }
-
-  return _handleV3CertificationScoring({
-    certificationAssessment,
+export const rescoreV3Certification = withTransaction(
+  /**
+   * @param {Object} params
+   * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
+   * @param {CertificationCourseRepository} params.certificationCourseRepository
+   * @param {EvaluationSessionRepository} params.evaluationSessionRepository
+   * @param {Services} services
+   *
+   * @returns {Promise<void>}
+   * @throws {Error} unrecognized event
+   * @throws {NotFinalizedSessionError}
+   * @throws {SessionAlreadyPublishedError}
+   */
+  async ({
     event,
-    locale: event.locale,
+    certificationAssessmentRepository,
     certificationCourseRepository,
+    evaluationSessionRepository,
     services,
-  });
-};
+  }) => {
+    checkEventTypes(event, eventTypes);
+
+    const certificationCourseId = event.certificationCourseId;
+
+    await _verifySessionIsPublishable({ certificationCourseId, evaluationSessionRepository });
+
+    const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
+      certificationCourseId,
+    });
+
+    if (certificationAssessment.isScoringBlockedDueToComplementaryOnlyChallenges) {
+      return;
+    }
+
+    return _handleV3CertificationScoring({
+      certificationAssessment,
+      event,
+      locale: event.locale,
+      certificationCourseRepository,
+      services,
+    });
+  },
+);
 
 /**
  * @param {Object} params
@@ -88,6 +90,10 @@ const _verifySessionIsPublishable = async ({ certificationCourseId, evaluationSe
   }
 };
 
+/**
+ * @param {Object} params
+ * @param {CertificationCourseRepository} params.certificationCourseRepository
+ */
 async function _handleV3CertificationScoring({
   certificationAssessment,
   event,

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-assessment-history-repository.js
@@ -1,7 +1,8 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 export const save = (certificationChallengeHistory) => {
-  return knex('certification-challenge-capacities')
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('certification-challenge-capacities')
     .insert(certificationChallengeHistory.capacityHistory)
     .onConflict('certificationChallengeId')
     .merge();

--- a/api/src/certification/evaluation/infrastructure/repositories/challenge-calibration-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/challenge-calibration-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ChallengeCalibration } from '../../../scoring/domain/read-models/ChallengeCalibration.js';
 
 export const getByCertificationCourseId = async ({ certificationCourseId }) => {
-  const challengeCalibrations = await knex('certification-challenges')
+  const knexConn = DomainTransaction.getConnection();
+  const challengeCalibrations = await knexConn('certification-challenges')
     .select({
       challengeId: 'challengeId',
       discriminant: 'discriminant',

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationScoringCriteria } from '../../domain/models/ComplementaryCertificationScoringCriteria.js';
 
-const findByCertificationCourseId = async function ({ certificationCourseId }) {
-  const results = await knex('complementary-certification-courses')
+export const findByCertificationCourseId = async function ({ certificationCourseId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const results = await knexConn('complementary-certification-courses')
     .select({
       complementaryCertificationCourseId: 'complementary-certification-courses.id',
       complementaryCertificationBadgeId: 'complementary-certification-courses.complementaryCertificationBadgeId',
@@ -46,5 +47,3 @@ const findByCertificationCourseId = async function ({ certificationCourseId }) {
       }),
   );
 };
-
-export { findByCertificationCourseId };

--- a/api/src/certification/session-management/domain/usecases/register-publishable-session.js
+++ b/api/src/certification/session-management/domain/usecases/register-publishable-session.js
@@ -4,32 +4,31 @@
  *  @typedef {import('./index.js').FinalizedSessionRepository} FinalizedSessionRepository
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { FinalizedSession } from '../models/FinalizedSession.js';
 
-/**
- * @param {Object} params
- * @param {SessionFinalized} params.sessionFinalized
- * @param {JuryCertificationSummaryRepository} params.juryCertificationSummaryRepository
- * @param {FinalizedSessionRepository} params.finalizedSessionRepository
- */
-export const registerPublishableSession = async ({
-  sessionFinalized,
-  juryCertificationSummaryRepository,
-  finalizedSessionRepository,
-}) => {
-  const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({
-    sessionId: sessionFinalized.sessionId,
-  });
+export const registerPublishableSession = withTransaction(
+  /**
+   * @param {Object} params
+   * @param {SessionFinalized} params.sessionFinalized
+   * @param {JuryCertificationSummaryRepository} params.juryCertificationSummaryRepository
+   * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+   */
+  async ({ sessionFinalized, juryCertificationSummaryRepository, finalizedSessionRepository }) => {
+    const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({
+      sessionId: sessionFinalized.sessionId,
+    });
 
-  const finalizedSession = FinalizedSession.from({
-    sessionId: sessionFinalized.sessionId,
-    finalizedAt: sessionFinalized.finalizedAt,
-    certificationCenterName: sessionFinalized.certificationCenterName,
-    sessionDate: sessionFinalized.sessionDate,
-    sessionTime: sessionFinalized.sessionTime,
-    hasExaminerGlobalComment: sessionFinalized.hasExaminerGlobalComment,
-    juryCertificationSummaries,
-  });
+    const finalizedSession = FinalizedSession.from({
+      sessionId: sessionFinalized.sessionId,
+      finalizedAt: sessionFinalized.finalizedAt,
+      certificationCenterName: sessionFinalized.certificationCenterName,
+      sessionDate: sessionFinalized.sessionDate,
+      sessionTime: sessionFinalized.sessionTime,
+      hasExaminerGlobalComment: sessionFinalized.hasExaminerGlobalComment,
+      juryCertificationSummaries,
+    });
 
-  await finalizedSessionRepository.save({ finalizedSession });
-};
+    await finalizedSessionRepository.save({ finalizedSession });
+  },
+);

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CertificationChallengeLiveAlert,
   CertificationChallengeLiveAlertStatus,
@@ -22,10 +23,13 @@ const getByAssessmentId = async ({ assessmentId }) => {
 };
 
 const getLiveAlertValidatedChallengeIdsByAssessmentId = async ({ assessmentId }) => {
-  const liveAlertValidatedChallengeIds = await knex('certification-challenge-live-alerts').select('challengeId').where({
-    assessmentId,
-    status: CertificationChallengeLiveAlertStatus.VALIDATED,
-  });
+  const knexConn = DomainTransaction.getConnection();
+  const liveAlertValidatedChallengeIds = await knexConn('certification-challenge-live-alerts')
+    .select('challengeId')
+    .where({
+      assessmentId,
+      status: CertificationChallengeLiveAlertStatus.VALIDATED,
+    });
 
   return _.map(liveAlertValidatedChallengeIds, 'challengeId');
 };

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationCourseResult } from '../../domain/models/ComplementaryCertificationCourseResult.js';
 
 const getPixSourceResultByComplementaryCertificationCourseId = async function ({ complementaryCertificationCourseId }) {
@@ -44,7 +45,8 @@ const save = async function ({
   acquired,
   source,
 }) {
-  return knex('complementary-certification-course-results')
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('complementary-certification-course-results')
     .insert({ complementaryCertificationBadgeId, acquired, complementaryCertificationCourseId, source })
     .onConflict(['complementaryCertificationCourseId', 'source'])
     .merge();

--- a/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,11 +1,12 @@
-import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../domain/models/FlashAssessmentAlgorithmConfiguration.js';
 
 const TABLE_NAME = 'flash-algorithm-configurations';
 
 const getMostRecent = async function () {
-  const flashAlgorithmConfiguration = await knex(TABLE_NAME).orderBy('createdAt', 'desc').first();
+  const knexConn = DomainTransaction.getConnection();
+  const flashAlgorithmConfiguration = await knexConn(TABLE_NAME).orderBy('createdAt', 'desc').first();
 
   if (!flashAlgorithmConfiguration) {
     return new FlashAssessmentAlgorithmConfiguration();
@@ -15,7 +16,8 @@ const getMostRecent = async function () {
 };
 
 const getMostRecentBeforeDate = async (date) => {
-  const flashAlgorithmConfiguration = await knex(TABLE_NAME)
+  const knexConn = DomainTransaction.getConnection();
+  const flashAlgorithmConfiguration = await knexConn(TABLE_NAME)
     .where('createdAt', '<=', date)
     .orderBy('createdAt', 'desc')
     .first();
@@ -24,7 +26,7 @@ const getMostRecentBeforeDate = async (date) => {
     return FlashAssessmentAlgorithmConfiguration.fromDTO(flashAlgorithmConfiguration);
   }
 
-  const firstFlashAlgoConfiguration = await knex(TABLE_NAME).orderBy('createdAt', 'asc').first();
+  const firstFlashAlgoConfiguration = await knexConn(TABLE_NAME).orderBy('createdAt', 'asc').first();
 
   if (!firstFlashAlgoConfiguration) {
     throw new NotFoundError('Configuration not found');

--- a/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/scoring-configuration-repository.js
@@ -1,15 +1,17 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import { V3CertificationScoring } from '../../domain/models/V3CertificationScoring.js';
 
 export const getLatestByDateAndLocale = async ({ locale, date }) => {
+  const knexConn = DomainTransaction.getConnection();
   const allAreas = await areaRepository.list();
   // NOTE : only works for certification of core competencies
   const competenceList = await competenceRepository.listPixCompetencesOnly({ locale });
 
-  const competenceScoringConfiguration = await knex('competence-scoring-configurations')
+  const competenceScoringConfiguration = await knexConn('competence-scoring-configurations')
     .select('configuration')
     .where('createdAt', '<=', date)
     .orderBy('createdAt', 'desc')
@@ -19,7 +21,7 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
     throw new NotFoundError(`No competence scoring configuration found for date ${date.toISOString()}`);
   }
 
-  const certificationScoringConfiguration = await knex('certification-scoring-configurations')
+  const certificationScoringConfiguration = await knexConn('certification-scoring-configurations')
     .select('configuration')
     .where('createdAt', '<=', date)
     .orderBy('createdAt', 'desc')

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -90,7 +90,8 @@ const findLatestLevelAndPixScoreByAssessmentId = async function ({ assessmentId,
 };
 
 const getByCertificationCourseId = async function ({ certificationCourseId }) {
-  const assessment = await knex('assessments')
+  const knexConn = DomainTransaction.getConnection();
+  const assessment = await knexConn('assessments')
     .select('id')
     .where({ certificationCourseId })
     .orderBy('createdAt', 'desc')
@@ -99,13 +100,13 @@ const getByCertificationCourseId = async function ({ certificationCourseId }) {
   if (assessment) {
     const assessmentId = assessment.id;
 
-    const latestAssessmentResult = await knex('assessment-results')
+    const latestAssessmentResult = await knexConn('assessment-results')
       .where({ assessmentId })
       .orderBy('createdAt', 'desc')
       .first();
 
     if (latestAssessmentResult) {
-      const competencesMarksDTO = await knex('competence-marks').where({
+      const competencesMarksDTO = await knexConn('competence-marks').where({
         assessmentResultId: latestAssessmentResult.id,
       });
 

--- a/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
@@ -1,0 +1,733 @@
+import _ from 'lodash';
+
+import { CertificationCompletedJobController } from '../../../../../../src/certification/evaluation/application/jobs/certification-completed-job-controller.js';
+import { CertificationCompletedJob } from '../../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../../test-helper.js';
+
+describe('Certification | Evaluation | Integration | Application | CertificationCompletedJobController', function () {
+  context('#handle', function () {
+    context('when certification is V3', function () {
+      beforeEach(async function () {
+        const easyChallengeParams = {
+          alpha: 1,
+          delta: -3,
+          langues: ['Franco Français'],
+        };
+        const hardChallengeParams = {
+          alpha: 1,
+          delta: 3,
+          langues: ['Franco Français'],
+        };
+        const learningContent = [
+          {
+            id: 'recArea0',
+            code: 'area0',
+            competences: [
+              {
+                id: 'recCompetence0',
+                index: '1.1',
+                tubes: [
+                  {
+                    id: 'recTube0_0',
+                    skills: [
+                      {
+                        id: 'recSkill0_0',
+                        nom: '@recSkill0_0',
+                        level: 2,
+                        challenges: [{ id: 'recChallenge0_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill0_1',
+                        nom: '@recSkill0_1',
+                        challenges: [{ id: 'recChallenge0_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill0_2',
+                        nom: '@recSkill0_2',
+                        challenges: [{ id: 'recChallenge0_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence1',
+                index: '1.2',
+                tubes: [
+                  {
+                    id: 'recTube1_0',
+                    skills: [
+                      {
+                        id: 'recSkill1_0',
+                        nom: '@recSkill1_0',
+                        challenges: [{ id: 'recChallenge1_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill1_1',
+                        nom: '@recSkill1_1',
+                        challenges: [{ id: 'recChallenge1_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill1_2',
+                        nom: '@recSkill1_2',
+                        challenges: [{ id: 'recChallenge1_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence2',
+                index: '1.3',
+                tubes: [
+                  {
+                    id: 'recTube2_0',
+                    skills: [
+                      {
+                        id: 'recSkill2_0',
+                        nom: '@recSkill2_0',
+                        challenges: [{ id: 'recChallenge2_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill2_1',
+                        nom: '@recSkill2_1',
+                        challenges: [{ id: 'recChallenge2_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill2_2',
+                        nom: '@recSkill2_2',
+                        challenges: [{ id: 'recChallenge2_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence3',
+                index: '1.4',
+                tubes: [
+                  {
+                    id: 'recTube3_0',
+                    skills: [
+                      {
+                        id: 'recSkill3_0',
+                        nom: '@recSkill3_0',
+                        challenges: [{ id: 'recChallenge3_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill3_1',
+                        nom: '@recSkill3_1',
+                        challenges: [{ id: 'recChallenge3_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill3_2',
+                        nom: '@recSkill3_2',
+                        challenges: [{ id: 'recChallenge3_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea1',
+            code: 'area1',
+            competences: [
+              {
+                id: 'recCompetence4',
+                index: '2.1',
+                tubes: [
+                  {
+                    id: 'recTube4_0',
+                    skills: [
+                      {
+                        id: 'recSkill4_0',
+                        nom: '@recSkill4_0',
+                        challenges: [{ id: 'recChallenge4_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill4_1',
+                        nom: '@recSkill4_1',
+                        challenges: [{ id: 'recChallenge4_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill4_2',
+                        nom: '@recSkill4_2',
+                        challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence5',
+                index: '2.2',
+                tubes: [
+                  {
+                    id: 'recTube5_0',
+                    skills: [
+                      {
+                        id: 'recSkill5_0',
+                        nom: '@recSkill5_0',
+                        challenges: [{ id: 'recChallenge5_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence6',
+                index: '2.3',
+                tubes: [
+                  {
+                    id: 'recTube6_0',
+                    skills: [
+                      {
+                        id: 'recSkill6_0',
+                        nom: '@recSkill6_0',
+                        challenges: [{ id: 'recChallenge6_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence7',
+                index: '2.4',
+                tubes: [
+                  {
+                    id: 'recTube7_0',
+                    skills: [
+                      {
+                        id: 'recSkill7_0',
+                        nom: '@recSkill7_0',
+                        challenges: [{ id: 'recChallenge7_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea2',
+            code: 'area2',
+            competences: [
+              {
+                id: 'recCompetence8',
+                index: '3.1',
+                tubes: [
+                  {
+                    id: 'recTube8_0',
+                    skills: [
+                      {
+                        id: 'recSkill8_0',
+                        nom: '@recSkill8_0',
+                        challenges: [{ id: 'recChallenge8_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence9',
+                index: '3.2',
+                tubes: [
+                  {
+                    id: 'recTube9_0',
+                    skills: [
+                      {
+                        id: 'recSkill9_0',
+                        nom: '@recSkill9_0',
+                        challenges: [{ id: 'recChallenge9_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence10',
+                index: '3.3',
+                tubes: [
+                  {
+                    id: 'recTube10_0',
+                    skills: [
+                      {
+                        id: 'recSkill10_0',
+                        nom: '@recSkill10_0',
+                        challenges: [{ id: 'recChallenge10_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence11',
+                index: '3.4',
+                tubes: [
+                  {
+                    id: 'recTube11_0',
+                    skills: [
+                      {
+                        id: 'recSkill11_0',
+                        nom: '@recSkill11_0',
+                        challenges: [{ id: 'recChallenge11_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea3',
+            code: 'area3',
+            competences: [
+              {
+                id: 'recCompetence12',
+                index: '4.1',
+                tubes: [
+                  {
+                    id: 'recTube12_0',
+                    skills: [
+                      {
+                        id: 'recSkill12_0',
+                        nom: '@recSkill12_0',
+                        challenges: [{ id: 'recChallenge12_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence13',
+                index: '4.2',
+                tubes: [
+                  {
+                    id: 'recTube13_0',
+                    skills: [
+                      {
+                        id: 'recSkill13_0',
+                        nom: '@recSkill13_0',
+                        challenges: [{ id: 'recChallenge13_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence14',
+                index: '4.3',
+                tubes: [
+                  {
+                    id: 'recTube14_0',
+                    skills: [
+                      {
+                        id: 'recSkill14_0',
+                        nom: '@recSkill14_0',
+                        challenges: [{ id: 'recChallenge14_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea4',
+            code: 'area4',
+            competences: [
+              {
+                id: 'recCompetence15',
+                index: '5.1',
+                tubes: [
+                  {
+                    id: 'recTube15_0',
+                    skills: [
+                      {
+                        id: 'recSkill15_0',
+                        nom: '@recSkill15_0',
+                        challenges: [{ id: 'recChallenge15_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence16',
+                index: '5.2',
+                tubes: [
+                  {
+                    id: 'recTube16_0',
+                    skills: [
+                      {
+                        id: 'recSkill16_0',
+                        nom: '@recSkill16_0',
+                        challenges: [{ id: 'recChallenge16_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+        await mockLearningContent(learningContentObjects);
+
+        const configurationCreatorId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCompetenceScoringConfiguration({
+          createdByUserId: configurationCreatorId,
+          configuration: [
+            {
+              competence: '1.1',
+              values: [
+                {
+                  bounds: {
+                    max: 0,
+                    min: -5,
+                  },
+                  competenceLevel: 0,
+                },
+                {
+                  bounds: {
+                    max: 5,
+                    min: 0,
+                  },
+                  competenceLevel: 1,
+                },
+              ],
+            },
+          ],
+        });
+        databaseBuilder.factory.buildScoringConfiguration({ createdByUserId: configurationCreatorId });
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration();
+
+        await databaseBuilder.commit();
+      });
+
+      context('when certification is a Pix Core', function () {
+        let certifiableUserId, certificationCourseId, completedCertificationAssessmentId;
+        beforeEach(async function () {
+          const limitDate = new Date('2020-01-01T00:00:00Z');
+          certifiableUserId = databaseBuilder.factory.buildUser().id;
+
+          const session = databaseBuilder.factory.buildSession({
+            version: AlgorithmEngineVersion.V3,
+          });
+
+          databaseBuilder.factory.buildCertificationCandidate({
+            sessionId: session.id,
+            userId: certifiableUserId,
+          });
+
+          certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            completedAt: null,
+            sessionId: session.id,
+            userId: certifiableUserId,
+            createdAt: limitDate,
+            version: AlgorithmEngineVersion.V3,
+          }).id;
+
+          completedCertificationAssessmentId = databaseBuilder.factory.buildAssessment({
+            certificationCourseId,
+            userId: certifiableUserId,
+            state: Assessment.states.COMPLETED,
+            type: Assessment.types.CERTIFICATION,
+            createdAt: limitDate,
+          }).id;
+
+          _buildValidAnswersAndCertificationChallenges({
+            assessmentId: completedCertificationAssessmentId,
+            certificationCourseId,
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('should score the certification', async function () {
+          // given
+          const handler = new CertificationCompletedJobController();
+          const data = new CertificationCompletedJob({
+            assessmentId: completedCertificationAssessmentId,
+            userId: certifiableUserId,
+            certificationCourseId,
+            locale: LOCALE.FRENCH_SPOKEN,
+          });
+
+          // when
+          await handler.handle({ data });
+
+          // then
+          const results = await knex('assessment-results').where({ assessmentId: completedCertificationAssessmentId });
+          expect(results).to.have.lengthOf(1);
+
+          const linkToCertifCourse = await knex('certification-courses-last-assessment-results')
+            .where({
+              lastAssessmentResultId: results[0].id,
+              certificationCourseId: certificationCourseId,
+            })
+            .first();
+          expect(linkToCertifCourse).to.deep.equal({
+            lastAssessmentResultId: results[0].id,
+            certificationCourseId: certificationCourseId,
+          });
+
+          const certifCourseCompletedAt = await knex('certification-courses')
+            .select('completedAt')
+            .where({
+              id: certificationCourseId,
+            })
+            .first();
+
+          expect(certifCourseCompletedAt).not.to.be.null;
+        });
+
+        it('should rollback scoring if any error happens', async function () {
+          // given
+          const handler = new CertificationCompletedJobController();
+          const data = new CertificationCompletedJob({
+            assessmentId: completedCertificationAssessmentId,
+            userId: certifiableUserId,
+            certificationCourseId,
+            locale: LOCALE.FRENCH_SPOKEN,
+          });
+
+          // when
+          const errorDuringTransaction = await catchErr(async (data) => {
+            await DomainTransaction.execute(async () => {
+              await handler.handle({ data });
+              throw new Error('test error');
+            });
+          })(data);
+
+          // then
+          expect(errorDuringTransaction.message).to.equal('test error');
+
+          const noScoring = await knex('assessment-results').where({
+            assessmentId: completedCertificationAssessmentId,
+          });
+          expect(noScoring).to.have.lengthOf(0);
+
+          const noResultForCertifCourse = await knex('certification-courses-last-assessment-results')
+            .where({
+              certificationCourseId: certificationCourseId,
+            })
+            .first();
+          expect(noResultForCertifCourse).not.to.exist;
+
+          const certifCourseNotUpdated = await knex('certification-courses')
+            .select('completedAt')
+            .where({
+              id: certificationCourseId,
+            })
+            .first();
+
+          expect(certifCourseNotUpdated.completedAt).to.be.null;
+        });
+      });
+      context('when certification is a Double Certification', function () {
+        let certifiableUserId,
+          certificationCourseId,
+          completedCertificationAssessmentId,
+          complementaryCertificationBadgeId,
+          complementaryCertificationCourseId;
+
+        beforeEach(async function () {
+          const limitDate = new Date('2020-01-01T00:00:00Z');
+          certifiableUserId = databaseBuilder.factory.buildUser().id;
+
+          const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+            key: ComplementaryCertificationKeys.CLEA,
+          });
+
+          const badgeId = databaseBuilder.factory.buildBadge({ isCertifiable: true }).id;
+          complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId,
+            complementaryCertificationId: cleaComplementaryCertification.id,
+          }).id;
+
+          databaseBuilder.factory.buildBadgeAcquisition({
+            userId: certifiableUserId,
+            badgeId,
+            createdAt: new Date('2020-01-01'),
+          });
+
+          const session = databaseBuilder.factory.buildSession({
+            version: AlgorithmEngineVersion.V3,
+          });
+
+          databaseBuilder.factory.buildCertificationCandidate({
+            sessionId: session.id,
+            userId: certifiableUserId,
+          });
+
+          certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            completedAt: null,
+            sessionId: session.id,
+            userId: certifiableUserId,
+            createdAt: limitDate,
+            version: AlgorithmEngineVersion.V3,
+          }).id;
+
+          complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
+            certificationCourseId,
+            complementaryCertificationBadgeId,
+            complementaryCertificationId: cleaComplementaryCertification.id,
+          }).id;
+
+          completedCertificationAssessmentId = databaseBuilder.factory.buildAssessment({
+            certificationCourseId,
+            userId: certifiableUserId,
+            state: Assessment.states.COMPLETED,
+            type: Assessment.types.CERTIFICATION,
+            createdAt: limitDate,
+          }).id;
+
+          _buildValidAnswersAndCertificationChallenges({
+            assessmentId: completedCertificationAssessmentId,
+            certificationCourseId,
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('should acquire the double certification', async function () {
+          // given
+          const handler = new CertificationCompletedJobController();
+          const data = new CertificationCompletedJob({
+            assessmentId: completedCertificationAssessmentId,
+            userId: certifiableUserId,
+            certificationCourseId,
+            locale: LOCALE.FRENCH_SPOKEN,
+          });
+
+          // when
+          await handler.handle({ data });
+
+          // then
+          const results = await knex('assessment-results').where({ assessmentId: completedCertificationAssessmentId });
+          expect(results).to.have.lengthOf(1);
+
+          const linkToCertifCourse = await knex('certification-courses-last-assessment-results')
+            .where({
+              lastAssessmentResultId: results[0].id,
+              certificationCourseId: certificationCourseId,
+            })
+            .first();
+          expect(linkToCertifCourse).to.deep.equal({
+            lastAssessmentResultId: results[0].id,
+            certificationCourseId: certificationCourseId,
+          });
+
+          const certifCourseCompletedAt = await knex('certification-courses')
+            .select('completedAt')
+            .where({
+              id: certificationCourseId,
+            })
+            .first();
+
+          expect(certifCourseCompletedAt).not.to.be.null;
+
+          const complementaryResults = await knex('complementary-certification-course-results').where({
+            complementaryCertificationCourseId,
+            complementaryCertificationBadgeId,
+          });
+          expect(complementaryResults).to.have.lengthOf(1);
+          expect(complementaryResults[0].acquired).to.be.true;
+        });
+
+        it('should rollback scoring if any error happens', async function () {
+          // given
+          const handler = new CertificationCompletedJobController();
+          const data = new CertificationCompletedJob({
+            assessmentId: completedCertificationAssessmentId,
+            userId: certifiableUserId,
+            certificationCourseId,
+            locale: LOCALE.FRENCH_SPOKEN,
+          });
+
+          // when
+          const errorDuringTransaction = await catchErr(async (data) => {
+            await DomainTransaction.execute(async () => {
+              await handler.handle({ data });
+              throw new Error('test error');
+            });
+          })(data);
+
+          // then
+          expect(errorDuringTransaction.message).to.equal('test error');
+
+          const noScoring = await knex('assessment-results').where({
+            assessmentId: completedCertificationAssessmentId,
+          });
+          expect(noScoring).to.have.lengthOf(0);
+
+          const noResultForCertifCourse = await knex('certification-courses-last-assessment-results')
+            .where({
+              certificationCourseId: certificationCourseId,
+            })
+            .first();
+          expect(noResultForCertifCourse).not.to.exist;
+
+          const certifCourseNotUpdated = await knex('certification-courses')
+            .select('completedAt')
+            .where({
+              id: certificationCourseId,
+            })
+            .first();
+
+          expect(certifCourseNotUpdated.completedAt).to.be.null;
+
+          const noComplementaryScoring = await knex('complementary-certification-course-results').where({
+            complementaryCertificationCourseId,
+            complementaryCertificationBadgeId,
+          });
+          expect(noComplementaryScoring).to.have.lengthOf(0);
+        });
+      });
+    });
+  });
+});
+
+function _buildValidAnswersAndCertificationChallenges({
+  certificationCourseId,
+  assessmentId,
+  difficulty = 0,
+  competenceId = 'recCompetence0',
+}) {
+  const answers = _.flatten(
+    _.range(0, 3).map((skillIndex) =>
+      _.range(0, 3).map((level) => {
+        return databaseBuilder.factory.buildAnswer({
+          challengeId: `recChallenge${skillIndex}_${level}_0`,
+          result: 'ok',
+          assessmentId: assessmentId,
+        });
+      }),
+    ),
+  );
+
+  answers.map(({ challengeId }) =>
+    databaseBuilder.factory.buildCertificationChallenge({
+      challengeId,
+      competenceId,
+      courseId: certificationCourseId,
+      difficulty,
+      discriminant: 2,
+    }),
+  );
+}

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
@@ -1,5 +1,6 @@
 import * as calibratedChallengeService from '../../../../../../../src/certification/evaluation/domain/services/scoring/calibrated-challenge-service.js';
 import { config } from '../../../../../../../src/shared/config.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 import { generateChallengeList } from '../../../../../shared/fixtures/challenges.js';
 
@@ -12,6 +13,10 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
     let challengeList;
 
     beforeEach(function () {
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
+
       challengeList = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification + 1 });
 
       challengeCalibrationRepository = {

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/score-double-certification-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/score-double-certification-v3_test.js
@@ -1,5 +1,6 @@
 import { scoreDoubleCertificationV3 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/score-double-certification-v3.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 
 describe('Certification | Evaluation | Unit | Domain | Services | Scoring Double Certification V3', function () {
@@ -16,6 +17,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Double
   };
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
     complementaryCertificationCourseResultRepository.save = sinon.stub();
     assessmentResultRepository.getByCertificationCourseId = sinon.stub();
     assessmentResultRepository.updateToAcquiredLowerLevelComplementaryCertification = sinon.stub();

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -6,6 +6,7 @@ import { AlgorithmEngineVersion } from '../../../../../../../src/certification/s
 import { ABORT_REASONS } from '../../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { AutoJuryCommentKeys } from '../../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { config } from '../../../../../../../src/shared/config.js';
+import { DomainTransaction } from '../../../../../../../src/shared/domain/DomainTransaction.js';
 import { AssessmentResult, status } from '../../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 import { generateAnswersForChallenges, generateChallengeList } from '../../../../../shared/fixtures/challenges.js';
@@ -32,6 +33,9 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
     let allChallenges;
 
     beforeEach(function () {
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
       clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       allChallenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification + 1 });
 

--- a/api/tests/certification/evaluation/unit/domain/usecases/rescore-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/rescore-v3-certification_test.js
@@ -4,10 +4,16 @@ import { CertificationCourseRejected } from '../../../../../../src/certification
 import { CertificationJuryDone } from '../../../../../../src/certification/session-management/domain/events/CertificationJuryDone.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFinalizedSessionError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Evaluation | UseCases | rescore-v3-certification', function () {
+  beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
+  });
   describe('session is not in a publishable state', function () {
     it('should reject to do a rescoring is session is still in progress', async function () {
       // given
@@ -265,9 +271,8 @@ describe('Unit | Certification | Evaluation | UseCases | rescore-v3-certificatio
       });
     });
 
-    context('when it is a complementary certification', function () {
+    context('when it is a double certification', function () {
       it('should trigger complementary certification scoring', async function () {
-        this.skip('');
         // given
         const certificationCourseStartDate = new Date('2022-01-01');
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -299,6 +304,7 @@ describe('Unit | Certification | Evaluation | UseCases | rescore-v3-certificatio
 
         // then
         expect(services.handleV3CertificationScoring).to.have.been.calledOnce;
+        expect(services.scoreDoubleCertificationV3).to.have.been.calledOnceWithExactly({ certificationCourseId });
       });
     });
   });

--- a/api/tests/certification/evaluation/unit/domain/usecases/score-completed-v3-certification_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/score-completed-v3-certification_test.js
@@ -4,6 +4,7 @@ import {
   ABORT_REASONS,
   CertificationCourse,
 } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Evaluation | UseCases | scoreCompletedV3Certification', function () {
@@ -14,6 +15,9 @@ describe('Unit | Certification | Evaluation | UseCases | scoreCompletedV3Certifi
   let clock;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
     clock = sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
     now = new Date(clock.now);
 

--- a/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/finalize-session_test.js
@@ -1,7 +1,8 @@
 import { SessionWithAbortReasonOnCompletedCertificationCourseError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
 import { ABORT_REASONS } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Certification | Session Management | Integration | Domain | UseCase | Finalize Session ', function () {
   context('When there is an abort reason for completed certification course', function () {
@@ -25,6 +26,51 @@ describe('Certification | Session Management | Integration | Domain | UseCase | 
         .where('id', certificationCourse.id)
         .first();
       expect(updatedCertificationCourse.abortReason).to.be.null;
+    });
+  });
+
+  context('when an error occurs', function () {
+    it('should rollback session finalization', async function () {
+      // given
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        abortReason: null,
+        updatedAt: new Date(),
+        completedAt: null,
+      });
+      await databaseBuilder.commit();
+      const certificationReports = [
+        domainBuilder.buildCertificationReport({
+          examinerComment: 'signalement sur le candidat',
+          certificationCourseId: certificationCourse.id,
+          isCompleted: true,
+        }),
+      ];
+
+      // when
+      const errorDuringTransaction = await catchErr(async ({ sessionId, certificationReports }) => {
+        await DomainTransaction.execute(async () => {
+          await usecases.finalizeSession({
+            sessionId,
+            certificationReports,
+          });
+          throw new Error('test error');
+        });
+      })({
+        sessionId: certificationCourse.sessionId,
+        certificationReports,
+      });
+
+      // then
+      expect(errorDuringTransaction.message).to.equal('test error');
+
+      const notFinalizedSession = await knex('sessions').where('id', certificationCourse.sessionId).first();
+      expect(notFinalizedSession.finalizedAt).to.be.null;
+
+      const updatedCertificationCourse = await knex('certification-courses')
+        .where('id', certificationCourse.id)
+        .first();
+      expect(updatedCertificationCourse.abortReason).to.be.null;
+      expect(updatedCertificationCourse.updatedAt).to.deep.equal(certificationCourse.updatedAt);
     });
   });
 });

--- a/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
@@ -1,0 +1,502 @@
+import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
+import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../../test-helper.js';
+
+describe('Certification | Session Management | Integration | Domain | UseCase | process-auto-jury_test ', function () {
+  context('when it is a V3 certification', function () {
+    context('when certification is not completed', function () {
+      beforeEach(async function () {
+        const easyChallengeParams = {
+          alpha: 1,
+          delta: -3,
+          langues: ['Franco Français'],
+        };
+        const hardChallengeParams = {
+          alpha: 1,
+          delta: 3,
+          langues: ['Franco Français'],
+        };
+        const learningContent = [
+          {
+            id: 'recArea0',
+            code: 'area0',
+            competences: [
+              {
+                id: 'recCompetence0',
+                index: '1.1',
+                tubes: [
+                  {
+                    id: 'recTube0_0',
+                    skills: [
+                      {
+                        id: 'recSkill0_0',
+                        nom: '@recSkill0_0',
+                        level: 2,
+                        challenges: [{ id: 'recChallenge0_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill0_1',
+                        nom: '@recSkill0_1',
+                        challenges: [{ id: 'recChallenge0_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill0_2',
+                        nom: '@recSkill0_2',
+                        challenges: [{ id: 'recChallenge0_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence1',
+                index: '1.2',
+                tubes: [
+                  {
+                    id: 'recTube1_0',
+                    skills: [
+                      {
+                        id: 'recSkill1_0',
+                        nom: '@recSkill1_0',
+                        challenges: [{ id: 'recChallenge1_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill1_1',
+                        nom: '@recSkill1_1',
+                        challenges: [{ id: 'recChallenge1_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill1_2',
+                        nom: '@recSkill1_2',
+                        challenges: [{ id: 'recChallenge1_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence2',
+                index: '1.3',
+                tubes: [
+                  {
+                    id: 'recTube2_0',
+                    skills: [
+                      {
+                        id: 'recSkill2_0',
+                        nom: '@recSkill2_0',
+                        challenges: [{ id: 'recChallenge2_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill2_1',
+                        nom: '@recSkill2_1',
+                        challenges: [{ id: 'recChallenge2_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill2_2',
+                        nom: '@recSkill2_2',
+                        challenges: [{ id: 'recChallenge2_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence3',
+                index: '1.4',
+                tubes: [
+                  {
+                    id: 'recTube3_0',
+                    skills: [
+                      {
+                        id: 'recSkill3_0',
+                        nom: '@recSkill3_0',
+                        challenges: [{ id: 'recChallenge3_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill3_1',
+                        nom: '@recSkill3_1',
+                        challenges: [{ id: 'recChallenge3_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill3_2',
+                        nom: '@recSkill3_2',
+                        challenges: [{ id: 'recChallenge3_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea1',
+            code: 'area1',
+            competences: [
+              {
+                id: 'recCompetence4',
+                index: '2.1',
+                tubes: [
+                  {
+                    id: 'recTube4_0',
+                    skills: [
+                      {
+                        id: 'recSkill4_0',
+                        nom: '@recSkill4_0',
+                        challenges: [{ id: 'recChallenge4_0_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill4_1',
+                        nom: '@recSkill4_1',
+                        challenges: [{ id: 'recChallenge4_1_0', ...easyChallengeParams }],
+                      },
+                      {
+                        id: 'recSkill4_2',
+                        nom: '@recSkill4_2',
+                        challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence5',
+                index: '2.2',
+                tubes: [
+                  {
+                    id: 'recTube5_0',
+                    skills: [
+                      {
+                        id: 'recSkill5_0',
+                        nom: '@recSkill5_0',
+                        challenges: [{ id: 'recChallenge5_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence6',
+                index: '2.3',
+                tubes: [
+                  {
+                    id: 'recTube6_0',
+                    skills: [
+                      {
+                        id: 'recSkill6_0',
+                        nom: '@recSkill6_0',
+                        challenges: [{ id: 'recChallenge6_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence7',
+                index: '2.4',
+                tubes: [
+                  {
+                    id: 'recTube7_0',
+                    skills: [
+                      {
+                        id: 'recSkill7_0',
+                        nom: '@recSkill7_0',
+                        challenges: [{ id: 'recChallenge7_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea2',
+            code: 'area2',
+            competences: [
+              {
+                id: 'recCompetence8',
+                index: '3.1',
+                tubes: [
+                  {
+                    id: 'recTube8_0',
+                    skills: [
+                      {
+                        id: 'recSkill8_0',
+                        nom: '@recSkill8_0',
+                        challenges: [{ id: 'recChallenge8_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence9',
+                index: '3.2',
+                tubes: [
+                  {
+                    id: 'recTube9_0',
+                    skills: [
+                      {
+                        id: 'recSkill9_0',
+                        nom: '@recSkill9_0',
+                        challenges: [{ id: 'recChallenge9_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence10',
+                index: '3.3',
+                tubes: [
+                  {
+                    id: 'recTube10_0',
+                    skills: [
+                      {
+                        id: 'recSkill10_0',
+                        nom: '@recSkill10_0',
+                        challenges: [{ id: 'recChallenge10_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence11',
+                index: '3.4',
+                tubes: [
+                  {
+                    id: 'recTube11_0',
+                    skills: [
+                      {
+                        id: 'recSkill11_0',
+                        nom: '@recSkill11_0',
+                        challenges: [{ id: 'recChallenge11_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea3',
+            code: 'area3',
+            competences: [
+              {
+                id: 'recCompetence12',
+                index: '4.1',
+                tubes: [
+                  {
+                    id: 'recTube12_0',
+                    skills: [
+                      {
+                        id: 'recSkill12_0',
+                        nom: '@recSkill12_0',
+                        challenges: [{ id: 'recChallenge12_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence13',
+                index: '4.2',
+                tubes: [
+                  {
+                    id: 'recTube13_0',
+                    skills: [
+                      {
+                        id: 'recSkill13_0',
+                        nom: '@recSkill13_0',
+                        challenges: [{ id: 'recChallenge13_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence14',
+                index: '4.3',
+                tubes: [
+                  {
+                    id: 'recTube14_0',
+                    skills: [
+                      {
+                        id: 'recSkill14_0',
+                        nom: '@recSkill14_0',
+                        challenges: [{ id: 'recChallenge14_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recArea4',
+            code: 'area4',
+            competences: [
+              {
+                id: 'recCompetence15',
+                index: '5.1',
+                tubes: [
+                  {
+                    id: 'recTube15_0',
+                    skills: [
+                      {
+                        id: 'recSkill15_0',
+                        nom: '@recSkill15_0',
+                        challenges: [{ id: 'recChallenge15_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 'recCompetence16',
+                index: '5.2',
+                tubes: [
+                  {
+                    id: 'recTube16_0',
+                    skills: [
+                      {
+                        id: 'recSkill16_0',
+                        nom: '@recSkill16_0',
+                        challenges: [{ id: 'recChallenge16_0_0', ...easyChallengeParams }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+        await mockLearningContent(learningContentObjects);
+
+        const configurationCreatorId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCompetenceScoringConfiguration({
+          createdByUserId: configurationCreatorId,
+          configuration: [
+            {
+              competence: '1.1',
+              values: [
+                {
+                  bounds: {
+                    max: 0,
+                    min: -5,
+                  },
+                  competenceLevel: 0,
+                },
+                {
+                  bounds: {
+                    max: 5,
+                    min: 0,
+                  },
+                  competenceLevel: 1,
+                },
+              ],
+            },
+          ],
+        });
+        databaseBuilder.factory.buildScoringConfiguration({ createdByUserId: configurationCreatorId });
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration();
+
+        await databaseBuilder.commit();
+      });
+
+      it('should score and end assessment by finalization', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date() }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({
+          sessionId,
+          userId,
+        });
+        const createdAt = new Date('2020-01-01T00:00:00Z');
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          completedAt: null,
+          sessionId,
+          userId,
+          version: AlgorithmEngineVersion.V3,
+          createdAt,
+        }).id;
+        const aStartedAssessmentId = databaseBuilder.factory.buildAssessment({
+          certificationCourseId,
+          userId,
+          state: Assessment.states.STARTED,
+          type: Assessment.types.CERTIFICATION,
+          createdAt,
+        }).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        await usecases.processAutoJury({ sessionId });
+
+        // then
+        const scoring = await knex('assessment-results').where({ assessmentId: aStartedAssessmentId });
+        expect(scoring).to.have.lengthOf(1);
+
+        const assessment = await knex('assessments').where({ id: aStartedAssessmentId }).first();
+        expect(assessment.state).to.equal(Assessment.states.ENDED_DUE_TO_FINALIZATION);
+      });
+
+      context('when an error occurs', function () {
+        it('should rollback auto jury', async function () {
+          // given
+          // an assessment completed and not ended by finalization
+          const sessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date() }).id;
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCertificationCandidate({
+            sessionId,
+            userId,
+          });
+          const createdAt = new Date('2020-01-01T00:00:00Z');
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            completedAt: null,
+            sessionId,
+            userId,
+            version: AlgorithmEngineVersion.V3,
+            createdAt,
+          }).id;
+          const aStartedAssessmentId = databaseBuilder.factory.buildAssessment({
+            certificationCourseId,
+            userId,
+            state: Assessment.states.STARTED,
+            type: Assessment.types.CERTIFICATION,
+            createdAt,
+          }).id;
+
+          await databaseBuilder.commit();
+
+          // when
+          const errorDuringTransaction = await catchErr(async (sessionId) => {
+            await DomainTransaction.execute(async () => {
+              await usecases.processAutoJury({ sessionId });
+              throw new Error('test error');
+            });
+          })(sessionId);
+
+          // then
+          expect(errorDuringTransaction.message).to.equal('test error');
+
+          const noScoring = await knex('assessment-results').where({ assessmentId: aStartedAssessmentId });
+          expect(noScoring).to.be.empty;
+
+          const notEndedDueToFinalization = await knex('assessments').where({ id: aStartedAssessmentId }).first();
+          expect(notEndedDueToFinalization.state).to.equal(Assessment.states.STARTED);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/session-management/integration/domain/usecases/register-publishable-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/register-publishable-session_test.js
@@ -1,0 +1,466 @@
+import { SessionFinalized } from '../../../../../../src/certification/session-management/domain/read-models/SessionFinalized.js';
+import { usecases } from '../../../../../../src/certification/session-management/domain/usecases/index.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../../test-helper.js';
+
+describe('Certification | Session Management | Integration | Domain | UseCase | register-publishable-session ', function () {
+  beforeEach(async function () {
+    const easyChallengeParams = {
+      alpha: 1,
+      delta: -3,
+      langues: ['Franco Français'],
+    };
+    const hardChallengeParams = {
+      alpha: 1,
+      delta: 3,
+      langues: ['Franco Français'],
+    };
+    const learningContent = [
+      {
+        id: 'recArea0',
+        code: 'area0',
+        competences: [
+          {
+            id: 'recCompetence0',
+            index: '1.1',
+            tubes: [
+              {
+                id: 'recTube0_0',
+                skills: [
+                  {
+                    id: 'recSkill0_0',
+                    nom: '@recSkill0_0',
+                    level: 2,
+                    challenges: [{ id: 'recChallenge0_0_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill0_1',
+                    nom: '@recSkill0_1',
+                    challenges: [{ id: 'recChallenge0_1_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill0_2',
+                    nom: '@recSkill0_2',
+                    challenges: [{ id: 'recChallenge0_2_0', ...hardChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence1',
+            index: '1.2',
+            tubes: [
+              {
+                id: 'recTube1_0',
+                skills: [
+                  {
+                    id: 'recSkill1_0',
+                    nom: '@recSkill1_0',
+                    challenges: [{ id: 'recChallenge1_0_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill1_1',
+                    nom: '@recSkill1_1',
+                    challenges: [{ id: 'recChallenge1_1_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill1_2',
+                    nom: '@recSkill1_2',
+                    challenges: [{ id: 'recChallenge1_2_0', ...hardChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence2',
+            index: '1.3',
+            tubes: [
+              {
+                id: 'recTube2_0',
+                skills: [
+                  {
+                    id: 'recSkill2_0',
+                    nom: '@recSkill2_0',
+                    challenges: [{ id: 'recChallenge2_0_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill2_1',
+                    nom: '@recSkill2_1',
+                    challenges: [{ id: 'recChallenge2_1_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill2_2',
+                    nom: '@recSkill2_2',
+                    challenges: [{ id: 'recChallenge2_2_0', ...hardChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence3',
+            index: '1.4',
+            tubes: [
+              {
+                id: 'recTube3_0',
+                skills: [
+                  {
+                    id: 'recSkill3_0',
+                    nom: '@recSkill3_0',
+                    challenges: [{ id: 'recChallenge3_0_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill3_1',
+                    nom: '@recSkill3_1',
+                    challenges: [{ id: 'recChallenge3_1_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill3_2',
+                    nom: '@recSkill3_2',
+                    challenges: [{ id: 'recChallenge3_2_0', ...hardChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'recArea1',
+        code: 'area1',
+        competences: [
+          {
+            id: 'recCompetence4',
+            index: '2.1',
+            tubes: [
+              {
+                id: 'recTube4_0',
+                skills: [
+                  {
+                    id: 'recSkill4_0',
+                    nom: '@recSkill4_0',
+                    challenges: [{ id: 'recChallenge4_0_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill4_1',
+                    nom: '@recSkill4_1',
+                    challenges: [{ id: 'recChallenge4_1_0', ...easyChallengeParams }],
+                  },
+                  {
+                    id: 'recSkill4_2',
+                    nom: '@recSkill4_2',
+                    challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence5',
+            index: '2.2',
+            tubes: [
+              {
+                id: 'recTube5_0',
+                skills: [
+                  {
+                    id: 'recSkill5_0',
+                    nom: '@recSkill5_0',
+                    challenges: [{ id: 'recChallenge5_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence6',
+            index: '2.3',
+            tubes: [
+              {
+                id: 'recTube6_0',
+                skills: [
+                  {
+                    id: 'recSkill6_0',
+                    nom: '@recSkill6_0',
+                    challenges: [{ id: 'recChallenge6_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence7',
+            index: '2.4',
+            tubes: [
+              {
+                id: 'recTube7_0',
+                skills: [
+                  {
+                    id: 'recSkill7_0',
+                    nom: '@recSkill7_0',
+                    challenges: [{ id: 'recChallenge7_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'recArea2',
+        code: 'area2',
+        competences: [
+          {
+            id: 'recCompetence8',
+            index: '3.1',
+            tubes: [
+              {
+                id: 'recTube8_0',
+                skills: [
+                  {
+                    id: 'recSkill8_0',
+                    nom: '@recSkill8_0',
+                    challenges: [{ id: 'recChallenge8_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence9',
+            index: '3.2',
+            tubes: [
+              {
+                id: 'recTube9_0',
+                skills: [
+                  {
+                    id: 'recSkill9_0',
+                    nom: '@recSkill9_0',
+                    challenges: [{ id: 'recChallenge9_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence10',
+            index: '3.3',
+            tubes: [
+              {
+                id: 'recTube10_0',
+                skills: [
+                  {
+                    id: 'recSkill10_0',
+                    nom: '@recSkill10_0',
+                    challenges: [{ id: 'recChallenge10_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence11',
+            index: '3.4',
+            tubes: [
+              {
+                id: 'recTube11_0',
+                skills: [
+                  {
+                    id: 'recSkill11_0',
+                    nom: '@recSkill11_0',
+                    challenges: [{ id: 'recChallenge11_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'recArea3',
+        code: 'area3',
+        competences: [
+          {
+            id: 'recCompetence12',
+            index: '4.1',
+            tubes: [
+              {
+                id: 'recTube12_0',
+                skills: [
+                  {
+                    id: 'recSkill12_0',
+                    nom: '@recSkill12_0',
+                    challenges: [{ id: 'recChallenge12_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence13',
+            index: '4.2',
+            tubes: [
+              {
+                id: 'recTube13_0',
+                skills: [
+                  {
+                    id: 'recSkill13_0',
+                    nom: '@recSkill13_0',
+                    challenges: [{ id: 'recChallenge13_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence14',
+            index: '4.3',
+            tubes: [
+              {
+                id: 'recTube14_0',
+                skills: [
+                  {
+                    id: 'recSkill14_0',
+                    nom: '@recSkill14_0',
+                    challenges: [{ id: 'recChallenge14_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'recArea4',
+        code: 'area4',
+        competences: [
+          {
+            id: 'recCompetence15',
+            index: '5.1',
+            tubes: [
+              {
+                id: 'recTube15_0',
+                skills: [
+                  {
+                    id: 'recSkill15_0',
+                    nom: '@recSkill15_0',
+                    challenges: [{ id: 'recChallenge15_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'recCompetence16',
+            index: '5.2',
+            tubes: [
+              {
+                id: 'recTube16_0',
+                skills: [
+                  {
+                    id: 'recSkill16_0',
+                    nom: '@recSkill16_0',
+                    challenges: [{ id: 'recChallenge16_0_0', ...easyChallengeParams }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+    await mockLearningContent(learningContentObjects);
+
+    const configurationCreatorId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdByUserId: configurationCreatorId,
+      configuration: [
+        {
+          competence: '1.1',
+          values: [
+            {
+              bounds: {
+                max: 0,
+                min: -5,
+              },
+              competenceLevel: 0,
+            },
+            {
+              bounds: {
+                max: 5,
+                min: 0,
+              },
+              competenceLevel: 1,
+            },
+          ],
+        },
+      ],
+    });
+    databaseBuilder.factory.buildScoringConfiguration({ createdByUserId: configurationCreatorId });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration();
+
+    await databaseBuilder.commit();
+  });
+
+  it('should register session as publishable', async function () {
+    // given
+    const sessionId = databaseBuilder.factory.buildSession().id;
+    const sessionFinalized = new SessionFinalized({
+      sessionId,
+      finalizedAt: new Date(),
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'test',
+      sessionDate: new Date(),
+      sessionTime: '12:00',
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.registerPublishableSession({ sessionFinalized });
+
+    // then
+    const publishableSession = await knex('finalized-sessions').first();
+    expect(publishableSession.sessionId).to.equal(sessionId);
+  });
+
+  context('when an error occurs', function () {
+    it('should rollback and not register session as publishable', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const sessionFinalized = new SessionFinalized({
+        sessionId,
+        finalizedAt: new Date(),
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'test',
+        sessionDate: new Date(),
+        sessionTime: '12:00',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const errorDuringTransaction = await catchErr(async (sessionFinalized) => {
+        await DomainTransaction.execute(async () => {
+          await usecases.registerPublishableSession({ sessionFinalized });
+          throw new Error('test error');
+        });
+      })(sessionFinalized);
+
+      // then
+      expect(errorDuringTransaction.message).to.equal('test error');
+
+      const noPublishableSession = await knex('finalized-sessions').first();
+      expect(noPublishableSession).to.not.exist;
+    });
+  });
+});

--- a/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/finalize-session_test.js
@@ -6,6 +6,7 @@ import {
 import { SessionFinalized } from '../../../../../../src/certification/session-management/domain/read-models/SessionFinalized.js';
 import { finalizeSession } from '../../../../../../src/certification/session-management/domain/usecases/finalize-session.js';
 import { InvalidCertificationReportForFinalization } from '../../../../../../src/certification/shared/domain/errors.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | finalize-session', function () {
@@ -19,6 +20,9 @@ describe('Unit | UseCase | finalize-session', function () {
   let hasJoiningIssue;
 
   beforeEach(async function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
     sessionId = 'dummy session id';
     updatedSession = domainBuilder.certification.sessionManagement.buildSession({
       id: sessionId,

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -8,6 +8,7 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -508,13 +509,16 @@ describe('Unit | UseCase | process-auto-jury', function () {
       certificationRescoringRepository;
 
     beforeEach(function () {
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
       certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       certificationRescoringRepository = { rescoreV3Certification: sinon.stub() };
     });
 
-    it('publishes a CertificationJuryDone event', async function () {
+    it('triggers a CertificationJuryDone rescoring event', async function () {
       // given
       const challenge = domainBuilder.buildCertificationChallengeWithType({
         challengeId: 'recChal123',
@@ -563,7 +567,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
     });
 
     describe('when the certification is started', function () {
-      it('publishes a CertificationJuryDone event', async function () {
+      it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
           certificationState: CertificationAssessment.states.STARTED,
@@ -680,7 +684,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
     });
 
     describe('when the certification was ended by the supervisor', function () {
-      it('publishes a CertificationJuryDone event', async function () {
+      it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
           certificationState: CertificationAssessment.states.ENDED_BY_SUPERVISOR,

--- a/api/tests/certification/session-management/unit/domain/usecases/register-publishable-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/register-publishable-session_test.js
@@ -3,6 +3,7 @@ import { JuryCertificationSummary } from '../../../../../../src/certification/se
 import { SessionFinalized } from '../../../../../../src/certification/session-management/domain/read-models/SessionFinalized.js';
 import { registerPublishableSession } from '../../../../../../src/certification/session-management/domain/usecases/register-publishable-session.js';
 import { CertificationIssueReportSubcategories } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { CertificationIssueReportCategory } from '../../../../../../src/shared/domain/models/index.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
@@ -17,6 +18,9 @@ const dependencies = {
 describe('Unit | UseCase |  register-publishable-session', function () {
   it('saves a finalized session', async function () {
     // given
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
     const sessionFinalized = new SessionFinalized({
       sessionId: 1234,
       finalizedAt: new Date(),


### PR DESCRIPTION
## 🔆 Problème

La finalisation est transactionnelle. On veut garder cela (je ne redetaille pas dans ce ticket, voir [bugfix de mars](https://1024pix.atlassian.net/wiki/spaces/DC/pages/5065375745/Erreur+en+PROD+Certification+V2+sans+finalized-sessions+2025-02-28)).
Soucis : on a besoin de rendre le scoring de complementaire v3 transactionnelle pour regler notre bug, car si un bout de code n’est pas transactionnel, alors qu’il depend de donnees qui sont modifiees dans la transaction, alors le bout qui n’est pas dans la transaction ne “voit rien“.

En ajoutant le cote transactionnel, grace au pouvoir du READ COMMITTED, on pourra brancher le scoring de complementaire v3.

## ⛱️ Proposition

Uniquement pour tout ce qui est V3

* Rendre transactionnel le double certification scoring
* Rendre transactionne le scoring v3
  * qui est appele au travers de l'API interne `rescoreV3Certification` 
* Verifier que l'evenement CertificationCompletedJOb est toujours OK
* puis rendre transactionnel toute la chaine de la route `finalize-session`

## 🌊 Remarques

* En principe j'ai essaye de faire en sorte que la relecture commit par commit soit sympa

* ⚠️ J'invite les relecteurs a bien verifier toutes les methodes de repositories appellees par tous les fichier pour assurer que je n'ai pas loupe l'ajout d'un `const knexConn = DomainTransaction.getConnection();`

* 💡 J'invite a activer la non-revue des espaces car en raison d'un decalage d'indentation un volume tres important a ete modifie de lignes

![image](https://github.com/user-attachments/assets/5df2c38e-b0d8-4943-afd7-baa311b083e3)

* Le LCMS n'a pas de transaction dessus, rappel : on considere que c'est un cache et avec le module Dataloader pas de transaction present.

* L'API interne est aussi utilise par plein d'autres boutons : cancel, uncancel, et rejeter/derejeter, ainsi que le rescoring. La mise en place de la transaction n'est pas propagee jusqu'a ces routes car cela ferait un volume de code et priorite au bg de PROD

## 🏄 Pour tester

( @Agnes-V dans cette PR aussi j'ai mis a 256pix le minimum earned pix)

Sur la base de
* Campagne CLEA : /campagnes/SKGRLM256
* certif-success a son badge
* Le centre PRO est habilite CLEA

* Passer une double certification CLEA jusqu'a ecran de fin
  * Aller jusqu'a la publication et verifier que tout est OK niveau score et CLEA obtenu
*  Passer une double certification CLEA **sans aller jusque ecran de fin**
  * Aller jusqu'a la publication et verifier que tout est OK niveau score et CLEA obtenu
* Passer au moins un certification CLEA avec echec (moins de 256 pix) 
  * Verifier que la complementaire est rejetee alors que la coeur est OK
* Faire au moins un test de non reg sur Pix Coeur en ecran de fin et sans ecran de fin
  * Pas de notif d'erreur   
