### PR TITLE
[BUMP] MàJ de @1024pix/epreuves-components

### DIFF
--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.4.2",
+        "@1024pix/epreuves-components": "^0.5.0",
         "@1024pix/eslint-plugin": "^2.1.5",
         "@1024pix/pix-ui": "^55.23.0",
         "@1024pix/stylelint-config": "^5.1.32",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.2.tgz",
-      "integrity": "sha512-01byOhxOX63x6rQb4Phr8WSlppsT8wPTlnegbUVgTVJsbulfDW3UyKOtomRAeWpCw1fXj/BevHmYzHBsS63t0g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.5.0.tgz",
+      "integrity": "sha512-GciWFtGyADykWuIiNCeLJVbG7vk1E/FlF9P5ZISuSuJW1WO9pyuj2gj+o17AHC3Fzgowu1BFmDagwifCbRnqlw==",
       "dev": true,
       "license": "MIT"
     },

--- a/junior/package.json
+++ b/junior/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.4.2",
+    "@1024pix/epreuves-components": "^0.5.0",
     "@1024pix/eslint-plugin": "^2.1.5",
     "@1024pix/pix-ui": "^55.23.0",
     "@1024pix/stylelint-config": "^5.1.32",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.4.2",
+        "@1024pix/epreuves-components": "^0.5.0",
         "@1024pix/eslint-plugin": "^2.1.5",
         "@1024pix/pix-ui": "^55.23.0",
         "@1024pix/stylelint-config": "^5.1.32",
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.4.2.tgz",
-      "integrity": "sha512-01byOhxOX63x6rQb4Phr8WSlppsT8wPTlnegbUVgTVJsbulfDW3UyKOtomRAeWpCw1fXj/BevHmYzHBsS63t0g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.5.0.tgz",
+      "integrity": "sha512-GciWFtGyADykWuIiNCeLJVbG7vk1E/FlF9P5ZISuSuJW1WO9pyuj2gj+o17AHC3Fzgowu1BFmDagwifCbRnqlw==",
       "dev": true,
       "license": "MIT"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.4.2",
+    "@1024pix/epreuves-components": "^0.5.0",
     "@1024pix/eslint-plugin": "^2.1.5",
     "@1024pix/pix-ui": "^55.23.0",
     "@1024pix/stylelint-config": "^5.1.32",


### PR DESCRIPTION
## 🔆 Problème

Il y a de nouveaux webcomponents dispos.

## ⛱️ Proposition

Mettre à jour @1024pix/epreuves-components.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Tester un qcu-image dans junior.
Tester message-conversation dans modulix.