### PR TITLE
[FEATURE] Bloquer les actions d'orga si la limite des places est atteinte (PIX-18669).

### DIFF
--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -13,6 +13,12 @@ export default class CampaignTabs extends Component {
   @service fileSaver;
   @service session;
   @service pixMetrics;
+  @service store;
+
+  get hasReachedPlacesLimit() {
+    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
+    return statistics?.hasReachMaximumPlacesWithThreshold;
+  }
 
   @action
   async exportData() {
@@ -38,6 +44,7 @@ export default class CampaignTabs extends Component {
         </LinkTo>
 
         <LinkTo
+          @disabled={{this.hasReachedPlacesLimit}}
           @route={{if
             (or @campaign.isTypeAssessment @campaign.isTypeExam)
             "authenticated.campaigns.campaign.assessment-results"
@@ -49,7 +56,11 @@ export default class CampaignTabs extends Component {
         </LinkTo>
 
         {{#if (or @campaign.isTypeAssessment @campaign.isTypeExam)}}
-          <LinkTo @route="authenticated.campaigns.campaign.analysis" @model={{@campaign}}>
+          <LinkTo
+            @disabled={{this.hasReachedPlacesLimit}}
+            @route="authenticated.campaigns.campaign.analysis"
+            @model={{@campaign}}
+          >
             {{t "pages.campaign.tab.review"}}
           </LinkTo>
         {{/if}}
@@ -60,7 +71,7 @@ export default class CampaignTabs extends Component {
       </PixTabs>
 
       <div class="campaign-header-tabs__export-button hide-on-mobile">
-        <PixButton @variant="primary" @triggerAction={{this.exportData}}>
+        <PixButton @isDisabled={{this.hasReachedPlacesLimit}} @variant="primary" @triggerAction={{this.exportData}}>
           {{t "pages.campaign.actions.export-results"}}
         </PixButton>
       </div>

--- a/orga/app/components/campaign/list-header.gjs
+++ b/orga/app/components/campaign/list-header.gjs
@@ -1,33 +1,52 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import PageTitle from '../ui/page-title';
 
-<template>
-  <header>
-    <PageTitle>
-      <:title>
-        {{t "pages.campaigns-list.title"}}
-      </:title>
-      <:tools>
-        <PixButtonLink
-          @route="authenticated.campaigns.new"
-          class="campaign-list-header__create-campaign-button hide-on-mobile"
-        >
-          {{t "pages.campaigns-list.action.create"}}
-        </PixButtonLink>
-      </:tools>
-    </PageTitle>
+export default class List extends Component {
+  @service store;
 
-    <PixTabs @variant="orga" class="campaign-list-header__tabs" @ariaLabel={{t "pages.campaigns-list.navigation"}}>
-      <LinkTo @route="authenticated.campaigns.list.my-campaigns">
-        {{t "pages.campaigns-list.tabs.my-campaigns"}}
-      </LinkTo>
-      <LinkTo @route="authenticated.campaigns.list.all-campaigns">
-        {{t "pages.campaigns-list.tabs.all-campaigns"}}
-      </LinkTo>
-    </PixTabs>
-  </header>
-</template>
+  get hasReachedPlacesLimit() {
+    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
+    return statistics?.hasReachMaximumPlacesWithThreshold;
+  }
+
+  get campaignCreationRoute() {
+    if (this.hasReachedPlacesLimit) {
+      return null;
+    }
+    return 'authenticated.campaigns.new';
+  }
+
+  <template>
+    <header>
+      <PageTitle>
+        <:title>
+          {{t "pages.campaigns-list.title"}}
+        </:title>
+        <:tools>
+          <PixButtonLink
+            @route={{this.campaignCreationRoute}}
+            class="campaign-list-header__create-campaign-button hide-on-mobile"
+            @isDisabled={{this.hasReachedPlacesLimit}}
+          >
+            {{t "pages.campaigns-list.action.create"}}
+          </PixButtonLink>
+        </:tools>
+      </PageTitle>
+
+      <PixTabs @variant="orga" class="campaign-list-header__tabs" @ariaLabel={{t "pages.campaigns-list.navigation"}}>
+        <LinkTo @route="authenticated.campaigns.list.my-campaigns">
+          {{t "pages.campaigns-list.tabs.my-campaigns"}}
+        </LinkTo>
+        <LinkTo @route="authenticated.campaigns.list.all-campaigns">
+          {{t "pages.campaigns-list.tabs.all-campaigns"}}
+        </LinkTo>
+      </PixTabs>
+    </header>
+  </template>
+}

--- a/orga/app/routes/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/analysis.js
@@ -6,7 +6,7 @@ export default class AnalysisRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    const campaignId = transition.to.params.campaign_id;
+    const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
     if (places?.hasReachMaximumPlacesWithThreshold) {

--- a/orga/app/routes/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/analysis.js
@@ -3,6 +3,16 @@ import { service } from '@ember/service';
 
 export default class AnalysisRoute extends Route {
   @service featureToggles;
+  @service router;
+
+  beforeModel(transition) {
+    const campaignId = transition.to.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
 
   async model() {
     const campaign = this.modelFor('authenticated.campaigns.campaign');

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -35,7 +35,7 @@ export default class AssessmentResultsRoute extends Route {
   };
 
   beforeModel(transition) {
-    const campaignId = transition.to.params.campaign_id;
+    const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
     if (places?.hasReachMaximumPlacesWithThreshold) {

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -5,6 +5,7 @@ import RSVP from 'rsvp';
 
 export default class AssessmentResultsRoute extends Route {
   @service store;
+  @service router;
 
   queryParams = {
     pageNumber: {
@@ -32,6 +33,15 @@ export default class AssessmentResultsRoute extends Route {
       refreshModel: true,
     },
   };
+
+  beforeModel(transition) {
+    const campaignId = transition.to.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
 
   async model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -5,6 +5,7 @@ import RSVP from 'rsvp';
 
 export default class ProfilesRoute extends Route {
   @service store;
+  @service router;
 
   queryParams = {
     pageNumber: {
@@ -31,6 +32,15 @@ export default class ProfilesRoute extends Route {
   loading(transition) {
     if (transition.from && transition.from.name === 'authenticated.campaigns.campaign.profile-results') {
       return false;
+    }
+  }
+
+  beforeModel(transition) {
+    const campaignId = transition.to.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }
 

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -36,7 +36,7 @@ export default class ProfilesRoute extends Route {
   }
 
   beforeModel(transition) {
-    const campaignId = transition.to.params.campaign_id;
+    const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
     if (places?.hasReachMaximumPlacesWithThreshold) {

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -13,6 +13,14 @@ export default class NewRoute extends Route {
     source: { refreshModel: true },
   };
 
+  beforeModel() {
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns');
+    }
+  }
+
   async model(params) {
     const organization = this.currentUser.organization;
     await organization.targetProfiles;

--- a/orga/app/routes/authenticated/campaigns/participant-assessment.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment.js
@@ -6,6 +6,15 @@ export default class AssessmentRoute extends Route {
   @service router;
   @service store;
 
+  beforeModel(transition) {
+    const campaignId = transition.to.parent.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
+
   async model(params) {
     try {
       const { campaign_id: campaignId, campaign_participation_id: campaignParticipationId } = params;

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
@@ -1,6 +1,18 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class AnalysisRoute extends Route {
+  @service router;
+
+  beforeModel(transition) {
+    const campaignId = transition.to.parent.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
+
   model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.participant-assessment');
     return campaignAssessmentParticipation;

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
@@ -1,6 +1,18 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
+  @service router;
+
+  beforeModel(transition) {
+    const campaignId = transition.to.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
+
   async model() {
     const { campaignAssessmentParticipation } = this.modelFor('authenticated.campaigns.participant-assessment');
     const campaignAssessmentParticipationResult =

--- a/orga/app/routes/authenticated/campaigns/participant-profile.js
+++ b/orga/app/routes/authenticated/campaigns/participant-profile.js
@@ -6,6 +6,15 @@ export default class ProfileRoute extends Route {
   @service router;
   @service store;
 
+  beforeModel(transition) {
+    const campaignId = transition.to.params.campaign_id;
+    const places = this.modelFor('authenticated');
+
+    if (places?.hasReachMaximumPlacesWithThreshold) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
+
   async model(params) {
     try {
       const { campaign_id: campaignId, campaign_participation_id: campaignParticipationId } = params;

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -84,23 +84,24 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         sharedParticipationsCount: 10,
         type: 'ASSESSMENT',
       });
-
-      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
     });
 
     test('it should display evaluation results item', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.results', { count: 10 }) });
 
       assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/resultats-evaluation');
     });
 
     test('it should display campaign analyse item', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.review') });
 
       assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/analyse');
     });
 
     test('it should call export result with right context', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
 
       assert.ok(notifications.sendError.notCalled);
@@ -110,6 +111,37 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
           token: access_token,
         }),
       );
+    });
+
+    module('when has reach maximum places threshold is true', function (hooks) {
+      hooks.beforeEach(function () {
+        const storeService = this.owner.lookup('service:store');
+        sinon.stub(storeService, 'peekAll');
+        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+      });
+
+      test('it should display disabled evaluation results item', async function (assert) {
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.results', { count: 10 }) });
+
+        assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/resultats-evaluation');
+        assert.dom(resultsLink).hasClass('disabled');
+      });
+
+      test('it should display disabled campaign analyse item', async function (assert) {
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.review') });
+
+        assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/analyse');
+        assert.dom(resultsLink).hasClass('disabled');
+      });
+
+      test('it should disabled download campaign result', async function (assert) {
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const downloadResultButton = screen.getByRole('button', { name: t('pages.campaign.actions.export-results') });
+
+        assert.dom(downloadResultButton).hasAttribute('aria-disabled', 'true');
+      });
     });
   });
 
@@ -121,21 +153,22 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         type: 'PROFILES_COLLECTION',
         sharedParticipationsCount: 6,
       });
-
-      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
     });
 
     test('it should display  profile results item', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.results', { count: 6 }) });
 
       assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/profils');
     });
 
     test('it should not display analyse item', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       assert.notOk(screen.queryByRole('link', { name: t('pages.campaign.tab.review') }));
     });
 
     test('it should call export result with right context', async function (assert) {
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
       await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
 
       assert.ok(notifications.sendError.notCalled);
@@ -162,6 +195,29 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         'pix-event-name': "Clic sur le bouton d'export",
       });
       assert.ok(true);
+    });
+
+    module('when has reach maximum places is true', function (hooks) {
+      hooks.beforeEach(function () {
+        const storeService = this.owner.lookup('service:store');
+        sinon.stub(storeService, 'peekAll');
+        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+      });
+
+      test('it should display disabled profile results item', async function (assert) {
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const resultsLink = screen.getByRole('link', { name: t('pages.campaign.tab.results', { count: 6 }) });
+
+        assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/profils');
+        assert.dom(resultsLink).hasClass('disabled');
+      });
+
+      test('it should display a disabled download campaign result button', async function (assert) {
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const downloadResultButton = screen.getByRole('button', { name: t('pages.campaign.actions.export-results') });
+
+        assert.dom(downloadResultButton).hasAttribute('aria-disabled', 'true');
+      });
     });
   });
 });

--- a/orga/tests/integration/components/campaign/list-header-test.gjs
+++ b/orga/tests/integration/components/campaign/list-header-test.gjs
@@ -1,0 +1,59 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ListHeader from 'pix-orga/components/campaign/list-header';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign | ListHeader', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when places limit feature is inactive', function () {
+    test('it displays a disabled link', async function (assert) {
+      // given
+      const storeService = this.owner.lookup('service:store');
+      sinon.stub(storeService, 'peekAll');
+      storeService.peekAll.returns(undefined);
+
+      // when
+      const screen = await render(<template><ListHeader /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: t('pages.campaigns-list.action.create') })).exists();
+    });
+  });
+
+  module('when places limit feature is active', function () {
+    module('when places limit is not reached', function () {
+      test('it displays a create link', async function (assert) {
+        // given
+        const storeService = this.owner.lookup('service:store');
+        sinon.stub(storeService, 'peekAll');
+        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: false }]);
+
+        // when
+        const screen = await render(<template><ListHeader /></template>);
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: t('pages.campaigns-list.action.create') })).exists();
+      });
+    });
+
+    module('when places limit is reached', function () {
+      test('it displays a disabled link', async function (assert) {
+        // given
+        const storeService = this.owner.lookup('service:store');
+        sinon.stub(storeService, 'peekAll');
+        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+
+        // when
+        const screen = await render(<template><ListHeader /></template>);
+
+        // then
+        assert.dom(screen.getByText(t('pages.campaigns-list.action.create'))).exists();
+        assert.dom(screen.queryByRole('link', { name: t('pages.campaigns-list.action.create') })).doesNotExist();
+      });
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
@@ -45,4 +45,50 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
       assert.false(result.isNewPage);
     });
   });
+
+  module('beforeModel', function () {
+    module('When places limit is reached', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When places limit is not reached', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      test('should not redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
@@ -62,7 +62,15 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
@@ -84,7 +92,15 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.notOk(replaceWithStub.called);

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -166,7 +166,15 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
@@ -184,7 +192,15 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.notOk(replaceWithStub.called);

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -149,4 +149,46 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       });
     });
   });
+
+  module('beforeModel', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect to main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
@@ -113,7 +113,15 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
@@ -131,7 +139,15 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
         modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
 
         //when
-        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
 
         //then
         assert.notOk(replaceWithStub.called);

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
@@ -96,4 +96,46 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
       assert.ok(controller.set.calledWith('search', null));
     });
   });
+
+  module('beforeModel', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-test.js
@@ -272,4 +272,48 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
       assert.true(controller.set.calledWithExactly('source', null));
     });
   });
+
+  module('beforeModel', function (hooks) {
+    let route;
+
+    hooks.beforeEach(function () {
+      route = this.owner.lookup('route:authenticated/campaigns/new');
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect to main campaign page', function (assert) {
+        //given
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel();
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns'));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect to main campaign page', function (assert) {
+        //given
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel();
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
@@ -1,0 +1,67 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaignParticipationId}', function (hooks) {
+  setupTest(hooks);
+
+  module('Before model', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment');
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect on main campaign page', function (assert) {
+        //given
+        const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment');
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
@@ -25,14 +25,14 @@ module(
 
           //when
           route.beforeModel({
-          to: {
-            parent: {
-              params: {
-                campaign_id: campaignId,
+            to: {
+              parent: {
+                params: {
+                  campaign_id: campaignId,
+                },
               },
             },
-          },
-        });
+          });
 
           //then
           assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
@@ -52,14 +52,14 @@ module(
 
           //when
           route.beforeModel({
-          to: {
-            parent: {
-              params: {
-                campaign_id: campaignId,
+            to: {
+              parent: {
+                params: {
+                  campaign_id: campaignId,
+                },
               },
             },
-          },
-        });
+          });
 
           //then
           assert.notOk(replaceWithStub.called);

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
@@ -1,0 +1,70 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaignParticipationId}/analyse',
+  function (hooks) {
+    setupTest(hooks);
+
+    module('before model', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      module('When places limit is reached', function () {
+        test('should redirect on main campaign page', function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/analysis');
+          const campaignId = Symbol('CampaignId');
+
+          const modelForStub = sinon.stub(route, 'modelFor');
+          const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+          //when
+          route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+          //then
+          assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+        });
+      });
+
+      module('When places limit is not reached', function () {
+        test('should not redirect on main campaign page', function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/analysis');
+          const campaignId = Symbol('CampaignId');
+
+          const modelForStub = sinon.stub(route, 'modelFor');
+          const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+          //when
+          route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+          //then
+          assert.notOk(replaceWithStub.called);
+        });
+      });
+    });
+  },
+);

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
@@ -1,0 +1,54 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaignParticipationId}/resultats',
+  function (hooks) {
+    setupTest(hooks);
+
+    module('Before model', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      module('When places limit is reached', function () {
+        test('should redirect on main campaign page', function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/results');
+          const campaignId = Symbol('CampaignId');
+
+          const modelForStub = sinon.stub(route, 'modelFor');
+          const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+          //when
+          route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+          //then
+          assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+        });
+      });
+
+      module('When places limit is not reached', function () {
+        test('should not redirect on main campaign page', function (assert) {
+          //given
+          const route = this.owner.lookup('route:authenticated/campaigns/participant-assessment/results');
+          const campaignId = Symbol('CampaignId');
+
+          const modelForStub = sinon.stub(route, 'modelFor');
+          const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+          //when
+          route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+          //then
+          assert.notOk(replaceWithStub.called);
+        });
+      });
+    });
+  },
+);

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
@@ -1,0 +1,51 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/{campaignId}/profils/{campaignParticipationId}', function (hooks) {
+  setupTest(hooks);
+
+  module('Before model', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    module('When places limit is reached', function () {
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const route = this.owner.lookup('route:authenticated/campaigns/participant-profile');
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When places limit is not reached', function () {
+      test('should not redirect on main campaign page', function (assert) {
+        //given
+        const route = this.owner.lookup('route:authenticated/campaigns/participant-profile');
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+
+        //when
+        route.beforeModel({ to: { params: { campaign_id: campaignId } } });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Nous avons bloqué les routes API que nous ne voulons pas voir utilisées lorsque l'orga a un nombre de place limité et que cette limite est dépassée.
Mais nous ne bloquons pas encore les actions sur PixOrga.

## ⛱️ Proposition

Sur PixOrga, bloquer les actions souhaitées et rediriger l'utilisateur s'il se trouve sur une page non souhaitée.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Avec l'orga "Pro classic", vérifier en RA que nous sommes bien redirigés si nous allons sur les URLs :
- https://orga-pr12801.review.pix.fr/campagnes/creation
- https://orga-pr12801.review.pix.fr/campagnes/6000/resultats-evaluation
- https://orga-pr12801.review.pix.fr/campagnes/6000/evaluations/102308/resultats
- https://orga-pr12801.review.pix.fr/campagnes/6000/evaluations/102308/analyse
- https://orga-pr12801.review.pix.fr/campagnes/6000/analyse
- https://orga-pr12801.review.pix.fr/campagnes/105779/profils
- https://orga-pr12801.review.pix.fr/campagnes/105779/profils/105782

Vérifier aussi les boutons / onglets désactivés :
- Création de campagne
- Exportation des résultats de campagne
- Analyse
- Résultats de campagne
- Profils