### PR TITLE
[BUGFIX] Répare l'accès aux campagnes qui ont isSimplifiedAccess et isForAbsoluteNovice à true

### DIFF
--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -78,6 +78,7 @@ Router.map(function () {
       this.route('student-sup', { path: '/etudiant' });
     });
     this.route('join', { path: '/rejoindre' }, function () {
+      this.route('anonymous', { path: '/anonyme' });
       this.route('student-sco', { path: '/identification' });
       this.route('sco-mediacentre', { path: '/mediacentre' });
     });
@@ -85,9 +86,6 @@ Router.map(function () {
   this.route('campaigns', { path: '/campagnes/:code' }, function () {
     this.route('entry-point', { path: '/' });
     this.route('archived-error', { path: '/oups' });
-    this.route('join', { path: '/rejoindre' }, function () {
-      this.route('anonymous', { path: '/anonyme' });
-    });
     this.route('campaign-landing-page', { path: '/presentation' });
     this.route('fill-in-participant-external-id', { path: '/identifiant' });
     this.route('entrance', { path: '/entree' });

--- a/mon-pix/app/routes/campaigns/join.js
+++ b/mon-pix/app/routes/campaigns/join.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+export default class JoinRoute extends Route {
+  @service session;
+  @service router;
+  beforeModel(transition) {
+    if (!transition.from) {
+      return this.router.replaceWith('campaigns.entry-point');
+    }
+    this.session.prohibitAuthentication('authenticated.user-dashboard');
+    this.routeIfAlreadyAuthenticated = 'organizations.access';
+
+    super.beforeModel(...arguments);
+  }
+
+  async model() {
+    return this.modelFor('campaigns');
+  }
+}

--- a/mon-pix/app/routes/organizations/access.js
+++ b/mon-pix/app/routes/organizations/access.js
@@ -38,7 +38,7 @@ export default class AccessRoute extends Route {
     } else if (this._shouldJoinFromMediacentre(organizationToJoin)) {
       this.authenticationRoute = 'organizations.join.sco-mediacentre';
     } else if (this._shouldJoinSimplifiedCampaignAsAnonymous(campaign)) {
-      this.authenticationRoute = 'campaigns.join.anonymous';
+      this.authenticationRoute = 'organizations.join.anonymous';
     }
     this.session.requireAuthenticationAndApprovedTermsOfService(transition, this.authenticationRoute);
   }

--- a/mon-pix/app/routes/organizations/join/anonymous.js
+++ b/mon-pix/app/routes/organizations/join/anonymous.js
@@ -1,0 +1,21 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AnonymousRoute extends Route {
+  @service session;
+  @service currentUser;
+  @service store;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('authenticated.user-dashboard');
+  }
+
+  async model() {
+    return this.modelFor('organizations');
+  }
+
+  async afterModel({ campaign }) {
+    await this.session.authenticate('authenticator:anonymous', { campaignCode: campaign.code });
+    await this.currentUser.load();
+  }
+}

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -754,9 +754,11 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       module('When is a simplified access campaign', function (hooks) {
         hooks.beforeEach(function () {
           campaign = server.create('campaign', 'withVerifiedCode', {
+            organizationId: 1,
             isSimplifiedAccess: true,
             externalIdLabel: 'Les anonymes',
           });
+          server.create('organization-to-join', { id: campaign.organizationId, code: campaign.code });
         });
 
         test('should redirect to landing page', async function (assert) {
@@ -784,9 +786,12 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       test('should replace previous connected anonymous user', async function (assert) {
         // given
         campaign = server.create('campaign', 'withVerifiedCode', {
+          organizationId: 1,
           isSimplifiedAccess: true,
           externalIdLabel: 'Les anonymes',
         });
+        server.create('organization-to-join', { id: campaign.organizationId, code: campaign.code });
+
         await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
         const session = currentSession();
         const previousUserId = session.data.authenticated['user_id'];

--- a/mon-pix/tests/unit/routes/organizations/access-test.js
+++ b/mon-pix/tests/unit/routes/organizations/access-test.js
@@ -200,7 +200,7 @@ module('Unit | Route | Access', function (hooks) {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        assert.strictEqual(route.authenticationRoute, 'campaigns.join.anonymous');
+        assert.strictEqual(route.authenticationRoute, 'organizations.join.anonymous');
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème
L'accès aux campagnes qui ont isSimplifiedAccess et isForAbsoluteNovice à true est cassé (le model "campaigns" n'est pas rempli côté front).

## ⛱️ Proposition
On déplace le composant campaign.join.anonymous vers organizations.join.anonymous pour ne pas perdre d'information.

