### PR TITLE
[FEATURE] Déclencher l'envoi automatique lorsque la participation a été créé après une date (PIX-18631).

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -119,6 +119,7 @@ module.exports = function (environment) {
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
+      AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
     },
 
     fontawesome: {

--- a/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
@@ -126,7 +126,10 @@ module('Unit | Route | Campaign | Assessment | Results', function (hooks) {
         const shareSpy = sinon.spy();
         sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
         // when
-        await route.afterModel({ campaignParticipationResult: { id: 123, isShared: false } });
+        await route.afterModel({
+          campaignParticipation: { createdAt: '2024-01-01' },
+          campaignParticipationResult: { id: 123, isShared: false },
+        });
 
         // then
         assert.ok(shareSpy.calledOnce);


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le déclenchement de l'envoi automatique est conditionné uniquement grâce à un feature toggle. Cependant, ce n'est pas suffisant, car des utilisateurs n'ayant pas été averti du changement pourrait voir leurs résultats envoyés sans leur consentement. 

## ⛱️ Proposition

Nous ajoutons une date à partir duquel tous les utilisateurs ayant rejoint une campagne (une campagne participation a été créée) aura vu un wording lui précisant que ses résultats seront automatiquement partagés.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Mettre le feature toggle `isAutoShareEnabled` à true : 
```
scalingo -a pix-api-review-pr1 run "npm run toggles -- -k isAutoShareEnabled -v true"
```

### Cas de l'envoi non automatique, car créé avant la date prévue 

1. Mettre une date dans le futur 
```
scalingo -a pix-front-review-pr1  env-set AUTO_SHARE_AFTER_DATE=2026-01-01
```

2. Déclencher le déploiement des fronts
3. Rejoindre la campagne `PROASSMUL`, constater à la fin que les résultats ne sont pas shared 


### La date est passée

1. Mettre une date dans le passé
```
scalingo -a pix-front-review-pr1  env-set AUTO_SHARE_AFTER_DATE=2025-01-01
```

2. Trigger le déploiement des fronts

3. Rejoindre à nouveau la campagne et constaté l'envoi automatique