### PR TITLE
[BUGFIX] Supprimer la redirection infini lors d'une fin de campagne (PIX-18666).

### DIFF
--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -103,14 +103,7 @@ export default class ResumeRoute extends Route {
   }
 
   async _rateAssessment(assessment) {
-    try {
-      await assessment.save({ adapterOptions: { completeAssessment: true } });
-    } catch (adapterError) {
-      if (adapterError.errors[0].status === '412') {
-        return this._routeToResults(assessment);
-      }
-      throw adapterError;
-    }
+    await assessment.save({ adapterOptions: { completeAssessment: true } });
     return this._routeToResults(assessment);
   }
 


### PR DESCRIPTION
## 🔆 Problème
Actuellement, sur Pix App, lorsqu'on est redirigé sur la page de fin de campagne et qu'on n'a pas les conditions requises, le front tente en boucle l'appel alors que les conditions ne peuvent pas changer. 

## ⛱️ Proposition

Ne pas catcher l'erreur pour que l'utilisateur ait l'erreur qui lui soit remontée.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
