### PR TITLE
[BUGFIX] Corriger le type du champ alt des images dans le schéma du QAB (PIX-18592)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qab.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qab.sample.js
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+
+export function getQabSample() {
+  return {
+    id: randomUUID(),
+    type: 'qab',
+    instruction:
+      '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>',
+    cards: [
+      {
+        id: randomUUID(),
+        image: {
+          url: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+          altText: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+        },
+        text: 'Les boules de pétanques sont creuses ?',
+        proposalA: 'Vrai',
+        proposalB: 'Faux',
+        solution: 'A',
+      },
+      {
+        id: randomUUID(),
+        text: 'Les chiens ne transpirent pas.',
+        proposalA: 'Vrai',
+        proposalB: 'Faux',
+        solution: 'B',
+      },
+      {
+        id: randomUUID(),
+        image: {
+          url: 'https://example.net/',
+          altText: '',
+        },
+        text: 'Les dauphins sont des poissons.',
+        proposalA: 'Vrai',
+        proposalB: 'Faux',
+        solution: 'B',
+      },
+    ],
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qab.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qab.sample.js
@@ -11,7 +11,7 @@ export function getQabSample() {
         id: randomUUID(),
         image: {
           url: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
-          altText: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+          altText: 'Plusieurs boules de pétanques',
         },
         text: 'Les boules de pétanques sont creuses ?',
         proposalA: 'Vrai',

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
@@ -12,7 +12,7 @@ const qabElementSchema = Joi.object({
       text: htmlNotAllowedSchema.allow('').required(),
       image: {
         url: htmlNotAllowedSchema.uri().allow('').required(),
-        altText: htmlNotAllowedSchema.uri().allow('').required(),
+        altText: htmlNotAllowedSchema.allow('').required(),
       },
       proposalA: htmlNotAllowedSchema.required(),
       proposalB: htmlNotAllowedSchema.required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -3,6 +3,7 @@ import { getDownloadSample } from '../../../../../../../src/devcomp/infrastructu
 import { getEmbedSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/embed.sample.js';
 import { getFlashcardsSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/flashcards.sample.js';
 import { getImageSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
+import { getQabSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qab.sample.js';
 import { getQcmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
 import { getQrocmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
@@ -15,6 +16,7 @@ import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
 import { flashcardsElementSchema } from './element/flashcards-schema.js';
 import { imageElementSchema } from './element/image-schema.js';
+import { qabElementSchema } from './element/qab-schema.js';
 import { qcmElementSchema } from './element/qcm-schema.js';
 import { qcuElementSchema } from './element/qcu-schema.js';
 import { blockInputSchema, blockSelectSchema, qrocmElementSchema } from './element/qrocm-schema.js';
@@ -67,6 +69,15 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     it('should validate sample image structure', async function () {
       try {
         await imageElementSchema.validateAsync(getImageSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample qab structure', async function () {
+      try {
+        await qabElementSchema.validateAsync(getQabSample(), { abortEarly: false });
       } catch (joiError) {
         const formattedError = joiErrorParser.format(joiError);
         expect(joiError).to.equal(undefined, formattedError);


### PR DESCRIPTION
## 🔆 Problème

Le champ cards.image.altText  dans le [schéma](https://github.com/1024pix/pix/blob/dev/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js#L15) de l'élément QAB requiert une Uri ce qui n’est pas correct.

## ⛱️ Proposition

Corriger cela en acceptant une chaîne de caractère.

## 🌊 Remarques

- Un test du schéma QAB a été ajouté pour tester ça 😄 

## 🏄 Pour tester

- (Non régression) Aller sur le module [bac-a-sable](https://app-pr12746.review.pix.fr/modules/bac-a-sable/passage)
- Passer le 1er grain
- Vérifier que l'élément QAB s'affiche toujours 😄 
