### PR TITLE
[FEATURE] Créer une table 'target_profiles_course_duration' et lui ajouter sa réplication maddo (PIX-18632).

### DIFF
--- a/api/datamart/datamart-builder/factory/build-target-profile-course-duration.js
+++ b/api/datamart/datamart-builder/factory/build-target-profile-course-duration.js
@@ -1,0 +1,12 @@
+import { datamartBuffer } from '../datamart-buffer.js';
+
+const buildTargetProfileCourseDuration = function ({ targetProfileId, median, quantile_75, quantile_95 } = {}) {
+  const values = { targetProfileId, median, quantile_75, quantile_95 };
+
+  datamartBuffer.pushInsertable({
+    tableName: 'target_profiles_course_duration',
+    values,
+  });
+};
+
+export { buildTargetProfileCourseDuration };

--- a/api/datamart/migrations/20250707091708_create-target_profiles_course_duration-table.js
+++ b/api/datamart/migrations/20250707091708_create-target_profiles_course_duration-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'target_profiles_course_duration';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.integer('targetProfileId').primary().notNullable().comment('Target profile id used as primary key');
+    table.integer('median').comment('Target profile median course duration');
+    table.integer('quantile_75').comment('Target profile 75 quantile course duration');
+    table.integer('quantile_95').comment('Target profile 95 quantile course duration');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/datamart/seeds/populate-target-profiles-course-duration-datamart.js
+++ b/api/datamart/seeds/populate-target-profiles-course-duration-datamart.js
@@ -1,0 +1,13 @@
+import { DatamartBuilder } from '../../datamart/datamart-builder/datamart-builder.js';
+import { TARGET_PROFILE_BADGES_STAGES_ID } from '../../db/seeds/data/team-prescription/constants.js';
+
+export async function seed(knex) {
+  const datamartBuilder = new DatamartBuilder({ knex });
+  datamartBuilder.factory.buildTargetProfileCourseDuration({
+    targetProfileId: TARGET_PROFILE_BADGES_STAGES_ID,
+    median: 312,
+    quantile_75: 513,
+    quantile_95: 963,
+  });
+  await datamartBuilder.commit();
+}

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -77,6 +77,23 @@ export const replications = [
       return datamartKnex('organizations_cover_rates').insert(chunk);
     },
   },
+  {
+    name: 'target_profiles_course_duration',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('target_profiles_course_duration').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_target_profiles_course_duration').select(
+        'targetProfileId',
+        'median',
+        'quantile_75',
+        'quantile_95',
+      );
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('target_profiles_course_duration').insert(chunk);
+    },
+  },
 ];
 
 export function getByName(name, dependencies = { replications }) {


### PR DESCRIPTION
## 🔆 Problème

Côté API, nous n'avons pas encore accès aux données de Data concernant la durée des profils-cibles.

## ⛱️ Proposition

Créer une table `target_profiles_course_duration` sur le datamart et ajouter la réplication associée.

## 🏄 Pour tester

...
