### PR TITLE
[BUGFIX] Modulix - QAB affichage KO (PIX-18510)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -13,7 +13,7 @@
   &__cards {
     display: grid;
     grid-template-areas: 'center';
-    justify-content: center;
+    justify-items: center;
   }
 
   &__proposals {
@@ -40,10 +40,6 @@
 
 @include breakpoints.device-is('tablet') {
   .element-qab {
-    &__cards {
-      justify-content: normal;
-    }
-
     &__proposals {
       gap: calc(var(--pix-spacing-10x) * 2);
       max-width: none;


### PR DESCRIPTION
## 🔆 Problème

Décalage du deck de QAB para rapport aux boutons de réponse dans certains modules. Comme dans cette image : 
![image](https://github.com/user-attachments/assets/87a1db22-4798-4c5d-bfb0-1f80e6215715)

## ⛱️ Proposition

Ajouter une largeur maximale pour le bloc `instruction` dans le template du QAB afin d'éviter ce décalage.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Ouvrir le [module](https://app-pr12787.review.pix.fr/modules/tmp-ia-int-mgo) signalé en erreur : 
- Défiler les grains jusqu'au QAB
- Constater qu'il n'y a plus d'erreur d'affichage
