### PR TITLE
[FEATURE] Modification du texte de presentation du mode interro (PIX-18621)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -635,7 +635,7 @@
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
         "exam": "Interrogation mode [beta]",
-        "exam-info": "A ‘interrogation mode’ campaign enables participants to be tested on specific subjects, without taking their user profile into account or having any impact on it.",
+        "exam-info": "A ‘interrogation mode’ campaign enables participants to be tested on specific subjects, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -635,7 +635,7 @@
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "exam": "Mode interro [bêta]",
-        "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci.",
+        "exam-info": "Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur, et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.",
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -597,7 +597,7 @@
       },
       "purpose": {
         "exam": "Vraagmodus [beta]",
-        "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben.",
+        "exam-info": "Met een campagne in de “quizmodus” kunnen deelnemers worden getest op specifieke onderwerpen, zonder rekening te houden met hun gebruikersprofiel of er invloed op te hebben. De aangeboden tests zijn gepersonaliseerd voor elke deelnemer, afhankelijk van hoe ver ze gevorderd zijn in het traject.",
         "assessment": "Deelnemers evalueren",
         "assessment-info": "Een beoordelingscampagne stelt deelnemers in staat om getest te worden op specifieke onderwerpen.",
         "label": "Wat is het doel van je campagne?",


### PR DESCRIPTION
## 🔆 Problème

On souhaite adapter le descriptif au moment de la création de campagne avec le mode interro pour expliquer que  l'algo rentre en jeu et que les participants n'auront donc pas le même nombre de questions.


## ⛱️ Proposition
Modifier le texte de présentation du mode interro par : 

Une campagne de type “mode interro” permet de tester les participants sur des sujets précis, sans prendre en compte le profil utilisateur et sans impacter celui-ci. Les épreuves proposées sont personnalisées pour chaque participant selon son avancement dans le parcours.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se connecter sur pix orga avec une orga ayant le mode interro.
Sélectionner Mode interro lors de la création de campagne.
Vérifier que le texte dans l'info bulle bleue corresponde au texte ci-dessus.
