### PR TITLE
[FEATURE] Construit une version à partir de la date a la création du référentiel cadre  (pix-18668)

### DIFF
--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -40,5 +40,15 @@ export const createConsolidatedFramework = async ({
 };
 
 function getVersionNumber() {
-  return new Date().toISOString().slice(0, 19).replace(/-|T|:/g, '');
+  const date = new Date();
+
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    date.getUTCFullYear().toString() +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getSeconds())
+  );
 }

--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -32,5 +32,13 @@ export const createConsolidatedFramework = async ({
 
   const challenges = await challengeRepository.findOperativeBySkills(skills, LOCALE.FRENCH_SPOKEN);
 
-  return consolidatedFrameworkRepository.create({ complementaryCertificationKey, challenges });
+  return consolidatedFrameworkRepository.create({
+    complementaryCertificationKey,
+    challenges,
+    version: getVersionNumber(),
+  });
 };
+
+function getVersionNumber() {
+  return new Date().toISOString().slice(0, 19).replace(/-|T|:/g, '');
+}

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -4,12 +4,13 @@ import * as challengeRepository from '../../../../shared/infrastructure/reposito
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { ConsolidatedFramework } from '../../domain/models/ConsolidatedFramework.js';
 
-export async function create({ complementaryCertificationKey, challenges }) {
+export async function create({ complementaryCertificationKey, challenges, version }) {
   const knexConn = DomainTransaction.getConnection();
 
   const challengesDTO = challenges.map((challenge) => ({
     complementaryCertificationKey,
     challengeId: challenge.id,
+    version,
   }));
 
   await knexConn('certification-frameworks-challenges').insert(challengesDTO);

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import * as consolidatedFrameworkRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
@@ -25,6 +23,7 @@ describe('Certification | Configuration | Integration | Repository | consolidate
       await consolidatedFrameworkRepository.create({
         complementaryCertificationKey: complementaryCertification.key,
         challenges: [challenge1, challenge2],
+        version: '1234',
       });
 
       // then
@@ -34,22 +33,18 @@ describe('Certification | Configuration | Integration | Repository | consolidate
         'discriminant',
         'difficulty',
         'createdAt',
+        'version',
       );
 
       expect(consolidatedFrameworkInDB).to.have.lengthOf(2);
-      expect(_.omit(consolidatedFrameworkInDB[0], 'createdAt')).to.deep.equal({
-        complementaryCertificationKey: complementaryCertification.key,
-        challengeId: challenge1.id,
-        discriminant: null,
-        difficulty: null,
-      });
-      expect(_.omit(consolidatedFrameworkInDB[1], 'createdAt')).to.deep.equal({
-        complementaryCertificationKey: complementaryCertification.key,
-        challengeId: challenge2.id,
-        discriminant: null,
-        difficulty: null,
-      });
-      expect(consolidatedFrameworkInDB[0].createdAt).to.deep.equal(consolidatedFrameworkInDB[1].createdAt);
+      expect(consolidatedFrameworkInDB[0].discriminant).to.equal(null);
+      expect(consolidatedFrameworkInDB[0].difficulty).to.equal(null);
+      expect(consolidatedFrameworkInDB[0].challengeId).to.equal(challenge1.id);
+      expect(consolidatedFrameworkInDB[1].challengeId).to.equal(challenge2.id);
+      expect(consolidatedFrameworkInDB[0].complementaryCertificationKey).to.equal(
+        consolidatedFrameworkInDB[1].complementaryCertificationKey,
+      );
+      expect(consolidatedFrameworkInDB[0].version).to.equal(consolidatedFrameworkInDB[1].version);
     });
   });
 

--- a/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
@@ -42,6 +42,8 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     skillRepository.findActiveByRecordIds.resolves([...tube1.skills, ...tube2.skills]);
     challengeRepository.findOperativeBySkills.resolves(challenges);
     consolidatedFrameworkRepository.create.resolves();
+    sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
+    const version = '20190101050607';
 
     // when
     await createConsolidatedFramework({
@@ -66,6 +68,7 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     expect(consolidatedFrameworkRepository.create).to.have.been.calledOnceWithExactly({
       complementaryCertificationKey,
       challenges,
+      version,
     });
   });
 });


### PR DESCRIPTION
:warning: Penser à faire demander aux captains de faire tourner le script en prod pour initialiser les valeurs des données existantes.

## 🔆 Problème

Il y a une nouvelle colonne pour gérer les versions de référentiel cadre. Elle n'est pas encore utilisée.

## ⛱️ Proposition

Remplir la version lors de la création d'un référentiel cadre. 
La version est construite à partir de la date du jour (YYYYMMDDHHMM, par exemple : `202506130946`)


## 🌊 Remarques

Suit la PR #12797 sur le flux de déploiement. :warning: ne doit surtout pas passer devant !

## 🏄 Pour tester

- [ ] Choisir un profil cible dans PixAdmin (par exemple (8000)
- [ ] Un référentiel cadre dans PixAdmin (par exemple "DROIT")
- [ ] Lancer le script avec

`scalingo -a "pix-api-review-pr12798" run "LOG_LEVEL=info node scripts/certification/target-profile-to-calibrated-framework.js --complementaryCertificationKey='DROIT' --targetProfileId=8000"`

Constater, en base de donnée, qu'il y a bien des certification-frameworks-challenges qui correspondent

Vérifier dans la table certification-frameworks-challenges que la valeur dans la colonne version correspond au moment de l'exécution pour une série d'enregistrements.