### PR TITLE
[BUGFIX] Rendre l'identifiant plus visible dans la double mire d'authentification SCO (PIX-18455)

### DIFF
--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -92,7 +92,7 @@ export default class RegisterForm extends Component {
         @validationStatus={{this.validation.firstName.status}}
         @errorMessage={{this.validation.firstName.message}}
         @disabled={{this.matchingStudentFound}}
-        autocomplete="firstname"
+        autocomplete="given-name"
         type="text"
       >
         <:label>{{t "pages.login-or-register.register-form.fields.firstname.label"}}</:label>
@@ -107,7 +107,7 @@ export default class RegisterForm extends Component {
         @validationStatus={{this.validation.lastName.status}}
         @errorMessage={{this.validation.lastName.message}}
         @disabled={{this.matchingStudentFound}}
-        autocomplete="lastName"
+        autocomplete="family-name"
         type="text"
       >
         <:label>{{t "pages.login-or-register.register-form.fields.lastname.label"}}</:label>
@@ -182,7 +182,7 @@ export default class RegisterForm extends Component {
             @errorMessage={{this.validation.email.message}}
             @disabled={{this.matchingStudentFound}}
             @subLabel={{t "pages.login-or-register.register-form.fields.email.help"}}
-            autocomplete="firstname"
+            autocomplete="email"
             type="email"
           >
             <:label>{{t "pages.login-or-register.register-form.fields.email.label"}}</:label>

--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -166,12 +166,10 @@ export default class RegisterForm extends Component {
 
       <form {{on "submit" this.register}} autocomplete="off" class="register-form">
         {{#if this.loginWithUsername}}
-          <div id="register-username-container" class="register-form-username-container">
-            <label class="register-form-username-container__label">
-              {{t "pages.login-or-register.register-form.fields.username.label"}}
-              <abbr title="{{t 'common.form.mandatory'}}" class="mandatory-mark">*</abbr>
-            </label>
-            <span class="register-form-username-container__span" data-test-username>{{this.username}}</span>
+          <div class="register-form-username-container">
+            <PixInput @id="username" @value={{this.username}} @requiredLabel={{true}} disabled={{true}} type="text">
+              <:label>{{t "pages.login-or-register.register-form.fields.username.label"}}</:label>
+            </PixInput>
           </div>
         {{else}}
           <PixInput

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -69,23 +69,8 @@
   }
 
   &-username-container {
-    display: flex;
-    flex-direction: column;
-
-    &__label {
+    .pix-input__input {
       color: var(--pix-neutral-800);
-      font-weight: var(--pix-font-medium);
-      font-size: 0.938rem;
-      letter-spacing: 0.031rem;
-    }
-
-    &__span {
-      padding: 15px 10px;
-      color: var(--pix-neutral-100);
-      font-size: 0.875rem;
-      font-family: fonts.$font-roboto;
-      background-color: var(--pix-neutral-20);
-      border-radius: 3px;
     }
   }
 }

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -297,7 +297,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             //go to username-based authentication window
             await click(screen.getByText('Mon identifiant'));
-            assert.dom(screen.getByText('first.last1010')).exists();
+            // The input label contains additional content (spaces and an HTML element) than just the label text
+            assert.dom(screen.getByRole('textbox', { name: /Mon identifiant/, value: 'first.last1010' })).exists();
             assert.strictEqual(screen.getByLabelText('Mot de passe', { exact: false }).value, 'pix123');
           });
 


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'un élève qui souhaite passer une campagne est redirigé vers l'inscription (double mire sco), il renseigne dans la partie gauche ses nom, prénom, date de naissance, puis dans un second temps choisit de s'inscrire avec un identifiant ou un mot de passe.
L'identifiant, qui se trouve dans un champ prérempli, n'est pas assez visible (trop peu de contraste avec le fond).

<img src="https://github.com/user-attachments/assets/35cffb9b-1252-4a97-b1c4-4cca333eea73" width=411/>


## ⛱️ Proposition

Utiliser un PixInput `disabled` et en utilisant une couleur plus sombre pour faire ressortir la valeur du champ.

![Screenshot-PixApp-Username_more-prominent](https://github.com/user-attachments/assets/0dd6ee8e-f996-49b5-a3d8-b03cc214a1ec)

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Reproduire les deux premières étapes du scénario de test de https://github.com/1024pix/pix/pull/12408 sur https://app-pr12707.review.pix.fr/campagnes/SCOBADGE1
- Constater que l'identifiant `harry.potter1212` est maintenant bien visible