### PR TITLE
[TECH] :card_file_box: Modification du type du champ `calibration_id` pour qu'il corresponde à celui de la table `calibrations` (PIX-18533)

### DIFF
--- a/api/datamart/migrations/20250701083849_update-active-calibrated-challenges-challenge_id-type.js
+++ b/api/datamart/migrations/20250701083849_update-active-calibrated-challenges-challenge_id-type.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'active_calibrated_challenges';
+const COLUMN_NAME = 'calibration_id';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).defaultTo(null).alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Le type du champ `calibration_id` (varchar) ne correspond à celui de la table `calibrations` (integer)
## ⛱️ Proposition

Modifier le type du champ `calibration_id` pour le mettre en `integer`

## 🌊 Remarques

La table est normalement vide en production pour le moment.

## 🏄 Pour tester


