### PR TITLE
[BUGFIX] Rediriger vers la prochaine épreuve quand on essaie d'accéder à une épreuve loin dans le futur.

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -16,6 +16,11 @@ export default class ChallengeRoute extends Route {
     let challenge;
     const currentChallengeNumber = parseInt(params.challenge_number);
     const isBackToPreviousChallenge = currentChallengeNumber < assessment.orderedChallengeIdsAnswered.length;
+    const hasFastFowarded = currentChallengeNumber > assessment.orderedChallengeIdsAnswered.length;
+    if (hasFastFowarded) {
+      this.router.replaceWith(`/assessments/${assessment.id}/resume`);
+      return;
+    }
     let answer = null;
     if (isBackToPreviousChallenge) {
       const challengeId = assessment.orderedChallengeIdsAnswered.at(currentChallengeNumber);

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -45,7 +45,7 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
     currentUserStub = { user: { firstName: 'John', lastname: 'Doe' } };
     route.currentUser = currentUserStub;
     route.store = storeStub;
-    route.router = { transitionTo: sinon.stub() };
+    route.router = { transitionTo: sinon.stub(), replaceWith: sinon.stub() };
     route.modelFor = sinon.stub().returns(assessment);
   });
 
@@ -69,6 +69,19 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
         sinon.assert.calledWith(route.modelFor, 'assessments');
         sinon.assert.calledOnce(findRecordStub);
         assert.strictEqual(returnedModel.answer, answer);
+      });
+    });
+
+    module('when fast-forwarding to a future challenge', function () {
+      test('should redirect to resume route', async function (assert) {
+        // given
+        model.assessment.orderedChallengeIdsAnswered = [];
+
+        // when
+        await route.model({ challenge_number: 1 });
+
+        // then
+        assert.ok(route.router.replaceWith.calledWith(`/assessments/${model.assessment.id}/resume`));
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

Quand on essaie d'accéder à une épreuve directement avec une url du type `/assessments/:assessmentId/challenges/:challenge_number` en spécifiant un `challenge_number` d'une épreuve dans le futur, on affiche bien la prochaine épreuve mais l'url ne change pas et la progression affichée n'est pas correcte.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Comparer le nombre de réponses faites par l'utilisateur et le numéro d'épreuve courant pour savoir si on est sur une page d'une épreuve loin dans le futur et rediriger vers la route `assessments.resume` le cas échéant.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## 🏄 Pour tester

Commencer un assessment, par exemple en cliquant sur une carte de compétences.
Modifier l'url pour spécifier un numéro d'épreuve dans le futur.
Vérifier que l'application redirige vers la dernière épreuve non répondue.
Vérifier que la progression affichée est correcte et que l'url affiche bien le numéro de la dernière épreuve non répondue.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
