### PR TITLE
[TECH] Réparer l'accès aux fichiers par Ember Inspector sur mon-pix

### DIFF
--- a/mon-pix/app/app.js
+++ b/mon-pix/app/app.js
@@ -7,8 +7,15 @@ import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
 import config from 'mon-pix/config/environment';
 
+import { inspectorSupport } from './inspector-support';
+
 if (config.sentry.enabled) {
   initSentry();
+}
+
+// This is a temporary solution, see https://github.com/emberjs/ember-inspector/issues/2612
+if (config.emberInspector.enabled) {
+  inspectorSupport();
 }
 
 export default class App extends Application {

--- a/mon-pix/app/inspector-support.js
+++ b/mon-pix/app/inspector-support.js
@@ -1,0 +1,20 @@
+import { RSVP } from '@ember/-internals/runtime';
+import * as destroyable from '@glimmer/destroyable';
+import * as reference from '@glimmer/reference';
+import * as runtime from '@glimmer/runtime';
+import * as tracking from '@glimmer/tracking';
+import * as validator from '@glimmer/validator';
+import Ember from 'ember';
+
+import config from './config/environment';
+
+export const inspectorSupport = () => {
+  window.define('@glimmer/tracking', () => tracking);
+  window.define('@glimmer/runtime', () => runtime);
+  window.define('@glimmer/validator', () => validator);
+  window.define('@glimmer/reference', () => reference);
+  window.define('@glimmer/destroyable', () => destroyable);
+  window.define('rsvp', () => RSVP);
+  window.define('ember', () => ({ default: Ember }));
+  window.define('mon-pix/config/environment', () => ({ default: config }));
+};

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -169,6 +169,10 @@ module.exports = function (environment) {
       enabled: _isFeatureEnabled(process.env.SENTRY_ENABLED),
     },
 
+    emberInspector: {
+      enabled: _isFeatureEnabled(process.env.ALLOW_EMBER_INSPECTOR),
+    },
+
     'ember-cli-mirage': {
       usingProxy: true,
     },


### PR DESCRIPTION
## 🔆 Problème
L'extension Chrome Ember Inspector ne fonctionne plus sur les différentes app pix depuis le passage à Ember source v.6.1 à part sur Pix Orga ce qui a tendance à complexifier les devs front.

## ⛱️ Proposition
C'est un problème récurrent sur les apps Ember, et une[ solution de contournement ](https://github.com/emberjs/ember-inspector/issues/2612) a été trouvée et est déjà implémentée sur Pix Orga. Voir PR : https://github.com/1024pix/pix/pull/11501

## 🏄 Pour tester
Ouvrir la RA de Pix App.
Vérifier que l'extension Ember Inspector n'a pas accès au code si ALLOW_EMBER_INSPECTOR n'est pas passé à "true" (et que ça fonctionne bien si c'est le cas)