### PR TITLE
[FEATURE] Créer une API interne permettant de récupérer le statut des modules pour un utlisateur (PIX-18342)

### DIFF
--- a/api/src/devcomp/application/api/models/ModuleStatus.js
+++ b/api/src/devcomp/application/api/models/ModuleStatus.js
@@ -1,0 +1,9 @@
+export class ModuleStatus {
+  constructor({ id, slug, title, status, duration }) {
+    this.id = id;
+    this.slug = slug;
+    this.title = title;
+    this.status = status;
+    this.duration = duration;
+  }
+}

--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -1,0 +1,53 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+import { usecases } from '../../domain/usecases/index.js';
+import { ModuleStatus } from './models/ModuleStatus.js';
+
+/**
+ * @function
+ * @name getUserModuleStatuses
+ *
+ * @param {object} params
+ * @param {number} params.userId mandatory target user id
+ * @param {number[]} params.moduleIds mandatory
+ *
+ * @typedef ModuleStatus
+ * @property {number} id
+ * @property {string} title
+ * @property {string} slug
+ * @property {duration} number
+ * @property {string} status ('not_started' | 'in_progress' | 'completed')
+ *
+ * @returns {ModuleStatus[]}
+ * @throws {BadRequestError} UserId field is missing
+ */
+const getUserModuleStatuses = async ({ userId, moduleIds }) => {
+  if (!userId) {
+    throw new DomainError('The userId is required');
+  }
+
+  if (!moduleIds || !(moduleIds.length > 0)) {
+    return [];
+  }
+
+  const moduleMetadataList = await usecases.getModuleMetadataList({ ids: moduleIds });
+  const userModuleStatus = await usecases.getUserModuleStatuses({ userId, moduleIds });
+
+  const moduleMetadataId = new Map();
+  moduleMetadataList.forEach((moduleMetadata) => {
+    moduleMetadataId.set(moduleMetadata.id, moduleMetadata);
+  });
+
+  return userModuleStatus.map((userModuleStatus) => {
+    const { id, slug, title, duration } = moduleMetadataId.get(userModuleStatus.moduleId);
+
+    return new ModuleStatus({
+      id,
+      slug,
+      title,
+      status: userModuleStatus.status,
+      duration,
+    });
+  });
+};
+
+export { getUserModuleStatuses };

--- a/api/src/devcomp/domain/models/module/ModuleMetadata.js
+++ b/api/src/devcomp/domain/models/module/ModuleMetadata.js
@@ -1,0 +1,25 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+export class ModuleMetadata {
+  constructor({ id, slug, title, isBeta, duration }) {
+    assertNotNullOrUndefined(id, 'The id is required for a module metadata');
+    assertNotNullOrUndefined(slug, 'The slug is required for a module metadata');
+    assertNotNullOrUndefined(title, 'The title is required for a module metadata');
+    assertNotNullOrUndefined(isBeta, 'Field isBeta is required for a module metadata');
+    assertNotNullOrUndefined(duration, 'The duration is required for a module metadata');
+    this.#assertDurationHasPositiveValue(Number(duration));
+
+    this.id = id;
+    this.slug = slug;
+    this.title = title;
+    this.isBeta = isBeta;
+    this.duration = Number(duration);
+  }
+
+  #assertDurationHasPositiveValue(duration) {
+    if (duration <= 0) {
+      throw new DomainError('The duration must be a positive integer for a module metadata');
+    }
+  }
+}

--- a/api/src/devcomp/domain/models/module/UserModuleStatus.js
+++ b/api/src/devcomp/domain/models/module/UserModuleStatus.js
@@ -1,0 +1,54 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+const StatusesEnumValues = Object.freeze({
+  NOT_STARTED: 'NOT_STARTED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+});
+
+class UserModuleStatus {
+  constructor({ userId, moduleId, passages }) {
+    assertNotNullOrUndefined(userId, 'The userId is required for a UserModuleStatus');
+    assertNotNullOrUndefined(moduleId, 'The moduleId is required for a UserModuleStatus');
+    assertNotNullOrUndefined(passages, 'The passages field is required for a UserModuleStatus');
+
+    this.moduleId = moduleId;
+    this.userId = userId;
+
+    this.#assertAllPassageHaveTheSameUserAndModuleId(passages);
+    this.passages = passages;
+    this.status = this.computeStatus();
+  }
+
+  computeStatus() {
+    if (this.passages.length === 0) {
+      return StatusesEnumValues.NOT_STARTED;
+    }
+
+    const mostRecentPassage = this.#findMostRecentPassage(this.passages);
+
+    if (!mostRecentPassage.terminatedAt) {
+      return StatusesEnumValues.IN_PROGRESS;
+    } else {
+      return StatusesEnumValues.COMPLETED;
+    }
+  }
+
+  #assertAllPassageHaveTheSameUserAndModuleId(passages) {
+    const assertion = passages.every((passage) => passage.moduleId === this.moduleId && passage.userId === this.userId);
+
+    if (!assertion) {
+      throw new DomainError('Module and user id of passages must be the same as UserModuleStatus attributes');
+    }
+  }
+
+  #findMostRecentPassage(passages) {
+    const sortedPassages = passages.sort((p1, p2) => {
+      return p2.updatedAt.getTime() - p1.updatedAt.getTime();
+    });
+    return sortedPassages[0];
+  }
+}
+
+export { UserModuleStatus };

--- a/api/src/devcomp/domain/usecases/get-module-metadata-list.js
+++ b/api/src/devcomp/domain/usecases/get-module-metadata-list.js
@@ -1,0 +1,12 @@
+import { ModuleMetadata } from '../models/module/ModuleMetadata.js';
+
+async function getModuleMetadataList({ ids, moduleRepository }) {
+  const modules = await moduleRepository.getAllByIds({ ids });
+
+  return modules.map(
+    ({ id, slug, title, isBeta, details }) =>
+      new ModuleMetadata({ id, slug, title, isBeta, duration: details.duration }),
+  );
+}
+
+export { getModuleMetadataList };

--- a/api/src/devcomp/domain/usecases/get-user-module-statuses.js
+++ b/api/src/devcomp/domain/usecases/get-user-module-statuses.js
@@ -1,0 +1,33 @@
+import { UserModuleStatus } from '../models/module/UserModuleStatus.js';
+
+async function getUserModuleStatuses({ userId, moduleIds, passageRepository }) {
+  const passages = await passageRepository.findAllByUserIdAndModuleIds({ userId, moduleIds });
+  const passagesModuleId = _groupPassagesByModuleId({ passages, moduleIds });
+
+  const result = passagesModuleId.keys().map(
+    (moduleId) =>
+      new UserModuleStatus({
+        moduleId,
+        userId,
+        passages: passagesModuleId.get(moduleId),
+      }),
+  );
+  return Array.from(result);
+}
+
+function _groupPassagesByModuleId({ passages, moduleIds }) {
+  const result = new Map();
+
+  moduleIds.forEach((moduleId) => {
+    result.set(moduleId, []);
+  });
+
+  passages.forEach((passage) => {
+    const passagesWithModuleId = result.get(passage.moduleId);
+    result.set(passage.moduleId, [...passagesWithModuleId, passage]);
+  });
+
+  return result;
+}
+
+export { getUserModuleStatuses };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -3,10 +3,23 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { LearningContentResourceNotFound } from '../../../../shared/domain/errors.js';
+import { ModuleDoesNotExistError } from '../../../domain/errors.js';
 
 const referential = await importModules();
 
 const moduleDatasource = {
+  getAllByIds: async (ids) => {
+    const modules = referential.modules.filter((module) => ids.includes(module.id));
+
+    const foundModulesIds = modules.map((module) => module.id);
+    const notFoundModulesIds = ids.filter((id) => !foundModulesIds.includes(id));
+
+    if (notFoundModulesIds.length > 0) {
+      throw new ModuleDoesNotExistError(`Ids with no module: ${notFoundModulesIds}`);
+    }
+
+    return modules;
+  },
   getById: async (id) => {
     const foundModule = referential.modules.find((module) => module.id === id);
 

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -6,6 +6,19 @@ import { ModuleFactory } from '../factories/module-factory.js';
 
 const memoizedModuleVersions = new Map();
 
+async function getAllByIds({ ids, moduleDatasource }) {
+  try {
+    const modules = await moduleDatasource.getAllByIds(ids);
+
+    return modules.map((moduleData) => {
+      const version = _computeModuleVersion(moduleData);
+      return ModuleFactory.build({ ...moduleData, version });
+    });
+  } catch (error) {
+    throw new NotFoundError(error.message);
+  }
+}
+
 async function getById({ id, moduleDatasource }) {
   return await _getModule({ ref: 'id', moduleDatasource, query: id });
 }
@@ -19,7 +32,7 @@ async function list({ moduleDatasource }) {
   return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
 }
 
-export { getById, getBySlug, list };
+export { getAllByIds, getById, getBySlug, list };
 
 function _computeModuleVersion(moduleData) {
   if (!memoizedModuleVersions.has(moduleData.slug)) {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -32,7 +32,11 @@ async function list({ moduleDatasource }) {
   return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
 }
 
-export { getAllByIds, getById, getBySlug, list };
+function resetMemoizedModuleVersions() {
+  memoizedModuleVersions.clear();
+}
+
+export { getAllByIds, getById, getBySlug, list, resetMemoizedModuleVersions };
 
 function _computeModuleVersion(moduleData) {
   if (!memoizedModuleVersions.has(moduleData.slug)) {

--- a/api/src/devcomp/infrastructure/repositories/passage-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-repository.js
@@ -16,6 +16,13 @@ const save = async ({ moduleId, userId }) => {
   return _toDomain(passage);
 };
 
+const findAllByUserIdAndModuleIds = async ({ moduleIds, userId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const passages = await knexConn('passages').where({ userId }).whereIn('moduleId', moduleIds);
+
+  return passages.map(_toDomain);
+};
+
 const get = async ({ passageId }) => {
   const knexConn = DomainTransaction.getConnection();
   const passage = await knexConn('passages').where({ id: passageId }).first();
@@ -43,4 +50,4 @@ function _toDomain({ id, moduleId, userId, createdAt, updatedAt, terminatedAt })
   return new Passage({ id, moduleId, userId, createdAt, updatedAt, terminatedAt });
 }
 
-export { get, save, update };
+export { findAllByUserIdAndModuleIds, get, save, update };

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -1,0 +1,103 @@
+import { ModuleStatus } from '../../../../../src/devcomp/application/api/models/ModuleStatus.js';
+import * as modulesApi from '../../../../../src/devcomp/application/api/modules-api.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Devcomp | Application | Api | Modules', function () {
+  let clock, now;
+
+  beforeEach(function () {
+    now = new Date('2023-10-05T18:02:00Z');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#getModuleStatuses', function () {
+    it('should return a list of Module statuses', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const existingModuleIdWithoutRelatedPassage = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const existingModuleId2 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+      const existingModuleId3 = '5df14039-803b-4db4-9778-67e4b84afbbd';
+      const moduleIds = [existingModuleIdWithoutRelatedPassage, existingModuleId2, existingModuleId3];
+
+      databaseBuilder.factory.buildPassage({
+        moduleId: existingModuleId2,
+        userId,
+        terminatedAt: null,
+      });
+
+      databaseBuilder.factory.buildPassage({
+        moduleId: existingModuleId3,
+        userId,
+        terminatedAt: now,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await modulesApi.getUserModuleStatuses({ userId, moduleIds });
+
+      // then
+      const expectedResult = [
+        new ModuleStatus({
+          id: existingModuleIdWithoutRelatedPassage,
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+          duration: 5,
+          status: 'NOT_STARTED',
+        }),
+        new ModuleStatus({
+          id: existingModuleId2,
+          slug: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire une adresse mail',
+          duration: 10,
+          status: 'IN_PROGRESS',
+        }),
+        new ModuleStatus({
+          id: existingModuleId3,
+          slug: 'adresse-ip-publique-et-vous',
+          title: "L'adresse IP publique : ce qu'elle révèle sur vous !",
+          duration: 10,
+          status: 'COMPLETED',
+        }),
+      ];
+
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    context('if userId passed is not defined', function () {
+      it('should throw a DomainError error', async function () {
+        // given
+        const existingModuleIdWithoutRelatedPassage = '6282925d-4775-4bca-b513-4c3009ec5886';
+        const existingModuleId2 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+        const existingModuleId3 = '5df14039-803b-4db4-9778-67e4b84afbbd';
+        const moduleIds = [existingModuleIdWithoutRelatedPassage, existingModuleId2, existingModuleId3];
+
+        // when
+        const error = await catchErr(modulesApi.getUserModuleStatuses)({ moduleIds });
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The userId is required');
+      });
+    });
+
+    context('if moduleIds is empty', function () {
+      it('should return an empty array', async function () {
+        // given
+        const userId = '1';
+        const moduleIds = [];
+
+        // when
+        const result = await modulesApi.getUserModuleStatuses({ userId, moduleIds });
+
+        // then
+        expect(result).to.be.empty;
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 
+import { ModuleDoesNotExistError } from '../../../../src/devcomp/domain/errors.js';
 import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
@@ -8,6 +9,169 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
+  describe('#getAllByIds', function () {
+    it('should return all modules with their version', async function () {
+      // given
+      const modulesIds = ['f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d', '6282925d-4775-4bca-b513-4c3009ec5886'];
+      const firstModule = {
+        id: modulesIds[0],
+        slug: 'getAllByIdsModuleSlug1',
+        title: 'Bien écrire son adresse mail',
+        isBeta: true,
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'Débutant',
+          tabletSupport: 'comfortable',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                  type: 'text',
+                  content:
+                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const secondModule = {
+        id: modulesIds[1],
+        slug: 'getAllByIdsModuleSlug2',
+        title: 'Bac à sable',
+        isBeta: true,
+        details: {
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          description:
+            "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+          duration: 5,
+          level: 'Débutant',
+          tabletSupport: 'inconvenient',
+          objectives: ['Non régression fonctionnelle'],
+        },
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                  type: 'text',
+                  content:
+                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const moduleDatasourceStub = {
+        getAllByIds: sinon.stub(),
+      };
+      moduleDatasourceStub.getAllByIds.withArgs(modulesIds).resolves([firstModule, secondModule]);
+
+      const version = Symbol('version');
+      const digestStub = sinon.stub().returns(version);
+      const updateStub = sinon.stub();
+      sinon.stub(crypto, 'createHash').returns({
+        copy: () => {
+          return {
+            digest: digestStub,
+          };
+        },
+        update: updateStub,
+      });
+
+      // when
+      const modules = await moduleRepository.getAllByIds({
+        ids: modulesIds,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(modules).to.have.lengthOf(2);
+      modules.forEach((module) => {
+        expect(module).to.be.instanceOf(Module);
+        expect(module.version).to.equal(version);
+      });
+    });
+
+    it('should throw a "NotFoundError" when a module does not exist', async function () {
+      // given
+      const notExistingModuleIds = ['not-existing-module-id-1', 'not-existing-module-id-2'];
+      const expectedErrorMessage = `Modules with ids not found : ${notExistingModuleIds}`;
+      const moduleDatasourceStub = {
+        getAllByIds: sinon.stub(),
+      };
+      moduleDatasourceStub.getAllByIds
+        .withArgs(notExistingModuleIds)
+        .throws(new ModuleDoesNotExistError(expectedErrorMessage));
+
+      // when
+      const error = await catchErr(moduleRepository.getAllByIds)({
+        ids: notExistingModuleIds,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(expectedErrorMessage);
+    });
+
+    it('should throw a "NotFoundError" if the module instanciation throws an error', async function () {
+      // given
+      const modulesIds = ['f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d'];
+      const module = {
+        id: modulesIds[0],
+      };
+
+      const moduleDatasourceStub = {
+        getAllByIds: sinon.stub(),
+      };
+      moduleDatasourceStub.getAllByIds.withArgs(modulesIds).resolves([module]);
+
+      const version = Symbol('version');
+      const digestStub = sinon.stub().returns(version);
+      const updateStub = sinon.stub();
+      sinon.stub(crypto, 'createHash').returns({
+        copy: () => {
+          return {
+            digest: digestStub,
+          };
+        },
+        update: updateStub,
+      });
+
+      // when
+      const error = await catchErr(moduleRepository.getAllByIds)({
+        ids: modulesIds,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
   describe('#getById', function () {
     describe('errors', function () {
       it('should throw a NotFoundError if the module does not exist', async function () {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -9,6 +9,10 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
+  beforeEach(function () {
+    moduleRepository.resetMemoizedModuleVersions();
+  });
+
   describe('#getAllByIds', function () {
     it('should return all modules with their version', async function () {
       // given

--- a/api/tests/devcomp/integration/repositories/passage-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-repository_test.js
@@ -148,4 +148,30 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
       });
     });
   });
+
+  describe('#findAllByUserIdAndModuleIds', function () {
+    it('should return passage matching userId and ids of modules', async function () {
+      // given
+      const moduleIds = ['moduleId1', 'moduleId2'];
+      const otherModuleId = 'moduleId3';
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildPassage({ moduleId: moduleIds[0], userId });
+      databaseBuilder.factory.buildPassage({ moduleId: moduleIds[1], userId });
+      databaseBuilder.factory.buildPassage({ moduleId: otherModuleId, userId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const passages = await passageRepository.findAllByUserIdAndModuleIds({ userId, moduleIds });
+
+      // then
+      const passageModuleIds = passages.map((passage) => passage.moduleId);
+
+      expect(passages).to.have.lengthOf(2);
+      passages.forEach((passage) => {
+        expect(passage.userId).to.equal(userId);
+      });
+      expect(passageModuleIds).to.deep.contains.members(moduleIds);
+    });
+  });
 });

--- a/api/tests/devcomp/unit/application/api/models/ModuleStatus_test.js
+++ b/api/tests/devcomp/unit/application/api/models/ModuleStatus_test.js
@@ -1,0 +1,29 @@
+import { ModuleStatus } from '../../../../../../src/devcomp/application/api/models/ModuleStatus.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Application | Api | Models | ModuleStatus', function () {
+  it('should init and keep attributes', function () {
+    // given
+    const id = '4016621a-8777-46c6-876b-ab39f2c737c2';
+    const slug = 'bien-ecrire-son-adresse-mail';
+    const title = 'Bien écrire une adresse mail';
+    const duration = 10;
+    const status = 'NOT_STARTED';
+
+    // when
+    const moduleStatus = new ModuleStatus({
+      id,
+      slug,
+      status,
+      title,
+      duration,
+    });
+
+    // then
+    expect(moduleStatus.id).to.equal(id);
+    expect(moduleStatus.slug).to.deep.equal(slug);
+    expect(moduleStatus.status).to.equal(status);
+    expect(moduleStatus.title).to.equal(title);
+    expect(moduleStatus.duration).to.equal(duration);
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
@@ -1,0 +1,168 @@
+import { ModuleMetadata } from '../../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function () {
+  let id, isBeta, slug, title, duration;
+
+  beforeEach(function () {
+    id = '12a3a2b4-e873-4789-ae1c-57f6f2b99890';
+    slug = 'tmp-module-test';
+    title = "Test d'un module";
+    isBeta = false;
+    duration = 10;
+  });
+
+  it('should init and keep attributes', function () {
+    // when
+    const module = new ModuleMetadata({ id, slug, title, isBeta, duration });
+
+    // then
+    expect(module.id).to.equal(id);
+    expect(module.slug).to.equal(slug);
+    expect(module.title).to.equal(title);
+    expect(module.isBeta).to.equal(isBeta);
+    expect(module.duration).to.equal(duration);
+  });
+
+  describe('if a module does not have an id', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            slug,
+            title,
+            isBeta,
+            duration,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for a module metadata');
+    });
+  });
+
+  describe('if a module does not have a slug', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            id,
+            title,
+            isBeta,
+            duration,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The slug is required for a module metadata');
+    });
+  });
+
+  describe('if a module does not have a title', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            id,
+            slug,
+            isBeta,
+            duration,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The title is required for a module metadata');
+    });
+  });
+
+  describe('if a module does not have a field isBeta', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            id,
+            title,
+            slug,
+            duration,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Field isBeta is required for a module metadata');
+    });
+  });
+
+  describe('if a module does not have a duration', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            id,
+            title,
+            slug,
+            isBeta,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The duration is required for a module metadata');
+    });
+  });
+
+  describe('if the module duration is 0', function () {
+    it('should throw an error', function () {
+      // given
+      const duration = 0;
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            duration,
+            id,
+            title,
+            slug,
+            isBeta,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The duration must be a positive integer for a module metadata');
+    });
+  });
+
+  describe('if the module duration is negative', function () {
+    it('should throw an error', function () {
+      // given
+      const duration = -5;
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            duration,
+            id,
+            title,
+            slug,
+            isBeta,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The duration must be a positive integer for a module metadata');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
@@ -1,0 +1,201 @@
+import { UserModuleStatus } from '../../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import { Passage } from '../../../../../../src/devcomp/domain/models/Passage.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', function () {
+  let userId, moduleId, passages;
+  let now;
+
+  beforeEach(function () {
+    userId = '1';
+    moduleId = '66f6dea7-1bb3-4ec2-b33d-1c5e7bde3675';
+    now = new Date('2025-07-02T14:00:00Z');
+    passages = [
+      new Passage({
+        id: 1,
+        moduleId,
+        userId,
+        createdAt: now,
+        updatedAt: now,
+        terminatedAt: now,
+      }),
+    ];
+  });
+
+  it('should init and keep attributes', function () {
+    // when
+    const userModuleStatus = new UserModuleStatus({ userId, moduleId, passages });
+
+    // then
+    expect(userModuleStatus.moduleId).to.equal(moduleId);
+    expect(userModuleStatus.passages).to.deep.equal(passages);
+    expect(userModuleStatus.userId).to.equal(userId);
+    expect(userModuleStatus.status).to.equal('COMPLETED');
+  });
+
+  describe('if userId passed is not defined', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new UserModuleStatus({
+            moduleId,
+            passages,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The userId is required for a UserModuleStatus');
+    });
+  });
+
+  describe('if moduleId passed is not defined', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new UserModuleStatus({
+            userId,
+            passages,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The moduleId is required for a UserModuleStatus');
+    });
+  });
+
+  describe('if passages passed is not defined', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new UserModuleStatus({
+            userId,
+            moduleId,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The passages field is required for a UserModuleStatus');
+    });
+  });
+
+  describe('if passages passed do not match userId and moduleId of class attributes', function () {
+    it('should throw an error', function () {
+      // given
+      const otherUserId = 'otherUserId';
+      const otherModuleId = 'otherModuleId';
+      passages = [
+        ...passages,
+        new Passage({
+          id: 2,
+          moduleId: otherModuleId,
+          userId: otherUserId,
+          createdAt: now,
+          updatedAt: now,
+          terminatedAt: now,
+        }),
+      ];
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new UserModuleStatus({
+            userId,
+            moduleId,
+            passages,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('Module and user id of passages must be the same as UserModuleStatus attributes');
+    });
+  });
+
+  describe('#computeStatus', function () {
+    context('when passages is empty', function () {
+      it('should return "NOT_STARTED"', function () {
+        // given
+        passages = [];
+        const userModuleStatus = new UserModuleStatus({ userId, moduleId, passages });
+
+        // when
+        const status = userModuleStatus.computeStatus();
+
+        // then
+        expect(status).to.equal('NOT_STARTED');
+      });
+    });
+
+    describe('when passages passed are not empty', function () {
+      context('when the most recent passage does not have a terminatedAt attribute', function () {
+        it('should return IN_PROGRESS', function () {
+          // given
+          const nowMinusOneHour = new Date(now.getTime() - 3600);
+          passages = [
+            new Passage({
+              id: 1,
+              moduleId,
+              userId,
+              createdAt: nowMinusOneHour,
+              updatedAt: nowMinusOneHour,
+              terminatedAt: nowMinusOneHour,
+            }),
+            new Passage({
+              id: 2,
+              moduleId,
+              userId,
+              createdAt: now,
+              updatedAt: now,
+              terminatedAt: null,
+            }),
+          ];
+          const userModuleStatus = new UserModuleStatus({ userId, moduleId, passages });
+
+          // when
+          const status = userModuleStatus.computeStatus();
+
+          // then
+          expect(status).to.equal('IN_PROGRESS');
+        });
+      });
+      context('when the most recent passage has a terminatedAt attribute', function () {
+        it('should set the status attribute to COMPLETED', function () {
+          // given
+          const nowMinusOneHour = new Date(now.getTime() - 3600);
+          passages = [
+            new Passage({
+              id: 1,
+              moduleId,
+              userId,
+              createdAt: nowMinusOneHour,
+              updatedAt: nowMinusOneHour,
+              terminatedAt: nowMinusOneHour,
+            }),
+            new Passage({
+              id: 2,
+              moduleId,
+              userId,
+              createdAt: now,
+              updatedAt: now,
+              terminatedAt: now,
+            }),
+          ];
+          const userModuleStatus = new UserModuleStatus({ userId, moduleId, passages });
+
+          // when
+          const status = userModuleStatus.computeStatus();
+
+          // then
+          expect(status).to.equal('COMPLETED');
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
@@ -1,0 +1,130 @@
+import { ModuleMetadata } from '../../../../../src/devcomp/domain/models/module/ModuleMetadata.js';
+import { getModuleMetadataList } from '../../../../../src/devcomp/domain/usecases/get-module-metadata-list.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', function () {
+  let firstModule, secondModule, modules;
+
+  beforeEach(function () {
+    firstModule = {
+      id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+      slug: 'getAllByIdsModuleSlug1',
+      title: 'Bien écrire son adresse mail',
+      isBeta: true,
+      details: {
+        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        description:
+          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+        duration: 12,
+        level: 'Débutant',
+        tabletSupport: 'comfortable',
+        objectives: [
+          'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+          'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+          'Comprendre les fonctions des parties d’une adresse mail',
+        ],
+      },
+      grains: [
+        {
+          id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          type: 'lesson',
+          title: 'Explications : les parties d’une adresse mail',
+          components: [
+            {
+              type: 'element',
+              element: {
+                id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                type: 'text',
+                content:
+                  "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    secondModule = {
+      id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      slug: 'getAllByIdsModuleSlug2',
+      title: 'Bac à sable',
+      isBeta: true,
+      details: {
+        image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        description:
+          "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement l'intégralité des fonctionnalités disponibles à date.</p>",
+        duration: 5,
+        level: 'Débutant',
+        tabletSupport: 'inconvenient',
+        objectives: ['Non régression fonctionnelle'],
+      },
+      grains: [
+        {
+          id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          type: 'lesson',
+          title: 'Explications : les parties d’une adresse mail',
+          components: [
+            {
+              type: 'element',
+              element: {
+                id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                type: 'text',
+                content:
+                  "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    modules = [firstModule, secondModule];
+  });
+
+  it('should get and return a list of ModuleMetadata', async function () {
+    // given
+    const ids = [modules[0].id, modules[1].id];
+    const moduleRepository = {
+      getAllByIds: sinon.stub(),
+    };
+    moduleRepository.getAllByIds.withArgs({ ids }).resolves(modules);
+
+    // when
+    const moduleMetadataList = await getModuleMetadataList({ ids, moduleRepository });
+
+    // then
+    const expectedModuleMetadataList = [
+      new ModuleMetadata({
+        id: firstModule.id,
+        slug: firstModule.slug,
+        title: firstModule.title,
+        isBeta: firstModule.isBeta,
+        duration: firstModule.details.duration,
+      }),
+      new ModuleMetadata({
+        id: secondModule.id,
+        slug: secondModule.slug,
+        title: secondModule.title,
+        isBeta: secondModule.isBeta,
+        duration: secondModule.details.duration,
+      }),
+    ];
+    expect(moduleMetadataList).to.deep.equal(expectedModuleMetadataList);
+  });
+
+  context('when a module id does not exist', function () {
+    it('should throw the NotFoundError thrown by repository', async function () {
+      // given
+      const ids = ['notFoundModuleId1', 'notFoundModuleId2'];
+      const moduleRepository = {
+        getAllByIds: sinon.stub(),
+      };
+      moduleRepository.getAllByIds.withArgs({ ids }).throws(new NotFoundError());
+
+      // when
+      const error = await catchErr(getModuleMetadataList)({ ids, moduleRepository });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
@@ -1,0 +1,61 @@
+import { UserModuleStatus } from '../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import { Passage } from '../../../../../src/devcomp/domain/models/Passage.js';
+import { getUserModuleStatuses } from '../../../../../src/devcomp/domain/usecases/get-user-module-statuses.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | get-user-module-statuses', function () {
+  let now;
+
+  beforeEach(function () {
+    now = new Date('2025-07-02T14:00:00Z');
+  });
+
+  it('should return a list of UserModuleStatuses', async function () {
+    // given
+    const firstModuleIdWithNoPassagesRelated = 'caf66fbe-285f-46b7-95f1-e18282d41a48';
+    const secondModuleId = '6ec3944f-5eb6-435a-9838-b5d0b033138b';
+    const thirdModuleId = 'a7b43070-bf13-44e3-b38d-4eeca99a014d';
+    const moduleIds = [firstModuleIdWithNoPassagesRelated, secondModuleId, thirdModuleId];
+
+    const userId = '1';
+
+    const inProgressPassage = new Passage({
+      id: 1,
+      moduleId: secondModuleId,
+      userId,
+      createdAt: now,
+      updatedAt: now,
+      terminatedAt: null,
+    });
+
+    const terminatedPassage = new Passage({
+      id: 1,
+      moduleId: thirdModuleId,
+      userId,
+      createdAt: now,
+      updatedAt: now,
+      terminatedAt: now,
+    });
+
+    const passageRepository = {
+      findAllByUserIdAndModuleIds: sinon.stub(),
+    };
+    passageRepository.findAllByUserIdAndModuleIds
+      .withArgs({ userId, moduleIds })
+      .resolves([inProgressPassage, terminatedPassage]);
+
+    // when
+    const result = await getUserModuleStatuses({ userId, moduleIds, passageRepository });
+
+    // then
+    const expectedUserModuleStatuses = [
+      new UserModuleStatus({ userId, moduleId: firstModuleIdWithNoPassagesRelated, passages: [] }),
+      new UserModuleStatus({ userId, moduleId: secondModuleId, passages: [inProgressPassage] }),
+      new UserModuleStatus({ userId, moduleId: thirdModuleId, passages: [terminatedPassage] }),
+    ];
+    expect(result).to.deep.equal(expectedUserModuleStatuses);
+    expect(result[0].status).to.equal('NOT_STARTED');
+    expect(result[1].status).to.equal('IN_PROGRESS');
+    expect(result[2].status).to.equal('COMPLETED');
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -1,12 +1,48 @@
+import { ModuleDoesNotExistError } from '../../../../../../src/devcomp/domain/errors.js';
 import moduleDatasource from '../../../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import { LearningContentResourceNotFound } from '../../../../../../src/shared/domain/errors.js';
-import { expect } from '../../../../../test-helper.js';
+import { catchErr, expect } from '../../../../../test-helper.js';
 import { joiErrorParser } from './validation/joi-error-parser.js';
 import { moduleSchema } from './validation/module-schema.js';
 
 const modules = await moduleDatasource.list();
 
 describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasource', function () {
+  describe('#getAllByIds', function () {
+    it('should return all modules with ids list in parameters', async function () {
+      // Given
+      const ids = ['f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d', '6282925d-4775-4bca-b513-4c3009ec5886'];
+
+      // When
+      const modules = await moduleDatasource.getAllByIds(ids);
+
+      // Then
+      const modulesIds = modules.map((module) => module.id);
+      expect(modulesIds).to.have.lengthOf(2);
+      expect(modulesIds).to.deep.contains.members(ids);
+    });
+
+    context('when modules in the ids list do not exist', function () {
+      it('should throw a "ModuleDoesNotExistError" error', async function () {
+        // Given
+        const notExistingModuleIds = ['not-existing-module-id-1', 'not-existing-module-id-2'];
+
+        const ids = [
+          'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          '6282925d-4775-4bca-b513-4c3009ec5886',
+          ...notExistingModuleIds,
+        ];
+
+        // When
+        const error = await catchErr(moduleDatasource.getAllByIds)(ids);
+
+        // Then
+        expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+        expect(error.message).to.equal(`Ids with no module: ${notExistingModuleIds}`);
+      });
+    });
+  });
+
   describe('#getById', function () {
     describe('when exists', function () {
       it('should return something', async function () {


### PR DESCRIPTION
## 🔆 Problème

L'équipe Combinix a besoin d'une API interne pour récupérer l'avancement d'un utilisateur sur des modules spécifiques.

## ⛱️ Proposition

On propose une unique API qui prend en paramètre un userId et un tableau de moduleId  et qui retourne un tableau avec pour chaque module :
- les détails (title, slug et duration)
- l'état du module pour l’utilisateur (jamais fait, commencé, terminé)

On considère un module n'a jamais été fait s'il n'y a pas de passage et on se base le dernier passage pour savoir s'il est commencé ou terminé.

## 🌊 Remarques

- Une fonction `resetMemoizedModuleVersions` a été ajouté pour réinitialiser côté `ModuleRepository` la Map correspondante. Ceci peut provoquer des effets de bord si on fait des tests d'intégration / Acceptance. 
- 2 entités `UserModuleStatus` et ModuleMetadata ont été crée pour refléter le métier dessus : 
  - `UserModulesStatus` pour y inclure la logique concernant le calcul du status.
  - `ModuleMetadata` pour représenter une version simplifiée d'un module comportant uniquement les métadonnées. 
- 2 usecases ont été ajouté pour récupérer chacun la liste des entités plus haut. Ceci (à discuter si besoin) car j'ai l'impression qu'il y a 2 besoins pour l'API concernée. A savoir récupérer l'avancement et les données des modules.
## 🏄 Pour tester

- CI au vert