### PR TITLE
[TECH] :hammer: Ajoute une colonne version au `certification-frameworks-challenge` (pix-18665)

### DIFF
--- a/api/db/migrations/20250709083801_add-version-col-to-certificaiton-frameworks-challenges.js
+++ b/api/db/migrations/20250709083801_add-version-col-to-certificaiton-frameworks-challenges.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'version';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).comment('version of consolidated framework');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/scripts/prod/certification-frameworks-challenges-version-migration.js
+++ b/api/scripts/prod/certification-frameworks-challenges-version-migration.js
@@ -1,0 +1,28 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+class CertificationFrameworksChallengesVersionMigration extends Script {
+  constructor() {
+    super({
+      description: 'Script oneshot to migrate createdAt value to a well formatted version column',
+      permanent: false,
+    });
+  }
+
+  async handle({ logger }) {
+    logger.info('initialization of vertsion column for CertificationFrameworksChallenges');
+    const certificationFrameworksChallengesToUpdate = await knex('certification-frameworks-challenges');
+
+    for (let i = 0; i < certificationFrameworksChallengesToUpdate.length; i++) {
+      const certificationFrameworksChallenge = certificationFrameworksChallengesToUpdate[i];
+      const createdAt = certificationFrameworksChallenge.createdAt;
+      const version = createdAt.toISOString().slice(0, 16).replace(/-|T|:/g, '');
+      await knex('certification-frameworks-challenges')
+        .where({ id: certificationFrameworksChallenge.id })
+        .update({ version });
+    }
+    logger.info(`${certificationFrameworksChallengesToUpdate.length} certification-frameworks-challenges rows updated`);
+  }
+}
+await ScriptRunner.execute(import.meta.url, CertificationFrameworksChallengesVersionMigration);


### PR DESCRIPTION
## 🔆 Problème

Le format date SQL et le format date Javascript ne sont pas comparables. 
La colonne `createdAt` ne peut donc pas être utilisé pour récupérer la liste des challenges d'une version de référentiel cadre.

## ⛱️ Proposition

Ajouter une colonne `version` avec une chaine de caractère construite à partir de l'année, du mois, du jour, de l'heure et des minutes (ex : `202506241256`).

## 🌊 Remarques

Cette PR contient la migration pour ajouter la colonne `version` et un script de migration pour remplir la colonne pour les données de production existante.

La modification du code pour prendre en compte cette nouvelle colonne sera déployé dans une prochaine PR. Cette table n'est pas encore utilisée en production (si ce n'est la première initialisation qui a eu lieu par script le 4 juillet 2025).


## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
