### PR TITLE
[FEATURE] Indiquer à l'utilisateur que ses résultats seront transmis automatiquement à la fin de son parcours (PIX-18482)

### DIFF
--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -62,6 +62,7 @@ export default class CampaignStartBlock extends Component {
   </template>
   @service currentUser;
   @service session;
+  @service featureToggles;
   @service intl;
 
   get showWarningMessage() {
@@ -94,6 +95,9 @@ export default class CampaignStartBlock extends Component {
   }
 
   get legalText() {
+    if (this.featureToggles.featureToggles.isAutoShareEnabled && this.campaignType === 'assessment') {
+      return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal-with-auto-share`);
+    }
     return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal`);
   }
 

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -10,6 +11,15 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | campaign-start-block', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    class FeatureTogglesStub extends Service {
+      featureToggles = {
+        isAutoShareEnabled: false,
+      };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesStub);
+  });
 
   module('When the organization has a logo and landing page text', function () {
     test('should display organization logo and landing page text', async function (assert) {
@@ -150,6 +160,24 @@ module('Integration | Component | campaign-start-block', function (hooks) {
           )
           .exists();
         assert.dom(screen.getByText(t('pages.campaign-landing.assessment.legal'))).exists();
+      });
+
+      test('should display legal with auto share', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = {
+            isAutoShareEnabled: true,
+          };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        // when
+        const screen = await render(
+          hbs`<CampaignStartBlock @campaign={{this.campaign}} @startCampaignParticipation={{this.startCampaignParticipation}} />`,
+        );
+
+        // then
+        assert.ok(screen.getByText(t('pages.campaign-landing.assessment.legal-with-auto-share')));
       });
 
       test('should display the userName', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -583,6 +583,7 @@
           "title": "Measure your digital skills with fun and educational challenges that adapt to your level of proficiency  (through an adaptive algorithm)."
         },
         "legal": "By clicking on “Begin“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your customised test, your results will be shared with your organisation when clicking on “Submit my results“.",
+        "legal-with-auto-share": "By clicking on “Begin your test“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your test, your results will be automatically shared with your organisation.",
         "title": "Begin your customised test",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ready to assess your digital skills?"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -574,6 +574,7 @@
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
+        "legal-with-autoshare": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -583,6 +583,7 @@
           "title": "Mesurer vos compétences numériques avec des défis ludiques et apprenants qui s'adaptent à votre niveau de maîtrise (via un algorithme adaptatif)."
         },
         "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. A la fin du parcours, en cliquant sur le bouton “J’envoie mes résultats” vos résultats seront transmis à l’organisateur.",
+        "legal-with-auto-share": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. À la fin du parcours, vos résultats seront transmis automatiquement à l’organisateur.",
         "title": "Commencez votre parcours Pix",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' prêt à évaluer vos compétences numériques ?"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -574,6 +574,7 @@
           "title": "Meet je digitale vaardigheden met leuke leeruitdagingen die zich aanpassen aan je vaardigheidsniveau (met behulp van een adaptief algoritme)."
         },
         "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Als je aan het einde van de cursus op de knop \"Stuur mijn resultaten\" klikt, worden je resultaten naar de organisator gestuurd.",
+        "legal-with-auto-share": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
         "title": "Begin je Pix-reis",
         "title-with-username": "<span>{userFirstName},</span><br> ben je klaar om je vaardigheden te testen?"
       },


### PR DESCRIPTION
## 🔆 Problème

Dans l'objectif de retirer le bouton d'envoie des résultats, on souhaite indiquer à l'utilisateur au début de son parcour que ses résultats seront transmis automatiquement.

## ⛱️ Proposition

Sous feature toggle, modifier le message.

## 🌊 Remarques

Cela ne concerne que les parcours classique, accès simplifiés, pas la collecte de profile.

## 🏄 Pour tester

- Vérifier que le feature toggle est activé:
```shell
npm run toggles -- -k isAutoShareEnabled
```
- L'activer si besoin:
```
npm run toggles -- -k isAutoShareEnabled -v true
```
- Se connecter sur pix-app,
- Accéder à la campagne avec le code PROASSMUL,
- Constater que le message indiquant que l'utilisateur pourra cliquer sur le bouton pour envoyer ses résultats a été remplacé par l'indication qu'ills seront envoyés automatiquement.