### PR TITLE
[TECH] désactivation du proxy buffering

### DIFF
--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -149,6 +149,8 @@ server {
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
 
+    proxy_buffering off;
+
     # Set X-Forwarded-For header to be able to know the remote client IP
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }


### PR DESCRIPTION
## 🔆 Problème
Pour l'integration llm, le buffering ne permet pas de streamer les réponses.

## ⛱️ Proposition
désactiver le proxy buffering sur les appels api.
