### PR TITLE
[TECH] Eviter le double appel à /api/assessments/:id/next

### DIFF
--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -41,8 +41,10 @@ const getNextChallenge = async function (request) {
   const userId = extractUserIdFromRequest(request);
 
   try {
-    const assessment = await DomainTransaction.execute(() => {
-      return sharedUsecases.getNextChallenge({ assessmentId, userId, locale });
+    const assessment = await DomainTransaction.execute(async () => {
+      const assessmentWithoutChallenge = await sharedUsecases.getAssessment({ assessmentId, locale });
+
+      return sharedUsecases.getNextChallenge({ assessment: assessmentWithoutChallenge, userId, locale });
     });
     return assessmentSerializer.serialize(assessment);
   } catch (error) {

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -42,10 +42,10 @@ const getNextChallenge = async function (request) {
   const userId = extractUserIdFromRequest(request);
 
   try {
-    const challenge = await DomainTransaction.execute(() => {
+    const assessment = await DomainTransaction.execute(() => {
       return sharedUsecases.getNextChallenge({ assessmentId, userId, locale });
     });
-    return challengeSerializer.serialize(challenge);
+    return assessmentSerializer.serialize(assessment);
   } catch (error) {
     if (error instanceof AssessmentEndedError) {
       const object = new JSONAPISerializer('', {});

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -1,15 +1,12 @@
 /**
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationEvaluationRepository} CertificationEvaluationRepository
  */
-import { Serializer as JSONAPISerializer } from 'jsonapi-serializer';
-
 import { usecases as certificationUsecases } from '../../../certification/session-management/domain/usecases/index.js';
 import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
-import { AssessmentEndedError } from '../../domain/errors.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
@@ -26,34 +23,17 @@ const save = async function (request, h, dependencies = { assessmentRepository }
   return h.response(assessmentSerializer.serialize(createdAssessment)).created();
 };
 
-const get = async function (request, _, dependencies = { assessmentSerializer }) {
-  const assessmentId = request.params.id;
-  const locale = extractLocaleFromRequest(request);
-
-  const assessment = await sharedUsecases.getAssessment({ assessmentId, locale });
-
-  return dependencies.assessmentSerializer.serialize(assessment);
-};
-
 const getNextChallenge = async function (request) {
   const assessmentId = request.params.id;
   const locale = extractLocaleFromRequest(request);
   const userId = extractUserIdFromRequest(request);
 
-  try {
-    const assessment = await DomainTransaction.execute(async () => {
-      const assessmentWithoutChallenge = await sharedUsecases.getAssessment({ assessmentId, locale });
+  const assessment = await DomainTransaction.execute(async () => {
+    const assessmentWithoutChallenge = await sharedUsecases.getAssessment({ assessmentId, locale });
 
-      return sharedUsecases.getNextChallenge({ assessment: assessmentWithoutChallenge, userId, locale });
-    });
-    return assessmentSerializer.serialize(assessment);
-  } catch (error) {
-    if (error instanceof AssessmentEndedError) {
-      const object = new JSONAPISerializer('', {});
-      return object.serialize(null);
-    }
-    throw error;
-  }
+    return sharedUsecases.getNextChallenge({ assessment: assessmentWithoutChallenge, userId, locale });
+  });
+  return assessmentSerializer.serialize(assessment);
 };
 
 const updateLastChallengeState = async function (request) {
@@ -136,7 +116,6 @@ const createCertificationChallengeLiveAlert = async function (request, h) {
 
 const assessmentController = {
   save,
-  get,
   getNextChallenge,
   updateLastChallengeState,
   findCompetenceEvaluations,

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -13,7 +13,6 @@ import { AssessmentEndedError } from '../../domain/errors.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
-import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';
 import {
   extractLocaleFromRequest,
   extractUserIdFromRequest,

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -62,7 +62,7 @@ const register = async function (server) {
             assign: 'authorizationCheck',
           },
         ],
-        handler: assessmentController.get,
+        handler: assessmentController.getNextChallenge,
         tags: ['api'],
       },
     },

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -1,18 +1,16 @@
-import { AssessmentEndedError } from '../errors.js';
-
 export async function getNextChallenge({
   assessmentId,
   userId,
   locale,
   assessmentRepository,
-  answerRepository,
   challengeRepository,
   evaluationUsecases,
   certificationEvaluationRepository,
 }) {
-  const assessment = await assessmentRepository.get(assessmentId);
+  const assessment = await assessmentRepository.getWithAnswers(assessmentId);
   if (!assessment.isStarted()) {
-    throw new AssessmentEndedError();
+    assessment.nextChallenge = null;
+    return assessment;
   }
   await assessmentRepository.updateLastQuestionDate({ id: assessment.id, lastQuestionDate: new Date() });
 
@@ -22,9 +20,8 @@ export async function getNextChallenge({
     // Force executing the usecase because of the live alert system
     waitingForLatestChallengeAnswer = false;
   } else {
-    const answers = await answerRepository.findByAssessment(assessment.id);
     waitingForLatestChallengeAnswer = checkIfLatestChallengeOfAssessmentIsAwaitingToBeAnswered({
-      answers,
+      answers: assessment.answers,
       lastChallengeId: assessment.lastChallengeId,
     });
   }
@@ -37,27 +34,31 @@ export async function getNextChallenge({
       nextChallenge = null;
     }
   }
-  if (assessment.isCertification()) {
-    nextChallenge = await certificationEvaluationRepository.selectNextCertificationChallenge({
-      assessmentId: assessment.id,
-      locale,
-    });
-  }
 
-  if (assessment.isPreview()) {
-    nextChallenge = await evaluationUsecases.getNextChallengeForPreview({});
-  }
+  try {
+    if (assessment.isCertification()) {
+      nextChallenge = await certificationEvaluationRepository.selectNextCertificationChallenge({
+        assessmentId: assessment.id,
+        locale,
+      });
+    }
 
-  if (assessment.isDemo()) {
-    nextChallenge = await evaluationUsecases.getNextChallengeForDemo({ assessment });
-  }
+    if (assessment.isPreview()) {
+      nextChallenge = await evaluationUsecases.getNextChallengeForPreview({});
+    }
 
-  if (assessment.isForCampaign()) {
-    nextChallenge = await evaluationUsecases.getNextChallengeForCampaignAssessment({ assessment, locale });
-  }
+    if (assessment.isDemo()) {
+      nextChallenge = await evaluationUsecases.getNextChallengeForDemo({ assessment });
+    }
 
-  if (assessment.isCompetenceEvaluation()) {
-    nextChallenge = await evaluationUsecases.getNextChallengeForCompetenceEvaluation({ assessment, userId, locale });
+    if (assessment.isForCampaign()) {
+      nextChallenge = await evaluationUsecases.getNextChallengeForCampaignAssessment({ assessment, locale });
+    }
+    if (assessment.isCompetenceEvaluation()) {
+      nextChallenge = await evaluationUsecases.getNextChallengeForCompetenceEvaluation({ assessment, userId, locale });
+    }
+  } catch {
+    nextChallenge = null;
   }
 
   if (nextChallenge && nextChallenge.id !== assessment.lastChallengeId) {

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -31,7 +31,8 @@ export async function getNextChallenge({
   if (waitingForLatestChallengeAnswer) {
     nextChallenge = await challengeRepository.get(assessment.lastChallengeId);
     if (nextChallenge.isOperative) {
-      return nextChallenge;
+      assessment.nextChallenge = nextChallenge;
+      return assessment;
     } else {
       nextChallenge = null;
     }
@@ -65,8 +66,9 @@ export async function getNextChallenge({
       lastChallengeId: nextChallenge.id,
     });
   }
+  assessment.nextChallenge = nextChallenge;
 
-  return nextChallenge;
+  return assessment;
 }
 
 function checkIfLatestChallengeOfAssessmentIsAwaitingToBeAnswered({ answers, lastChallengeId }) {

--- a/api/src/shared/domain/usecases/get-next-challenge.js
+++ b/api/src/shared/domain/usecases/get-next-challenge.js
@@ -1,5 +1,5 @@
 export async function getNextChallenge({
-  assessmentId,
+  assessment,
   userId,
   locale,
   assessmentRepository,
@@ -7,7 +7,6 @@ export async function getNextChallenge({
   evaluationUsecases,
   certificationEvaluationRepository,
 }) {
-  const assessment = await assessmentRepository.getWithAnswers(assessmentId);
   if (!assessment.isStarted()) {
     assessment.nextChallenge = null;
     return assessment;

--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -3,8 +3,17 @@ import jsonapiSerializer from 'jsonapi-serializer';
 import { Progression } from '../../../../evaluation/domain/models/Progression.js';
 import { DomainError } from '../../../domain/errors.js';
 import { Assessment } from '../../../domain/models/Assessment.js';
+import { config as challengeSerializerConfig } from './challenge-serializer.js';
 
 const { Serializer } = jsonapiSerializer;
+
+const typesMapping = {
+  answers: 'answers',
+  nextChallenge: 'challenges',
+  course: 'courses',
+  certificationCourse: 'certification-courses',
+  progression: 'progressions',
+};
 
 const serialize = function (assessments) {
   return new Serializer('assessment', {
@@ -58,7 +67,9 @@ const serialize = function (assessments) {
       'showLevelup',
       'showQuestionCounter',
       'orderedChallengeIdsAnswered',
+      'nextChallenge',
     ],
+    typeForAttribute: (attribute) => typesMapping[attribute],
     answers: {
       ref: 'id',
       relationshipLinks: {
@@ -66,6 +77,10 @@ const serialize = function (assessments) {
           return `/api/answers?assessmentId=${record.id}`;
         },
       },
+    },
+    nextChallenge: {
+      ref: 'id',
+      ...challengeSerializerConfig,
     },
     course: {
       ref: 'id',

--- a/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -3,38 +3,40 @@ import _ from 'lodash';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (challenges) {
-  return new Serializer('challenge', {
-    attributes: [
-      'type',
-      'instruction',
-      'competence',
-      'proposals',
-      'timer',
-      'illustrationUrl',
-      'attachments',
-      'competence',
-      'embedUrl',
-      'embedTitle',
-      'embedHeight',
-      'webComponentTagName',
-      'webComponentProps',
-      'illustrationAlt',
-      'format',
-      'autoReply',
-      'alternativeInstruction',
-      'focused',
-      'shuffled',
-      'locales',
-    ],
-    transform: (record) => {
-      const challenge = _.pickBy(record, (value) => !_.isUndefined(value));
+const config = {
+  attributes: [
+    'type',
+    'instruction',
+    'competence',
+    'proposals',
+    'timer',
+    'illustrationUrl',
+    'attachments',
+    'competence',
+    'embedUrl',
+    'embedTitle',
+    'embedHeight',
+    'webComponentTagName',
+    'webComponentProps',
+    'illustrationAlt',
+    'format',
+    'autoReply',
+    'alternativeInstruction',
+    'focused',
+    'shuffled',
+    'locales',
+  ],
+  transform: (record) => {
+    const challenge = _.pickBy(record, (value) => !_.isUndefined(value));
 
-      challenge.competence = challenge.competenceId || 'N/A';
+    challenge.competence = challenge.competenceId || 'N/A';
 
-      return challenge;
-    },
-  }).serialize(challenges);
+    return challenge;
+  },
 };
 
-export { serialize };
+const serialize = function (challenges) {
+  return new Serializer('challenge', config).serialize(challenges);
+};
+
+export { config, serialize };

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -113,7 +113,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
         clock.restore();
       });
 
-      it('should return a challenge', async function () {
+      it('should return an assessment', async function () {
         // given
         const options = {
           method: 'GET',
@@ -129,7 +129,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
         // then
         const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastQuestionDate');
         expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
-        expect(response.result.data.id).to.be.oneOf([
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data.id).to.be.oneOf([
           firstChallengeId,
           secondChallengeId,
           thirdChallengeId,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -118,7 +118,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           clock.restore();
         });
 
-        it('should save and return a challenge', async function () {
+        it('should save and return an assessment', async function () {
           // given
           const options = {
             method: 'GET',
@@ -137,7 +137,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
 
           expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
           expect(countSavedChallenge).to.equal(1);
-          expect(response.result.data.id).to.be.oneOf([
+          expect(response.result.data.id).to.equal(assessmentId.toString());
+          expect(response.result.data.relationships['next-challenge'].data.id).to.be.oneOf([
             firstChallengeId,
             secondChallengeId,
             thirdChallengeId,
@@ -248,7 +249,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           const response = await server.inject(options);
 
           // then
-          expect(response.result.data.id).to.equal(secondChallengeId);
+          expect(response.result.data.relationships['next-challenge'].data.id).to.equal(secondChallengeId);
         });
       });
     });
@@ -301,7 +302,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           const response = await server.inject(options);
 
           // then
-          expect(response.result.data.id).to.equal(firstChallengeId);
+          expect(response.result.data.relationships['next-challenge'].data.id).to.equal(firstChallengeId);
         });
       });
     });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -1,4 +1,6 @@
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
+import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
@@ -144,6 +146,61 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             thirdChallengeId,
             otherChallengeId,
           ]);
+        });
+      });
+
+      context('When there is are ongoing live and companion alerts for a challenge', function () {
+        beforeEach(async function () {
+          const user = databaseBuilder.factory.buildUser({ id: userId });
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+          const sessionId = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+            version: AlgorithmEngineVersion.V3,
+          }).id;
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            isPublished: false,
+            version: AlgorithmEngineVersion.V3,
+            userId,
+            sessionId,
+          }).id;
+          databaseBuilder.factory.buildCertificationCandidate({ ...user, userId: user.id, sessionId });
+          const assessment = databaseBuilder.factory.buildAssessment({
+            id: assessmentId,
+            type: Assessment.types.CERTIFICATION,
+            certificationCourseId,
+            lastChallengeId: firstChallengeId,
+            userId,
+            lastQuestionDate: new Date('2020-01-20'),
+            state: 'started',
+          });
+          databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+            assessmentId: assessment.id,
+            challengeId: firstChallengeId,
+            status: CertificationChallengeLiveAlertStatus.ONGOING,
+          });
+          databaseBuilder.factory.buildCertificationCompanionLiveAlert({
+            assessmentId: assessment.id,
+            status: CertificationCompanionLiveAlertStatus.ONGOING,
+          });
+          databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+          await databaseBuilder.commit();
+        });
+
+        it('returns flags related to live alerts', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: `/api/assessments/${assessmentId}/next`,
+            headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.result.data.attributes['has-ongoing-challenge-live-alert']).to.be.true;
+          expect(response.result.data.attributes['has-ongoing-companion-live-alert']).to.be.true;
         });
       });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -134,7 +134,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // then
         const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastQuestionDate');
         expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
-        expect(response.result.data.id).to.equal(secondChallengeId);
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data.id).to.equal(secondChallengeId);
       });
 
       it('should save the asked challenge', async function () {
@@ -151,7 +152,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // then
         const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastChallengeId');
         expect(assessmentsInDb.lastChallengeId).to.deep.equal(secondChallengeId);
-        expect(response.result.data.id).to.equal(secondChallengeId);
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data.id).to.equal(secondChallengeId);
       });
     });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -223,9 +223,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal({
-          data: null,
-        });
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data).to.be.null;
       });
 
       it('should not save a null challenge for the lastChallengeId', async function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -118,6 +118,22 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         clock.restore();
       });
 
+      it('should return assessment with title', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/assessments/${assessmentId}/next`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.attributes.title).to.equal('Mener une recherche et une veille d’information');
+      });
+
       it('should return the second challenge if the first answer is correct', async function () {
         // given
         const options = {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -41,6 +41,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
             id: 'course_id',
             competenceId: 'competence_id',
             challengeIds: ['first_challenge', 'second_challenge'],
+            name: 'Test statique de démo',
           },
         ],
       },
@@ -76,6 +77,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.contain('application/json');
         expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.attributes.title).to.equal('Test statique de démo');
         expect(response.result.data.relationships['next-challenge'].data.id).to.equal('first_challenge');
         expect(response.result.included.find(({ id }) => id === 'first_challenge')).to.exist;
       });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -76,7 +76,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.contain('application/json');
         expect(response.result.data.id).to.equal(assessmentId.toString());
-        expect(response.result.data.relationships['next-challenge'].id).to.equal('first_challenge');
+        expect(response.result.data.relationships['next-challenge'].data.id).to.equal('first_challenge');
         expect(response.result.included.find(({ id }) => id === 'first_challenge')).to.exist;
       });
     });
@@ -104,7 +104,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         const response = await server.inject(options);
 
         // then
-        expect(response.result.data.id).to.equal('second_challenge');
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data.id).to.equal('second_challenge');
       });
     });
 
@@ -132,7 +133,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         const response = await server.inject(options);
 
         // then
-        expect(response.result.data.id).to.equal('first_challenge');
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data.id).to.equal('first_challenge');
       });
     });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -75,7 +75,9 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         const response = await server.inject(options);
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.contain('application/json');
-        expect(response.result.data.id).to.equal('first_challenge');
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].id).to.equal('first_challenge');
+        expect(response.result.included.find(({ id }) => id === 'first_challenge')).to.exist;
       });
     });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -150,7 +150,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         return databaseBuilder.commit();
       });
 
-      it('should finish the test', async function () {
+      it('should return the assessment with no next challenge', async function () {
         // given
         const options = {
           method: 'GET',
@@ -162,9 +162,8 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal({
-          data: null,
-        });
+        expect(response.result.data.id).to.equal(assessmentId.toString());
+        expect(response.result.data.relationships['next-challenge'].data).to.be.null;
       });
     });
   });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -184,6 +184,9 @@ describe('Acceptance | API | assessment-controller-get', function () {
               related: `/api/answers?assessmentId=${assessmentId}`,
             },
           },
+          'next-challenge': {
+            data: null,
+          },
         },
       };
       const assessment = response.result.data;
@@ -321,11 +324,18 @@ describe('Acceptance | API | assessment-controller-get', function () {
               },
             ],
           },
+          'next-challenge': {
+            data: null,
+          },
         },
       };
       const assessment = response.result.data;
       expect(assessment.attributes).to.deep.equal(expectedAssessment.attributes);
       expect(assessment.relationships.answers.data).to.have.deep.members(expectedAssessment.relationships.answers.data);
+      expect(assessment.relationships.course).to.deep.equal(expectedAssessment.relationships.course);
+      expect(assessment.relationships['next-challenge']).to.deep.equal(
+        expectedAssessment.relationships['next-challenge'],
+      );
     });
   });
 });

--- a/api/tests/shared/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/integration/application/assessments/assessment-controller_test.js
@@ -33,7 +33,7 @@ describe('Integration | Application | Assessments | assessment-controller', func
         expect(response.statusCode).to.equal(200);
       });
 
-      it('should return a JSON API organization', async function () {
+      it('should return a JSON API assessment', async function () {
         // given
         sharedUsecases.getAssessment.resolves(assessment);
 

--- a/api/tests/shared/unit/application/assessements/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessements/assessment-controller_test.js
@@ -1,46 +1,9 @@
 import { usecases as certificationUsecases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
-import { sharedUsecases } from '../../../../../src/shared/domain/usecases/index.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | assessment-controller', function () {
-  describe('#get', function () {
-    const authenticatedUserId = '12';
-    const locale = 'fr';
-    const assessmentId = 104974;
-
-    const assessment = { id: assessmentId, title: 'Ordinary Wizarding Level assessment' };
-    let assessmentSerializerStub;
-
-    beforeEach(function () {
-      sinon.stub(sharedUsecases, 'getAssessment').withArgs({ assessmentId, locale }).resolves(assessment);
-      assessmentSerializerStub = { serialize: sinon.stub() };
-      assessmentSerializerStub.serialize.resolvesArg(0);
-    });
-
-    it('should call the expected usecase', async function () {
-      // given
-      const request = {
-        auth: {
-          credentials: {
-            userId: authenticatedUserId,
-          },
-        },
-        params: {
-          id: assessmentId,
-        },
-        headers: { 'accept-language': locale },
-      };
-
-      // when
-      const result = await assessmentController.get(request, hFake, { assessmentSerializer: assessmentSerializerStub });
-
-      // then
-      expect(result).to.be.equal(assessment);
-    });
-  });
-
   describe('#findCompetenceEvaluations', function () {
     it('should return the competence evaluations', async function () {
       // given

--- a/api/tests/shared/unit/application/assessements/index_test.js
+++ b/api/tests/shared/unit/application/assessements/index_test.js
@@ -68,7 +68,7 @@ describe('Unit | Application | Router | assessment-router', function () {
     it('should return 200', async function () {
       // given
       sinon.stub(assessmentAuthorization, 'verify').callsFake((request, h) => h.response(null));
-      sinon.stub(assessmentController, 'get').callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(assessmentController, 'getNextChallenge').callsFake((request, h) => h.response('ok').code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -82,7 +82,7 @@ describe('Unit | Application | Router | assessment-router', function () {
     it('should call pre-handler', async function () {
       // given
       sinon.stub(assessmentAuthorization, 'verify').callsFake((request, h) => h.response(null));
-      sinon.stub(assessmentController, 'get').callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(assessmentController, 'getNextChallenge').callsFake((request, h) => h.response('ok').code(200));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/shared/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/get-next-challenge_test.js
@@ -7,7 +7,6 @@ import { domainBuilder, expect, preventStubsToBeCalledUnexpectedly, sinon } from
 describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () {
   describe('#getNextChallenge', function () {
     let userId, assessmentId, locale, dependencies;
-    let assessmentRepository_getWithAnswersStub;
     let assessmentRepository_updateLastQuestionDateStub;
     let assessmentRepository_updateWhenNewChallengeIsAskedStub;
     let challengeRepository_getStub;
@@ -21,7 +20,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       userId = 'someUserId';
       assessmentId = 'someAssessmentId';
       locale = 'someLocale';
-      assessmentRepository_getWithAnswersStub = sinon.stub().named('getWithAnswersStub');
       assessmentRepository_updateLastQuestionDateStub = sinon.stub().named('updateLastQuestionDate');
       assessmentRepository_updateWhenNewChallengeIsAskedStub = sinon.stub().named('updateWhenNewChallengeIsAsked');
       challengeRepository_getStub = sinon.stub().named('get');
@@ -37,7 +35,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         .stub()
         .named('selectNextCertificationChallenge');
       preventStubsToBeCalledUnexpectedly([
-        assessmentRepository_getWithAnswersStub,
         assessmentRepository_updateLastQuestionDateStub,
         assessmentRepository_updateWhenNewChallengeIsAskedStub,
         challengeRepository_getStub,
@@ -49,7 +46,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       ]);
 
       const assessmentRepository = {
-        getWithAnswers: assessmentRepository_getWithAnswersStub,
         updateLastQuestionDate: assessmentRepository_updateLastQuestionDateStub,
         updateWhenNewChallengeIsAsked: assessmentRepository_updateWhenNewChallengeIsAskedStub,
       };
@@ -70,7 +66,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       };
 
       dependencies = {
-        assessmentId,
         userId,
         locale,
         assessmentRepository,
@@ -95,9 +90,8 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       ].forEach((assessmentState) => {
         it(`should return an assessment with its answers`, async function () {
           assessment.state = assessmentState;
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
 
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge).to.deepEqualInstance(assessment);
           expect(assessmentWithNextChallenge.nextChallenge).to.be.null;
@@ -112,13 +106,12 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           type: Assessment.types.PREVIEW,
           lastChallengeId: null,
         });
-        assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
         assessmentRepository_updateLastQuestionDateStub.resolves();
         assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         const challenge = domainBuilder.buildChallenge({ id: 'challengeForPreview' });
         evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
 
-        const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+        const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
         expect(assessmentWithNextChallenge).to.deepEqualInstance(assessment);
       });
@@ -130,13 +123,12 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.PREVIEW,
             lastChallengeId: null,
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
           const challenge = domainBuilder.buildChallenge({ id: 'challengeForPreview' });
           evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
 
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -150,13 +142,12 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             lastChallengeId: 'previousChallengeId',
             answers: [domainBuilder.buildAnswer({ challengeId: 'previousChallengeId' })],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
           const challenge = domainBuilder.buildChallenge({ id: 'challengeForPreview' });
           evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
 
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -170,7 +161,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               type: Assessment.types.PREVIEW,
               lastChallengeId: 'previousChallengeId',
             });
-            assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
             assessmentRepository_updateLastQuestionDateStub.resolves();
             assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
             const previousChallenge = domainBuilder.buildChallenge({
@@ -179,7 +169,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             });
             challengeRepository_getStub.withArgs('previousChallengeId').resolves(previousChallenge);
 
-            const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+            const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
             expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(previousChallenge);
           });
@@ -192,7 +182,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               type: Assessment.types.PREVIEW,
               lastChallengeId: 'previousChallengeId',
             });
-            assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
             assessmentRepository_updateLastQuestionDateStub.resolves();
             assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
             const challenge = domainBuilder.buildChallenge({ id: 'nextChallengeForPreview' });
@@ -203,7 +192,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
             challengeRepository_getStub.withArgs('previousChallengeId').resolves(previousChallenge);
 
-            const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+            const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
             expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
           });
@@ -221,14 +210,13 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.PREVIEW,
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
 
         it('should call usecase and return value from preview usecase', async function () {
           evaluationUsecases_getNextChallengeForPreviewStub.rejects(new AssessmentEndedError());
-          const assessmentWithoutChallenge = await getNextChallenge(dependencies);
+          const assessmentWithoutChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
         });
@@ -243,7 +231,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.DEMO,
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
@@ -251,7 +238,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         it('should call usecase and return value from demo usecase', async function () {
           const challenge = domainBuilder.buildChallenge({ id: 'challengeForDemo' });
           evaluationUsecases_getNextChallengeForDemoStub.withArgs({ assessment }).resolves(challenge);
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -261,7 +248,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             evaluationUsecases_getNextChallengeForDemoStub.rejects(new AssessmentEndedError());
 
             // when
-            const assessmentWithoutChallenge = await getNextChallenge(dependencies);
+            const assessmentWithoutChallenge = await getNextChallenge({ assessment, ...dependencies });
             // then
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });
@@ -277,7 +264,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.CAMPAIGN,
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
@@ -287,7 +273,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           evaluationUsecases_getNextChallengeForCampaignAssessmentStub
             .withArgs({ assessment, locale })
             .resolves(challenge);
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -298,7 +284,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             evaluationUsecases_getNextChallengeForCampaignAssessmentStub.rejects(new AssessmentEndedError());
 
             // when
-            const assessmentWithoutChallenge = await getNextChallenge(dependencies);
+            const assessmentWithoutChallenge = await getNextChallenge({ assessment, ...dependencies });
             // then
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });
@@ -314,7 +300,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.COMPETENCE_EVALUATION,
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
@@ -324,7 +309,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           evaluationUsecases_getNextChallengeForCompetenceEvaluationStub
             .withArgs({ assessment, userId, locale })
             .resolves(challenge);
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -335,7 +320,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             evaluationUsecases_getNextChallengeForCompetenceEvaluationStub.rejects(new AssessmentEndedError());
 
             // when
-            const assessmentWithoutChallenge = await getNextChallenge(dependencies);
+            const assessmentWithoutChallenge = await getNextChallenge({ assessment, ...dependencies });
             // then
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });
@@ -352,7 +337,6 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: Assessment.types.CERTIFICATION,
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
@@ -362,7 +346,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           certificationEvaluationRepository_selectNextCertificationChallengeStub
             .withArgs({ assessmentId: assessment.id, locale })
             .resolves(challenge);
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
@@ -373,7 +357,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             certificationEvaluationRepository_selectNextCertificationChallengeStub.rejects(new AssessmentEndedError());
 
             // when
-            const assessmentWithoutChallenge = await getNextChallenge(dependencies);
+            const assessmentWithoutChallenge = await getNextChallenge({ assessment, ...dependencies });
             // then
             expect(assessmentWithoutChallenge.nextChallenge).to.be.null;
           });
@@ -390,13 +374,12 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             type: 'coucou les zamis',
             answers: [],
           });
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
           assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
         });
 
         it('should return null', async function () {
-          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentWithNextChallenge.nextChallenge).to.be.null;
         });
@@ -425,10 +408,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         });
 
         it(`should update the last question date`, async function () {
-          assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
           assessmentRepository_updateLastQuestionDateStub.resolves();
 
-          await getNextChallenge(dependencies);
+          await getNextChallenge({ assessment, ...dependencies });
 
           expect(assessmentRepository_updateLastQuestionDateStub).to.have.been.calledWithExactly({
             id: assessmentId,
@@ -449,10 +431,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               state: Assessment.states.STARTED,
               type: Assessment.types.PREVIEW,
             });
-            assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
             evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(null);
 
-            await getNextChallenge(dependencies);
+            await getNextChallenge({ assessment, ...dependencies });
 
             expect(assessmentRepository_updateWhenNewChallengeIsAskedStub).to.not.have.been.called;
           });
@@ -468,12 +449,11 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               answers: [domainBuilder.buildAnswer({ challengeId: 'currentChallengeId' })],
             });
 
-            assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
             evaluationUsecases_getNextChallengeForPreviewStub
               .withArgs({})
               .resolves(domainBuilder.buildChallenge({ id: 'currentChallengeId' }));
 
-            await getNextChallenge(dependencies);
+            await getNextChallenge({ assessment, ...dependencies });
 
             expect(assessmentRepository_updateWhenNewChallengeIsAskedStub).to.not.have.been.called;
           });
@@ -489,13 +469,12 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               answers: [domainBuilder.buildAnswer({ challengeId: 'previousChallengeId' })],
             });
 
-            assessmentRepository_getWithAnswersStub.withArgs(assessmentId).resolves(assessment);
             evaluationUsecases_getNextChallengeForPreviewStub
               .withArgs({})
               .resolves(domainBuilder.buildChallenge({ id: 'nextChallengeId' }));
             assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
 
-            await getNextChallenge(dependencies);
+            await getNextChallenge({ assessment, ...dependencies });
 
             expect(assessmentRepository_updateWhenNewChallengeIsAskedStub).to.have.been.calledWithExactly({
               id: assessmentId,

--- a/api/tests/shared/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/get-next-challenge_test.js
@@ -112,7 +112,25 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       });
     });
 
-    context('latest challenge asked', function () {
+    context('when assessment is started', function () {
+      it('should return an Assessment', async function () {
+        const assessment = domainBuilder.buildAssessment({
+          state: Assessment.states.STARTED,
+          type: Assessment.types.PREVIEW,
+          lastChallengeId: null,
+        });
+        assessmentRepository_getStub.withArgs(assessmentId).resolves(assessment);
+        assessmentRepository_updateLastQuestionDateStub.resolves();
+        assessmentRepository_updateWhenNewChallengeIsAskedStub.resolves();
+        const challenge = domainBuilder.buildChallenge({ id: 'challengeForPreview' });
+        evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
+        answerRepository_findByAssessmentStub.withArgs(assessment.id).resolves([domainBuilder.buildAnswer()]);
+
+        const assessmentWithNextChallenge = await getNextChallenge(dependencies);
+
+        expect(assessmentWithNextChallenge).to.deepEqualInstance(assessment);
+      });
+
       context('when there are no challenge saved as latest challenge asked in assessment', function () {
         it('should compute next challenge', async function () {
           const assessment = domainBuilder.buildAssessment({
@@ -127,9 +145,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
           answerRepository_findByAssessmentStub.withArgs(assessment.id).resolves([domainBuilder.buildAnswer()]);
 
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -149,9 +167,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             .withArgs(assessment.id)
             .resolves([domainBuilder.buildAnswer({ challengeId: 'previousChallengeId' })]);
 
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -178,9 +196,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
               ]);
             challengeRepository_getStub.withArgs('previousChallengeId').resolves(previousChallenge);
 
-            const actualNextChallenge = await getNextChallenge(dependencies);
+            const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-            expect(actualNextChallenge).to.deepEqualInstance(previousChallenge);
+            expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(previousChallenge);
           });
         });
 
@@ -203,9 +221,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
             answerRepository_findByAssessmentStub.withArgs(assessment.id).resolves([]);
             challengeRepository_getStub.withArgs('previousChallengeId').resolves(previousChallenge);
 
-            const actualNextChallenge = await getNextChallenge(dependencies);
+            const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-            expect(actualNextChallenge).to.deepEqualInstance(challenge);
+            expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
           });
         });
       });
@@ -229,9 +247,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         it('should call usecase and return value from preview usecase', async function () {
           const challenge = domainBuilder.buildChallenge({ id: 'challengeForPreview' });
           evaluationUsecases_getNextChallengeForPreviewStub.withArgs({}).resolves(challenge);
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -252,9 +270,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         it('should call usecase and return value from demo usecase', async function () {
           const challenge = domainBuilder.buildChallenge({ id: 'challengeForDemo' });
           evaluationUsecases_getNextChallengeForDemoStub.withArgs({ assessment }).resolves(challenge);
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -277,9 +295,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           evaluationUsecases_getNextChallengeForCampaignAssessmentStub
             .withArgs({ assessment, locale })
             .resolves(challenge);
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -302,9 +320,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           evaluationUsecases_getNextChallengeForCompetenceEvaluationStub
             .withArgs({ assessment, userId, locale })
             .resolves(challenge);
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -328,9 +346,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
           certificationEvaluationRepository_selectNextCertificationChallengeStub
             .withArgs({ assessmentId: assessment.id, locale })
             .resolves(challenge);
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.deepEqualInstance(challenge);
+          expect(assessmentWithNextChallenge.nextChallenge).to.deepEqualInstance(challenge);
         });
       });
 
@@ -350,9 +368,9 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
         });
 
         it('should return null', async function () {
-          const actualNextChallenge = await getNextChallenge(dependencies);
+          const assessmentWithNextChallenge = await getNextChallenge(dependencies);
 
-          expect(actualNextChallenge).to.be.null;
+          expect(assessmentWithNextChallenge.nextChallenge).to.be.null;
         });
       });
     });

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -18,6 +18,8 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
         certificationCourseId,
         answers,
       });
+      const challenge = domainBuilder.buildChallenge({ id: 'challenge0' });
+      assessment.nextChallenge = challenge;
       assessment.hasCheckpoints = false;
       assessment.showProgressBar = false;
       assessment.showLevelup = false;
@@ -74,6 +76,12 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
                 related: `/api/certification-courses/${certificationCourseId}`,
               },
             },
+            'next-challenge': {
+              data: {
+                id: 'challenge0',
+                type: 'challenges',
+              },
+            },
           },
         },
         included: [
@@ -85,6 +93,30 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
               name: assessment.course.name,
               'nb-challenges': assessment.course.nbChallenges,
             },
+          },
+          {
+            attributes: {
+              'alternative-instruction': 'Des instructions alternatives',
+              attachments: ['URL pièce jointe'],
+              'auto-reply': false,
+              'embed-height': undefined,
+              'embed-title': undefined,
+              'embed-url': undefined,
+              focused: false,
+              format: 'petit',
+              'illustration-alt': "Le texte de l'illustration",
+              'illustration-url': "Une URL vers l'illustration",
+              instruction: 'Des instructions',
+              locales: ['fr'],
+              proposals: 'Une proposition',
+              shuffled: false,
+              timer: undefined,
+              type: 'QCM',
+              'web-component-props': undefined,
+              'web-component-tag-name': undefined,
+            },
+            id: 'challenge0',
+            type: 'challenges',
           },
         ],
       };

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -36,6 +36,7 @@ export default class Assessment extends Model {
   @belongsTo('certification-course', { async: true, inverse: 'assessment' }) certificationCourse;
   @belongsTo('course', { async: true, inverse: null }) course;
   @belongsTo('progression', { async: true, inverse: null }) progression;
+  @belongsTo('challenge', { async: false, inverse: null }) nextChallenge;
 
   // methods
   @equal('type', 'CERTIFICATION') isCertification;

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -25,7 +25,7 @@ export default class ChallengeRoute extends Route {
       if (assessment.isPreview && params.challengeId) {
         challenge = await this.store.findRecord('challenge', params.challengeId);
       } else if (!assessment.isPreview) {
-        challenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
+        challenge = assessment.nextChallenge;
       }
     }
 

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -26,10 +26,10 @@ export default class ResumeRoute extends Route {
     if (!transition.to.parent.params.assessment_id) {
       this.assessmentHasNoMoreQuestions = false;
     } else {
-      const nextChallenge = await this.store.queryRecord('challenge', {
+      const assessment = await this.store.queryRecord('challenge', {
         assessmentId: transition.to.parent.params.assessment_id,
       });
-      this.assessmentHasNoMoreQuestions = !nextChallenge;
+      this.assessmentHasNoMoreQuestions = !assessment.nextChallenge;
     }
   }
 

--- a/mon-pix/mirage/routes/assessments/get-next-challenge.js
+++ b/mon-pix/mirage/routes/assessments/get-next-challenge.js
@@ -29,5 +29,7 @@ export default function (schema, request) {
   const allChallengeIds = map(allChallenges.models, 'id');
 
   const nextChallengeId = first(difference(allChallengeIds, answeredChallengeIds));
-  return nextChallengeId ? schema.challenges.find(nextChallengeId) : new Response(200, {}, { data: null });
+  const nextChallenge = nextChallengeId ? schema.challenges.find(nextChallengeId) : null;
+  assessment.nextChallenge = nextChallenge;
+  return assessment;
 }

--- a/mon-pix/mirage/routes/assessments/get-next-challenge.js
+++ b/mon-pix/mirage/routes/assessments/get-next-challenge.js
@@ -1,7 +1,6 @@
 import difference from 'lodash/difference';
 import first from 'lodash/first';
 import map from 'lodash/map';
-import { Response } from 'miragejs';
 
 export default function (schema, request) {
   const assessmentId = request.params.id;

--- a/mon-pix/mirage/routes/assessments/get-next-challenge.js
+++ b/mon-pix/mirage/routes/assessments/get-next-challenge.js
@@ -31,5 +31,8 @@ export default function (schema, request) {
   const nextChallengeId = first(difference(allChallengeIds, answeredChallengeIds));
   const nextChallenge = nextChallengeId ? schema.challenges.find(nextChallengeId) : null;
   assessment.nextChallenge = nextChallenge;
+
+  assessment.orderedChallengeIdsAnswered = answeredChallengeIds;
+
   return assessment;
 }

--- a/mon-pix/mirage/serializers/assessment.js
+++ b/mon-pix/mirage/serializers/assessment.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['answers', 'certificationCourse', 'progression'],
+  include: ['answers', 'certificationCourse', 'progression', 'nextChallenge'],
 });

--- a/mon-pix/tests/acceptance/application-test.js
+++ b/mon-pix/tests/acceptance/application-test.js
@@ -61,10 +61,11 @@ module('Acceptance | Application', function (hooks) {
 
     test('should rewrite id in URL', async function (assert) {
       // given
+      const challenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {});
       server.create('assessment', 'ofCompetenceEvaluationType', {
+        nextChallenge: challenge,
         id: 1,
       });
-      server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {});
 
       const metricService = this.owner.lookup('service:metrics');
       await visit('/assessments/1/challenges/0');
@@ -91,10 +92,11 @@ module('Acceptance | Application', function (hooks) {
     test('should forward query params', async function (assert) {
       // given
       const metricService = this.owner.lookup('service:metrics');
+      const challenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {});
       server.create('assessment', 'ofCompetenceEvaluationType', {
         id: 1,
+        nextChallenge: challenge,
       });
-      server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {});
 
       // when
       await visit('/assessments/1/challenges/0?id=1');

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -264,8 +264,9 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           const NB_CHALLENGES = 3;
 
           hooks.beforeEach(function () {
+            const challenges = [];
             for (let i = 0; i < NB_CHALLENGES; ++i) {
-              server.create('challenge', 'forCertification');
+              challenges.push(server.create('challenge', 'forCertification'));
             }
             certificationCourse = this.server.create('certification-course', {
               accessCode: 'ABCD12',
@@ -275,6 +276,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               lastName: 'Bravo',
             });
             assessment = certificationCourse.assessment;
+            assessment.update({ nextChallenge: challenges[NB_CHALLENGES - 1] });
 
             this.server.create('certification-candidate-subscription', {
               id: '2',
@@ -389,16 +391,18 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
         user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
 
         const NB_CHALLENGES = 3;
+        const challenges = [];
         for (let i = 0; i < NB_CHALLENGES; ++i) {
-          server.create('challenge', 'forCertification');
+          challenges.push(server.create('challenge', 'forCertification'));
         }
-        this.server.create('certification-course', {
+        const certificationCourse = this.server.create('certification-course', {
           accessCode: 'ABCD12',
           sessionId: 1,
           nbChallenges: NB_CHALLENGES,
           firstName: 'Laura',
           lastName: 'Bravo',
         });
+        certificationCourse.assessment.update({ nextChallenge: challenges[NB_CHALLENGES - 1] });
         this.server.create('certification-candidate-subscription', {
           id: '2',
           sessionId: 1,

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -463,7 +463,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           test('should redirect to "Votre surveillant a mis fin…"', async function (assert) {
             // given
             user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
-            server.create('challenge', 'forCertification');
+            const challenge = server.create('challenge', 'forCertification');
             server.create('challenge', 'forCertification');
             server.create('certification-course', {
               id: '99',
@@ -477,6 +477,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               certificationCourseId: 99,
               type: 'CERTIFICATION',
               state: assessmentStates.STARTED,
+              nextChallenge: challenge,
             });
             server.create('certification-candidate-subscription', {
               id: '2',
@@ -547,8 +548,8 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           // given
           user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
 
-          server.create('challenge', 'forCertification');
-
+          const challenge = server.create('challenge', 'forCertification');
+          const assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge });
           this.server.create('certification-course', {
             accessCode: 'ABCD12',
             sessionId: 1,
@@ -556,6 +557,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             firstName: 'Laura',
             lastName: 'Bravo',
             version: 2,
+            assessment,
           });
           this.server.create('certification-candidate-subscription', {
             id: '2',
@@ -597,7 +599,8 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           // given
           user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
 
-          server.create('challenge', 'forCertification');
+          const challenge = server.create('challenge', 'forCertification');
+          const assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge });
 
           this.server.create('certification-course', {
             accessCode: 'ABCD12',
@@ -606,6 +609,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             firstName: 'Laura',
             lastName: 'Bravo',
             version: 3,
+            assessment,
           });
 
           this.server.create('certification-candidate-subscription', {
@@ -643,7 +647,8 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
             await authenticate(user);
 
-            server.create('challenge', 'forCertification');
+            const challenge = server.create('challenge', 'forCertification');
+            const assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge });
 
             this.server.create('certification-course', {
               accessCode: 'ABCD12',
@@ -652,6 +657,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               firstName: 'Laura',
               lastName: 'Bravo',
               version: 3,
+              assessment,
             });
 
             this.server.create('certification-candidate-subscription', {

--- a/mon-pix/tests/acceptance/challenge-attachment-test.js
+++ b/mon-pix/tests/acceptance/challenge-attachment-test.js
@@ -13,8 +13,8 @@ module('Acceptance | Download an attachment from a challenge', function (hooks) 
   let assessment;
 
   hooks.beforeEach(function () {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     challengeWithAttachment = server.create('challenge', 'forCompetenceEvaluation', 'withAttachment');
+    assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challengeWithAttachment });
     server.create('challenge', 'forCompetenceEvaluation');
   });
 

--- a/mon-pix/tests/acceptance/challenge-commons-test.js
+++ b/mon-pix/tests/acceptance/challenge-commons-test.js
@@ -42,19 +42,15 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
 
   module('Challenge not answered', function (hooks) {
     let assessment;
-    let challengeBis;
 
     hooks.beforeEach(async function () {
       user = server.create('user', 'withEmail');
       await authenticate(user);
       assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
         title: 'Assessment title',
-      });
-      server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
-        instruction: 'Instruction [lien](http://www.a.link.example.url)',
-      });
-      challengeBis = server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
-        instruction: 'Second instruction',
+        nextChallenge: server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
+          instruction: 'Instruction [lien](http://www.a.link.example.url)',
+        }),
       });
     });
 
@@ -69,6 +65,11 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
     });
 
     test('should display the challenge to answered instead of challenge asked', async function (assert) {
+      // given
+      const challengeBis = server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
+        instruction: 'Second instruction',
+      });
+
       // when
       const screen = await visit(`/assessments/${assessment.id}/challenges/${challengeBis.id}`);
 
@@ -157,9 +158,10 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
   module('When user is anonymous', function () {
     test('should not display home link', async function (assert) {
       //given
-      const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-      server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
-        instruction: 'Instruction [lien](http://www.a.link.example.url)',
+      const assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
+        nextChallenge: server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
+          instruction: 'Instruction [lien](http://www.a.link.example.url)',
+        }),
       });
       const user = server.create('user', 'withEmail', {
         isAnonymous: true,

--- a/mon-pix/tests/acceptance/challenge-feedback-test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback-test.js
@@ -15,8 +15,8 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
   let firstChallenge;
 
   hooks.beforeEach(function () {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     firstChallenge = server.create('challenge', 'forCompetenceEvaluation');
+    assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: firstChallenge });
     server.create('challenge', 'forCompetenceEvaluation');
   });
 

--- a/mon-pix/tests/acceptance/challenge-item-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm-test.js
@@ -11,8 +11,8 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
   let qcmChallenge;
 
   hooks.beforeEach(async function () {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcmChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCM');
+    assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qcmChallenge });
   });
 
   module('When challenge is not already answered', function (hooks) {

--- a/mon-pix/tests/acceptance/challenge-item-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu-test.js
@@ -16,8 +16,10 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
   let qcuChallenge;
 
   hooks.beforeEach(async function () {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcuChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCU');
+    assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
+      nextChallenge: qcuChallenge,
+    });
   });
 
   module('When challenge is not already answered', function (hooks) {
@@ -28,7 +30,7 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
       screen = await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    test('should render challenge information and question', function (assert) {
+    test('should render challenge information and question', async function (assert) {
       // then
       assert.ok(screen.getByText(qcuChallenge.instruction));
       assert.strictEqual(screen.getAllByRole('radio', { name: /possibilite/ }).length, 4);

--- a/mon-pix/tests/acceptance/challenge-item-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc-test.js
@@ -68,9 +68,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       hooks.beforeEach(async function () {
         // given
-        assessment.update({
-          nextChallenge: this.server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withEmbed'),
-        });
+        this.server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withEmbed');
 
         // when
         screen = await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -236,7 +234,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       hooks.beforeEach(async function () {
         qrocWithFile1Challenge = this.server.create('challenge', 'forDemo', 'QROCwithFile1');
         qrocWithFile2Challenge = this.server.create('challenge', 'forDemo', 'QROCwithFile2');
-        assessment = this.server.create('assessment', 'ofDemoType');
+        assessment = this.server.create('assessment', 'ofDemoType', { nextChallenge: qrocWithFile1Challenge });
 
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
@@ -270,8 +268,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
   module('with text-area format', function (hooks) {
     hooks.beforeEach(async function () {
-      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = this.server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withTextArea');
+      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocChallenge });
     });
 
     module('When challenge is not already answered', function (hooks) {
@@ -387,8 +385,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
   module('with select format', function (hooks) {
     hooks.beforeEach(async function () {
-      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = this.server.create('challenge', 'forCompetenceEvaluation', 'QROCWithSelect');
+      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocChallenge });
     });
 
     module('When challenge is not already answered', function () {

--- a/mon-pix/tests/acceptance/challenge-item-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc-test.js
@@ -14,8 +14,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
   module('with input format', function (hooks) {
     hooks.beforeEach(async function () {
-      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = this.server.create('challenge', 'forCompetenceEvaluation', 'QROC');
+      assessment = this.server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocChallenge });
     });
 
     module('When challenge is an auto validated embed (autoReply=true)', function (hooks) {
@@ -59,7 +59,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         // then
         await click(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')));
-        assert.ok(currentURL().includes(`/assessments/${assessment.id}/challenges/2`));
+        assert.strictEqual(currentURL(), `/assessments/${assessment.id}/challenges/2`);
       });
     });
 
@@ -68,7 +68,9 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       hooks.beforeEach(async function () {
         // given
-        this.server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withEmbed');
+        assessment.update({
+          nextChallenge: this.server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withEmbed'),
+        });
 
         // when
         screen = await visit(`/assessments/${assessment.id}/challenges/0`);

--- a/mon-pix/tests/acceptance/challenge-item-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm-test.js
@@ -15,17 +15,15 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   let assessment;
   let qrocmDepChallenge;
 
-  hooks.beforeEach(async function () {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-  });
-
   module('When challenge is not already answered', function () {
     module('and challenge only has input fields', function (hooks) {
       let screen;
 
       hooks.beforeEach(async function () {
-        // when
+        // given
         qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocmDepChallenge });
+        // when
         screen = await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
@@ -82,10 +80,15 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       });
     });
 
-    module('and challenge contains select field', function () {
+    module('and challenge contains select field', function (hooks) {
+      hooks.beforeEach(async function () {
+        // given
+        qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocmDepChallenge });
+      });
+
       test('should not be able to validate with the initial option', async function (assert) {
         // given
-        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
@@ -98,7 +101,6 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       test('should not be able to validate the empty option', async function (assert) {
         // given
-        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
@@ -113,7 +115,6 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       test('should validate an option and redirect to next page', async function (assert) {
         // given
-        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
@@ -134,12 +135,14 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       hooks.beforeEach(async function () {
         // given
+        const alreadyAnsweredChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
         qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocmDepChallenge });
         server.create('answer', {
           value: "station1: 'Republique'\nstation2: 'Chatelet'\n",
           result: 'ko',
           assessment,
-          challenge: qrocmDepChallenge,
+          challenge: alreadyAnsweredChallenge,
         });
 
         // when
@@ -164,12 +167,14 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
     module('and challenge contains select field', function () {
       test('should set the select with previous answer and propose to continue', async function (assert) {
         // given
-        const qrocmWithSelectChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        const alreadyAnsweredChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: qrocmDepChallenge });
         server.create('answer', {
           value: "banana: 'mango'\n",
           result: 'ko',
           assessment,
-          challenge: qrocmWithSelectChallenge,
+          challenge: alreadyAnsweredChallenge,
         });
 
         // when
@@ -196,6 +201,8 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
     hooks.beforeEach(async function () {
       // given
+      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+
       qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
       qrocmIndChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMind');
       qrocmIndSelectChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');

--- a/mon-pix/tests/acceptance/challenge-item-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-test.js
@@ -23,8 +23,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         let screen;
         test('should display a specific page title', async function (assert) {
           // given
-          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-          server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+          const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
           // when
           await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -42,8 +42,13 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               });
               await authenticate(user);
 
-              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              const challenge = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
               // when
               await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -68,8 +73,13 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             module('when user closes tooltip', function (hooks) {
               hooks.beforeEach(async function () {
                 // given
-                assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-                server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+                const challenge = server.create(
+                  'challenge',
+                  'forCompetenceEvaluation',
+                  data.challengeType,
+                  'withFocused',
+                );
+                assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
                 // when
                 screen = await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -141,8 +151,13 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               });
               await authenticate(user);
 
-              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              const challenge = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
               screen = await visit(`/assessments/${assessment.id}/challenges/0`);
             });
@@ -160,9 +175,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               assert
                 .dom(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')))
                 .doesNotHaveAttribute('aria-disabled');
-              assert
-                .dom(find('[data-test="challenge-response-proposal-selector"]'))
-                .doesNotHaveAttribute('aria-disabled');
+              assert.dom(find('[data-test="challenge-response-proposal-selector"]')).doesNotHaveAttribute('disabled');
             });
           });
         });
@@ -209,8 +222,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               );
               focusedCertificationChallengeWarningManager.reset();
 
-              assessment = server.create('assessment', 'ofCertificationType');
-              server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+              const challenge = server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+              assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge });
 
               const certificationCourse = server.create('certification-course', {
                 accessCode: 'ABCD12',
@@ -219,9 +232,9 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                 firstName: 'Laura',
                 lastName: 'Bravo',
                 version: 2,
+                assessment,
               });
-              assessment = certificationCourse.assessment;
-              screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+              screen = await visit(`/assessments/${certificationCourse.assessment.id}/challenges/0`);
               await click(screen.getByRole('button', { name: 'Je suis prêt' }));
               await triggerEvent(document, 'focusedout');
             });
@@ -253,8 +266,13 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           module('when assessment is not of type certification', function (hooks) {
             hooks.beforeEach(async function () {
               // given
-              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              const challenge = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
@@ -283,8 +301,10 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               hasSeenFocusedChallengeTooltip: true,
             });
             await authenticate(user);
-            assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeUnfocus');
-            server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+            const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+            assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeUnfocus', {
+              nextChallenge: challenge,
+            });
 
             // when
             screen = await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -318,13 +338,27 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           module('when user goes to another assessment', function () {
             test('should not display a warning alert saying it has been focused out', async function (assert) {
               // given
+              const focusedChallenge1 = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
+              const focusedChallenge2 = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
               const assessment1 = server.create(
                 'assessment',
                 'ofCompetenceEvaluationType',
                 'withCurrentChallengeUnfocus',
+                { nextChallenge: focusedChallenge1 },
               );
-              const assessment2 = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              const assessment2 = server.create('assessment', 'ofCompetenceEvaluationType', {
+                nextChallenge: focusedChallenge2,
+              });
               await visit(`/assessments/${assessment1.id}/challenges/0`);
 
               // when
@@ -340,8 +374,15 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           module('when user returns to the same assessment', function () {
             test('should display a warning alert saying it has been focused out', async function (assert) {
               // given
-              const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              const challenge = server.create(
+                'challenge',
+                'forCompetenceEvaluation',
+                data.challengeType,
+                'withFocused',
+              );
+              const assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
+                nextChallenge: challenge,
+              });
               await visit(`/assessments/${assessment.id}/challenges/0`);
 
               // when
@@ -356,83 +397,43 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         });
       });
 
-      [
-        { challengeType: 'QROC' },
-        { challengeType: 'QROCM' },
-        { challengeType: 'QCM' },
-        { challengeType: 'QCU' },
-      ].forEach(function (data) {
-        module(`when ${data.challengeType} challenge is not focused`, function () {
-          // eslint-disable-next-line qunit/no-identical-names
-          module('when user has not answered the question', function () {
-            module('when user has not seen the challenge tooltip yet', function (hooks) {
-              let screen;
+      module(`when ${data.challengeType} challenge is not focused`, function () {
+        // eslint-disable-next-line qunit/no-identical-names
+        module('when user has not answered the question', function () {
+          module('when user has not seen the challenge tooltip yet', function (hooks) {
+            let screen;
+            hooks.beforeEach(async function () {
+              // given
+              const user = server.create('user', 'withEmail', {
+                hasSeenOtherChallengesTooltip: false,
+              });
+              await authenticate(user);
+
+              const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
+
+              // when
+              screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+            });
+
+            test('should display a tooltip', async function (assert) {
+              // then
+              assert.dom('.tooltip-tag__information').exists();
+            });
+
+            module('when user closes tooltip', function (hooks) {
               hooks.beforeEach(async function () {
                 // given
-                const user = server.create('user', 'withEmail', {
-                  hasSeenOtherChallengesTooltip: false,
-                });
-                await authenticate(user);
-
-                assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-                server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+                const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+                assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
                 // when
                 screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+                await click('.tooltip-tag-information__button');
               });
 
-              test('should display a tooltip', async function (assert) {
+              test('should hide a tooltip', async function (assert) {
                 // then
-                assert.dom('.tooltip-tag__information').exists();
-              });
-
-              module('when user closes tooltip', function (hooks) {
-                hooks.beforeEach(async function () {
-                  // given
-                  assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-                  server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
-
-                  // when
-                  screen = await visit(`/assessments/${assessment.id}/challenges/0`);
-                  await click('.tooltip-tag-information__button');
-                });
-
-                test('should hide a tooltip', async function (assert) {
-                  // then
-                  assert.dom('#challenge-statement-tag--tooltip').doesNotExist();
-                });
-
-                test('should enable input and buttons', async function (assert) {
-                  // then
-                  assert
-                    .dom(screen.getByLabelText(t('pages.challenge.actions.skip-go-to-next')))
-                    .doesNotHaveAttribute('aria-disabled');
-                  assert
-                    .dom(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')))
-                    .doesNotHaveAttribute('aria-disabled');
-
-                  assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
-                });
-              });
-            });
-
-            module('when user has already seen challenge tooltip', function (hooks) {
-              let screen;
-              hooks.beforeEach(async function () {
-                const user = server.create('user', 'withEmail', {
-                  hasSeenOtherChallengesTooltip: true,
-                });
-                await authenticate(user);
-
-                assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-                server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
-
-                screen = await visit(`/assessments/${assessment.id}/challenges/0`);
-              });
-
-              test('should hide the overlay and tooltip', async function (assert) {
-                // then
-                assert.dom('.challenge__overlay').doesNotExist();
                 assert.dom('#challenge-statement-tag--tooltip').doesNotExist();
               });
 
@@ -450,71 +451,99 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             });
           });
 
-          // eslint-disable-next-line qunit/no-identical-names
-          module('when user has already answered the question', function () {
-            test('should not display the overlay, dashed-border and warning messages', async function (assert) {
-              // given
-              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('answer', {
-                value: 'Reponse',
-                result: 'ko',
-                assessment,
-                challenge: server.create(
-                  'challenge',
-                  'forCompetenceEvaluation',
-                  `${data.challengeType}`,
-                  'withFocused',
-                ),
+          module('when user has already seen challenge tooltip', function (hooks) {
+            let screen;
+            hooks.beforeEach(async function () {
+              const user = server.create('user', 'withEmail', {
+                hasSeenOtherChallengesTooltip: true,
               });
+              await authenticate(user);
 
-              // when
-              await visit(`/assessments/${assessment.id}/challenges/0`);
-              const challengeItem = find('.challenge-item');
-              await triggerEvent(challengeItem, 'mouseleave');
+              const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+              assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
 
+              screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+            });
+
+            test('should hide the overlay and tooltip', async function (assert) {
               // then
-              assert.dom(find('.challenge__info-alert--could-show')).doesNotExist();
-              assert.dom(find('.challenge__focused-out-overlay')).doesNotExist();
-              assert.dom(find('.challenge-actions__focused-out-of-window')).doesNotExist();
-              assert.dom(find('.challenge-actions__already-answered')).exists();
+              assert.dom('.challenge__overlay').doesNotExist();
+              assert.dom('#challenge-statement-tag--tooltip').doesNotExist();
+            });
+
+            test('should enable input and buttons', async function (assert) {
+              // then
+              assert
+                .dom(screen.getByLabelText(t('pages.challenge.actions.skip-go-to-next')))
+                .doesNotHaveAttribute('aria-disabled');
+              assert
+                .dom(screen.getByLabelText(t('pages.challenge.actions.validate-go-to-next')))
+                .doesNotHaveAttribute('aria-disabled');
+
+              assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
             });
           });
+        });
 
-          test('should not display warning block', async function (assert) {
+        // eslint-disable-next-line qunit/no-identical-names
+        module('when user has already answered the question', function () {
+          test('should not display the overlay, dashed-border and warning messages', async function (assert) {
             // given
             assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-            server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+            server.create('answer', {
+              value: 'Reponse',
+              result: 'ko',
+              assessment,
+              challenge: server.create('challenge', 'forCompetenceEvaluation', `${data.challengeType}`, 'withFocused'),
+            });
 
             // when
             await visit(`/assessments/${assessment.id}/challenges/0`);
+            const challengeItem = find('.challenge-item');
+            await triggerEvent(challengeItem, 'mouseleave');
 
             // then
-            assert.dom('.challenge__info-alert').doesNotExist();
+            assert.dom(find('.challenge__info-alert--could-show')).doesNotExist();
+            assert.dom(find('.challenge__focused-out-overlay')).doesNotExist();
+            assert.dom(find('.challenge-actions__focused-out-of-window')).doesNotExist();
+            assert.dom(find('.challenge-actions__already-answered')).exists();
+          });
+        });
+
+        test('should not display warning block', async function (assert) {
+          // given
+          const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
+
+          // when
+          await visit(`/assessments/${assessment.id}/challenges/0`);
+
+          // then
+          assert.dom('.challenge__info-alert').doesNotExist();
+        });
+
+        module('when user has focused out of document', function (hooks) {
+          hooks.beforeEach(async function () {
+            // given
+            const user = server.create('user', 'withEmail');
+            await authenticate(user);
+            const challenge = server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+            assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
+
+            // when
+            await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          module('when user has focused out of document', function (hooks) {
-            hooks.beforeEach(async function () {
-              // given
-              const user = server.create('user', 'withEmail');
-              await authenticate(user);
-              assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-              server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
+          test('should not display instructions', async function (assert) {
+            // then
+            assert.dom('.focused-challenge-instructions-action__confirmation-button').doesNotExist();
+          });
 
-              // when
-              await visit(`/assessments/${assessment.id}/challenges/0`);
-            });
-
-            test('should not display instructions', async function (assert) {
-              // then
-              assert.dom('.focused-challenge-instructions-action__confirmation-button').doesNotExist();
-            });
-
-            test('should not display a warning alert', async function (assert) {
-              // when
-              await triggerEvent(document, 'focusedout');
-              // then
-              assert.dom('.challenge-actions__focused-out-of-window').doesNotExist();
-            });
+          test('should not display a warning alert', async function (assert) {
+            // when
+            await triggerEvent(document, 'focusedout');
+            // then
+            assert.dom('.challenge-actions__focused-out-of-window').doesNotExist();
           });
         });
       });
@@ -533,8 +562,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         );
         focusedCertificationChallengeWarningManager.reset();
 
-        assessment = server.create('assessment', 'ofCertificationType');
-        server.create('challenge', 'forCertification', 'QCM', 'withFocused');
+        const challenge1 = server.create('challenge', 'forCertification', 'QCM', 'withFocused');
+        assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge1 });
         server.create('challenge', 'forCertification', 'QCM', 'withFocused');
 
         const certificationCourse = server.create('certification-course', {
@@ -543,6 +572,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           nbChallenges: 2,
           firstName: 'Laura',
           lastName: 'Bravo',
+          assessment,
         });
         assessment = certificationCourse.assessment;
 
@@ -572,10 +602,11 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         );
         focusedCertificationChallengeWarningManager.reset();
 
-        assessment = server.create('assessment', 'ofCertificationType');
-        server.create('challenge', 'forCertification', 'QCM', 'withFocused');
         server.create('challenge', 'forCertification', 'QCM');
         server.create('challenge', 'forCertification', 'QCM', 'withFocused');
+        assessment = server.create('assessment', 'ofCertificationType', {
+          nextChallenge: server.create('challenge', 'forCertification', 'QCM', 'withFocused'),
+        });
 
         const certificationCourse = server.create('certification-course', {
           accessCode: 'ABCD12',
@@ -583,6 +614,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           nbChallenges: 2,
           firstName: 'Laura',
           lastName: 'Bravo',
+          assessment,
         });
         assessment = certificationCourse.assessment;
 
@@ -613,8 +645,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         );
         focusedCertificationChallengeWarningManager.reset();
 
-        assessment = server.create('assessment', 'ofCertificationType');
-        server.create('challenge', 'forCertification', 'QCM', 'withFocused', { timer: 60 });
+        const challenge = server.create('challenge', 'forCertification', 'QCM', 'withFocused', { timer: 60 });
+        assessment = server.create('assessment', 'ofCertificationType', { nextChallenge: challenge });
 
         const certificationCourse = server.create('certification-course', {
           accessCode: 'ABCD12',
@@ -622,6 +654,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           nbChallenges: 2,
           firstName: 'Alin',
           lastName: 'Cendy',
+          assessment,
         });
         assessment = certificationCourse.assessment;
 
@@ -678,6 +711,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
         firstName: 'Laura',
         lastName: 'Bravo',
         version: 2,
+        assessment,
       });
       assessment = certificationCourse.assessment;
     });
@@ -686,7 +720,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
       function (data) {
         module(`when ${data.challengeType} challenge is focused`, function (hooks) {
           hooks.beforeEach(function () {
-            server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+            const challenge = server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+            assessment.update({ nextChallenge: challenge });
           });
           module('when user has not answered the question', function () {
             module('when user has not seen the challenge tooltip yet', function (hooks) {
@@ -798,11 +833,11 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             type: 'CERTIFICATION',
             title: 'assessment COMPANION',
             hasOngoingCompanionLiveAlert: true,
+            nextChallenge: server.create('challenge', 'forCertification', 'QCM'),
           }),
         });
 
         assessment = certificationCourse.assessment;
-        server.create('challenge', 'forCertification', 'QCM');
 
         // when
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -824,15 +859,15 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
         assessment = server.create('assessment', 'ofCertificationType');
 
-        const certificationCourse = server.create('certification-course', {
+        server.create('certification-course', {
           accessCode: 'ABCD12',
           sessionId: 1,
           nbChallenges: 1,
           firstName: 'Laura',
           lastName: 'Bravo',
           version: 3,
+          assessment,
         });
-        assessment = certificationCourse.assessment;
       });
 
       [
@@ -843,7 +878,9 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
       ].forEach(function (data) {
         module(`when ${data.challengeType} challenge is focused`, function (hooks) {
           hooks.beforeEach(function () {
-            server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+            assessment.update({
+              nextChallenge: server.create('challenge', 'forCertification', data.challengeType, 'withFocused'),
+            });
           });
           module('when user has not answered the question', function () {
             module('when user has not seen the challenge tooltip yet', function (hooks) {
@@ -939,7 +976,6 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
     module('when certification is adjusted', function (hooks) {
       let screen;
-      let certificationCourse;
       hooks.beforeEach(function () {
         const focusedCertificationChallengeWarningManager = this.owner.lookup(
           'service:focused-certification-challenge-warning-manager',
@@ -948,7 +984,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
         assessment = server.create('assessment', 'ofCertificationType');
 
-        certificationCourse = server.create('certification-course', {
+        server.create('certification-course', {
           accessCode: 'ABCD12',
           sessionId: 1,
           nbChallenges: 1,
@@ -956,8 +992,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           lastName: 'Bravo',
           version: 3,
           isAdjustedForAccessibility: true,
+          assessment,
         });
-        assessment = certificationCourse.assessment;
       });
 
       [
@@ -968,7 +1004,9 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
       ].forEach(function (data) {
         module(`when ${data.challengeType} challenge is focused`, function (hooks) {
           hooks.beforeEach(function () {
-            server.create('challenge', 'forCertification', data.challengeType, 'withFocused');
+            assessment.update({
+              nextChallenge: server.create('challenge', 'forCertification', data.challengeType, 'withFocused'),
+            });
           });
           module('when user has not answered the question', function () {
             module('when user has not seen the challenge tooltip yet', function (hooks) {
@@ -1075,14 +1113,12 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             type: 'CERTIFICATION',
             title: 'assessment COMPANION',
             hasOngoingCompanionLiveAlert: true,
+            nextChallenge: server.create('challenge', 'forCertification', 'QCM'),
           }),
         });
 
-        assessment = certificationCourse.assessment;
-        server.create('challenge', 'forCertification', 'QCM');
-
         // when
-        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${certificationCourse.assessment.id}/challenges/0`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Signaler un problème avec la question' })).doesNotExist();

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -67,11 +67,12 @@ module('Acceptance | Challenge page banner', function (hooks) {
 
       hooks.beforeEach(function () {
         server.create('feature-toggle', { id: '0', isTextToSpeechButtonEnabled: true });
-        assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
-          title: 'Assessment title',
-        });
         challenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
           instruction: 'Instruction à lire',
+        });
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', {
+          title: 'Assessment title',
+          nextChallenge: challenge,
         });
       });
 

--- a/mon-pix/tests/acceptance/challenge-timed-test.js
+++ b/mon-pix/tests/acceptance/challenge-timed-test.js
@@ -16,8 +16,8 @@ module('Acceptance | Timed challenge', function (hooks) {
     module('when asking for confirmation', function (hooks) {
       hooks.beforeEach(async function () {
         // given
-        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
         timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: timedChallenge });
 
         // when
         await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -36,8 +36,8 @@ module('Acceptance | Timed challenge', function (hooks) {
       module('and the challenge has not been already answered', function (hooks) {
         hooks.beforeEach(async function () {
           // given
-          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
           timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: timedChallenge });
 
           // when
           await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -91,8 +91,10 @@ module('Acceptance | Timed challenge', function (hooks) {
       let screen;
       hooks.beforeEach(async function () {
         // given
-        assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeTimeout');
         timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeTimeout', {
+          nextChallenge: timedChallenge,
+        });
 
         // when
         screen = await visit(`/assessments/${assessment.id}/challenges/0`);
@@ -121,8 +123,8 @@ module('Acceptance | Timed challenge', function (hooks) {
   module('when user seen two timed challenge', function (hooks) {
     hooks.beforeEach(async function () {
       // given
-      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+      assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: timedChallenge });
       server.create('challenge', 'forCompetenceEvaluation', 'timed');
 
       // when
@@ -142,8 +144,8 @@ module('Acceptance | Timed challenge', function (hooks) {
 
   module('Not Timed Challenge', function (hooks) {
     hooks.beforeEach(function () {
-      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-      server.create('challenge', 'forCompetenceEvaluation');
+      const nextChallenge = server.create('challenge', 'forCompetenceEvaluation');
+      assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge });
     });
 
     test('should display the challenge statement', async function (assert) {

--- a/mon-pix/tests/acceptance/resume-competence-evaluations-test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations-test.js
@@ -49,11 +49,12 @@ module('Acceptance | Competence Evaluations | Resume Competence Evaluations', f
       module('When competence evaluation exists', function () {
         test('should redirect to assessment', async function (assert) {
           // given & when
+          server.create('challenge', { id: 'recCOMPEVAL0', instruction: 'consigne de test' });
           const screen = await visit('/competences/1/evaluer');
 
           // then
-          assert.ok(currentURL().includes('/assessments/'));
-          assert.dom(screen.getByRole('banner')).exists();
+          assert.strictEqual(currentURL(), '/assessments/1/challenges/0');
+          assert.dom(screen.getByText('consigne de test')).exists();
         });
       });
 

--- a/mon-pix/tests/acceptance/tutorial-actions-test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions-test.js
@@ -18,8 +18,8 @@ module('Acceptance | Tutorial | Actions', function (hooks) {
     user = server.create('user', 'withEmail');
     firstScorecard = user.scorecards.models[0];
     competenceId = firstScorecard.competenceId;
-    const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-    server.create('challenge', 'forCompetenceEvaluation', 'QCM');
+    const challenge = server.create('challenge', 'forCompetenceEvaluation', 'QCM');
+    const assessment = server.create('assessment', 'ofCompetenceEvaluationType', { nextChallenge: challenge });
     server.create('competence-evaluation', { user, competenceId, assessment });
 
     // when

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -73,20 +73,19 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
     });
 
     module('when accessing next challenge', function () {
-      test('should correctly call the store to find assessment and challenge', async function (assert) {
+      test('should correctly call the store to find assessment', async function (assert) {
         // given
         model.assessment.orderedChallengeIdsAnswered = [];
         const challenge = Symbol('challenge');
-        queryRecordStub.withArgs('challenge', { assessmentId: model.assessment.id }).resolves(challenge);
+        model.assessment.nextChallenge = challenge;
 
         // when
         const returnedModel = await route.model(params);
 
         // then
         sinon.assert.calledWith(route.modelFor, 'assessments');
-        sinon.assert.calledOnceWithExactly(queryRecordStub, 'challenge', { assessmentId: assessment.id });
         assert.strictEqual(returnedModel.answer, null);
-        assert.strictEqual(returnedModel.challenge, challenge);
+        assert.strictEqual(returnedModel.assessment.nextChallenge, challenge);
       });
     });
 

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -1,5 +1,4 @@
 import EmberObject from '@ember/object';
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -8,20 +7,9 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
   setupTest(hooks);
 
   let route;
-  let storeStub;
-  let findRecordStub;
-  let queryRecordStub;
 
   hooks.beforeEach(function () {
-    findRecordStub = sinon.stub();
-    queryRecordStub = sinon.stub();
-    storeStub = Service.create({
-      findRecord: findRecordStub,
-      queryRecord: queryRecordStub,
-    });
-
     route = this.owner.lookup('route:assessments.resume');
-    this.owner.register('service:store', storeStub);
     route.router = { replaceWith: sinon.stub() };
   });
 
@@ -42,11 +30,7 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
     });
 
     module('when the next challenge exists', function (hooks) {
-      let nextChallenge;
-
       hooks.beforeEach(function () {
-        nextChallenge = EmberObject.create({ id: '456' });
-        queryRecordStub.resolves(nextChallenge);
         route.assessmentHasNoMoreQuestions = false;
       });
 
@@ -136,7 +120,6 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
 
     module('when the next challenge does not exist (is null)', function (hooks) {
       hooks.beforeEach(function () {
-        queryRecordStub.resolves(null);
         route.assessmentHasNoMoreQuestions = true;
       });
 


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de l'enchainement d'épreuves dans Pix App, on constate que les appels pour déterminer et obtenir la prochaine épreuve sont faits en double, comme on peut le voir sur la capture d'écran ci-dessous.

<img width="575" alt="Appels réseaux enregistrés suite au passage de 2 épreuves" src="https://github.com/user-attachments/assets/3d994f7a-f614-4ae0-8726-e5864855de37" />

Le passage d'épreuves étant de loin la fonctionnalité la plus utilisée cela surcharge inutilement les conteneurs d'API et dégrade la performance globale de la plateforme.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

En analysant le code, on constate que la route `GET /api/assessments/:id/next` retourne une épreuve.
On décide donc dans un premier temps que cette route retourne l'assessment mis à jour, en lui ajoutant une relation avec une épreuve qu'on appelle `nextChallenge`.
On inclut les données de cette épreuve dans la réponse afin de ne pas nécessiter un appel d'api pour obtenir les données de l'épreuve.

Cela donne l'enchainement de requêtes réseau suivant : 
<img width="786" alt="Capture d’écran 2025-07-07 à 09 08 59" src="https://github.com/user-attachments/assets/a0fce8ed-0367-44cb-93ca-42b846eda13e" />


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

Plusieurs améliorations/refactoring ont été volontairement laissés de côté dans cette PR afin d'avoir une version minimale fonctionnelle.
On s'est noté pour le futur les modifications suivantes à apporter : 
- Déplacer les règles sur l'assessment du front vers le back
- Déplacer les règles depuis le serializer de l'assessment vers un modèle dédié
- Renommer le usecase `getNextChallenge` puisqu'il retourne un assessment désormais
- Utiliser l'adapter Assessment plutôt que l'adapter Challenge pour initier l'appel à `GET /api/assessments/:id/next` depuis le front.

## 🏄 Pour tester

En preview, en évaluation de compétences, en certification, en campagine et en démo, enchainer des épreuves et vérifier que la progression et les checkpoints sont bien affichés.

Tester de revenir sur une épreuve déjà répondue.

Tester également l'affichage des corrections.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
