### PR TITLE
[FEATURE] Déplacer le curseur sur l'étape en cours dans le didacticiel et rendre la navigation dans les étapes plus agréable au lecteur d'écran (PIX-18545)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/tutorial/steps.gjs
+++ b/mon-pix/app/components/campaigns/assessment/tutorial/steps.gjs
@@ -9,11 +9,13 @@ import t from 'ember-intl/helpers/t';
 import eq from 'ember-truth-helpers/helpers/eq';
 import inc from 'mon-pix/helpers/inc';
 
+import didInsert from '../../../../modifiers/modifier-did-insert';
+
 export default class Steps extends Component {
   <template>
     {{#each this.steps as |step index|}}
       {{#if (eq index this.currentStep)}}
-        <div class="campaign-tutorial__title">
+        <div class="campaign-tutorial__title" tabIndex="-1" {{didInsert this.setFocus}}>
           {{step.text}}
         </div>
 
@@ -100,6 +102,11 @@ export default class Steps extends Component {
 
   get showNextButton() {
     return this.currentStep < this.steps.length - 1;
+  }
+
+  @action
+  setFocus(element) {
+    element.focus({ focusVisible: false });
   }
 
   @action

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2081,6 +2081,7 @@
       }
     },
     "tutorial": {
+      "dot-action-description": "Access step {stepNumber} on {stepsCount}",
       "dot-action-title": "Tutorial step {stepNumber} of {stepsCount}",
       "dots-nav-label": "Tutorial steps",
       "next": "Next",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2081,7 +2081,7 @@
       }
     },
     "tutorial": {
-      "dot-action-title": "Display tutorial step {stepNumber}/{stepsCount}",
+      "dot-action-title": "Tutorial step {stepNumber} of {stepsCount}",
       "dots-nav-label": "Tutorial steps",
       "next": "Next",
       "next-title": "Show tutorial next step",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2072,7 +2072,7 @@
       "title": "Para tener éxito la próxima vez"
     },
     "tutorial": {
-      "dot-action-title": "Paso de visualización {stepNumber}/{stepsCount}",
+      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dots-nav-label": "Pasos del tutorial",
       "next": "Siguiente",
       "next-title": "Mostrar siguiente paso",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2073,6 +2073,7 @@
     },
     "tutorial": {
       "dot-action-title": "Paso {stepNumber} de {stepsCount}",
+      "dot-action-description": "Acceder al paso {stepNumber} en {stepsCount}",
       "dots-nav-label": "Pasos del tutorial",
       "next": "Siguiente",
       "next-title": "Mostrar siguiente paso",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2081,6 +2081,7 @@
       }
     },
     "tutorial": {
+      "dot-action-description": "Accéder à l'étape {stepNumber} sur {stepsCount}",
       "dot-action-title": "Etape {stepNumber} sur {stepsCount}",
       "dots-nav-label": "Étapes du didacticiel",
       "next": "Suivant",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2081,7 +2081,7 @@
       }
     },
     "tutorial": {
-      "dot-action-title": "Afficher l'étape {stepNumber}/{stepsCount}",
+      "dot-action-title": "Etape {stepNumber} sur {stepsCount}",
       "dots-nav-label": "Étapes du didacticiel",
       "next": "Suivant",
       "next-title": "Afficher l'étape suivante",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2076,6 +2076,7 @@
     },
     "tutorial": {
       "dot-action-title": "Stap {stepNumber} van {stepsCount}",
+      "dot-action-description": "Ga naar stap {stepNumber} op {stepsCount}",
       "dots-nav-label": "Stappen uit de tutorial",
       "next": "Volgende",
       "next-title": "Volgende stap tonen",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2075,7 +2075,7 @@
       "title": "Om de volgende keer te slagen"
     },
     "tutorial": {
-      "dot-action-title": "Weergave stap {stepNumber}/{stepsCount}",
+      "dot-action-title": "Stap {stepNumber} van {stepsCount}",
       "dots-nav-label": "Stappen uit de tutorial",
       "next": "Volgende",
       "next-title": "Volgende stap tonen",


### PR DESCRIPTION
- **feat(mon-pix): focus user when navigate in tutorial**
- **chore(mon-pix): update translations to keep only the step term**
- **feat(mon-pix): add description on the steps button**

## 🔆 Problème

Des testes utilisateurs ont montré que le didacticiel d'entrée en campagne était accessible, mais pas confortable. 

## ⛱️ Proposition

- Déplacer le focus sur le contenu de l'étape dès que celui-ci change (c'est-à-dire lorsqu'on navigue ou qu'on clique sur le bouton suivant),
- Modifier les titres des bouton en ne gardant que le terme étape et en utilisant des mot plutôt que des signe (1/2 devient 1 sur 2),
- Ajouter des description dans un élément aria-description pour que l'utilisateur reste clairement informé.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

- Se connecter ou se créer un compte sur [Pix app](https://app-pr12720.review.pix.fr/),
- Aller sur un parcours "PROASMULL" par exemple,
- Arriver dans le didacticiel,
- Activer un lecteur d'écran,
- Avec tab ou les flèches, naviguer sur le menu des étapes,
- Constater qu'on a le terme "étape 1 sur 5" puis quelque secondes après "Accéder à l'étape 1 sur 5",
- Constater que lorsqu'on clique sur le bouton le lecteur d'écran redirige automatiquement sur le texte.
