### PR TITLE
[TECH] Récupérer Ember Inspector sur Pix Admin (PIX-18558).

### DIFF
--- a/admin/app/app.js
+++ b/admin/app/app.js
@@ -1,4 +1,9 @@
+import { RSVP } from '@ember/-internals/runtime';
 import Application from '@ember/application';
+import * as runtime from '@glimmer/runtime';
+import * as tracking from '@glimmer/tracking';
+import * as validator from '@glimmer/validator';
+import Ember from 'ember';
 import loadInitializers from 'ember-load-initializers';
 import config from 'pix-admin/config/environment';
 
@@ -9,6 +14,16 @@ class App extends Application {
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
 }
+
+// This is a temporary solution, see https://github.com/emberjs/ember-inspector/issues/2612
+window.define('@glimmer/tracking', () => tracking);
+window.define('@glimmer/runtime', () => runtime);
+window.define('@glimmer/validator', () => validator);
+window.define('rsvp', () => RSVP);
+window.define('ember', () => ({ default: Ember }));
+window.define('<my-app>/config/environment', () => ({
+  default: config,
+}));
 
 loadInitializers(App, config.modulePrefix);
 


### PR DESCRIPTION
## 🔆 Problème

Ember inspector c'est très utile et quand ça fonctionne plus, c'est compliqué.

## ⛱️ Proposition

De la même manière que fait coté Pix App et Orga, on fixe temporairement le soucis (issue : https://github.com/emberjs/ember-inspector/issues/2612)

## 🌊 Remarques

https://github.com/1024pix/pix/pull/12718
https://github.com/1024pix/pix/pull/11501

## 🏄 Pour tester

Aller sur admin, ouvrir sa console et voir Ember Inspector renaître de ses cendres