### PR TITLE
[FEATURE] Lister les participants avec leur status d'obtention d'une attestation sur Pix Orga (PIX-18562).

### DIFF
--- a/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
+++ b/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
@@ -13,6 +13,7 @@ const buildOrganizationLearner = function ({
   updatedAt = new Date('2021-02-01'), // for BEGINNING_OF_THE_2020_SCHOOL_YEAR, can outdate very fast! ;)
   organizationId,
   userId,
+  division,
   deletedBy = null,
   deletedAt = null,
   attributes = null,
@@ -31,6 +32,7 @@ const buildOrganizationLearner = function ({
     updatedAt,
     organizationId,
     userId,
+    division,
     deletedBy,
     deletedAt,
     attributes,

--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -1,6 +1,7 @@
 import { NoProfileRewardsFoundError } from '../../../profile/domain/errors.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as analysisByTubesSerializer from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
+import * as attestationParticipantStatusSerializer from '../infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
 
 const getAttestationZipForDivisions = async function (request, h) {
   const organizationId = request.params.organizationId;
@@ -25,9 +26,26 @@ const getAnalysisByTubes = async function (request, h, dependencies = { analysis
   return h.response(serializedResult).code(200);
 };
 
+const getAttestationParticipantsStatus = async function (
+  request,
+  h,
+  dependencies = { attestationParticipantStatusSerializer },
+) {
+  const { organizationId, attestationKey } = request.params;
+  const { filter, page } = request.query;
+  const result = await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+    attestationKey,
+    organizationId,
+    filter,
+    page,
+  });
+  return h.response(dependencies.attestationParticipantStatusSerializer.serialize(result)).code(200);
+};
+
 const organizationLearnersController = {
   getAnalysisByTubes,
   getAttestationZipForDivisions,
+  getAttestationParticipantsStatus,
 };
 
 export { organizationLearnersController };

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -70,6 +70,48 @@ const register = async function (server) {
         tags: ['api', 'organization', 'attestations'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/organizations/{organizationId}/attestations/{attestationKey}/statuses',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'checkUserIsAdminInOrganization',
+          },
+          {
+            method: securityPreHandlers.makeCheckOrganizationHasFeature(
+              ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+            ),
+            assign: 'makeCheckOrganizationHasFeature',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            attestationKey: Joi.string(),
+          }),
+          query: Joi.object({
+            filter: Joi.object({
+              divisions: Joi.array().items(Joi.string()).optional(),
+              statuses: Joi.array().items(Joi.string().valid('OBTAINED', 'NOT_OBTAINED')).optional(),
+              search: Joi.string().allow(null).empty('').optional(),
+            }).default({}),
+            page: {
+              number: Joi.number().integer(),
+              size: Joi.number().integer(),
+            },
+          }),
+        },
+        handler: organizationLearnersController.getAttestationParticipantsStatus,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Retourne le status d'obtention des participants pour une attestation donnée" +
+            "- L'utilisateur doit être administrateur de l'organisation'",
+        ],
+        tags: ['api', 'organization', 'attestations'],
+      },
+    },
   ]);
 };
 

--- a/api/src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js
+++ b/api/src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js
@@ -1,0 +1,11 @@
+export class AttestationParticipantStatus {
+  constructor({ organizationLearnerId, firstName, lastName, division, obtainedAt, attestationKey }) {
+    this.id = `${attestationKey}_${organizationLearnerId}`;
+    this.organizationLearnerId = organizationLearnerId;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.division = division;
+    this.obtainedAt = obtainedAt || null;
+    this.attestationKey = attestationKey;
+  }
+}

--- a/api/src/prescription/organization-learner/domain/usecases/find-paginated-filtered-attestation-participants-status.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-paginated-filtered-attestation-participants-status.js
@@ -1,0 +1,38 @@
+export const findPaginatedFilteredAttestationParticipantsStatus = async ({
+  attestationKey,
+  organizationId,
+  filter,
+  page,
+  organizationLearnerRepository,
+}) => {
+  const { search: name, divisions, statuses } = filter;
+  const { learners, pagination } = await organizationLearnerRepository.findPaginatedLearners({
+    organizationId,
+    filter: { name, divisions },
+    page,
+  });
+
+  let attestationParticipantsStatus =
+    await organizationLearnerRepository.getAttestationStatusForOrganizationLearnersAndKey({
+      attestationKey,
+      organizationLearners: learners,
+      organizationId,
+    });
+
+  if (statuses?.length > 0) {
+    attestationParticipantsStatus = attestationParticipantsStatus.filter((attestationParticipantStatus) =>
+      _filterByStatuses(attestationParticipantStatus, statuses),
+    );
+  }
+
+  return {
+    attestationParticipantsStatus,
+    pagination,
+  };
+};
+
+function _filterByStatuses(attestationParticipantStatus, filterStatuses) {
+  const isFilteredByObtained = filterStatuses.includes('OBTAINED') && Boolean(attestationParticipantStatus.obtainedAt);
+  const isFilteredByNotObtained = filterStatuses.includes('NOT_OBTAINED') && !attestationParticipantStatus.obtainedAt;
+  return isFilteredByObtained || isFilteredByNotObtained;
+}

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -4,6 +4,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
+import { AttestationParticipantStatus } from '../../domain/read-models/AttestationParticipantStatus.js';
 import { OrganizationLearner } from '../../domain/read-models/OrganizationLearner.js';
 
 function _buildIsCertifiable(queryBuilder, organizationLearnerId) {
@@ -146,9 +147,34 @@ async function getAttestationsForOrganizationLearnersAndKey({
   });
 }
 
+async function getAttestationStatusForOrganizationLearnersAndKey({
+  attestationKey,
+  organizationLearners,
+  organizationId,
+  attestationsApi,
+}) {
+  const userIds = organizationLearners.map((learner) => learner.userId);
+  const attestations = await attestationsApi.getAttestationsUserDetail({
+    attestationKey,
+    userIds,
+    organizationId,
+  });
+  return organizationLearners.map((organizationLearner) => {
+    const attestation = attestations.find(({ userId }) => userId === organizationLearner.userId);
+    return new AttestationParticipantStatus({
+      attestationKey,
+      organizationLearnerId: organizationLearner.id,
+      obtainedAt: attestation?.createdAt,
+      ...attestation,
+      ...organizationLearner,
+    });
+  });
+}
+
 export {
   findOrganizationLearnersByDivisions,
   findPaginatedLearners,
   get,
   getAttestationsForOrganizationLearnersAndKey,
+  getAttestationStatusForOrganizationLearnersAndKey,
 };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -86,7 +86,7 @@ async function get({ organizationLearnerId }) {
 
 async function findPaginatedLearners({ organizationId, page, filter }) {
   const query = knex
-    .select('id', 'userId', 'firstName', 'lastName', 'organizationId', 'attributes')
+    .select('id', 'userId', 'firstName', 'lastName', 'organizationId', 'division', 'attributes')
     .from('view-active-organization-learners')
     .where({ isDisabled: false, organizationId })
     .orderByRaw('LOWER("firstName") ASC')

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -85,14 +85,14 @@ async function get({ organizationLearnerId }) {
 
 async function findPaginatedLearners({ organizationId, page, filter }) {
   const query = knex
-    .select('id', 'firstName', 'lastName', 'organizationId', 'attributes')
+    .select('id', 'userId', 'firstName', 'lastName', 'organizationId', 'attributes')
     .from('view-active-organization-learners')
     .where({ isDisabled: false, organizationId })
     .orderByRaw('LOWER("firstName") ASC')
     .orderByRaw('LOWER("lastName") ASC');
 
   if (filter) {
-    const { name, ...attributesToFilter } = filter;
+    const { name, divisions, ...attributesToFilter } = filter;
     Object.entries(attributesToFilter)
       .filter(([_, values]) => values !== undefined)
       .forEach(([name, values]) => {
@@ -103,6 +103,9 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
       });
     if (name) {
       filterByFullName(query, name, 'firstName', 'lastName');
+    }
+    if (divisions?.length > 0) {
+      query.whereIn('division', divisions);
     }
   }
 

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js
@@ -1,0 +1,13 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function ({ attestationParticipantsStatus, pagination }) {
+  return new Serializer('attestation-participant-status', {
+    id: 'id',
+    attributes: ['lastName', 'firstName', 'obtainedAt', 'attestationKey', 'division', 'organizationLearnerId'],
+    meta: pagination,
+  }).serialize(attestationParticipantsStatus);
+};
+
+export { serialize };

--- a/api/src/profile/application/api/attestations-api.js
+++ b/api/src/profile/application/api/attestations-api.js
@@ -25,3 +25,15 @@ export const generateAttestations = async function ({
 
   return dependencies.pdfWithFormSerializer.serialize(templatePath, data);
 };
+
+export const getAttestationsUserDetail = async function ({ attestationKey, userIds, organizationId }) {
+  const locale = LOCALE.FRENCH_FRANCE;
+  const attestations = await usecases.getSharedAttestationsUserDetailForOrganizationByUserIds({
+    attestationKey,
+    userIds,
+    organizationId,
+    locale,
+  });
+
+  return attestations;
+};

--- a/api/src/profile/domain/models/AttestationUserDetail.js
+++ b/api/src/profile/domain/models/AttestationUserDetail.js
@@ -1,0 +1,7 @@
+export class AttestationUserDetail {
+  constructor({ attestationKey, obtainedAt, userId } = {}) {
+    this.attestationKey = attestationKey;
+    this.userId = userId;
+    this.obtainedAt = obtainedAt;
+  }
+}

--- a/api/src/profile/domain/usecases/get-shared-attestations-user-detail-for-organization-by-user-ids.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-user-detail-for-organization-by-user-ids.js
@@ -1,0 +1,44 @@
+import { AttestationNotFoundError } from '../errors.js';
+import { AttestationUserDetail } from '../models/AttestationUserDetail.js';
+
+export async function getSharedAttestationsUserDetailForOrganizationByUserIds({
+  attestationKey,
+  userIds,
+  organizationId,
+  userRepository,
+  profileRewardRepository,
+  attestationRepository,
+  organizationProfileRewardRepository,
+}) {
+  const attestationData = await attestationRepository.getByKey({ attestationKey });
+
+  if (!attestationData) {
+    throw new AttestationNotFoundError();
+  }
+
+  const users = await userRepository.getByIds({ userIds });
+
+  const sharedProfileRewards = await organizationProfileRewardRepository.getByOrganizationId({
+    attestationKey,
+    organizationId,
+  });
+  const profileRewardIds = sharedProfileRewards.map((sharedProfileReward) => sharedProfileReward.profileRewardId);
+
+  const profileRewards = await profileRewardRepository.getByIds({ profileRewardIds });
+
+  const filteredUsers = users.filter((user) => !user.isAnonymous && !user.hasBeenAnonymised);
+
+  return profileRewards
+    .filter((profileReward) => _hasActiveUser(profileReward, filteredUsers))
+    .map((profileReward) => {
+      return new AttestationUserDetail({
+        attestationKey,
+        obtainedAt: profileReward.createdAt,
+        userId: profileReward.userId,
+      });
+    });
+}
+
+function _hasActiveUser(profileReward, activeUsers) {
+  return activeUsers.some(({ id }) => id === profileReward.userId);
+}

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -1339,6 +1339,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
               ...firstOrganizationLearnerInDB,
               organizationName: firstOrganizationInDB.name,
               canBeDissociated: firstOrganizationInDB.isManagingStudents,
+              division: null,
             },
             {
               ...secondOrganizationLearnerInDB,

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-paginated-filtered-attestation-participants-status_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-paginated-filtered-attestation-participants-status_test.js
@@ -1,0 +1,135 @@
+import { AttestationParticipantStatus } from '../../../../../../src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Prescription | Learner Management | Domain | UseCase | find-paginated-filtered-attestation-participant-status', function () {
+  let attestation, organizationId, firstLearner, secondLearner;
+
+  beforeEach(async function () {
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    firstLearner = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      firstName: 'Jean',
+      division: '6eme A',
+    });
+    secondLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, division: '6eme B' });
+    attestation = databaseBuilder.factory.buildAttestation();
+    const firstRewardId = databaseBuilder.factory.buildProfileReward({
+      rewardId: attestation.id,
+      userId: firstLearner.userId,
+    });
+    databaseBuilder.factory.buildProfileReward({ rewardId: attestation.id, userId: secondLearner.userId });
+    databaseBuilder.factory.buildOrganizationsProfileRewards({ organizationId, profileRewardId: firstRewardId.id });
+    await databaseBuilder.commit();
+  });
+
+  it('returns attestation participant status', async function () {
+    // when
+    const { attestationParticipantsStatus: result } = await usecases.findPaginatedFilteredAttestationParticipantsStatus(
+      {
+        attestationKey: attestation.key,
+        organizationId,
+        filter: {},
+      },
+    );
+
+    // then
+    expect(result).to.have.lengthOf(2);
+    expect(result[0]).to.be.instanceOf(AttestationParticipantStatus);
+  });
+
+  context('when filter are provided', function () {
+    it('should filter by divisions when there are present', async function () {
+      // when
+      const { attestationParticipantsStatus: result } =
+        await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+          attestationKey: attestation.key,
+          organizationId,
+          filter: { divisions: ['6eme A'] },
+        });
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].organizationLearnerId).to.be.equal(firstLearner.id);
+    });
+
+    it('should filter by search', async function () {
+      // when
+      const { attestationParticipantsStatus: result } =
+        await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+          attestationKey: attestation.key,
+          organizationId,
+          filter: { search: 'Jean' },
+        });
+
+      // then
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].organizationLearnerId).to.be.equal(firstLearner.id);
+    });
+
+    context('when statuses filter are present', function () {
+      context('when OBTAINED is present', function () {
+        it('should only return attestation participant status with obtainedAt', async function () {
+          // given & when
+          const { attestationParticipantsStatus: result } =
+            await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+              attestationKey: attestation.key,
+              organizationId,
+              filter: { statuses: ['OBTAINED'] },
+            });
+
+          // then
+          expect(result).to.have.lengthOf(1);
+          expect(result[0].organizationLearnerId).to.be.equal(firstLearner.id);
+        });
+      });
+
+      context('when NOT_OBTAINED is present', function () {
+        it('should return attestation participants status with obtainedAt at null', async function () {
+          // given & when
+          const { attestationParticipantsStatus: result } =
+            await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+              attestationKey: attestation.key,
+              organizationId,
+              filter: { statuses: ['NOT_OBTAINED'] },
+            });
+
+          // then
+          expect(result).to.have.lengthOf(1);
+          expect(result[0].obtainedAt).to.be.null;
+          expect(result[0].organizationLearnerId).to.equal(secondLearner.id);
+        });
+      });
+
+      context('when both are present', function () {
+        it('should return all attestation participants status', async function () {
+          // given & when
+          const { attestationParticipantsStatus: result } =
+            await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+              attestationKey: attestation.key,
+              organizationId,
+              filter: { statuses: ['NOT_OBTAINED', 'OBTAINED'] },
+            });
+
+          // then
+          expect(result).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    context('when unknow filter is provided', function () {
+      it('should not used it', async function () {
+        // when
+        const { attestationParticipantsStatus: result } =
+          await usecases.findPaginatedFilteredAttestationParticipantsStatus({
+            attestationKey: attestation.key,
+            organizationId,
+            filter: { unknown: 'test' },
+          });
+
+        // then
+        expect(result).to.have.lengthOf(2);
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -633,6 +633,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             organizationId,
             firstName: 'Zoé',
             attributes: { 'Libellé classe': 'Rogue' },
+            division: '6ème',
           });
 
           await databaseBuilder.commit();
@@ -643,7 +644,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
               size: 1,
               number: 1,
             },
-            filter: { 'Libellé classe': ['Witch', 'Rogue'], name: 'Zoé' },
+            filter: { 'Libellé classe': ['Witch', 'Rogue'], name: 'Zoé', divisions: ['6ème'] },
           });
 
           expect(result.pagination).to.deep.equal({

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/attestation-participants-status-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/attestation-participants-status-serializer_test.js
@@ -1,0 +1,50 @@
+import { AttestationParticipantStatus } from '../../../../../../../src/prescription/organization-learner/domain/read-models/AttestationParticipantStatus.js';
+import * as serializer from '../../../../../../../src/prescription/organization-learner/infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | attestation-participants-status-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an attestation participant status read-model object into JSON API data', function () {
+      // given
+      const attestationParticipantsStatus = [
+        new AttestationParticipantStatus({
+          attestationKey: 'SIXTH_GRADE',
+          division: '3DS',
+          firstName: 'first-name',
+          lastName: 'last-name',
+          obtainedAt: new Date('2025-07-08'),
+          organizationLearnerId: 100008,
+        }),
+      ];
+      const pagination = { page: 1, pageCount: 1, pageSize: 10, rowCount: 1 };
+      const expectedData = {
+        data: [
+          {
+            attributes: {
+              'attestation-key': 'SIXTH_GRADE',
+              division: '3DS',
+              'first-name': 'first-name',
+              'last-name': 'last-name',
+              'obtained-at': new Date('2025-07-08'),
+              'organization-learner-id': 100008,
+            },
+            id: 'SIXTH_GRADE_100008',
+            type: 'attestation-participant-statuses',
+          },
+        ],
+        meta: {
+          page: 1,
+          pageCount: 1,
+          pageSize: 10,
+          rowCount: 1,
+        },
+      };
+
+      // when
+      const json = serializer.serialize({ attestationParticipantsStatus, pagination });
+
+      // then
+      expect(json).to.deep.equal(expectedData);
+    });
+  });
+});

--- a/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-for-organization-by-user-ids_test.js
+++ b/api/tests/profile/integration/domain/usecases/get-shared-attestations-user-detail-for-organization-by-user-ids_test.js
@@ -1,0 +1,165 @@
+import { AttestationNotFoundError } from '../../../../../src/profile/domain/errors.js';
+import { AttestationUserDetail } from '../../../../../src/profile/domain/models/AttestationUserDetail.js';
+import { User } from '../../../../../src/profile/domain/models/User.js';
+import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { buildAttestationUserDetail } from '../../../../tooling/domain-builder/factory/index.js';
+
+describe('Profile | Integration | Domain | get-shared-attestations-user-detail-for-organization-by-user-ids', function () {
+  let clock;
+  const now = new Date('2022-12-25');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({
+      now,
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  describe('#getSharedAttestationsUserDetailForOrganizationByUserIds', function () {
+    it('should return array of AttestationUserDetail for given userIds', async function () {
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'alex', lastName: 'Terieur' }));
+      const secondUser = new User(databaseBuilder.factory.buildUser({ firstName: 'theo', lastName: 'Courant' }));
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: firstUser.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: secondUser.id });
+
+      const firstProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: firstUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: firstProfileReward.id,
+      });
+      const secondProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: secondUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: secondProfileReward.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await usecases.getSharedAttestationsUserDetailForOrganizationByUserIds({
+        attestationKey: attestation.key,
+        organizationId,
+        userIds: [firstUser.id],
+        locale,
+      });
+
+      expect(results[0]).to.be.instanceOf(AttestationUserDetail);
+      expect(results).to.deep.equal([
+        buildAttestationUserDetail({
+          attestationKey: attestation.key,
+          obtainedAt: firstProfileReward.createdAt,
+          userId: firstUser.id,
+        }),
+      ]);
+      expect(results[0].obtainedAt).to.deep.equal(firstProfileReward.createdAt);
+    });
+
+    it('should not return attestations for anonymous userIds', async function () {
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const firstUser = databaseBuilder.factory.buildUser({
+        firstName: 'alex',
+        lastName: 'Terieur',
+        isAnonymous: true,
+        hasBeenAnonymised: false,
+      });
+      const secondUser = databaseBuilder.factory.buildUser({
+        firstName: 'theo',
+        lastName: 'Courant',
+        isAnonymous: false,
+        hasBeenAnonymised: true,
+      });
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: firstUser.id });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId: secondUser.id });
+
+      const firstProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: firstUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: firstProfileReward.id,
+      });
+      const secondProfileReward = databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: secondUser.id,
+      });
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        organizationId,
+        profileRewardId: secondProfileReward.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await usecases.getSharedAttestationsUserDetailForOrganizationByUserIds({
+        attestationKey: attestation.key,
+        organizationId,
+        userIds: [firstUser.id, secondUser.id],
+        locale,
+      });
+
+      expect(results).to.deep.equal([]);
+    });
+
+    it('should return AttestationNotFound error if attestation does not exist', async function () {
+      //given
+      const locale = 'FR-fr';
+      const firstUser = new User(databaseBuilder.factory.buildUser());
+
+      databaseBuilder.factory.buildProfileReward({
+        userId: firstUser.id,
+      });
+      await databaseBuilder.commit();
+
+      //when
+      const error = await catchErr(usecases.getSharedAttestationsForOrganizationByUserIds)({
+        attestationKey: 'NOT_EXISTING_ATTESTATION',
+        userIds: [firstUser.id],
+        organizationId: 1,
+        locale,
+      });
+
+      //then
+      expect(error).to.be.an.instanceof(AttestationNotFoundError);
+    });
+
+    it('should return empty array if there is no profile rewards', async function () {
+      //given
+      const locale = 'FR-fr';
+      const attestation = databaseBuilder.factory.buildAttestation();
+      const firstUser = new User(databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Terieur' }));
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildProfileReward({
+        rewardId: attestation.id,
+        userId: firstUser.id,
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      const results = await usecases.getSharedAttestationsUserDetailForOrganizationByUserIds({
+        attestationKey: attestation.key,
+        userIds: [firstUser.id],
+        organizationId,
+        locale,
+      });
+
+      //then
+      expect(results).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/profile/unit/application/api/attestations-api_test.js
+++ b/api/tests/profile/unit/application/api/attestations-api_test.js
@@ -1,4 +1,7 @@
-import { generateAttestations } from '../../../../../src/profile/application/api/attestations-api.js';
+import {
+  generateAttestations,
+  getAttestationsUserDetail,
+} from '../../../../../src/profile/application/api/attestations-api.js';
 import { usecases } from '../../../../../src/profile/domain/usecases/index.js';
 import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 import { expect, sinon } from '../../../../test-helper.js';
@@ -35,6 +38,32 @@ describe('Profile | Unit | Application | Api | attestations', function () {
       const result = await generateAttestations({ attestationKey, userIds, organizationId, dependencies });
 
       expect(result).to.equal(expectedBuffer);
+    });
+  });
+
+  describe('#getAttestationsUserDetail', function () {
+    it('should return users attestations', async function () {
+      const attestationKey = Symbol('attestationKey');
+      const userIds = Symbol('userIds');
+      const organizationId = Symbol('organizationId');
+      const data = Symbol('data');
+      const locale = LOCALE.FRENCH_FRANCE;
+
+      const dependencies = {
+        pdfWithFormSerializer: {
+          serialize: sinon.stub(),
+        },
+      };
+
+      sinon.stub(usecases, 'getSharedAttestationsUserDetailForOrganizationByUserIds');
+
+      usecases.getSharedAttestationsUserDetailForOrganizationByUserIds
+        .withArgs({ attestationKey, userIds, organizationId, locale })
+        .resolves(data);
+
+      const result = await getAttestationsUserDetail({ attestationKey, userIds, organizationId, dependencies });
+
+      expect(result).to.equal(data);
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-attestation-user-detail.js
+++ b/api/tests/tooling/domain-builder/factory/build-attestation-user-detail.js
@@ -1,0 +1,9 @@
+import { AttestationUserDetail } from '../../../../src/profile/domain/models/AttestationUserDetail.js';
+
+export function buildAttestationUserDetail({
+  attestationKey = 'attestation-key',
+  userId = 123,
+  obtainedAt = new Date(),
+} = {}) {
+  return new AttestationUserDetail({ attestationKey, userId, obtainedAt });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -10,6 +10,7 @@ import { buildAnswer } from './build-answer.js';
 import { buildArea } from './build-area.js';
 import { buildAssessment } from './build-assessment.js';
 import { buildAssessmentResult } from './build-assessment-result.js';
+import { buildAttestationUserDetail } from './build-attestation-user-detail.js';
 import { buildAuthenticationMethod } from './build-authentication-method.js';
 import { buildBadge } from './build-badge.js';
 import { buildBadgeCriterion } from './build-badge-criterion.js';
@@ -340,6 +341,7 @@ export {
   buildArea,
   buildAssessment,
   buildAssessmentResult,
+  buildAttestationUserDetail,
   buildAuthenticationMethod,
   buildBadge,
   buildBadgeCriterion,

--- a/orga/app/adapters/attestation-participant-status.js
+++ b/orga/app/adapters/attestation-participant-status.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class AttestationParticipantStatusAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    const { attestationKey, organizationId } = query;
+    delete query.attestationKey;
+    delete query.organizationId;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/attestations/${attestationKey}/statuses`;
+  }
+}

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -8,6 +8,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { and, eq } from 'ember-truth-helpers';
+import List from 'pix-orga/components/attestations/list';
 
 import PageTitle from './ui/page-title';
 
@@ -43,17 +44,38 @@ export default class Attestations extends Component {
       <:title>{{t "pages.attestations.title"}}</:title>
     </PageTitle>
 
-    {{#if this.displaySixthGrade}}
-      <SixthGrade @divisions={{@divisions}} @onSubmit={{@onSubmit}} />
-    {{/if}}
+    <section>
+      <h2 class="attestations-page__section-title attestations-page__section-title--download">{{t
+          "pages.attestations.section.download"
+        }}</h2>
 
-    {{#if (and this.displaySixthGrade this.displayAttestations)}}
-      <div class="attestations-page__separator" />
-    {{/if}}
+      {{#if this.displaySixthGrade}}
+        <SixthGrade @divisions={{@divisions}} @onSubmit={{@onSubmit}} />
+      {{/if}}
 
-    {{#if this.displayAttestations}}
-      <OtherAttestations @attestations={{this.availableAttestations}} @onSubmit={{@onSubmit}} />
-    {{/if}}
+      {{#if (and this.displaySixthGrade this.displayAttestations)}}
+        <div class="attestations-page__separator" />
+      {{/if}}
+
+      {{#if this.displayAttestations}}
+        <OtherAttestations @attestations={{this.availableAttestations}} @onSubmit={{@onSubmit}} />
+      {{/if}}
+    </section>
+
+    <section class="attestation-page__list">
+      <h2 class="attestations-page__section-title attestations-page__section-title--list">
+        {{t "pages.attestations.section.list"}}
+      </h2>
+      <List
+        @participantStatuses={{@participantStatuses}}
+        @clearFilters={{@clearFilters}}
+        @onFilter={{@onFilter}}
+        @searchFilter={{@searchFilter}}
+        @statusesFilter={{@statusesFilter}}
+        @divisionsFilter={{@divisionsFilter}}
+        @divisionsOptions={{@divisions}}
+      />
+    </section>
   </template>
 }
 
@@ -133,9 +155,6 @@ class SixthGrade extends Component {
   }
 
   <template>
-    <p class="attestations-page__text">
-      {{t "pages.attestations.divisions-description"}}
-    </p>
     <div class="attestations-page__action">
       <PixMultiSelect
         @isSearchable={{true}}

--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -1,0 +1,121 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
+import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
+import MultiSelectFilter from 'pix-orga/components/ui/multi-select-filter';
+import ENV from 'pix-orga/config/environment';
+
+export default class AttestationList extends Component {
+  @service intl;
+
+  debounceTime = ENV.pagination.debounce;
+
+  get statusesOptions() {
+    return [
+      { value: 'OBTAINED', label: this.intl.t('pages.attestations.table.filter.status.obtained') },
+      { value: 'NOT_OBTAINED', label: this.intl.t('pages.attestations.table.filter.status.not-obtained') },
+    ];
+  }
+
+  get shouldShowDivisionColumn() {
+    return this.args.participantStatuses?.some((participantStatus) => Boolean(participantStatus.division));
+  }
+
+  <template>
+    <PixFilterBanner
+      @title={{t "common.filters.title"}}
+      class="participant-filter-banner hide-on-mobile"
+      aria-label={{t "pages.attestations.table.filter.legend"}}
+      @details={{t "pages.attestations.table.filter.results" total=@participantStatuses.length}}
+      @clearFiltersLabel={{t "common.filters.actions.clear"}}
+      @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+      @onClearFilters={{@clearFilters}}
+    >
+      <PixSearchInput
+        @id="search"
+        value={{@searchFilter}}
+        @screenReaderOnly={{true}}
+        @placeholder={{t "common.filters.fullname.placeholder"}}
+        @debounceTimeInMs={{this.debounceTime}}
+        @triggerFiltering={{@onFilter}}
+      >
+        <:label>{{t "common.filters.fullname.label"}}</:label>
+      </PixSearchInput>
+      <MultiSelectFilter
+        @field="divisions"
+        @label={{t "pages.attestations.table.filter.divisions.label"}}
+        @onSelect={{@onFilter}}
+        @selectedOption={{@divisionsFilter}}
+        @options={{@divisionsOptions}}
+        @placeholder={{t "pages.attestations.table.filter.divisions.empty-option"}}
+      />
+
+      <MultiSelectFilter
+        @field="statuses"
+        @label={{t "pages.attestations.table.filter.status.label"}}
+        @onSelect={{@onFilter}}
+        @selectedOption={{@statusesFilter}}
+        @options={{this.statusesOptions}}
+        @placeholder={{t "pages.attestations.table.filter.status.empty-option"}}
+      />
+    </PixFilterBanner>
+
+    <PixTable class="attestations-page__list" @variant="orga" @data={{@participantStatuses}}>
+      <:columns as |participantStatus context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.attestations.table.column.last-name"}}
+          </:header>
+          <:cell>
+            {{participantStatus.lastName}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.attestations.table.column.first-name"}}
+          </:header>
+          <:cell>
+            {{participantStatus.firstName}}
+          </:cell>
+        </PixTableColumn>
+        {{#if this.shouldShowDivisionColumn}}
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.attestations.table.column.division"}}
+            </:header>
+            <:cell>
+              {{participantStatus.division}}
+            </:cell>
+          </PixTableColumn>
+        {{/if}}
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.attestations.table.column.status"}}
+          </:header>
+          <:cell>
+            {{#if participantStatus.obtainedAt}}
+              <PixTag @color="green">
+                {{t
+                  "pages.attestations.table.status.obtained"
+                  date=(dayjsFormat participantStatus.obtainedAt "DD/MM/YYYY")
+                }}
+              </PixTag>
+            {{else}}
+              <PixTag @color="yellow">
+                {{t "pages.attestations.table.status.not-obtained"}}
+              </PixTag>
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+
+    <PixPagination @pagination={{@participantStatuses.meta}} />
+  </template>
+}

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export const SIXTH_GRADE_ATTESTATION_KEY = 'SIXTH_GRADE';
 export const FILE_NAME = 'attestations';
@@ -12,6 +13,12 @@ export default class AuthenticatedAttestationsController extends Controller {
   @service pixMetrics;
   @service notifications;
   @service intl;
+
+  @tracked pageNumber = 1;
+  @tracked pageSize = 50;
+  @tracked statuses = [];
+  @tracked divisions = [];
+  @tracked search = null;
 
   @action
   async downloadAttestations(attestationKey, selectedDivisions) {
@@ -43,6 +50,20 @@ export default class AuthenticatedAttestationsController extends Controller {
     } catch (error) {
       this.notifications.sendError(error.message, { autoClear: false });
     }
+  }
+
+  @action
+  clearFilters() {
+    this.statuses = [];
+    this.divisions = [];
+    this.search = null;
+    this.pageNumber = 1;
+  }
+
+  @action
+  triggerFiltering(fieldName, value) {
+    this[fieldName] = value || undefined;
+    this.pageNumber = 1;
   }
 
   sendMetrics() {

--- a/orga/app/models/attestation-participant-status.js
+++ b/orga/app/models/attestation-participant-status.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AttestationParticipantStatus extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') division;
+  @attr('date') obtainedAt;
+}

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -4,6 +4,12 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedAttestationsRoute extends Route {
   queryParams = {
+    pageNumber: {
+      refreshModel: true,
+    },
+    pageSize: {
+      refreshModel: true,
+    },
     statuses: {
       refreshModel: true,
     },
@@ -38,6 +44,10 @@ export default class AuthenticatedAttestationsRoute extends Route {
           divisions: params.divisions,
           search: params.search,
         },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
       },
       { reload: true },
     );
@@ -56,6 +66,8 @@ export default class AuthenticatedAttestationsRoute extends Route {
       controller.statuses = [];
       controller.divisions = [];
       controller.search = null;
+      controller.pageSize = 50;
+      controller.pageNumber = 1;
     }
   }
 

--- a/orga/app/styles/pages/authenticated/attestations.scss
+++ b/orga/app/styles/pages/authenticated/attestations.scss
@@ -3,25 +3,33 @@
 .attestations-page {
   display: flex;
   flex-direction: column;
+  padding: var(--pix-spacing-8x) 0;
 
   &__title {
     @extend %pix-title-m;
+  }
 
-    margin: var(--pix-spacing-8x) 0;
+  &__section-title {
+    @extend %pix-title-s;
+
+    margin-bottom: var(--pix-spacing-4x);
+
+    &--list {
+      margin-top: var(--pix-spacing-12x);
+    }
   }
 
   &__text {
     @extend %pix-body-m;
 
     margin-bottom: var(--pix-spacing-8x);
-
   }
 
   &__action {
     display: flex;
     flex-wrap: wrap;
     gap: var(--pix-spacing-4x);
-    align-items: end
+    align-items: end;
   }
 
   &__select-form {
@@ -34,5 +42,9 @@
     margin-top: var(--pix-spacing-8x);
     margin-bottom: var(--pix-spacing-8x);
     border-bottom: 1px solid var(--pix-neutral-100);
+  }
+
+  &__list {
+    margin-bottom: var(--pix-spacing-8x);
   }
 }

--- a/orga/app/templates/authenticated/attestations.gjs
+++ b/orga/app/templates/authenticated/attestations.gjs
@@ -5,6 +5,15 @@ import Attestations from 'pix-orga/components/attestations';
   {{pageTitle (t "pages.attestations.title")}}
 
   <div class="attestations-page">
-    <Attestations @divisions={{@model.options}} @onSubmit={{@controller.downloadAttestations}} />
+    <Attestations
+      @participantStatuses={{@model.attestationParticipantStatuses}}
+      @divisions={{@model.options}}
+      @onSubmit={{@controller.downloadAttestations}}
+      @clearFilters={{@controller.clearFilters}}
+      @onFilter={{@controller.triggerFiltering}}
+      @searchFilter={{@controller.search}}
+      @statusesFilter={{@controller.statuses}}
+      @divisionsFilter={{@controller.divisions}}
+    />
   </div>
 </template>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -584,4 +584,37 @@ function routes() {
     const { target } = request.params;
     return schema.informationBanners.find(target);
   });
+
+  this.get('/organizations/:organizationId/attestations/:attestationKey/statuses', (schema, request) => {
+    const {
+      'filter[statuses]': statuses,
+      'filter[divisions]': divisions,
+      'filter[search]': search,
+    } = request.queryParams;
+
+    if (!statuses && !divisions && !search) {
+      return schema.attestationParticipantStatuses.all();
+    }
+
+    return schema.attestationParticipantStatuses.where((learner) => {
+      let match = true;
+
+      if (statuses?.length > 0) {
+        const hasObtained = Boolean(learner.obtainedAt);
+        match =
+          match &&
+          ((statuses.includes('OBTAINED') && hasObtained) || (statuses.includes('NOT_OBTAINED') && !hasObtained));
+      }
+
+      if (divisions?.length > 0) {
+        match = match && divisions.includes(learner.division);
+      }
+
+      if (search) {
+        match = match && (learner.firstName.includes(search) || learner.lastName.includes(search));
+      }
+
+      return match;
+    });
+  });
 }

--- a/orga/mirage/serializers/attestation-participant-status.js
+++ b/orga/mirage/serializers/attestation-participant-status.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/orga/tests/acceptance/attestations-test.js
+++ b/orga/tests/acceptance/attestations-test.js
@@ -1,0 +1,65 @@
+import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import authenticateSession from '../helpers/authenticate-session';
+import setupIntl from '../helpers/setup-intl';
+import {
+  createPrescriberByUser,
+  createUserMembershipWithRole,
+  createUserWithMembershipAndTermsOfServiceAccepted,
+} from '../helpers/test-init';
+
+module('Acceptance | Attestations', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(() => {});
+
+  test('it should not be accessible by an unauthenticated user', async function (assert) {
+    // when
+    await visit('/attestations');
+
+    // then
+    assert.strictEqual(currentURL(), '/connexion');
+  });
+
+  module('when the prescriber is authenticated', (hooks) => {
+    hooks.beforeEach(async () => {
+      const user = createUserMembershipWithRole('ADMIN');
+      server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
+      server.create('attestation-participant-status', {
+        firstName: 'Jean',
+        lastName: 'LastName1',
+        obtainedAt: null,
+        division: '6eme',
+      });
+      server.create('attestation-participant-status', {
+        firstName: 'Eude',
+        lastName: 'LastName2',
+        obtainedAt: '2024-01-01',
+        division: '5eme',
+      });
+      const prescriber = createPrescriberByUser({ user });
+      prescriber.features = {
+        ...prescriber.features,
+        ATTESTATIONS_MANAGEMENT: { active: true, params: ['SIXTH_GRADE'] },
+      };
+      await authenticateSession(user.id);
+    });
+
+    hooks.afterEach(function () {});
+
+    test('it should be accessible for an authenticated prescriber', async function (assert) {
+      // when
+      await visit('/attestations');
+
+      // then
+      assert.strictEqual(currentURL(), '/attestations');
+    });
+  });
+});

--- a/orga/tests/acceptance/attestations-test.js
+++ b/orga/tests/acceptance/attestations-test.js
@@ -1,4 +1,4 @@
-import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { t } from 'ember-intl/test-support';
@@ -7,11 +7,7 @@ import { module, test } from 'qunit';
 
 import authenticateSession from '../helpers/authenticate-session';
 import setupIntl from '../helpers/setup-intl';
-import {
-  createPrescriberByUser,
-  createUserMembershipWithRole,
-  createUserWithMembershipAndTermsOfServiceAccepted,
-} from '../helpers/test-init';
+import { createPrescriberByUser, createUserManagingStudents } from '../helpers/test-init';
 
 module('Acceptance | Attestations', function (hooks) {
   setupApplicationTest(hooks);
@@ -30,7 +26,13 @@ module('Acceptance | Attestations', function (hooks) {
 
   module('when the prescriber is authenticated', (hooks) => {
     hooks.beforeEach(async () => {
-      const user = createUserMembershipWithRole('ADMIN');
+      const user = createUserManagingStudents('ADMIN', 'SCO');
+      server.create('division', {
+        name: '6eme',
+      });
+      server.create('division', {
+        name: '5eme',
+      });
       server.create('member-identity', { id: user.id, firstName: user.firstName, lastName: user.lastName });
       server.create('attestation-participant-status', {
         firstName: 'Jean',
@@ -60,6 +62,108 @@ module('Acceptance | Attestations', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/attestations');
+    });
+
+    test('it should list learners with their status', async function (assert) {
+      // when
+      const screen = await visit('/attestations');
+
+      // then
+      assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.table.filter.divisions.label') }));
+      assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.table.filter.status.label') }));
+      assert.ok(screen.getByRole('textbox', { name: t('common.filters.fullname.label') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.attestations.table.column.first-name') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.attestations.table.column.last-name') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.attestations.table.column.status') }));
+      assert.ok(screen.getByRole('columnheader', { name: t('pages.attestations.table.column.division') }));
+      assert.ok(screen.getByRole('cell', { name: 'Jean' }));
+      assert.ok(screen.getByRole('cell', { name: 'LastName1' }));
+      assert.ok(screen.getByRole('cell', { name: 'Eude' }));
+      assert.ok(screen.getByRole('cell', { name: 'LastName2' }));
+      assert.ok(
+        screen.getByRole('cell', { name: t('pages.attestations.table.status.obtained', { date: '01/01/2024' }) }),
+      );
+      assert.ok(screen.getByRole('cell', { name: t('pages.attestations.table.status.not-obtained') }));
+      assert.ok(screen.getByRole('cell', { name: '6eme' }));
+      assert.ok(screen.getByRole('cell', { name: '5eme' }));
+    });
+
+    module('when using attestation filters', function () {
+      test('should be possible to filter by status', async function (assert) {
+        // given
+        const screen = await visit('/attestations');
+
+        // when
+        await click(screen.getByLabelText(t('pages.attestations.table.filter.status.label')));
+        await click(
+          await screen.findByRole('checkbox', {
+            name: t('pages.attestations.table.filter.status.not-obtained'),
+          }),
+        );
+
+        // then
+        assert.ok(screen.getByRole('cell', { name: t('pages.attestations.table.status.not-obtained') }));
+        assert.notOk(
+          screen.queryByRole('cell', { name: t('pages.attestations.table.status.obtained', { date: '01/01/2024' }) }),
+        );
+      });
+
+      test('should be possible to filter by divisions', async function (assert) {
+        // given
+        const screen = await visit('/attestations');
+
+        // when
+        await click(screen.getByLabelText(t('pages.attestations.table.filter.divisions.label')));
+        await click(
+          await screen.findByRole('checkbox', {
+            name: '6eme',
+          }),
+        );
+
+        // then
+        assert.ok(screen.getByRole('cell', { name: '6eme' }));
+        assert.notOk(screen.queryByRole('cell', { name: '5eme' }));
+      });
+
+      test('should be possible to filter by name', async function (assert) {
+        // given
+        const screen = await visit('/attestations');
+
+        // when
+        await fillByLabel(t('common.filters.fullname.label'), 'Je');
+
+        // then
+        assert.ok(screen.getByRole('cell', { name: 'Jean' }));
+        assert.notOk(screen.queryByRole('cell', { name: 'Eude' }));
+      });
+
+      module('when prescriber click on reset filters', function () {
+        test('should reset filters', async function (assert) {
+          // given
+          const screen = await visit('/attestations');
+          await fillByLabel(t('common.filters.fullname.label'), 'Je');
+          await click(screen.getByLabelText(t('pages.attestations.table.filter.status.label')));
+          await click(
+            await screen.findByRole('checkbox', {
+              name: t('pages.attestations.table.filter.status.not-obtained'),
+            }),
+          );
+          await click(screen.getByLabelText(t('pages.attestations.table.filter.divisions.label')));
+          await click(
+            await screen.findByRole('checkbox', {
+              name: '6eme',
+            }),
+          );
+
+          // when
+          await clickByName('Effacer les filtres');
+
+          // then
+          assert.strictEqual(screen.getByLabelText(t('common.filters.fullname.label')).value, '');
+          assert.strictEqual(screen.getByLabelText(t('pages.attestations.table.filter.status.label')).value, '');
+          assert.strictEqual(screen.getByLabelText(t('pages.attestations.table.filter.divisions.label')).value, '');
+        });
+      });
     });
   });
 });

--- a/orga/tests/acceptance/attestations-test.js
+++ b/orga/tests/acceptance/attestations-test.js
@@ -1,4 +1,4 @@
-import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { t } from 'ember-intl/test-support';
@@ -163,6 +163,24 @@ module('Acceptance | Attestations', function (hooks) {
           assert.strictEqual(screen.getByLabelText(t('pages.attestations.table.filter.status.label')).value, '');
           assert.strictEqual(screen.getByLabelText(t('pages.attestations.table.filter.divisions.label')).value, '');
         });
+      });
+    });
+
+    module('when using attestation pagination', function () {
+      test('should be possible to change page', async function (assert) {
+        // given
+        const screen = await visit('/attestations?pageSize=1');
+
+        assert.ok(screen.getByRole('cell', { name: 'Jean' }));
+        assert.notOk(screen.queryByText('Eude'));
+
+        // when
+        await clickByName('Aller à la page suivante');
+
+        // then
+        assert.strictEqual(currentURL(), '/attestations?pageNumber=2&pageSize=1');
+        assert.ok(screen.getByRole('cell', { name: 'Eude' }));
+        assert.notOk(screen.queryByText('Jean'));
       });
     });
   });

--- a/orga/tests/integration/components/attestations_test.gjs
+++ b/orga/tests/integration/components/attestations_test.gjs
@@ -25,36 +25,35 @@ module('Integration | Component | Attestations', function (hooks) {
   module('when organization has divisions, SIXTH_GRADE attestation and another attestation', function () {
     test('it displays both way to download attestations', async function (assert) {
       // given
+      const noop = sinon.stub();
       const currentUser = this.owner.lookup('service:current-user');
       currentUser.prescriber.availableAttestations = [SIXTH_GRADE_ATTESTATION_KEY, PARENTHOOD_ATTESTATION_KEY];
-      const onSubmit = sinon.stub();
       const divisions = [];
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
       );
 
       // then
-      assert.ok(screen.getByText(t('pages.attestations.divisions-description')));
       assert.ok(screen.getByText(t('pages.attestations.basic-description')));
     });
   });
 
   module('when organization has divisions and SIXTH_GRADE attestation', function () {
-    test('it should display all specifics informations for divisions', async function (assert) {
+    test('it should display all specifics information for divisions', async function (assert) {
       // given
+      const noop = sinon.stub();
       const onSubmit = sinon.stub();
       const divisions = [];
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
       );
 
       // then
       assert.ok(screen.getByRole('heading', { name: t('pages.attestations.title') }));
-      assert.ok(screen.getByText(t('pages.attestations.divisions-description')));
       assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.select-divisions-label') }));
       assert.ok(screen.getByPlaceholderText(t('common.filters.placeholder')));
       assert.ok(screen.getByRole('button', { name: t('pages.attestations.download-attestations-button') }));
@@ -62,12 +61,12 @@ module('Integration | Component | Attestations', function (hooks) {
 
     test('download button is disabled if there is no selected divisions', async function (assert) {
       // given
-      const onSubmit = sinon.stub();
+      const noop = sinon.stub();
       const divisions = [];
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
       );
 
       // then
@@ -79,13 +78,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
     test('it should call onSubmit action with selected divisions', async function (assert) {
       // given
+      const noop = sinon.stub();
       const onSubmit = sinon.stub();
 
       const divisions = [{ label: 'division1', value: 'division1' }];
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
       );
 
       const multiSelect = await screen.getByRole('textbox', { name: t('pages.attestations.select-divisions-label') });
@@ -107,14 +107,14 @@ module('Integration | Component | Attestations', function (hooks) {
   });
 
   module('when organization does not have divisions and SIXTH_GRADE attestation', function () {
-    test('it should display all basics informations', async function (assert) {
+    test('it should display all basics information', async function (assert) {
       // given
-      const onSubmit = sinon.stub();
+      const noop = sinon.stub();
       const divisions = undefined;
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{noop}} @onFilter={{noop}} /></template>,
       );
       // then
       assert.notOk(screen.queryByRole('textbox', { name: t('pages.attestations.select-label') }));
@@ -125,13 +125,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
     test('it should call onSubmit action with empty divisions', async function (assert) {
       // given
+      const noop = sinon.stub();
       const onSubmit = sinon.stub();
 
       const divisions = undefined;
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} /></template>,
+        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
       );
 
       const downloadButton = await screen.getByRole('button', {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -485,12 +485,41 @@
     "attestations": {
       "PARENTHOOD": "Attestation de sensibilisation au numérique",
       "SIXTH_GRADE": "Attestation de sensibilisation au numérique",
-      "basic-description": "Export all attestations in PDF format",
-      "divisions-description": "Select the class for which you wish to export attestations in PDF format.",
-      "download-attestations-button": "Download",
+      "basic-description": "Export all attestations",
+      "download-attestations-button": "Download (.pdf)",
       "no-attestations": "No attestation available",
-      "select-divisions-label": "Select one or more classes",
+      "section": {
+        "download": "Download",
+        "list": "Follow-up"
+      },
+      "select-divisions-label": "Select attestations for one or more classes",
       "select-label": "Attestation",
+      "table": {
+        "column": {
+          "division": "Class",
+          "first-name": "First name",
+          "last-name": "Last name",
+          "status": "Obtained"
+        },
+        "filter": {
+          "divisions": {
+            "empty-option": "Class",
+            "label": "Class"
+          },
+          "legend": "Filters for the attestations table, input fields allow you to filter the table by a student's first or last name and by classes. Buttons can be used to filter attestations obtained or not.",
+          "results": "{total, plural, =0 {0 result} =1 {1 result} other {{total, number} results}}",
+          "status": {
+            "empty-option": "Obtained / Not obtained",
+            "label": "Obtained",
+            "not-obtained": "Not obtained",
+            "obtained": "Obtained"
+          }
+        },
+        "status": {
+          "not-obtained": "Not obtained",
+          "obtained": "Obtained on {date}"
+        }
+      },
       "title": "Attestations"
     },
     "campaign": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -485,12 +485,41 @@
     "attestations": {
       "PARENTHOOD": "Attestation de sensibilisation au numérique",
       "SIXTH_GRADE": "Attestation de sensibilisation au numérique",
-      "basic-description": "Exportez toutes les attestations au format PDF",
-      "divisions-description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les attestations au format PDF.",
-      "download-attestations-button": "Télécharger",
+      "basic-description": "Exportez toutes les attestations",
+      "download-attestations-button": "Télécharger (.pdf)",
       "no-attestations": "Aucune attestation disponible pour votre sélection",
-      "select-divisions-label": "Sélectionnez une ou plusieurs classes",
+      "section": {
+        "download": "Téléchargement",
+        "list": "Suivi"
+      },
+      "select-divisions-label": "Sélectionnez les attestations d'une ou plusieurs classes",
       "select-label": "Attestation",
+      "table": {
+        "column": {
+          "division": "Classe",
+          "first-name": "Prénom",
+          "last-name": "Nom",
+          "status": "Obtention"
+        },
+        "filter": {
+          "divisions": {
+            "empty-option": "Classe",
+            "label": "Classe"
+          },
+          "legend": "Filtres pour le tableau des attestations, des champs de saisie permettent de filtrer le tableau par le nom ou prénom d'un élève et par classes. Des boutons permettent de filtrer les attestations obtenues ou non.",
+          "results": "{total, plural, =0 {0 résultat} =1 {1 résultat} other {{total, number} résultats}}",
+          "status": {
+            "empty-option": "Obtenu / Non obtenu",
+            "label": "Obtention",
+            "not-obtained": "Non obtenu",
+            "obtained": "Obtenu"
+          }
+        },
+        "status": {
+          "not-obtained": "Non obtenu",
+          "obtained": "Obtenu le {date}"
+        }
+      },
       "title": "Attestations"
     },
     "campaign": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -484,14 +484,43 @@
     },
     "attestations": {
       "title": "Certificaten",
-      "basic-description": "Alle attesten exporteren in PDF-formaat",
-      "divisions-description": "Selecteer de klas waarvoor je de attesten in PDF-formaat wilt exporteren.",
-      "download-attestations-button": "Downloaden",
+      "basic-description": "Alle attesten exporteren",
+      "download-attestations-button": "Downloaden (.pdf)",
       "no-attestations": "Er zijn geen certificaten beschikbaar voor jouw selectie",
-      "select-divisions-label": "Selecteer een of meer klassen",
+      "select-divisions-label": "Selecteer de certificaten voor een of meer klassen",
       "select-label": "Certificat",
       "SIXTH_GRADE": "Attestation de sensibilisation au numérique",
-      "PARENTHOOD": "Attestation de sensibilisation au numérique"
+      "PARENTHOOD": "Attestation de sensibilisation au numérique",
+      "section": {
+        "download": "Downloaden",
+        "list": "Follow-up"
+      },
+      "table": {
+        "column": {
+          "first-name": "Voornaam",
+          "last-name": "Naam",
+          "division": "Klasse",
+          "status": "Verkrijgen"
+        },
+        "filter": {
+          "status": {
+            "label": "Verkrijgen",
+            "empty-option": "Verkrijgen / Niet verkregen",
+            "obtained": "Verkrijgen",
+            "not-obtained": "Niet verkregen"
+          },
+          "divisions": {
+            "label": "Klasse",
+            "empty-option": "Klasse"
+          },
+          "results": "{total, plural, =0 {0 resultaat} =1 {1 resultaat} other {{total, number} resultaten}}",
+          "legend": "Filters voor de tabel met certificaten: invoervelden kunnen worden gebruikt om de tabel te filteren op de voor- of achternaam van een leerling en op klas. Met knoppen kun je de behaalde certificaten filteren of niet."
+        },
+        "status": {
+          "obtained": "Verkregen op {date}",
+          "not-obtained": "Niet verkregen"
+        }
+      }
     },
     "campaign-activity": {
       "actions": {


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le seul moyen pour retrouver les participants n'ayant pas obtenu leur attestation est que le prescripteur fasse la différence entre ceux qui l'ont obtenu en téléchargeant leur attestation avec les participants de son organisation/campagnes/autres. C'est donc fastidieux pour les prescripteurs, ce n'est pas notre souhait de leur rajouter du boulot. 

## ⛱️ Proposition

Nous proposons d'ajouter, en dessous de la section téléchargement, la liste des participants de l'organisation avec leur status d'obtention de l'attestation. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- Se connecter à Pix Orga en tant qu'admin
- Se rendre sur l'orga qui a des attestations
- Se rendre sur l'onglet "attestations"
- Observer comment c'est BG dans toutes les langues
- Utiliser les filtres et la pagination
- Changer d'onglet et revenir