### PR TITLE
[FEATURE] N'avoir qu'un seul logger afin d'être sur d'avoir les correlationId lorsque nécessaire (PIX-18554)

### DIFF
--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -11,7 +11,6 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcError, OidcMissingFieldsError } from '../../../shared/domain/errors.js';
 import { AuthenticationMethod, AuthenticationSessionContent } from '../../../shared/domain/models/index.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { DEFAULT_CLAIM_MAPPING } from '../constants/oidc-identity-providers.js';
 import { ClaimManager } from '../models/ClaimManager.js';
@@ -328,5 +327,5 @@ function _monitorOidcError(message, { data, error, event }) {
     error.response && Object.assign(monitoringData.error, { response: error.response });
   }
 
-  monitoringTools.logErrorWithCorrelationIds(monitoringData);
+  logger.error(monitoringData);
 }

--- a/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/find-user-for-oidc-reconciliation.usecase.js
@@ -1,5 +1,5 @@
 import { UserNotFoundError } from '../../../shared/domain/errors.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import {
   AuthenticationKeyExpired,
   DifferentExternalIdentifierError,
@@ -51,7 +51,7 @@ const findUserForOidcReconciliation = async function ({
       const isDifferentFromPreviousExternalIdentifier =
         sessionContentAndUserInfo.userInfo.externalIdentityId != oidcAuthenticationMethod.externalIdentifier;
       if (isDifferentFromPreviousExternalIdentifier) {
-        monitoringTools.logErrorWithCorrelationIds({
+        logger.error({
           message: 'Different externalIdentifier (sub)',
           context: 'oidc',
           data: {

--- a/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js
@@ -1,5 +1,5 @@
 import { config } from '../../../shared/config.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 /**
  * @param {{
@@ -33,7 +33,7 @@ export const validateUserAccountEmail = async ({
     await userRepository.update(user.mapToDatabaseDto());
     await emailValidationDemandRepository.remove(token);
   } catch (error) {
-    monitoringTools.logErrorWithCorrelationIds({
+    logger.error({
       message: error.message,
       context: 'email-validation',
       data: { token },

--- a/api/src/identity-access-management/infrastructure/server-authentication.js
+++ b/api/src/identity-access-management/infrastructure/server-authentication.js
@@ -6,7 +6,7 @@ import {
   jwtApplicationAuthenticationStrategyName,
   jwtUserAuthenticationStrategyName,
 } from '../../shared/infrastructure/authentication-strategy-names.js';
-import { monitoringTools } from '../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../shared/infrastructure/utils/logger.js';
 import { revokedUserAccessRepository } from '../infrastructure/repositories/revoked-user-access.repository.js';
 import { getForwardedOrigin } from '../infrastructure/utils/network.js';
 
@@ -50,7 +50,7 @@ async function validateUser(decodedAccessToken, { request, revokedUserAccessRepo
 
   const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
   if (revokedUserAccess.isAccessTokenRevoked(decodedAccessToken)) {
-    monitoringTools.logWarnWithCorrelationIds({
+    logger.warn({
       message: 'Revoked user AccessToken usage',
       decodedAccessToken,
     });
@@ -60,7 +60,7 @@ async function validateUser(decodedAccessToken, { request, revokedUserAccessRepo
 
   const audience = getForwardedOrigin(request.headers);
   if (decodedAccessToken.aud !== audience) {
-    monitoringTools.logWarnWithCorrelationIds({
+    logger.warn({
       message: 'User AccessToken audience mismatch',
       audience,
       decodedAccessToken,

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -12,7 +12,7 @@ import {
 import { Organization, OrganizationForAdmin, OrganizationTag } from '../../../shared/domain/models/index.js';
 import * as codeGenerator from '../../../shared/domain/services/code-generator.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../shared/infrastructure/constants.js';
-import { monitoringTools } from '../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
 
 const SEPARATOR = '_';
@@ -303,5 +303,5 @@ function _monitorError(message, { data, error, event } = {}) {
     monitoringData.error = { name: error.constructor.name };
   }
 
-  monitoringTools.logErrorWithCorrelationIds(monitoringData);
+  logger.error(monitoringData);
 }

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -1,21 +1,14 @@
 import fs from 'node:fs/promises';
 
 import { FileValidationError } from '../../../../src/shared/domain/errors.js';
-import {
-  logErrorWithCorrelationIds,
-  logWarnWithCorrelationIds,
-} from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../domain/usecases/index.js';
 import { OrganizationLearnerParser } from '../infrastructure/serializers/csv/organization-learner-parser.js';
 import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
 const INVALID_FILE_EXTENSION_ERROR = 'INVALID_FILE_EXTENSION';
 
-const importOrganizationLearnersFromSIECLE = async function (
-  request,
-  h,
-  dependencies = { logErrorWithCorrelationIds, logWarnWithCorrelationIds },
-) {
+const importOrganizationLearnersFromSIECLE = async function (request, h, dependencies = { logger }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const organizationId = request.params.id;
   const userId = request.auth.credentials.userId;
@@ -41,7 +34,7 @@ const importOrganizationLearnersFromSIECLE = async function (
       });
     }
   } catch (error) {
-    dependencies.logWarnWithCorrelationIds(error);
+    dependencies.logger.warn(error);
 
     throw error;
   } finally {
@@ -50,7 +43,7 @@ const importOrganizationLearnersFromSIECLE = async function (
     try {
       await fs.unlink(request.payload.path);
     } catch (error) {
-      dependencies.logErrorWithCorrelationIds(error);
+      dependencies.logger.error(error);
     }
   }
 

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 
-import { logErrorWithCorrelationIds } from '../../../../src/shared/infrastructure/monitoring-tools.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../domain/usecases/index.js';
 import { SupOrganizationLearnerParser } from '../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 
@@ -9,7 +9,7 @@ const importSupOrganizationLearners = async function (
   request,
   h,
   dependencies = {
-    logErrorWithCorrelationIds,
+    logger,
     unlink: fs.unlink,
   },
 ) {
@@ -26,14 +26,14 @@ const importSupOrganizationLearners = async function (
       type: 'ADDITIONAL_STUDENT',
     });
   } catch (error) {
-    dependencies.logWarnWithCorrelationIds(error);
+    dependencies.logger.warn(error);
 
     throw error;
   } finally {
     try {
       dependencies.unlink(request.payload.path);
     } catch (err) {
-      dependencies.logErrorWithCorrelationIds(err);
+      dependencies.logger.error(err);
     }
   }
 
@@ -44,7 +44,7 @@ const replaceSupOrganizationLearners = async function (
   request,
   h,
   dependencies = {
-    logErrorWithCorrelationIds,
+    logger,
     unlink: fs.unlink,
   },
 ) {
@@ -61,7 +61,7 @@ const replaceSupOrganizationLearners = async function (
       type: 'REPLACE_STUDENT',
     });
   } catch (error) {
-    dependencies.logWarnWithCorrelationIds(error);
+    dependencies.logger.warn(error);
 
     throw error;
   } finally {
@@ -70,7 +70,7 @@ const replaceSupOrganizationLearners = async function (
     try {
       dependencies.unlink(request.payload.path);
     } catch (err) {
-      dependencies.logErrorWithCorrelationIds(err);
+      dependencies.logger.error(err);
     }
   }
 

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -11,7 +11,6 @@ import * as obfuscationService from '../../../../shared/domain/services/obfuscat
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import * as userReconciliationService from '../../../../shared/domain/services/user-reconciliation-service.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
-import { logErrorWithCorrelationIds } from '../../../../shared/infrastructure/monitoring-tools.js';
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as libOrganizationLearnerRepository from '../../../../shared/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
@@ -55,7 +54,6 @@ const dependencies = {
   importStorage,
   importSupOrganizationLearnersJobRepository,
   libOrganizationLearnerRepository,
-  logErrorWithCorrelationIds,
   logger,
   membershipRepository,
   obfuscationService,

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 
-import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';
 import * as zip from '../../infrastructure/utils/xml/zip.js';
 import { OrganizationImportStatus } from '../models/OrganizationImportStatus.js';
@@ -18,7 +18,7 @@ const uploadSiecleFile = async function ({
     unzip: zip.unzip,
     detectEncoding,
   },
-  dependencies = { logErrorWithCorrelationIds },
+  dependencies = { logger },
 }) {
   await DomainTransaction.execute(async () => {
     let organizationImport = OrganizationImportStatus.create({ organizationId, createdBy: userId });
@@ -38,7 +38,7 @@ const uploadSiecleFile = async function ({
         try {
           await fs.rm(directory, { recursive: true });
         } catch (rmError) {
-          dependencies.logErrorWithCorrelationIds(rmError);
+          dependencies.logger.error(rmError);
         }
       }
       await validateOrganizationImportFileJobRepository.performAsync(

--- a/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
+++ b/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { logErrorWithCorrelationIds } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
 import { config } from '../../../../shared/config.js';
 import { DomainError, FileValidationError } from '../../../../shared/domain/errors.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
@@ -38,7 +37,7 @@ class ImportStorage {
         throw error;
       });
     } catch (error) {
-      logErrorWithCorrelationIds(error);
+      logger.error(error);
       throw new FileValidationError('INVALID_FILE');
     }
     try {

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs/promises';
 import xmlBufferTostring from 'xml-buffer-tostring';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 
 const { xmlEncoding } = xmlBufferTostring;
 const { Buffer } = buffer;
@@ -28,7 +28,7 @@ async function readFirstLine(path) {
     await file.read(buffer, 0, 128, 0);
     file.close();
   } catch (err) {
-    logErrorWithCorrelationIds(err);
+    logger.error(err);
     throw new FileValidationError(ERRORS.INVALID_FILE);
   }
 

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import sax from 'sax';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 import { SiecleXmlImportError } from '../../../domain/errors.js';
 
 /*
@@ -18,7 +18,7 @@ const ERRORS = {
 };
 
 class SiecleFileStreamer {
-  static async create(readableStream, encoding = 'utf-8', logError = logErrorWithCorrelationIds) {
+  static async create(readableStream, encoding = 'utf-8', logError = logger.error) {
     const stream = new SiecleFileStreamer(readableStream, encoding, logError);
     return stream;
   }
@@ -68,7 +68,7 @@ function _getDecodingStream(encoding) {
   try {
     return iconv.decodeStream(encoding);
   } catch (err) {
-    logErrorWithCorrelationIds(err);
+    logger.error(err);
     throw new SiecleXmlImportError(ERRORS.ENCODING_NOT_SUPPORTED);
   }
 }

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
@@ -10,7 +10,7 @@ import { fileTypeFromFile } from 'file-type';
 import StreamZip from 'node-stream-zip';
 
 import { FileValidationError } from '../../../../../shared/domain/errors.js';
-import { logErrorWithCorrelationIds } from '../../../../../shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 
 const VALID_FILE_NAME_REGEX = /^([^.][^/]*\/)*[^./][^/]*\.xml$/;
 const ZIP = 'application/zip';
@@ -47,7 +47,7 @@ async function _unzipFile(directory, path) {
 
     if (fileNames.length != 1) {
       await zip.close();
-      logErrorWithCorrelationIds({ ERROR: ERRORS.INVALID_FILE });
+      logger.error({ ERROR: ERRORS.INVALID_FILE });
       throw new FileValidationError(ERRORS.INVALID_FILE);
     }
 

--- a/api/src/shared/infrastructure/http-agent.js
+++ b/api/src/shared/infrastructure/http-agent.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 const { performance } = perf_hooks;
 
-import { monitoringTools } from '../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from './utils/logger.js';
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {
@@ -27,7 +27,7 @@ const httpAgent = {
       }
       const httpResponse = await axios.post(url, payload, config);
       responseTime = performance.now() - startTime;
-      monitoringTools.logInfoWithCorrelationIds({
+      logger.info({
         metrics: { responseTime },
         message: `End POST request to ${url} success: ${httpResponse.status}`,
       });
@@ -52,7 +52,7 @@ const httpAgent = {
 
       const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
 
-      monitoringTools.logErrorWithCorrelationIds({
+      logger.error({
         metrics: { responseTime },
         message,
       });
@@ -77,7 +77,7 @@ const httpAgent = {
       }
       const httpResponse = await axios.get(url, config);
       responseTime = performance.now() - startTime;
-      monitoringTools.logInfoWithCorrelationIds({
+      logger.info({
         metrics: { responseTime },
         message: `End GET request to ${url} success: ${httpResponse.status}`,
       });
@@ -102,7 +102,7 @@ const httpAgent = {
         data = null;
       }
 
-      monitoringTools.logErrorWithCorrelationIds({
+      logger.error({
         metrics: { responseTime },
         message: `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
       });

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -2,9 +2,8 @@ import lodash from 'lodash';
 
 import { config } from '../config.js';
 
-const { get, update, omit } = lodash;
+const { get, update } = lodash;
 import { asyncLocalStorage, getContext, getInContext, setInContext } from './async-local-storage.js';
-import { logger } from './utils/logger.js';
 import * as requestResponseUtils from './utils/request-response-utils.js';
 
 function getRequestId() {
@@ -22,63 +21,14 @@ function getCorrelationContext() {
     return {};
   }
   const context = asyncLocalStorage.getStore();
-  const request = get(context, 'request');
+  const request = get(context, 'request', null);
+
+  if (!request) return {};
+
   return {
     user_id: extractUserIdFromRequest(request),
     request_id: get(request, 'headers.x-request-id', '-'),
-    id: get(request, 'info.id', '-'),
   };
-}
-
-function logInfoWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.info(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
-}
-
-function logWarnWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.warn(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
-}
-
-/**
- * In order to be displayed properly in Datadog,
- * the parameter "data" should contain
- * - a required property message as string
- * - all other properties you need to pass to Datadog
- *
- * @example
- * const data = {
- *   message: 'Error message',
- *   context: 'My Context',
- *   data: { more: 'data', if: 'needed' },
- *   event: 'Event which trigger this error',
- *   team: 'My Team',
- * };
- * monitoringTools.logErrorWithCorrelationIds(data);
- *
- * @param {object} data
- */
-function logErrorWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.error(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
 }
 
 function extractUserIdFromRequest(request) {
@@ -98,23 +48,17 @@ const monitoringTools = {
   getContext,
   getInContext,
   incrementInContext,
-  logErrorWithCorrelationIds,
-  logWarnWithCorrelationIds,
-  logInfoWithCorrelationIds,
   setInContext,
-  asyncLocalStorage,
 };
 
 export {
   asyncLocalStorage,
   extractUserIdFromRequest,
   getContext,
+  getCorrelationContext,
   getInContext,
   getRequestId,
   incrementInContext,
-  logErrorWithCorrelationIds,
-  logInfoWithCorrelationIds,
-  logWarnWithCorrelationIds,
   monitoringTools,
   setInContext,
 };

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -5,7 +5,9 @@ import pino from 'pino';
 import pretty from 'pino-pretty';
 
 import { config } from '../../config.js';
+/*
 import { getCorrelationContext } from '../monitoring-tools.js';
+*/
 
 const { logging } = config;
 
@@ -33,32 +35,42 @@ const loggerPino = pino(
 
 export const logger = {
   trace: (mergingObject, message) => {
-    const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.trace(mergingObject, message);
+    /*const childLogger = loggerPino.child(getCorrelationContext);*/
+    loggerPino.trace(mergingObject, message);
   },
   debug: (mergingObject, message) => {
-    const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.debug(mergingObject, message);
+    /*const childLogger = loggerPino.child(getCorrelationContext());*/
+    loggerPino.debug(mergingObject, message);
   },
   info: (mergingObject, message) => {
+    /*
     const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.info(mergingObject, message);
+*/
+    loggerPino.info(mergingObject, message);
   },
   warn: (mergingObject, message) => {
+    /*
     const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.warn(mergingObject, message);
+*/
+    loggerPino.warn(mergingObject, message);
   },
   error: (mergingObject, message) => {
+    /*
     const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.error(mergingObject, message);
+*/
+    loggerPino.error(mergingObject, message);
   },
   fatal: (mergingObject, message) => {
+    /*
     const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.fatal(mergingObject, message);
+*/
+    loggerPino.fatal(mergingObject, message);
   },
   silent: (mergingObject, message) => {
+    /*
     const childLogger = loggerPino.child(getCorrelationContext());
-    childLogger.silent(mergingObject, message);
+*/
+    loggerPino.silent(mergingObject, message);
   },
 };
 

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -5,6 +5,7 @@ import pino from 'pino';
 import pretty from 'pino-pretty';
 
 import { config } from '../../config.js';
+import { getCorrelationContext } from '../monitoring-tools.js';
 
 const { logging } = config;
 
@@ -21,7 +22,7 @@ if (logging.logForHumans) {
   });
 }
 
-export const logger = pino(
+const loggerPino = pino(
   {
     level: logging.logLevel,
     redact: ['req.headers.authorization'],
@@ -29,6 +30,37 @@ export const logger = pino(
   },
   prettyPrint,
 );
+
+export const logger = {
+  trace: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.trace(mergingObject, message);
+  },
+  debug: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.debug(mergingObject, message);
+  },
+  info: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.info(mergingObject, message);
+  },
+  warn: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.warn(mergingObject, message);
+  },
+  error: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.error(mergingObject, message);
+  },
+  fatal: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.fatal(mergingObject, message);
+  },
+  silent: (mergingObject, message) => {
+    const childLogger = loggerPino.child(getCorrelationContext());
+    childLogger.silent(mergingObject, message);
+  },
+};
 
 /**
  * Creates a child logger for a section.
@@ -43,7 +75,7 @@ export function child(section, bindings, options) {
   if (micromatch.isMatch(section, logging.debugSections)) {
     optionsOverride.level = 'debug';
   }
-  return logger.child(bindings, { ...options, ...optionsOverride });
+  return loggerPino.child(bindings, { ...options, ...optionsOverride });
 }
 
 export const SCOPES = {

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -11,7 +11,7 @@ import {
   AuthenticationSessionContent,
   UserToCreate,
 } from '../../../../../src/shared/domain/models/index.js';
-import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';
 import { createOpenIdClientMock } from '../../../../tooling/openid-client/openid-client-mocks.js';
 
@@ -24,7 +24,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
   beforeEach(function () {
     openIdClient = createOpenIdClientMock(MOCK_OIDC_PROVIDER_CONFIG);
-    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+    sinon.stub(logger, 'error');
   });
 
   describe('constructor', function () {
@@ -272,7 +272,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate endSessionUrl');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
+        expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
           error: { name: errorThrown.name },
@@ -373,7 +373,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get tokens');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
+        expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: {
             code,
@@ -467,7 +467,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate authorization url');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
+        expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
           error: { name: errorThrown.name },
@@ -757,7 +757,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get user info');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
+        expect(logger.error).to.have.been.calledWithExactly({
           message: errorThrown.message,
           context: 'oidc',
           data: { organizationName: 'Oidc Example' },
@@ -810,7 +810,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
+        expect(logger.error).to.have.been.calledWithExactly({
           context: 'oidc',
           data: {
             missingFields: 'family_name',

--- a/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/validate-user-account-email.usecase.test.js
@@ -1,6 +1,6 @@
 import { validateUserAccountEmail } from '../../../../../src/identity-access-management/domain/usecases/validate-user-account-email.usecase.js';
 import { config } from '../../../../../src/shared/config.js';
-import { monitoringTools } from '../../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | validate-user-account-email', function () {
@@ -25,7 +25,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
     clock = sinon.useFakeTimers({ now: new Date('2024-06-26'), toFake: ['Date'] });
     now = new Date(clock.now);
 
-    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+    sinon.stub(logger, 'error');
   });
 
   afterEach(function () {
@@ -135,7 +135,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | validate-user-a
       });
 
       // then
-      expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+      expect(logger.error).to.have.been.calledWith({
         message: 'error',
         context: 'email-validation',
         data: { token },

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -113,13 +113,13 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
         deserialize: sinon.stub(),
       };
 
-      const monitoringToolsStub = {
-        logErrorWithCorrelationIds: sinon.stub(),
+      const loggerStub = {
+        error: sinon.stub(),
       };
 
       dependencies = {
         campaignParticipationSerializer: campaignParticipationSerializerStub,
-        monitoringTools: monitoringToolsStub,
+        logger: loggerStub,
       };
 
       request = {

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -27,7 +27,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       sinon.stub(usecases, 'uploadCsvFile');
 
       usecases.uploadSiecleFile.resolves();
-      dependencies = { logErrorWithCorrelationIds: sinon.stub(), logWarnWithCorrelationIds: sinon.stub() };
+      dependencies = { logger: { error: sinon.stub(), warn: sinon.stub() } };
     });
 
     it('should delete uploaded file', async function () {
@@ -56,7 +56,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(fs.unlink).to.have.been.calledWithExactly(request.payload.path);
-      expect(dependencies.logErrorWithCorrelationIds).to.have.been.calledWith(error);
+      expect(dependencies.logger.error).to.have.been.calledWith(error);
     });
 
     it('should call usecases to import organizationLearners xml', async function () {
@@ -98,7 +98,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       );
 
       // then
-      expect(dependencies.logWarnWithCorrelationIds).to.have.been.calledWithExactly(uploadedError);
+      expect(dependencies.logger.warn).to.have.been.calledWithExactly(uploadedError);
       expect(error).to.be.deep.equal(uploadedError);
     });
 

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -9,7 +9,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   let i18n;
   let userId;
 
-  let logErrorWithCorrelationIdsStub;
+  let loggerStub;
   let unlinkStub;
 
   beforeEach(function () {
@@ -19,7 +19,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     userId = Symbol('userId');
 
     sinon.stub(usecases, 'uploadCsvFile');
-    logErrorWithCorrelationIdsStub = sinon.stub();
+    loggerStub = { error: sinon.stub() };
     unlinkStub = sinon.stub();
   });
 
@@ -38,7 +38,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -60,7 +60,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       await catchErr(supOrganizationManagementController.importSupOrganizationLearners)(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -81,14 +81,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
       // then
       expect(response.statusCode).to.be.equal(204);
 
-      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
+      expect(loggerStub.error).to.have.been.calledWith(error);
     });
   });
 
@@ -107,7 +107,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -129,7 +129,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       await catchErr(supOrganizationManagementController.replaceSupOrganizationLearners)(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
@@ -150,14 +150,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        logger: loggerStub,
         unlink: unlinkStub,
       });
 
       // then
       expect(response.statusCode).to.be.equal(204);
 
-      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
+      expect(loggerStub.error).to.have.been.calledWith(error);
     });
   });
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -104,7 +104,7 @@ describe('Unit | UseCase | upload-siecle-file', function () {
         siecleServiceStub.unzip.withArgs(payload.path).resolves({ directory: 'tmp', file: filepath });
         const rmError = new Error('rm');
         rmStub.rejects(rmError);
-        const logErrorWithCorrelationIdsStub = sinon.stub();
+        const loggerStub = { error: sinon.stub() };
         // when
         await uploadSiecleFile({
           userId,
@@ -114,11 +114,11 @@ describe('Unit | UseCase | upload-siecle-file', function () {
           siecleService: siecleServiceStub,
           importStorage: importStorageStub,
           validateOrganizationImportFileJobRepository: validateOrganizationImportFileJobRepositoryStub,
-          dependencies: { logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub },
+          dependencies: { logger: loggerStub },
         });
 
         // then
-        expect(logErrorWithCorrelationIdsStub).to.have.been.calledWithExactly(rmError);
+        expect(loggerStub.error).to.have.been.calledWithExactly(rmError);
         expect(organizationImportSavedStub.upload).to.have.been.calledWithExactly({
           filename: s3filename,
           encoding,

--- a/api/tests/shared/unit/infrastructure/http-agent_test.js
+++ b/api/tests/shared/unit/infrastructure/http-agent_test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
-import { monitoringTools } from '../../../../src/shared/infrastructure/monitoring-tools.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { expect, sinon } from '../../../test-helper.js';
 
 const { post, get } = httpAgent;
@@ -40,8 +40,8 @@ describe('Shared | Unit | Infrastructure | http-agent', function () {
     context('when an error occurs', function () {
       it('should log the response error data and response time', async function () {
         // given
-        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
-        monitoringTools.logErrorWithCorrelationIds.resolves();
+        sinon.stub(logger, 'error');
+        logger.error.resolves();
 
         const url = 'someUrl';
         const payload = 'somePayload';
@@ -59,7 +59,7 @@ describe('Shared | Unit | Infrastructure | http-agent', function () {
 
         // then
         const expected = 'End POST request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const { message, metrics } = logger.error.firstCall.args[0];
         expect(message).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });
@@ -147,8 +147,8 @@ describe('Shared | Unit | Infrastructure | http-agent', function () {
     context('when an error occurs', function () {
       it('should log the response error data and response time', async function () {
         // given
-        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
-        monitoringTools.logErrorWithCorrelationIds.resolves();
+        sinon.stub(logger, 'error');
+        logger.error.resolves();
 
         const url = 'someUrl';
         const payload = 'somePayload';
@@ -166,7 +166,7 @@ describe('Shared | Unit | Infrastructure | http-agent', function () {
 
         // then
         const expected = 'End GET request to someUrl error: 400 {"a":"1","b":"2"}';
-        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const { message, metrics } = logger.error.firstCall.args[0];
         expect(message).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);
       });


### PR DESCRIPTION
## 🔆 Problème

On utilise le loggerWithCorrelation parfois pas. ce qui fait des trou dans les raquettes

## ⛱️ Proposition

revoir l'utilisation des loggers pour n'en n'avoir qu'un qui pousse le correlationId dans tout les cas. 

## 🌊 Remarques

Vérifier que l'on push correctement les logs là ou c'est nécessaire
Supprimer le dernier commit qui sert simplement de tests. 

## 🏄 Pour tester

Vérifier à la création de la campagne que les logs sont formatté comme souhaité.
