### PR TITLE
[TECH] utiliser un getByText plutôt qu'un getAllByText (PIX-16656)

### DIFF
--- a/orga/tests/integration/components/participant/assessment/header-test.js
+++ b/orga/tests/integration/components/participant/assessment/header-test.js
@@ -342,10 +342,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
-
-          // We should keep getAllByText instead of getByText because in the ci the npm run test fails.
-          // It finds two occurences instead of one for some reason related to a nbsp; not being present in this context.
-          assert.ok(screen.getAllByText('65%')[0]);
+          assert.ok(screen.getByText('65%'));
         });
       });
 


### PR DESCRIPTION
## 🔆 Problème

Dans le teste "Integration | Component | Participant::Assessment::Header" on utilise un getAllByText qui n'est pas nécessaire.

## ⛱️ Proposition

Le remplacer par un getByText.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

CI en vert.
