### PR TITLE
[TECH] Afficher en console les erreurs d'API identifiées par leur request-id (PIX-18618).

### DIFF
--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -21,4 +21,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   ajax() {
     return this.ajaxQueue.add(() => super.ajax(...arguments));
   }
+
+  handleResponse(status, headers, errors) {
+    if (errors?.errors?.[0]?.id) {
+      console.table(errors.errors[0]);
+    }
+
+    return super.handleResponse(...arguments);
+  }
 }

--- a/admin/tests/unit/adapters/application-test.js
+++ b/admin/tests/unit/adapters/application-test.js
@@ -1,3 +1,4 @@
+import REST from '@ember-data/adapter/rest';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -50,6 +51,25 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       // Then
       sinon.assert.calledOnce(applicationAdapter.ajaxQueue.add);
       assert.ok(applicationAdapter);
+    });
+  });
+
+  module('#handleResponse', function () {
+    test('should log identified API error', function (assert) {
+      // Given
+      const consoleTable = sinon.stub(console, 'table');
+
+      const applicationAdapter = this.owner.lookup('adapter:application');
+      sinon.stub(REST.prototype, 'handleResponse');
+
+      const myApiError = { id: 1, title: 'title' };
+
+      // When
+      applicationAdapter.handleResponse(null, null, { errors: [myApiError] });
+
+      // Then
+      sinon.assert.calledOnceWithExactly(consoleTable, myApiError);
+      assert.ok(true);
     });
   });
 });

--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -24,4 +24,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   ajax() {
     return this.ajaxQueue.add(() => super.ajax(...arguments));
   }
+
+  handleResponse(status, headers, errors) {
+    if (errors?.errors?.[0]?.id) {
+      console.table(errors.errors[0]);
+    }
+
+    return super.handleResponse(...arguments);
+  }
 }

--- a/certif/tests/unit/adapters/application-test.js
+++ b/certif/tests/unit/adapters/application-test.js
@@ -1,3 +1,4 @@
+import REST from '@ember-data/adapter/rest';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -61,6 +62,25 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       // Then
       sinon.assert.calledOnce(applicationAdapter.ajaxQueue.add);
       assert.ok(applicationAdapter);
+    });
+  });
+
+  module('#handleResponse', function () {
+    test('should log identified API error', function (assert) {
+      // Given
+      const consoleTable = sinon.stub(console, 'table');
+
+      const applicationAdapter = this.owner.lookup('adapter:application');
+      sinon.stub(REST.prototype, 'handleResponse');
+
+      const myApiError = { id: 1, title: 'title' };
+
+      // When
+      applicationAdapter.handleResponse(null, null, { errors: [myApiError] });
+
+      // Then
+      sinon.assert.calledOnceWithExactly(consoleTable, myApiError);
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -37,10 +37,15 @@ export default class Application extends JSONAPIAdapter {
     return currentLocale;
   }
 
-  handleResponse(status) {
+  handleResponse(status, headers, errors) {
     if (status === 401 && this.session.isAuthenticated) {
       // no-await-on-purpose -- We want the session invalidation to happen in the background
       this.session.invalidate();
+    }
+
+    if (errors?.errors?.[0]?.id) {
+      // eslint-disable-next-line no-console
+      console.table(errors.errors[0]);
     }
 
     return super.handleResponse(...arguments);

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -148,5 +148,22 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
         assert.ok(true);
       });
     });
+
+    test('should log identified API error', function (assert) {
+      // Given
+      const consoleTable = sinon.stub(console, 'table');
+
+      const applicationAdapter = this.owner.lookup('adapter:application');
+      sinon.stub(REST.prototype, 'handleResponse');
+
+      const myApiError = { id: 1, title: 'title' };
+
+      // When
+      applicationAdapter.handleResponse(null, null, { errors: [myApiError] });
+
+      // Then
+      sinon.assert.calledOnceWithExactly(consoleTable, myApiError);
+      assert.ok(true);
+    });
   });
 });

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -36,4 +36,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     }
     return currentLocale;
   }
+
+  handleResponse(status, headers, errors) {
+    if (errors?.errors?.[0]?.id) {
+      console.table(errors.errors[0]);
+    }
+
+    return super.handleResponse(...arguments);
+  }
 }

--- a/orga/tests/unit/adapters/application-test.js
+++ b/orga/tests/unit/adapters/application-test.js
@@ -1,3 +1,4 @@
+import REST from '@ember-data/adapter/rest';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -93,6 +94,25 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       // Then
       sinon.assert.calledOnce(applicationAdapter.ajaxQueue.add);
       assert.ok(applicationAdapter);
+    });
+  });
+
+  module('#handleResponse', function () {
+    test('should log identified API error', function (assert) {
+      // Given
+      const consoleTable = sinon.stub(console, 'table');
+
+      const applicationAdapter = this.owner.lookup('adapter:application');
+      sinon.stub(REST.prototype, 'handleResponse');
+
+      const myApiError = { id: 1, title: 'title' };
+
+      // When
+      applicationAdapter.handleResponse(null, null, { errors: [myApiError] });
+
+      // Then
+      sinon.assert.calledOnceWithExactly(consoleTable, myApiError);
+      assert.ok(true);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Il nous était compliqué de savoir rapidement les erreurs rencontrées par les utilisateurs.

## ⛱️ Proposition

Afficher dans la console, sous forme de table, le détail d'une erreur de requête API.
On ne l'affiche que si cette erreur est identifiée par sa `requestId`.

## 🌊 Remarques

Même si ça reste un comportement pas vraiment user-friendly, c'est déjà plus simple à expliquer à un utilisateur que de passer par l'onglet "Réseau".

## 🏄 Pour tester

<img width="409" alt="image" src="https://github.com/user-attachments/assets/4e8950b5-c3a4-4adb-b80b-ff32a0205206" />

