### PR TITLE
[FEATURE] Ajouter la possibilité de bloquer une organisation qui n'a plus de place dispo (PIX-18548).

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -9,7 +9,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { notEq, or } from 'ember-truth-helpers';
+import { and, eq, notEq, or } from 'ember-truth-helpers';
 import lodashGet from 'lodash/get';
 import lodashSet from 'lodash/set';
 import Organization from 'pix-admin/models/organization';
@@ -21,6 +21,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @tracked isEditMode = false;
   @tracked showArchivingConfirmationModal = false;
+  @tracked toggleLockPlaces = false;
 
   noIdentityProviderOption = { label: 'Aucun', value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
@@ -28,6 +29,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
   constructor() {
     super(...arguments);
     this._initForm();
+
+    this.toggleLockPlaces = this.form.features['PLACES_MANAGEMENT']?.active ?? false;
   }
 
   get isManagingStudentAvailable() {
@@ -58,6 +61,10 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   updateFormCheckBoxValue(key) {
+    if (key === 'features.PLACES_MANAGEMENT.active') {
+      this.toggleLockPlaces = !lodashGet(this.form, key);
+    }
+
     lodashSet(this.form, key, !lodashGet(this.form, key));
   }
 
@@ -221,6 +228,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
           @features={{this.form.features}}
           @updateFormCheckBoxValue={{this.updateFormCheckBoxValue}}
           @isManagingStudentAvailable={{this.isManagingStudentAvailable}}
+          @toggleLockPlaces={{this.toggleLockPlaces}}
         />
 
         <div class="form-actions">
@@ -252,6 +260,19 @@ const FeaturesForm = <template>
             @checked={{organizationFeature.active}}
             {{on "change" (fn @updateFormCheckBoxValue (concat "features." feature ".active"))}}
           ><:label>{{t featureLabel}}</:label></PixCheckbox>
+        </div>
+      {{/if}}
+      {{#if (and (eq feature "PLACES_MANAGEMENT") @toggleLockPlaces)}}
+        <div class="form-field">
+          <PixCheckbox
+            @checked={{organizationFeature.params.enablePlacesThresholdLock}}
+            {{on
+              "change"
+              (fn @updateFormCheckBoxValue (concat "features." feature ".params.enablePlacesThresholdLock"))
+            }}
+          ><:label>{{t
+                "components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK"
+              }}</:label></PixCheckbox>
         </div>
       {{/if}}
     {{/let}}

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -11,7 +11,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { notEq, or } from 'ember-truth-helpers';
 import lodashGet from 'lodash/get';
-import set from 'lodash/set';
+import lodashSet from 'lodash/set';
 import Organization from 'pix-admin/models/organization';
 
 export default class OrganizationInformationSectionEditionMode extends Component {
@@ -58,7 +58,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   updateFormCheckBoxValue(key) {
-    set(this.form, key, !lodashGet(this.form, key));
+    lodashSet(this.form, key, !lodashGet(this.form, key));
   }
 
   @action

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -2,6 +2,7 @@ import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import InformationSectionEdit from 'pix-admin/components/organizations/information-section-edit';
 import { module, test } from 'qunit';
 
@@ -138,6 +139,71 @@ module('Integration | Component | organizations/information-section-edit', funct
 
       // then
       assert.dom(screen.getByText("Le lien n'est pas valide.")).exists();
+    });
+
+    module('#features', function () {
+      test('should display place management features as deactivated', async function (assert) {
+        organization.features = {
+          PLACES_MANAGEMENT: {
+            active: false,
+            params: null,
+          },
+        };
+
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+        assert.false(
+          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+            .checked,
+        );
+        assert.notOk(
+          screen.queryByLabelText(
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+          ),
+        );
+      });
+
+      test('should display place management features as activated and lockThreshold deactivated', async function (assert) {
+        organization.features = {
+          PLACES_MANAGEMENT: {
+            active: true,
+            params: { enablePlacesThresholdLock: false },
+          },
+        };
+
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+        assert.true(
+          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+            .checked,
+        );
+        assert.false(
+          screen.getByLabelText(
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+          ).checked,
+        );
+      });
+
+      test('should display place management features as activated  and lockThreshold activated', async function (assert) {
+        organization.features = {
+          PLACES_MANAGEMENT: {
+            active: true,
+            params: { enablePlacesThresholdLock: true },
+          },
+        };
+
+        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+        assert.true(
+          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+            .checked,
+        );
+        assert.true(
+          screen.getByLabelText(
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+          ).checked,
+        );
+      });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -509,6 +509,7 @@
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",
+          "ORGANIZATION_PLACES_LOCK": "Bloc organization in case of places threshold exceeded",
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -509,6 +509,7 @@
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Envoi multiple sur les campagnes d'évaluation",
+          "ORGANIZATION_PLACES_LOCK": "Blocage de l'organisation en cas de dépassement des places",
           "PLACES_MANAGEMENT": "Affichage de la page Places sur PixOrga",
           "SHOW_NPS": "Affichage du Net Promoter Score",
           "SHOW_SKILLS": "Affichage des acquis dans l'export de résultats",

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -173,7 +173,7 @@ const register = async function (server) {
     },
     {
       method: 'PATCH',
-      path: '/api/admin/organizations/{id}',
+      path: '/api/admin/organizations/{organizationId}',
       config: {
         pre: [
           {
@@ -188,7 +188,7 @@ const register = async function (server) {
         ],
         validate: {
           params: Joi.object({
-            id: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId,
           }),
         },
         payload: {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -160,6 +160,17 @@ const get = async function ({ organizationId }) {
         },
       };
     }
+
+    if (key === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key) {
+      return {
+        ...features,
+        [key]: {
+          active: enabled,
+          params,
+        },
+      };
+    }
+
     return { ...features, [key]: { active: enabled, params: null } };
   }, {});
 
@@ -330,8 +341,8 @@ async function _enableFeatures(knexConn, featuresToEnable, organizationId) {
           params: _paramsForFeature(importFormats, key, featuresToEnable[key]),
         })),
     )
-    .onConflict()
-    .ignore();
+    .onConflict(['organizationId', 'featureId'])
+    .merge(['params']);
 }
 
 function _setSearchFiltersForQueryBuilder(qb, filter) {
@@ -357,6 +368,10 @@ function _paramsForFeature(importFormats, key, value) {
   if (key === ORGANIZATION_FEATURE.LEARNER_IMPORT.key) {
     const learnerImportFormat = importFormats.find(({ name }) => name === value.params.name);
     return { organizationLearnerImportFormatId: learnerImportFormat.id };
+  }
+
+  if (key === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key) {
+    return { enablePlacesThresholdLock: value.params?.enablePlacesThresholdLock || false };
   }
 }
 

--- a/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import { config } from '../../../../shared/config.js';
+
 export class PlaceStatistics {
   #placesLots;
   #placeRepartition;
@@ -40,5 +42,13 @@ export class PlaceStatistics {
 
   get placesLotsTotal() {
     return this.#activePlacesLots.length;
+  }
+
+  get hasReachMaximumPlacesWithThreshold() {
+    if (this.occupied === 0) return false;
+
+    const thresholdLock = config.features.organizationPlacesManagementThreshold;
+    const maximumPlaces = this.total + this.total * thresholdLock;
+    return this.occupied >= maximumPlaces;
   }
 }

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -10,6 +10,7 @@ import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import { Organization } from '../domain/models/index.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
 import { PromiseUtils } from '../infrastructure/utils/promise-utils.js';
+import * as checkOrganizationAccessUseCase from './usecases/check-organization-access.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
 import * as checkAdminMemberHasRoleCertifUseCase from './usecases/checkAdminMemberHasRoleCertif.js';
@@ -775,6 +776,22 @@ async function checkOrganizationHasFeature(request, h, dependencies = { checkOrg
   }
 }
 
+async function checkOrganizationAccess(request, h, dependencies = { checkOrganizationAccessUseCase }) {
+  try {
+    // yeah this is ugly. should rework that later.
+    const organizationId =
+      request.params.organizationId || parseInt(request.payload.data?.relationships?.organization?.data?.id);
+
+    await dependencies.checkOrganizationAccessUseCase.execute({
+      organizationId,
+    });
+
+    return h.response(true);
+  } catch {
+    return _replyForbiddenError(h);
+  }
+}
+
 function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
 }
@@ -814,6 +831,7 @@ const securityPreHandlers = {
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,
   checkUserOwnsCertificationCourse,
   makeCheckOrganizationHasFeature,
+  checkOrganizationAccess,
 };
 
 export { securityPreHandlers };

--- a/api/src/shared/application/usecases/check-organization-access.js
+++ b/api/src/shared/application/usecases/check-organization-access.js
@@ -1,0 +1,25 @@
+import { getAllFeaturesFromOrganization } from '../../../organizational-entities/application/api/organization-features-api.js';
+import { usecases as prescriptionUsecases } from '../../../prescription/organization-place/domain/usecases/index.js';
+import { ORGANIZATION_FEATURE } from '../../domain/constants.js';
+import { ForbiddenAccess } from '../../domain/errors.js';
+
+const execute = async function ({ organizationId, dependencies = { getAllFeaturesFromOrganization } }) {
+  const { features } = await dependencies.getAllFeaturesFromOrganization(organizationId);
+
+  const placesManagementFeature = features.find(
+    (feature) => feature.name === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+  );
+  const hasLockEnabled = placesManagementFeature?.params?.enablePlacesThresholdLock;
+
+  if (!hasLockEnabled) return true;
+
+  const placesStatistics = await prescriptionUsecases.getOrganizationPlacesStatistics({ organizationId });
+
+  if (placesStatistics.hasReachMaximumPlacesWithThreshold) {
+    throw new ForbiddenAccess('Maximum places reached', 'MAXIMUM_PLACES_REACHED');
+  }
+
+  return true;
+};
+
+export { execute };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -291,6 +291,7 @@ const configuration = (function () {
         synchronously: toBoolean(process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_SYNCHRONOUSLY),
       },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
+      organizationPlacesManagementThreshold: parseFloat(process.env.ORGANIZATION_PLACES_MANAGEMENT_THRESHOLD ?? '0.1'),
     },
     featureToggles: {
       deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -577,7 +577,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('PATCH /api/admin/organizations/{id}', function () {
+  describe('PATCH /api/admin/organizations/{organizationId}', function () {
     it('should return the updated organization and status code 200', async function () {
       // given
       const organizationAttributes = {

--- a/api/tests/organizational-entities/integration/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/integration/application/organization/organization.admin.route.test.js
@@ -249,7 +249,7 @@ describe('Integration | Organizational Entities | Application | Route | Admin | 
     });
   });
 
-  describe('PATCH /api/admin/organizations/{id}', function () {
+  describe('PATCH /api/admin/organizations/{organizationId}', function () {
     it('returns forbidden access if admin member has CERTIF role', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif').callsFake((request, h) => h.response(true));

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1170,6 +1170,96 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         const enabledFeatures = await knex('organization-features');
         expect(enabledFeatures).to.have.lengthOf(0);
       });
+
+      describe('PLACES_MANAGEMENT', function () {
+        let organization, placeManagementFeature;
+
+        beforeEach(async function () {
+          placeManagementFeature = databaseBuilder.factory.buildFeature({
+            key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+          });
+          const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+          organization = databaseBuilder.factory.buildOrganization({
+            name: 'super orga',
+            createdBy: userId,
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('should insert new feature with given params', async function () {
+          // given && when
+          const organizationToUpdate = new OrganizationForAdmin({
+            id: organization.id,
+            documentationUrl: 'https://pix.fr/',
+            features: {
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
+              [ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key]: {
+                active: true,
+                params: { enablePlacesThresholdLock: true },
+              },
+            },
+          });
+          await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+          //then
+          const enabledFeatures = await knex('organization-features');
+          expect(enabledFeatures).lengthOf(1);
+          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: true });
+        });
+
+        it('by default, should insert new feature with falsy enablePlacesThresholdLock param', async function () {
+          // given && when
+          const organizationToUpdate = new OrganizationForAdmin({
+            id: organization.id,
+            documentationUrl: 'https://pix.fr/',
+            features: {
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
+              [ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key]: {
+                active: true,
+                params: null,
+              },
+            },
+          });
+
+          await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+          //then
+          const enabledFeatures = await knex('organization-features');
+          expect(enabledFeatures).lengthOf(1);
+          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: false });
+        });
+
+        it('should be possible to update enablePlacesThresholdLock param value', async function () {
+          // given && when
+          databaseBuilder.factory.buildOrganizationFeature({
+            featureId: placeManagementFeature.id,
+            organizationId: organization.id,
+            params: { enablePlacesThresholdLock: false },
+          });
+
+          await databaseBuilder.commit();
+
+          const organizationToUpdate = new OrganizationForAdmin({
+            id: organization.id,
+            documentationUrl: 'https://pix.fr/',
+            features: {
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
+              [ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key]: {
+                active: true,
+                params: { enablePlacesThresholdLock: true },
+              },
+            },
+          });
+
+          await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+          //then
+          const enabledFeatures = await knex('organization-features');
+          expect(enabledFeatures).lengthOf(1);
+          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: true });
+        });
+      });
     });
 
     it('should create data protection officer', async function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1049,125 +1049,127 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(updatedOrganization.updatedAt).to.deep.equal(new Date('2022-02-02'));
     });
 
-    it('should enable feature', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
-      const organization = databaseBuilder.factory.buildOrganization({
-        name: 'super orga',
-        createdBy: userId,
-      });
-      const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
-      await databaseBuilder.commit();
+    describe('#features', function () {
+      it('should enable feature', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'super orga',
+          createdBy: userId,
+        });
+        const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
+        await databaseBuilder.commit();
 
-      // when
-      const organizationToUpdate = new OrganizationForAdmin({
-        id: organization.id,
-        documentationUrl: 'https://pix.fr/',
-        features: {
-          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: false },
-          [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: true },
-        },
-      });
-      await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+        // when
+        const organizationToUpdate = new OrganizationForAdmin({
+          id: organization.id,
+          documentationUrl: 'https://pix.fr/',
+          features: {
+            [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: false },
+            [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: true },
+          },
+        });
+        await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
 
-      // then
-      const enabledFeatures = await knex('organization-features')
-        .where({ organizationId: organization.id, featureId })
-        .whereNot({ featureId: byDefaultFeatureId });
-      expect(enabledFeatures).to.have.lengthOf(1);
-      expect(enabledFeatures[0].featureId).to.equal(featureId);
-    });
-
-    it('should not enable feature twice', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
-      const organization = databaseBuilder.factory.buildOrganization({
-        name: 'super orga',
-        createdBy: userId,
+        // then
+        const enabledFeatures = await knex('organization-features')
+          .where({ organizationId: organization.id, featureId })
+          .whereNot({ featureId: byDefaultFeatureId });
+        expect(enabledFeatures).to.have.lengthOf(1);
+        expect(enabledFeatures[0].featureId).to.equal(featureId);
       });
 
-      const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
+      it('should not enable feature twice', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'super orga',
+          createdBy: userId,
+        });
 
-      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId });
-      await databaseBuilder.commit();
+        const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
 
-      // when
-      const organizationToUpdate = new OrganizationForAdmin({
-        id: organization.id,
-        documentationUrl: 'https://pix.fr/',
-        features: {
-          [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: true },
-        },
+        databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId });
+        await databaseBuilder.commit();
+
+        // when
+        const organizationToUpdate = new OrganizationForAdmin({
+          id: organization.id,
+          documentationUrl: 'https://pix.fr/',
+          features: {
+            [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: true },
+          },
+        });
+
+        await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+        // then
+        const enabledFeatures = await knex('organization-features')
+          .where({ organizationId: organization.id })
+          .whereNot({ featureId: byDefaultFeatureId });
+        expect(enabledFeatures).to.have.lengthOf(1);
+        expect(enabledFeatures[0].featureId).to.equal(featureId);
       });
 
-      await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+      it('should disable feature for a given organization', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'super orga',
+          createdBy: userId,
+        });
 
-      // then
-      const enabledFeatures = await knex('organization-features')
-        .where({ organizationId: organization.id })
-        .whereNot({ featureId: byDefaultFeatureId });
-      expect(enabledFeatures).to.have.lengthOf(1);
-      expect(enabledFeatures[0].featureId).to.equal(featureId);
-    });
+        const otherOrganization = databaseBuilder.factory.buildOrganization({
+          name: 'other orga',
+          createdBy: userId,
+        });
 
-    it('should disable feature for a given organization', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
-      const organization = databaseBuilder.factory.buildOrganization({
-        name: 'super orga',
-        createdBy: userId,
+        const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
+        databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId });
+        databaseBuilder.factory.buildOrganizationFeature({ organizationId: otherOrganization.id, featureId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const organizationToUpdate = new OrganizationForAdmin({
+          id: organization.id,
+          documentationUrl: 'https://pix.fr/',
+          features: {
+            [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: false },
+          },
+        });
+        await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+        //then
+        const enabledFeatures = await knex('organization-features').whereNot({ featureId: byDefaultFeatureId });
+        expect(enabledFeatures).to.have.lengthOf(1);
+        expect(enabledFeatures[0].organizationId).to.equal(otherOrganization.id);
       });
 
-      const otherOrganization = databaseBuilder.factory.buildOrganization({
-        name: 'other orga',
-        createdBy: userId,
+      it('should disable the "by default" feature for a given organization', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'super orga',
+          createdBy: userId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const organizationToUpdate = new OrganizationForAdmin({
+          id: organization.id,
+          documentationUrl: 'https://pix.fr/',
+          features: {
+            [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
+          },
+        });
+        await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+        //then
+        const enabledFeatures = await knex('organization-features');
+        expect(enabledFeatures).to.have.lengthOf(0);
       });
-
-      const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
-      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId });
-      databaseBuilder.factory.buildOrganizationFeature({ organizationId: otherOrganization.id, featureId });
-
-      await databaseBuilder.commit();
-
-      // when
-      const organizationToUpdate = new OrganizationForAdmin({
-        id: organization.id,
-        documentationUrl: 'https://pix.fr/',
-        features: {
-          [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: false },
-        },
-      });
-      await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
-
-      //then
-      const enabledFeatures = await knex('organization-features').whereNot({ featureId: byDefaultFeatureId });
-      expect(enabledFeatures).to.have.lengthOf(1);
-      expect(enabledFeatures[0].organizationId).to.equal(otherOrganization.id);
-    });
-
-    it('should disable the "by default" feature for a given organization', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
-      const organization = databaseBuilder.factory.buildOrganization({
-        name: 'super orga',
-        createdBy: userId,
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const organizationToUpdate = new OrganizationForAdmin({
-        id: organization.id,
-        documentationUrl: 'https://pix.fr/',
-        features: {
-          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
-        },
-      });
-      await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
-
-      //then
-      const enabledFeatures = await knex('organization-features');
-      expect(enabledFeatures).to.have.lengthOf(0);
     });
 
     it('should create data protection officer', async function () {

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -1,5 +1,6 @@
 import { PlacesLot } from '../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
 import { PlaceStatistics } from '../../../../../../src/prescription/organization-place/domain/read-models/PlaceStatistics.js';
+import { config } from '../../../../../../src/shared/config.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
@@ -220,6 +221,51 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
       });
 
       expect(statistics.placesLotsTotal).to.equal(2);
+    });
+  });
+
+  describe('#hasReachMaximumPlacesWithThreshold', function () {
+    describe('when there is no occupied places', function () {
+      it('should return false', function () {
+        // when
+        const statistics = new PlaceStatistics({
+          placesLots: [{ count: 0, isActive: true }],
+          placeRepartition: { totalUnRegisteredParticipant: 0, totalRegisteredParticipant: 0 },
+        });
+
+        // then
+        expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.false;
+      });
+    });
+
+    describe('when there are participant', function () {
+      it('should return true when maximum places count is reached', function () {
+        // given
+        sinon.stub(config.features, 'organizationPlacesManagementThreshold').value(0.1);
+
+        // when
+        const statistics = new PlaceStatistics({
+          placesLots: [{ count: 100, isActive: true }],
+          placeRepartition: { totalUnRegisteredParticipant: 10, totalRegisteredParticipant: 100 },
+        });
+
+        // then
+        expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.true;
+      });
+
+      it('should return false when maximum places count is not reached', function () {
+        // given
+        sinon.stub(config.features, 'organizationPlacesManagementThreshold').value(0.1);
+
+        // when
+        const statistics = new PlaceStatistics({
+          placesLots: [{ count: 100, isActive: true }],
+          placeRepartition: { totalUnRegisteredParticipant: 10, totalRegisteredParticipant: 99 },
+        });
+
+        // then
+        expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, lors d'un dépassement de place. Nous ne pouvons rien faire pour inciter à réguler la situation. 

## ⛱️ Proposition

Ajouter la possibilité de bloquer un prescripteur dans le but de réguler sa situation

## 🌊 Remarques

Cette feature sera activable à la maille de l'organisation

## 🏄 Pour tester
Aller sur PixAdmin activer la feature des places. lors de la seconde édition, il est possible d'activer ou de désactiver le verrouillage si dépassement il y a. 