### PR TITLE
[FEATURE] Ajout d'une colonnne "name" sur la table quests

### DIFF
--- a/api/db/migrations/20250707125520_add-name-column-in-quests.js
+++ b/api/db/migrations/20250707125520_add-name-column-in-quests.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'quests';
+const COLUMN_NAME = 'name';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).comment('Name of the quest, used on landing page for combined courses');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre du développement des parcours combinés, on a besoin de pouvoir afficher un "name" sur la table quests.

## ⛱️ Proposition
RAS

## 🌊 Remarques
Le name ne doit pas devenir obligatoire sur toutes les quêtes, d'où le defaultToNull.

## 🏄 Pour tester
Aller sur Scalingo dans la RA, faire une requête SELECT sur quests et vérifier que la colonne "name" y est bien.