### PR TITLE
[BUGFIX] :lipstick: Masquer les chiffres dans le Pix Gauge sur la page certificat sur Pix App (PIX-18626)

### DIFF
--- a/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/candidate-global-level.gjs
@@ -41,6 +41,7 @@ export default class candidateGlobalLevel extends Component {
         @reachedLevel={{@certificate.level}}
         @maxLevel="7"
         @stepLabels={{this.stepLabels}}
+        @hideValues="true"
       />
     </div>
 


### PR DESCRIPTION
## 🔆 Problème

Actuellement sur la page de détails d’une certification V3, des chiffres sont visibles sur la jauge de niveau global.
Or celle-ci n’est pas censé indiquer le chiffre du niveau Pix mais des niveaux globaux type (avancé 1, avancé 2, intermédiaire 1 etc…)

## ⛱️ Proposition

Ajouter le paramètre hideValues au composant Pix Gauge.

## 🌊 Remarques

Pour voir la gauge, il faut activer le feature toggle isV3CertificationPageEnabled

## 🏄 Pour tester

Consulter les résultats de certification d'un utilisateur et vérifier que les chiffres ne sont pas visibles dans la gauge.
