### PR TITLE
[BUGFIX] Ne pas prendre en compte l'envoie de la PJ dans le compte du pormpt limite lorsqu'il est accompagné d'un message (PIX-18500)

### DIFF
--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -89,14 +89,14 @@ export async function prompt({ chatId, userId, message, attachmentName }) {
     throw new NoAttachmentNeededError();
   }
   if (attachmentName && attachmentName === configuration.attachmentName) {
-    chat.addAttachmentContextMessages(configuration.attachmentName, configuration.attachmentContext);
+    chat.addAttachmentContextMessages(configuration.attachmentName, configuration.attachmentContext, !!message);
   }
   let readableStream = null;
   if (message) {
     if (message.length > configuration.inputMaxChars) {
       throw new TooLargeMessageInputError();
     }
-    // TODO quelque chose cloche avec cette histoire de -1 sur les prompts
+
     if (chat.currentPromptsCount >= configuration.inputMaxPrompts) {
       throw new MaxPromptsReachedError();
     }

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -65,7 +65,7 @@ export class Chat {
    * @returns {number}
    */
   get currentPromptsCount() {
-    return this.messages.filter((message) => message.isFromUser).length;
+    return this.messages.filter((message) => message.isFromUser && !message.notCounted).length;
   }
 
   /**
@@ -88,9 +88,10 @@ export class Message {
    * @param {string} params.content
    * @param {Boolean} params.isFromUser
    */
-  constructor({ content, isFromUser }) {
+  constructor({ content, isFromUser, notCounted }) {
     this.content = content;
     this.isFromUser = isFromUser;
+    this.notCounted = !!notCounted;
   }
 
   /**
@@ -100,6 +101,7 @@ export class Message {
     return {
       content: this.content,
       isFromUser: this.isFromUser,
+      notCounted: this.notCounted,
     };
   }
 }

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -27,9 +27,10 @@ export class Chat {
   /**
    * @param {string} attachmentName
    * @param {string} attachmentContext
+   * @param {boolean} notCounted
    * @returns {void}
    */
-  addAttachmentContextMessages(attachmentName, attachmentContext) {
+  addAttachmentContextMessages(attachmentName, attachmentContext, notCounted) {
     if (!this.hasAttachmentContextBeenAdded) {
       const userContent = `
 <system_notification>
@@ -38,7 +39,7 @@ export class Chat {
     ${attachmentName}
   </attachment_name>
 </system_notification>`;
-      this.messages.push(new Message({ content: userContent, isFromUser: true }));
+      this.messages.push(new Message({ content: userContent, isFromUser: true, notCounted }));
       const llmContent = `
 <read_attachment_tool>
   Lecture de la pièce jointe, ${attachmentName} :

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -410,12 +410,25 @@ describe('LLM | Integration | Application | API | llm', function () {
               configurationId: 'uneConfigQuiExist',
               hasAttachmentContextBeenAdded: false,
               messages: [
-                { content: 'coucou user1', isFromUser: true },
-                { content: 'coucou LLM1', isFromUser: false },
-                { content: 'un message', isFromUser: true },
+                {
+                  content: 'coucou user1',
+                  isFromUser: true,
+                  notCounted: false,
+                },
+                {
+                  content: 'coucou LLM1',
+                  isFromUser: false,
+                  notCounted: false,
+                },
+                {
+                  content: 'un message',
+                  isFromUser: true,
+                  notCounted: false,
+                },
                 {
                   content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
                   isFromUser: false,
+                  notCounted: false,
                 },
               ],
             });
@@ -547,12 +560,13 @@ describe('LLM | Integration | Application | API | llm', function () {
                   configurationId: 'uneConfigQuiExist',
                   hasAttachmentContextBeenAdded: false,
                   messages: [
-                    { content: 'coucou user1', isFromUser: true },
-                    { content: 'coucou LLM1', isFromUser: false },
-                    { content: 'un message', isFromUser: true },
+                    { content: 'coucou user1', isFromUser: true, notCounted: false },
+                    { content: 'coucou LLM1', isFromUser: false, notCounted: false },
+                    { content: 'un message', isFromUser: true, notCounted: false },
                     {
                       content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
                       isFromUser: false,
+                      notCounted: false,
                     },
                   ],
                 });
@@ -661,23 +675,26 @@ describe('LLM | Integration | Application | API | llm', function () {
                     configurationId: 'uneConfigQuiExist',
                     hasAttachmentContextBeenAdded: true,
                     messages: [
-                      { content: 'coucou user1', isFromUser: true },
-                      { content: 'coucou LLM1', isFromUser: false },
+                      { content: 'coucou user1', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
                         content:
                           'Ajoute le fichier fictif "expected_file.txt" à ton contexte. Voici le contenu du fichier :\nadd me in the chat !',
                         isFromUser: true,
+                        notCounted: false,
                       },
                       {
                         content: 'Le contenu du fichier fictif a été ajouté au contexte.',
                         isFromUser: false,
+                        notCounted: false,
                       },
-                      { content: 'coucou user2', isFromUser: true },
-                      { content: 'coucou LLM2', isFromUser: false },
-                      { content: 'un message', isFromUser: true },
+                      { content: 'coucou user2', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM2', isFromUser: false, notCounted: false },
+                      { content: 'un message', isFromUser: true, notCounted: false },
                       {
                         content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
                         isFromUser: false,
+                        notCounted: false,
                       },
                     ],
                   });
@@ -773,22 +790,25 @@ describe('LLM | Integration | Application | API | llm', function () {
                     configurationId: 'uneConfigQuiExist',
                     hasAttachmentContextBeenAdded: true,
                     messages: [
-                      { content: 'coucou user1', isFromUser: true },
-                      { content: 'coucou LLM1', isFromUser: false },
+                      { content: 'coucou user1', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
                         content:
                           "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
                         isFromUser: true,
+                        notCounted: false,
                       },
                       {
                         content:
                           '\n<read_attachment_tool>\n  Lecture de la pièce jointe, expected_file.txt :\n  <attachment_content>\n    add me in the chat !\n  </attachment_content>\n</read_attachment_tool>',
                         isFromUser: false,
+                        notCounted: false,
                       },
-                      { content: 'un message', isFromUser: true },
+                      { content: 'un message', isFromUser: true, notCounted: false },
                       {
                         content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
                         isFromUser: false,
+                        notCounted: false,
                       },
                     ],
                   });
@@ -936,8 +956,8 @@ describe('LLM | Integration | Application | API | llm', function () {
                   configurationId: 'uneConfigQuiExist',
                   hasAttachmentContextBeenAdded: false,
                   messages: [
-                    { content: 'coucou user1', isFromUser: true },
-                    { content: 'coucou LLM1', isFromUser: false },
+                    { content: 'coucou user1', isFromUser: true, notCounted: false },
+                    { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                   ],
                 });
                 expect(llmConfigurationScope.isDone()).to.be.true;
@@ -1013,19 +1033,21 @@ describe('LLM | Integration | Application | API | llm', function () {
                     configurationId: 'uneConfigQuiExist',
                     hasAttachmentContextBeenAdded: true,
                     messages: [
-                      { content: 'coucou user1', isFromUser: true },
-                      { content: 'coucou LLM1', isFromUser: false },
+                      { content: 'coucou user1', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
                         content:
                           'Ajoute le fichier fictif "expected_file.txt" à ton contexte. Voici le contenu du fichier :\nadd me in the chat !',
                         isFromUser: true,
+                        notCounted: false,
                       },
                       {
                         content: 'Le contenu du fichier fictif a été ajouté au contexte.',
                         isFromUser: false,
+                        notCounted: false,
                       },
-                      { content: 'coucou user2', isFromUser: true },
-                      { content: 'coucou LLM2', isFromUser: false },
+                      { content: 'coucou user2', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM2', isFromUser: false, notCounted: false },
                     ],
                   });
                   expect(llmConfigurationScope.isDone()).to.be.true;
@@ -1089,17 +1111,19 @@ describe('LLM | Integration | Application | API | llm', function () {
                     configurationId: 'uneConfigQuiExist',
                     hasAttachmentContextBeenAdded: true,
                     messages: [
-                      { content: 'coucou user1', isFromUser: true },
-                      { content: 'coucou LLM1', isFromUser: false },
+                      { content: 'coucou user1', isFromUser: true, notCounted: false },
+                      { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
                         content:
                           "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
                         isFromUser: true,
+                        notCounted: false,
                       },
                       {
                         content:
                           '\n<read_attachment_tool>\n  Lecture de la pièce jointe, expected_file.txt :\n  <attachment_content>\n    add me in the chat !\n  </attachment_content>\n</read_attachment_tool>',
                         isFromUser: false,
+                        notCounted: false,
                       },
                     ],
                   });

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -796,7 +796,7 @@ describe('LLM | Integration | Application | API | llm', function () {
                         content:
                           "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
                         isFromUser: true,
-                        notCounted: false,
+                        notCounted: true,
                       },
                       {
                         content:
@@ -820,6 +820,7 @@ describe('LLM | Integration | Application | API | llm', function () {
           });
         });
       });
+
       context('when no prompt is provided', function () {
         context('when no attachmentName is provided', function () {
           it('should throw a NoAttachmentNorMessageProvidedError', async function () {

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -33,8 +33,8 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         configurationId: 'someConfigurationId',
         hasAttachmentContextBeenAdded: false,
         messages: [
-          { content: 'je suis user', isFromUser: true },
-          { content: 'je suis LLM', isFromUser: false },
+          { content: 'je suis user', isFromUser: true, notCounted: false },
+          { content: 'je suis LLM', isFromUser: false, notCounted: false },
         ],
       });
     });
@@ -54,8 +54,8 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
             configurationId: 'someConfigurationId',
             hasAttachmentContextBeenAdded: false,
             messages: [
-              new Message({ content: 'je suis user', isFromUser: true }),
-              new Message({ content: 'je suis LLM', isFromUser: false }),
+              new Message({ content: 'je suis user', isFromUser: true, notCounted: false }),
+              new Message({ content: 'je suis LLM', isFromUser: false, notCounted: false }),
             ],
           });
           await save(chat);
@@ -78,8 +78,8 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           configurationId: 'someConfigurationId',
           hasAttachmentContextBeenAdded: false,
           messages: [
-            new Message({ content: 'je suis user', isFromUser: true }),
-            new Message({ content: 'je suis LLM', isFromUser: false }),
+            new Message({ content: 'je suis user', isFromUser: true, notCounted: false }),
+            new Message({ content: 'je suis LLM', isFromUser: false, notCounted: false }),
           ],
         });
         await save(chat);

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -25,10 +25,12 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           {
             content: 'some message',
             isFromUser: false,
+            notCounted: false,
           },
           {
             content: 'un message pas vide',
             isFromUser: true,
+            notCounted: false,
           },
         ],
       });
@@ -57,6 +59,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           {
             content: 'some message',
             isFromUser: false,
+            notCounted: false,
           },
         ],
       });
@@ -86,10 +89,12 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           {
             content: 'some message',
             isFromUser: false,
+            notCounted: false,
           },
           {
             content: 'un message pas vide',
             isFromUser: false,
+            notCounted: false,
           },
         ],
       });
@@ -118,6 +123,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           {
             content: 'some message',
             isFromUser: false,
+            notCounted: false,
           },
         ],
       });
@@ -153,20 +159,24 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             {
               content: 'some message',
               isFromUser: true,
+              notCounted: false,
             },
             {
               content: 'some answer',
               isFromUser: false,
+              notCounted: false,
             },
             {
               content:
                 "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    winter_lyrics.txt\n  </attachment_name>\n</system_notification>",
               isFromUser: true,
+              notCounted: false,
             },
             {
               content:
                 "\n<read_attachment_tool>\n  Lecture de la pièce jointe, winter_lyrics.txt :\n  <attachment_content>\n    J'étais assise sur une pierre\nDes larmes coulaient sur mon visage\n  </attachment_content>\n</read_attachment_tool>",
               isFromUser: false,
+              notCounted: false,
             },
           ],
         });
@@ -201,10 +211,12 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             {
               content: 'some message',
               isFromUser: true,
+              notCounted: false,
             },
             {
               content: 'some answer',
               isFromUser: false,
+              notCounted: false,
             },
           ],
         });
@@ -250,7 +262,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
     });
 
     context('when chat has user messages', function () {
-      it('should return the number of user messages', function () {
+      it('should return the number of counted user messages', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
@@ -271,6 +283,29 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         expect(currentPromptsCount).to.equal(2);
       });
     });
+
+    context('when chat has user uncounted messages ', function () {
+      it('should return the number of counted user messages', function () {
+        // given
+        const chat = new Chat({
+          id: 'some-chat-id',
+          configurationId: 'some-config-id',
+          hasAttachmentContextBeenAdded: false,
+          messages: [
+            new Message({ content: 'message llm 1', isFromUser: false }),
+            new Message({ content: 'message user 1', isFromUser: true }),
+            new Message({ content: 'message llm 2', isFromUser: false }),
+            new Message({ content: 'message user 2', isFromUser: true, notCounted: true }),
+          ],
+        });
+
+        // when
+        const currentPromptsCount = chat.currentPromptsCount;
+
+        // then
+        expect(currentPromptsCount).to.equal(1);
+      });
+    });
   });
 
   describe('#toDTO', function () {
@@ -282,7 +317,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         hasAttachmentContextBeenAdded: false,
         messages: [
           new Message({ content: 'message llm 1', isFromUser: false }),
-          new Message({ content: 'message user 1', isFromUser: true }),
+          new Message({ content: 'message user 1', isFromUser: true, notCounted: true }),
         ],
       });
 
@@ -298,10 +333,12 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           {
             content: 'message llm 1',
             isFromUser: false,
+            notCounted: false,
           },
           {
             content: 'message user 1',
             isFromUser: true,
+            notCounted: true,
           },
         ],
       });


### PR DESCRIPTION
## 🔆 Problème

Si un utilisateur envoie une pièce jointe avec un message alors on doit lui décompter un seul prompt et non deux.

## ⛱️ Proposition

Ignorer le prompt d'ajout de PJ lorsqu’il est accompagné d'un message

## 🌊 Remarques

Si l'utilisateur envoie une mauvaise PJ, alors le front aura décompté un prompt alors que le back non.

## 🏄 Pour tester

je ne sais pas les tests sont vert
