### PR TITLE
[TECH] N'appelle pas GET /attestation-details en double.

### DIFF
--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -23,7 +23,7 @@ export default class CurrentUserService extends Service {
     if (this.session.isAuthenticated) {
       try {
         this.#user = await this.store.queryRecord('user', { me: true });
-        this.#attestationsDetails = await this.store.findAll('attestation-detail');
+        await this.loadAttestationDetails();
       } catch {
         this.#user = null;
         return this.session.invalidate();

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -116,7 +116,6 @@ export default class CurrentSessionService extends SessionService {
 
   async _loadCurrentUserAndSetLocale(locale = null) {
     await this.currentUser.load();
-    await this.currentUser.loadAttestationDetails();
     await this._handleLocale(locale);
   }
 

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -17,7 +17,7 @@ module('Unit | Services | session', function (hooks) {
 
   hooks.beforeEach(function () {
     sessionService = this.owner.lookup('service:session');
-    sessionService.currentUser = { load: sinon.stub(), loadAttestationDetails: sinon.stub(), user: null };
+    sessionService.currentUser = { load: sinon.stub(), user: null };
     sessionService.currentDomain = { getExtension: sinon.stub() };
     sessionService.locale = {
       setLocaleCookie: sinon.stub(),
@@ -106,7 +106,6 @@ module('Unit | Services | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(sessionService.currentUser.load);
-        sinon.assert.calledOnce(sessionService.currentUser.loadAttestationDetails);
         sinon.assert.calledWith(sessionService.locale.setLocale, DEFAULT_LOCALE);
         assert.ok(true);
       });


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

En regardant l'activité réseau, on constate que tous les appels vers `/attestation-details` sont en double.

## ⛱️ Proposition

Après investigation nous constatons qu'au démarrage du session service, on appelle la fonction `_loadCurrentUserAndSetLocale` qui enchaine `await this.currentUser.load();`
et `await this.currentUser.loadAttestationDetails();`
Le soucis est que load appelle `await this.store.findAll('attestation-detail')`, ce qui déclenche un appel supplémentaire.
On décide donc de supprimer l'appel fait dans `_loadCurrentUserAndSetLocale`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se connecter à Pix App.
Dans la console réseau, vérifier que l'appel à `/attestation-details` n'est pas doublé.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
