### PR TITLE
[FEATURE] Mob design quickwin sur les modules (PIX-18619)

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -1,25 +1,19 @@
 .feedback {
   position: relative;
-  padding-left: var(--pix-spacing-4x);
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  border-radius: var(--pix-spacing-4x);
+
 
   &--success {
     --modulix-feedback-state-color: var(--pix-success-700);
+
+    background-color: var(--pix-success-50);
   }
 
   &--error {
     --modulix-feedback-state-color: var(--pix-error-700);
-  }
 
-  &::before {
-    $correctness-indicator-bar: 6px;
-
-    position: absolute;
-    left: 0;
-    width: $correctness-indicator-bar;
-    height: 100%;
-    background-color: var(--modulix-feedback-state-color);
-    border-radius: $correctness-indicator-bar;
-    content: '';
+    background-color: var(--pix-error-50);
   }
 
   &__state {

--- a/mon-pix/app/components/module/element/_text.scss
+++ b/mon-pix/app/components/module/element/_text.scss
@@ -1,7 +1,11 @@
-
-
-
 .element-text {
+  iframe {
+    width: 100%;
+    padding: var(--pix-spacing-2x);
+    border: 2px dashed rgb(var(--pix-tertiary-500-inline), 0.6);
+    border-radius: var(--pix-spacing-2x);
+  }
+
   table {
     width: 100%;
     background: var(--pix-neutral-0);

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -1,4 +1,6 @@
 @use '../passage';
+@use 'pix-design-tokens/typography';
+
 
 $grain-card-border-radius: var(--pix-spacing-4x);
 
@@ -78,6 +80,18 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     padding: var(--pix-spacing-6x);
     background: var(--modulix-challenge-card-background);
   }
+
+  &--lesson {
+    padding: var(--pix-spacing-6x);
+    background: var(--pix-primary-10);
+    border-radius: var(--pix-spacing-4x);
+  }
+}
+
+.grain-card-title {
+  @extend %pix-title-s;
+
+  margin-bottom: var(--pix-spacing-4x);
 }
 
 .grain-card-content {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -187,6 +187,21 @@ export default class ModuleGrain extends Component {
     return `grain_${this.args.grain.id}`;
   }
 
+  get isGrainTypeWithTitle() {
+    return this.args.grain.type === 'lesson' || this.args.grain.type === 'summary';
+  }
+
+  get grainTitle() {
+    switch (this.args.grain.type) {
+      case 'lesson':
+        return 'A retenir';
+      case 'summary':
+        return 'Fiche récap';
+      default:
+        return '';
+    }
+  }
+
   <template>
     <article
       id={{this.elementId}}
@@ -200,6 +215,9 @@ export default class ModuleGrain extends Component {
           total=@totalSteps
         }}</h2>
       <div class="grain__card grain-card--{{this.grainType}}">
+        {{#if this.isGrainTypeWithTitle}}
+          <h2 class="grain-card-title">{{this.grainTitle}}</h2>
+        {{/if}}
         <div class="grain-card__content">
           <!-- eslint-disable-next-line no-unused-vars -->
           {{#each this.displayableComponents as |component|}}


### PR DESCRIPTION
## 🔆 Contexte

On veut tester l'affichage de corrections rapides sur le module.


## ⛱️ Proposition

Faire cela 😄 

## 🌊 Remarques

Liste des changements faits : 
- Ajout d'une couleur de fond et titre sur les grains recap et leçon
- Modification de l'affichage des feedbacks QCU / QCM avec la suppression de la barre à gauche et l'apparition d'une couleur de fond rouge / verte suivant s'il a réussi ou non
- Ajout d'une bordure sur les POI / balise Iframe dans les éléments texte

## 🏄 Pour tester

Aller sur https://app-pr12754.review.pix.fr/modules/tmp-prompt-intermediaire
