### PR TITLE
[TECH] :truck: Déplace la route `get course` vers `src/evaluation/`

### DIFF
--- a/api/src/evaluation/application/courses/course-controller.js
+++ b/api/src/evaluation/application/courses/course-controller.js
@@ -1,6 +1,6 @@
+import * as courseSerializer from '../../../shared/infrastructure/serializers/jsonapi/course-serializer.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as courseService from '../../domain/services/course-service.js';
-import * as courseSerializer from '../../infrastructure/serializers/jsonapi/course-serializer.js';
-import { extractUserIdFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 
 const get = async function (request, h, dependencies = { courseService, courseSerializer }) {
   const courseId = request.params.id;

--- a/api/src/evaluation/application/courses/course-route.js
+++ b/api/src/evaluation/application/courses/course-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { courseController } from './course-controller.js';
 
 const register = async function (server) {

--- a/api/src/evaluation/domain/services/course-service.js
+++ b/api/src/evaluation/domain/services/course-service.js
@@ -1,5 +1,5 @@
-import * as courseRepository from '../../infrastructure/repositories/course-repository.js';
-import { NotFoundError } from '../errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import * as courseRepository from '../../../shared/infrastructure/repositories/course-repository.js';
 
 const getCourse = async function ({ courseId, dependencies = { courseRepository } }) {
   const course = await dependencies.courseRepository.get(courseId);

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -4,6 +4,7 @@ import * as autonomousCoursesRoutes from './application/autonomous-courses/index
 import * as badgeCriteriaRoutes from './application/badge-criteria/index.js';
 import * as badgesRoutes from './application/badges/index.js';
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
+import * as courses from './application/courses/course-route.js';
 import * as feedbacksRoutes from './application/feedbacks/index.js';
 import * as progressionsRoutes from './application/progressions/index.js';
 import * as scorecardsRoutes from './application/scorecards/index.js';
@@ -19,6 +20,7 @@ const evaluationRoutes = [
   badgeCriteriaRoutes,
   badgesRoutes,
   competenceEvaluationsRoutes,
+  courses,
   stageCollectionRoutes,
   feedbacksRoutes,
   progressionsRoutes,

--- a/api/src/shared/routes.js
+++ b/api/src/shared/routes.js
@@ -1,9 +1,8 @@
 import * as assessmentsRoutes from './application/assessments/index.js';
 import * as challengesRoutes from './application/challenges/index.js';
-import * as courses from './application/courses/index.js';
 import * as featureToggles from './application/feature-toggles/index.js';
 import * as healthcheck from './application/healthcheck/index.js';
 
-const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, courses, featureToggles];
+const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, featureToggles];
 
 export { sharedRoutes };

--- a/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/courses/course-controller_test.js
@@ -5,7 +5,7 @@ import {
   learningContentBuilder,
   mockLearningContent,
   nock,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
 describe('Acceptance | API | Courses', function () {
   let server;

--- a/api/tests/evaluation/unit/application/courses/course-controller_test.js
+++ b/api/tests/evaluation/unit/application/courses/course-controller_test.js
@@ -1,4 +1,4 @@
-import { courseController } from '../../../../../src/shared/application/courses/course-controller.js';
+import { courseController } from '../../../../../src/evaluation/application/courses/course-controller.js';
 import { Course } from '../../../../../src/shared/domain/models/Course.js';
 import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/evaluation/unit/application/courses/course-route_test.js
+++ b/api/tests/evaluation/unit/application/courses/course-route_test.js
@@ -1,6 +1,6 @@
-import { courseController } from '../../../../src/shared/application/courses/course-controller.js';
-import * as moduleUnderTest from '../../../../src/shared/application/courses/index.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { courseController } from '../../../../../src/evaluation/application/courses/course-controller.js';
+import * as moduleUnderTest from '../../../../../src/evaluation/application/courses/course-route.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | course-router', function () {
   describe('GET /api/courses/{id}', function () {

--- a/api/tests/evaluation/unit/domain/services/course-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/course-service_test.js
@@ -1,5 +1,5 @@
+import * as courseService from '../../../../../src/evaluation/domain/services/course-service.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import * as courseService from '../../../../../src/shared/domain/services/course-service.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 


### PR DESCRIPTION
## 🔆 Problème

La route `get course` ne sont utilisés que par l'application 'mon-pix' lors d'une évaluation.

## ⛱️ Proposition

Déplacer la route `get course` vers `src/evaluation/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Faire une évaluation. Tout devrait fonctionner comme avant.
