### PR TITLE
[FEATURE] Afficher une bannière sur Pix Orga lorsque le nombre de places limite est atteint (PIX-18633).

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -509,7 +509,7 @@
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",
-          "ORGANIZATION_PLACES_LOCK": "Bloc organization in case of places threshold exceeded",
+          "ORGANIZATION_PLACES_LOCK": "Block organization in case of places threshold exceeded",
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",

--- a/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (places) {
   return new Serializer('organization-place-statistics', {
-    attributes: ['total', 'occupied', 'available', 'anonymousSeat'],
+    attributes: ['total', 'occupied', 'available', 'anonymousSeat', 'hasReachMaximumPlacesWithThreshold'],
   }).serialize(places);
 };
 

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
@@ -1,27 +1,38 @@
+import dayjs from 'dayjs';
+
+import { PlacesLot } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlacesLot.js';
+import { PlaceStatistics } from '../../../../../../../src/prescription/organization-place/domain/read-models/PlaceStatistics.js';
 import * as organizationPlaceStatisticsSerializer from '../../../../../../../src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js';
 import { expect } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | organization-places-statistics-serializer', function () {
   describe('#serialize', function () {
-    it('should convert an PlaceStatistics model object into JSON API data', function () {
+    it('should convert a PlaceStatistics entity into JSON API data', function () {
       // given
-      const placeStatistics = {
-        id: '1_place_statistics',
-        total: 10,
-        occupied: 5,
-        available: 5,
-        anonymousSeat: 3,
-      };
+      const placeStatistics = new PlaceStatistics({
+        placesLots: [
+          new PlacesLot({
+            id: 1,
+            count: 10,
+            expirationDate: dayjs().add(1, 'months').toDate(),
+            activationDate: new Date('2019-04-01'),
+            deletedAt: null,
+          }),
+        ],
+        placeRepartition: { totalUnRegisteredParticipant: 3, totalRegisteredParticipant: 2 },
+        organizationId: 22,
+      });
 
       const expectedJSON = {
         data: {
           type: 'organization-place-statistics',
-          id: '1_place_statistics',
+          id: '22_place_statistics',
           attributes: {
-            total: placeStatistics.total,
-            occupied: placeStatistics.occupied,
-            available: placeStatistics.available,
-            'anonymous-seat': placeStatistics.anonymousSeat,
+            total: 10,
+            occupied: 5,
+            available: 5,
+            'anonymous-seat': 3,
+            'has-reach-maximum-places-with-threshold': false,
           },
         },
       };

--- a/orga/app/components/banner/maximum-places-exceeded.gjs
+++ b/orga/app/components/banner/maximum-places-exceeded.gjs
@@ -1,0 +1,21 @@
+import PixBannerAlert from '@1024pix/pix-ui/components/pix-banner-alert';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class MaximumPlacesExceeded extends Component {
+  @service store;
+
+  get displayMaximumPlacesExceededBanner() {
+    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
+    return statistics?.hasReachMaximumPlacesWithThreshold;
+  }
+
+  <template>
+    {{#if this.displayMaximumPlacesExceededBanner}}
+      <PixBannerAlert @type="warning">
+        {{t "banners.maximum-places-exceeded.message"}}
+      </PixBannerAlert>
+    {{/if}}
+  </template>
+}

--- a/orga/app/models/organization-place-statistic.js
+++ b/orga/app/models/organization-place-statistic.js
@@ -5,6 +5,7 @@ export default class PlaceStatistics extends Model {
   @attr('number') total;
   @attr('number') occupied;
   @attr('number') anonymousSeat;
+  @attr('boolean') hasReachMaximumPlacesWithThreshold;
 
   get hasAnonymousSeat() {
     return this.anonymousSeat > 0;

--- a/orga/app/templates/application.gjs
+++ b/orga/app/templates/application.gjs
@@ -4,6 +4,7 @@ import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Communication from 'pix-orga/components/banner/communication';
 import InformationBanners from 'pix-orga/components/banner/information-banners';
+import MaximumPlacesExceeded from 'pix-orga/components/banner/maximum-places-exceeded';
 import Footer from 'pix-orga/components/layout/footer';
 import Sidebar from 'pix-orga/components/layout/sidebar';
 
@@ -18,6 +19,7 @@ import Sidebar from 'pix-orga/components/layout/sidebar';
     <:banner>
       <Communication />
       <InformationBanners @banners={{@model.informationBanner.banners}} />
+      <MaximumPlacesExceeded />
     </:banner>
     <:navigation>
       {{#if @controller.isAuthenticatedRoute}}

--- a/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
+++ b/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
@@ -1,0 +1,54 @@
+import { render } from '@1024pix/ember-testing-library';
+import MaximumPlacesExceeded from 'pix-orga/components/banner/maximum-places-exceeded';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Banner | Maximum places exceeded', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    this.intl = this.owner.lookup('service:intl');
+  });
+
+  module('when places feature is disabled', function () {
+    test('it should not display a banner', async function (assert) {
+      // when
+      const screen = await render(<template><MaximumPlacesExceeded /></template>);
+
+      // then
+      assert.notOk(screen.queryByText(this.intl.t('banners.maximum-places-exceeded.message')));
+    });
+  });
+
+  module('when places feature is enabled', function () {
+    module('when maximum places is not reached', function () {
+      test('it should not display a banner', async function (assert) {
+        // given
+        store.createRecord('organization-place-statistic', { hasReachMaximumPlacesWithThreshold: false });
+
+        // when
+        const screen = await render(<template><MaximumPlacesExceeded /></template>);
+
+        // then
+        assert.notOk(screen.queryByText(this.intl.t('banners.maximum-places-exceeded.message')));
+      });
+    });
+
+    module('when maximum places is reached', function () {
+      test('it should display a banner', async function (assert) {
+        // given
+        store.createRecord('organization-place-statistic', { hasReachMaximumPlacesWithThreshold: true });
+
+        // when
+        const screen = await render(<template><MaximumPlacesExceeded /></template>);
+
+        // then
+        assert.ok(screen.getByText(this.intl.t('banners.maximum-places-exceeded.message')));
+      });
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -80,6 +80,9 @@
     "last-places-lot-available": {
       "message": "Please note that your seats will expire in {days, number} days."
     },
+    "maximum-places-exceeded": {
+      "message": "No more available places for the organization."
+    },
     "over-capacity": {
       "message": "Please note that you are using more seats than your total capacity."
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -80,6 +80,9 @@
     "last-places-lot-available": {
       "message": "Attention, vos places arrivent à échéance dans {days, number} jours."
     },
+    "maximum-places-exceeded": {
+      "message": "Plus de places disponibles pour l'organisation."
+    },
     "over-capacity": {
       "message": "Attention, vous consommez plus de places que votre capacité totale."
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -80,6 +80,9 @@
     "last-places-lot-available": {
       "message": "{days, number} Houd er rekening mee dat je tickets over enkele dagen verlopen."
     },
+    "maximum-places-exceeded": {
+      "message": "Er zijn geen plaatsen meer beschikbaar voor de organisatie."
+    },
     "over-capacity": {
       "message": "Houd er rekening mee dat je meer plaats inneemt dan je totale capaciteit."
     },


### PR DESCRIPTION
## 🔆 Problème

Dorénavant, l'API est capable de savoir lorsque le nombre maximum est atteint, mais on ne récupère pas encore l'info côté front.

## ⛱️ Proposition

Récupérer l'info et afficher une bannière si le nombre maximum de places est dépassé.

## 🏄 Pour tester
- Se connecter à Pix Admin
- Aller sur l'orga PRO Classic
- Cliquer sur Modifier l'orga puis Activer le Blocage de l'organisation en cas de dépassement des places
- Aller sur l'onglet Places
- Supprimer les places dispo
- Créer 2 places pour cette organisation
- Se connecter à Pix Orga avec le compte admin-orga@example.net
- Aller sur l'orga Pro Classic
- Constater la présence du bandeau Warning avec le message "Plus de places disponibles pour l'organisation."
- Retourner sur PixAdmin et désactiver `Blocage de l'organisation en cas de dépassement des places`
- Recharger PixOrga et vérifier la disparition de la banner 🪄 
