### PR TITLE
[FEATURE] Afficher la date et l'heure de l'envoie des résultats de campagne (PIX-18081)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -20,6 +20,7 @@ const serialize = function (results) {
       'canReset',
       'canImprove',
       'isDisabled',
+      'sharedAt',
     ],
     campaignParticipationBadges: {
       ref: 'id',

--- a/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
@@ -81,6 +81,7 @@ class AssessmentResult {
       isShared: this.isShared,
       campaignType,
     });
+    this.sharedAt = sharedAt;
   }
 
   _computeMasteryRate(masteryRate, isShared, totalSkillsCount, validatedSkillsCount) {

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -434,11 +434,13 @@ describe('Acceptance | API | Campaign Participations', function () {
 
     let server, badge1, badge2, stage;
 
+    let recentDate;
+
     beforeEach(async function () {
       server = await createServer();
 
       const oldDate = new Date('2018-02-03');
-      const recentDate = new Date('2018-05-06');
+      recentDate = new Date('2018-05-06');
       const futureDate = new Date('2018-07-10');
       const skillIds = [
         'recSkill1',
@@ -638,6 +640,7 @@ describe('Acceptance | API | Campaign Participations', function () {
             'can-improve': false,
             'is-disabled': false,
             'participant-external-id': 'participantExternalId',
+            'shared-at': recentDate,
           },
           relationships: {
             'campaign-participation-badges': {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -465,11 +465,12 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         _buildCampaignSkills(campaignId);
+        const sharedAt = new Date('2020-01-02');
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
           status: CampaignParticipationStatuses.SHARED,
-          sharedAt: new Date('2020-01-02'),
+          sharedAt,
           masteryRate: 0.6,
         });
 
@@ -484,6 +485,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           locale: 'FR',
         });
         expect(participantResult.masteryRate).to.equal(0.6);
+        expect(participantResult.sharedAt).to.deep.equal(sharedAt);
       });
     });
 

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -13,6 +13,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
     const isTargetProfileResetAllowed = true;
     const isOrganizationLearnerActive = true;
     const isCampaignArchived = false;
+    const sharedAt = new Date('2020-01-01');
     let participationResults, competences, stages, badgeResultsDTO, reachedStage;
 
     beforeEach(function () {
@@ -32,7 +33,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
       participationResults = {
         campaignParticipationId: 1,
         isCompleted: true,
-        sharedAt: new Date('2020-01-01'),
+        sharedAt,
         status: CampaignParticipationStatuses.SHARED,
         knowledgeElements: knowledgeElements,
         acquiredBadgeIds: [3],
@@ -117,6 +118,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'tested-skills-count': 2,
             'total-skills-count': 2,
             'validated-skills-count': 1,
+            'shared-at': sharedAt,
           },
           id: '1',
           relationships: {

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -15,7 +15,7 @@ When(
 
 When(`j'ouvre le sujet {string}`, (tubeName) => {
   cy.contains(tubeName)
-    .closest('tr')
+    .closest("tr")
     .within(() => {
       cy.get("button").click();
     });
@@ -35,12 +35,14 @@ When(
 );
 
 Then(`je vois {int} campagne\(s\)`, (campaignsCount) => {
-  cy.findAllByRole('row').should("have.lengthOf", campaignsCount + 1);
+  cy.findAllByRole("row").should("have.lengthOf", campaignsCount + 1);
 });
 
 Then(`je vois {int} tutoriel\(s\)`, (tutorialsCount) => {
-  cy.findByRole('table', { name: "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels" }).within(() => {
-    cy.findAllByRole('listitem').should("have.lengthOf", tutorialsCount);
+  cy.findByRole("table", {
+    name: "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels",
+  }).within(() => {
+    cy.findAllByRole("listitem").should("have.lengthOf", tutorialsCount);
   });
 });
 
@@ -49,23 +51,22 @@ When(`je recherche une campagne avec le nom {string}`, (campaignSearchName) => {
 });
 
 Then(`je vois le détail de la campagne {string}`, (campaignName) => {
-  cy.findByRole('heading', { level: 1 }).contains(campaignName);
+  cy.findByRole("heading", { level: 1 }).contains(campaignName);
 });
 
 Then(`je vois {int} participants`, (numberOfParticipants) => {
-  cy.findByRole('table', {name: "Liste des participants"}).within(() => {
-    cy.findAllByRole('row').should(
-      "have.lengthOf",
-      numberOfParticipants + 1,
-    );
-  })
+  cy.findByRole("table", { name: "Liste des participants" }).within(() => {
+    cy.findAllByRole("row").should("have.lengthOf", numberOfParticipants + 1);
+  });
 });
 
 Then(`je vois {int} profils`, (numberOfProfiles) => {
-  if(numberOfProfiles === 0) {
-    cy.contains('Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.');
+  if (numberOfProfiles === 0) {
+    cy.contains(
+      "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
+    );
   } else {
-    cy.findAllByRole('row').should("have.lengthOf", numberOfProfiles + 1);
+    cy.findAllByRole("row").should("have.lengthOf", numberOfProfiles + 1);
   }
 });
 
@@ -75,7 +76,7 @@ When(
     if (numberOfResultsByCompetence === 0) {
       cy.findByText("En attente de résultats");
     } else {
-      cy.findAllByRole('row').should(
+      cy.findAllByRole("row").should(
         "have.lengthOf",
         numberOfResultsByCompetence + 1,
       );
@@ -88,7 +89,7 @@ When(
   (numberOfResultsByCompetence) => {
     cy.get("[role='tabpanel'][tabindex='0']").within(() => {
       cy.get("tr").should("have.lengthOf", numberOfResultsByCompetence);
-      cy.contains("Détails des résultats")
+      cy.contains("Détails des résultats");
     });
   },
 );
@@ -122,12 +123,14 @@ Then(`je vois que j'ai partagé mon profil`, () => {
 });
 
 Then(`je vois que j'ai envoyé les résultats`, () => {
-  cy.contains("Merci d'avoir envoyé vos résultats.");
+  cy.contains("Vos résultats ont été envoyés le");
 });
 
 Then(`je vois {int} sujets`, (tubeCount) => {
-  cy.findByRole('table', { name: "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels"}).within(() => {
-    cy.findAllByRole('row').should("have.lengthOf", tubeCount + 1);
+  cy.findByRole("table", {
+    name: "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels",
+  }).within(() => {
+    cy.findAllByRole("row").should("have.lengthOf", tubeCount + 1);
   });
 });
 
@@ -135,7 +138,7 @@ Then(
   `je vois que le sujet {string} est {string}`,
   (tubeName, recommendationLevel) => {
     cy.contains(tubeName)
-      .closest('tr')
+      .closest("tr")
       .get(`[aria-label="${recommendationLevel}"]`);
   },
 );

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -7,6 +7,9 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
+import CustomParseFormat from 'dayjs/plugin/customParseFormat';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
 import { not } from 'ember-truth-helpers';
 import or from 'ember-truth-helpers/helpers/or';
@@ -17,8 +20,12 @@ import AttestationResult from './attestation-result';
 import CustomOrganizationBlock from './custom-organization-block';
 import RetryOrResetBlock from './retry-or-reset-block';
 
+dayjs.extend(LocalizedFormat);
+dayjs.extend(CustomParseFormat);
+
 export default class EvaluationResultsHero extends Component {
   @service currentUser;
+
   @service metrics;
   @service router;
   @service store;
@@ -73,6 +80,14 @@ export default class EvaluationResultsHero extends Component {
     return this.args.questResults && this.args.questResults.length > 0;
   }
 
+  get sharedAtDate() {
+    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LL');
+  }
+
+  get sharedAtTime() {
+    return dayjs(this.args.campaignParticipationResult.sharedAt).format('LT');
+  }
+
   @action
   handleSeeTrainingsClick() {
     this.args.showTrainings();
@@ -122,6 +137,7 @@ export default class EvaluationResultsHero extends Component {
 
       campaignParticipationResult.isShared = true;
       campaignParticipationResult.canImprove = false;
+      campaignParticipationResult.sharedAt = new Date();
 
       this.metrics.trackEvent({
         event: 'custom-event',
@@ -213,8 +229,9 @@ export default class EvaluationResultsHero extends Component {
               @type="success"
               @withIcon={{true}}
             >
-              {{t "pages.skill-review.hero.shared-message"}}
+              {{t "pages.skill-review.hero.shared-message" date=this.sharedAtDate time=this.sharedAtTime}}
             </PixNotificationAlert>
+
             {{#if @hasTrainings}}
               <p class="evaluation-results-hero-details__explanations">
                 {{t "pages.skill-review.hero.explanations.trainings"}}

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -12,6 +12,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('boolean') isDisabled;
   @attr('boolean') isShared;
   @attr('string') participantExternalId;
+  @attr('date') sharedAt;
 
   // includes
   @hasMany('campaign-participation-badge', {

--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -54,6 +54,7 @@ export default class ResultsRoute extends Route {
     await this.store.adapterFor('campaign-participation-result').share(model.campaignParticipationResult.id);
     model.campaignParticipationResult.isShared = true;
     model.campaignParticipationResult.canImprove = false;
+    model.campaignParticipationResult.sharedAt = new Date();
     model.showTrainings = true;
   }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1976,7 +1976,7 @@
           "title": "Improve your results"
         },
         "see-trainings": "See trainings",
-        "shared-message": "Thank you for sending us your results."
+        "shared-message": "Your results were sent on {date} at {time}."
       },
       "improve": {
         "description": "You can retake some of the questions",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1963,7 +1963,7 @@
           "title": "Mejore sus resultados"
         },
         "see-trainings": "Ver los cursos",
-        "shared-message": "Gracias por enviarnos sus resultados."
+        "shared-message": "Tus resultados se enviaron el {date} a las {time}."
       },
       "improve": {
         "description": "Puedes volver a intentar algunas de las preguntas",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1976,7 +1976,7 @@
           "title": "Améliorez vos résultats"
         },
         "see-trainings": "Voir les formations",
-        "shared-message": "Merci d'avoir envoyé vos résultats."
+        "shared-message": "Vos résultats ont été envoyés le {date} à {time}."
       },
       "improve": {
         "description": "Vous pouvez retenter certaines questions",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1966,7 +1966,7 @@
           "title": "Verbeter uw resultaten"
         },
         "see-trainings": "Bekijk de cursussen",
-        "shared-message": "Bedankt voor het sturen van je resultaten."
+        "shared-message": "Je resultaten zijn verzonden op {date} om {time}."
       },
       "improve": {
         "description": "Je kunt sommige vragen opnieuw proberen",


### PR DESCRIPTION
## 🔆 Problème

En tant qu'utilisateur, on souhaiterais savoir à quelle heure ont été envoyé les résultats d'une participation à une campagne.

## ⛱️ Proposition

Faire remonter la donnée sharedAt jusqu'au front.

## 🌊 Remarques

La date s'écrira dans le format de la langue.

Nous n'avons pas testé les cas où nous fixons la sharedAt au moment des envoies, car en test d'acceptance c'est compliqué de bloquer la date.

## 🏄 Pour tester

- Se rendre sur Pix app,
- Se connecter avec le compte superadmin@example.net,
- Faire la campagne PROASSMUL,
- Constater en fin de parcour que la date et l'heure sont affichés correctement sur la page des résultats,
- Aller sur pix-app .org et répéter les opérations précédentes,
- Vérifier que la date s'adapte en fonction de la langue en utilisant le local switcher pour switcher:)