### PR TITLE
[TECH] Renommer les colonnes alpha et delta dans la table certification-frameworks-challenges (PIX-18509).

### DIFF
--- a/api/db/database-builder/factory/build-certification-frameworks-challenge.js
+++ b/api/db/database-builder/factory/build-certification-frameworks-challenge.js
@@ -6,8 +6,8 @@ import { buildChallenge } from './learning-content/build-challenge.js';
 
 const buildCertificationFrameworksChallenge = function ({
   id = databaseBuffer.getNextId(),
-  alpha = 2.2,
-  delta = 3.5,
+  discriminant = 2.2,
+  difficulty = 3.5,
   complementaryCertificationKey,
   challengeId,
   createdAt,
@@ -20,8 +20,8 @@ const buildCertificationFrameworksChallenge = function ({
 
   const values = {
     id,
-    alpha,
-    delta,
+    discriminant,
+    difficulty,
     complementaryCertificationKey,
     challengeId,
     createdAt,

--- a/api/db/migrations/20250702143656_rename-alpha-and-delta-on-certification-frameworks-challenges-table.js
+++ b/api/db/migrations/20250702143656_rename-alpha-and-delta-on-certification-frameworks-challenges-table.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const ALPHA_OLD_COLUMN_NAME = 'alpha';
+const ALPHA_NEW_COLUMN_NAME = 'discriminant';
+const DELTA_OLD_COLUMN_NAME = 'delta';
+const DELTA_NEW_COLUMN_NAME = 'difficulty';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.renameColumn(ALPHA_OLD_COLUMN_NAME, ALPHA_NEW_COLUMN_NAME);
+    table.renameColumn(DELTA_OLD_COLUMN_NAME, DELTA_NEW_COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.renameColumn(ALPHA_NEW_COLUMN_NAME, ALPHA_OLD_COLUMN_NAME);
+    table.renameColumn(DELTA_NEW_COLUMN_NAME, DELTA_OLD_COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -288,14 +288,14 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       expect(response.result.data.id).to.exist;
 
       const consolidatedFramework = await knex('certification-frameworks-challenges')
-        .select('alpha', 'delta', 'challengeId', 'complementaryCertificationKey')
+        .select('discriminant', 'difficulty', 'challengeId', 'complementaryCertificationKey')
         .where({
           complementaryCertificationKey: complementaryCertification.key,
         });
       expect(consolidatedFramework).to.deep.equal([
         {
-          alpha: null,
-          delta: null,
+          discriminant: null,
+          difficulty: null,
           challengeId: challenge.id,
           complementaryCertificationKey: complementaryCertification.key,
         },

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -31,8 +31,8 @@ describe('Certification | Configuration | Integration | Repository | consolidate
       const consolidatedFrameworkInDB = await knex('certification-frameworks-challenges').select(
         'complementaryCertificationKey',
         'challengeId',
-        'alpha',
-        'delta',
+        'discriminant',
+        'difficulty',
         'createdAt',
       );
 
@@ -40,14 +40,14 @@ describe('Certification | Configuration | Integration | Repository | consolidate
       expect(_.omit(consolidatedFrameworkInDB[0], 'createdAt')).to.deep.equal({
         complementaryCertificationKey: complementaryCertification.key,
         challengeId: challenge1.id,
-        alpha: null,
-        delta: null,
+        discriminant: null,
+        difficulty: null,
       });
       expect(_.omit(consolidatedFrameworkInDB[1], 'createdAt')).to.deep.equal({
         complementaryCertificationKey: complementaryCertification.key,
         challengeId: challenge2.id,
-        alpha: null,
-        delta: null,
+        discriminant: null,
+        difficulty: null,
       });
       expect(consolidatedFrameworkInDB[0].createdAt).to.deep.equal(consolidatedFrameworkInDB[1].createdAt);
     });

--- a/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
+++ b/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
@@ -36,8 +36,8 @@ describe('Integration | Scripts | Certification | target-profile-to-calibrated-f
     expect(frameworksChallenges[0].challengeId).to.equal(learningContent.challenges[0].id);
     expect(frameworksChallenges[0].complementaryCertificationKey).to.equal(complementaryCertification.key);
     expect(frameworksChallenges[0].createdAt).to.be.instanceOf(Date);
-    expect(frameworksChallenges[0].alpha).to.be.null;
-    expect(frameworksChallenges[0].delta).to.be.null;
+    expect(frameworksChallenges[0].discriminant).to.be.null;
+    expect(frameworksChallenges[0].difficulty).to.be.null;
   });
 
   context('when the certification key option does not exist in the domain', function () {


### PR DESCRIPTION
## 🔆 Problème

Coté certif on a plutôt fait l'usage de discriminant et difficulty pour parler de l'alpha et delta des challenges. Pourtant notre nouvelle table n'est pas iso à cet usage.

## ⛱️ Proposition

renommer les colonnes dans certification-frameworks-challenges

## 🌊 Remarques

Une autre PR sera faite pour transformer l'alpha/delta qu'on reçoit du datamart pour renseigner la table
