### PR TITLE
[FEATURE] Masquer la valeur des « claims to store » dans la double mire SSO (PIX-18536)

### DIFF
--- a/mon-pix/app/components/authentication/login-or-register-oidc.gjs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.gjs
@@ -180,14 +180,14 @@ export default class LoginOrRegisterOidcComponent extends Component {
       result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.firstName`)} ${firstName}`);
       result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.lastName`)} ${lastName}`);
 
-      Object.entries(rest).map(([key, value]) => {
+      Object.entries(rest).map(([key, _value]) => {
         let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.claims.${key}`)}`;
 
         if (label.includes('Missing translation')) {
-          label = `${key} :`;
+          label = key;
         }
 
-        return result.push(`${label} ${value}`);
+        return result.push(label);
       });
     }
 

--- a/mon-pix/app/components/authentication/login-or-register-oidc.gjs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.gjs
@@ -177,8 +177,8 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
     if (userClaims) {
       const { firstName, lastName, ...rest } = userClaims;
-      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.firstName`)} ${firstName}`);
-      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.lastName`)} ${lastName}`);
+      result.push(this.intl.t('pages.login-or-register-oidc.register-form.first-name-label-and-value', { firstName }));
+      result.push(this.intl.t('pages.login-or-register-oidc.register-form.last-name-label-and-value', { lastName }));
 
       Object.entries(rest).map(([key, _value]) => {
         let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.claims.${key}`)}`;

--- a/mon-pix/app/components/authentication/login-or-register-oidc.gjs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.gjs
@@ -164,7 +164,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
     const { userClaims } = this.args;
 
     if (!userClaims) {
-      return this.intl.t(`pages.login-or-register-oidc.register-form.information.error`);
+      return this.intl.t(`pages.login-or-register-oidc.register-form.error`);
     } else {
       return null;
     }
@@ -177,11 +177,11 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
     if (userClaims) {
       const { firstName, lastName, ...rest } = userClaims;
-      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.information.firstName`)} ${firstName}`);
-      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.information.lastName`)} ${lastName}`);
+      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.firstName`)} ${firstName}`);
+      result.push(`${this.intl.t(`pages.login-or-register-oidc.register-form.claims.lastName`)} ${lastName}`);
 
       Object.entries(rest).map(([key, value]) => {
-        let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.information.${key}`)}`;
+        let label = `${this.intl.t(`pages.login-or-register-oidc.register-form.claims.${key}`)}`;
 
         if (label.includes('Missing translation')) {
           label = `${key} :`;

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
@@ -71,10 +71,10 @@ module('Integration | Component | authentication | login-or-register-oidc', func
         assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.register-form.button') }));
         assert.ok(screen.getByText('Partenaire OIDC'));
         assert.ok(
-          screen.getByText(`${t('pages.login-or-register-oidc.register-form.information.firstName')} Mélusine`),
+          screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`),
         );
         assert.ok(
-          screen.getByText(`${t('pages.login-or-register-oidc.register-form.information.lastName')} TITEGOUTTE`),
+          screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`),
         );
         assert.ok(screen.getByRole('checkbox', { name: t('common.cgu.label') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
@@ -96,14 +96,14 @@ module('Integration | Component | authentication | login-or-register-oidc', func
             level: 2,
           }),
         );
-        assert.ok(screen.getByText(t('pages.login-or-register-oidc.register-form.information.error')));
+        assert.ok(screen.getByText(t('pages.login-or-register-oidc.register-form.error')));
         assert.notOk(screen.queryByRole('button', { name: t('pages.login-or-register-oidc.register-form.button') }));
         assert.notOk(screen.queryByText('Partenaire OIDC'));
         assert.notOk(
-          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.information.firstName')} Mélusine`),
+          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`),
         );
         assert.notOk(
-          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.information.lastName')} TITEGOUTTE`),
+          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`),
         );
         assert.notOk(screen.queryByRole('checkbox', { name: t('common.cgu.label') }));
         assert.notOk(screen.queryByRole('link', { name: t('common.cgu.cgu') }));
@@ -130,8 +130,8 @@ module('Integration | Component | authentication | login-or-register-oidc', func
       assert.ok(screen.getByRole('textbox', { name: t('pages.login-or-register-oidc.login-form.email') }));
       assert.ok(screen.getByRole('link', { name: t('pages.sign-in.forgotten-password') }));
       assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.login-form.button') }));
-      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.information.firstName')} Mélusine`));
-      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.information.lastName')} TITEGOUTTE`));
+      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`));
+      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`));
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
@@ -121,13 +121,10 @@ module('Integration | Component | authentication | login-or-register-oidc', func
   });
 
   module('on login form', function () {
-    test('should display elements for OIDC identity provider', async function (assert) {
+    test('displays some form elements', async function (assert) {
       // given & when
       const screen = await render(
-        hbs`<Authentication::LoginOrRegisterOidc
-  @identityProviderSlug={{this.identityProviderSlug}}
-  @userClaims={{this.userClaims}}
-/>`,
+        hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} @userClaims={{null}} />`,
       ); // then
       assert.ok(
         screen.getByRole('heading', {
@@ -138,20 +135,6 @@ module('Integration | Component | authentication | login-or-register-oidc', func
       assert.ok(screen.getByRole('textbox', { name: t('pages.login-or-register-oidc.login-form.email') }));
       assert.ok(screen.getByRole('link', { name: t('pages.sign-in.forgotten-password') }));
       assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.login-form.button') }));
-      assert.ok(
-        screen.getByText(
-          t('pages.login-or-register-oidc.register-form.first-name-label-and-value', {
-            firstName: 'Mélusine',
-          }),
-        ),
-      );
-      assert.ok(
-        screen.getByText(
-          t('pages.login-or-register-oidc.register-form.last-name-label-and-value', {
-            lastName: 'TITEGOUTTE',
-          }),
-        ),
-      );
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
@@ -70,8 +70,16 @@ module('Integration | Component | authentication | login-or-register-oidc', func
         );
         assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.register-form.button') }));
         assert.ok(screen.getByText('Partenaire OIDC'));
-        assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`));
-        assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`));
+        assert.ok(
+          screen.getByText(
+            t('pages.login-or-register-oidc.register-form.first-name-label-and-value', { firstName: 'Mélusine' }),
+          ),
+        );
+        assert.ok(
+          screen.getByText(
+            t('pages.login-or-register-oidc.register-form.last-name-label-and-value', { lastName: 'TITEGOUTTE' }),
+          ),
+        );
         assert.ok(screen.getByRole('checkbox', { name: t('common.cgu.label') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));
@@ -96,10 +104,14 @@ module('Integration | Component | authentication | login-or-register-oidc', func
         assert.notOk(screen.queryByRole('button', { name: t('pages.login-or-register-oidc.register-form.button') }));
         assert.notOk(screen.queryByText('Partenaire OIDC'));
         assert.notOk(
-          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`),
+          screen.queryByText(t('pages.login-or-register-oidc.register-form.first-name-label-and-value'), {
+            firstName: 'Mélusine',
+          }),
         );
         assert.notOk(
-          screen.queryByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`),
+          screen.queryByText(t('pages.login-or-register-oidc.register-form.last-name-label-and-value'), {
+            lastName: 'TITEGOUTTE',
+          }),
         );
         assert.notOk(screen.queryByRole('checkbox', { name: t('common.cgu.label') }));
         assert.notOk(screen.queryByRole('link', { name: t('common.cgu.cgu') }));
@@ -126,8 +138,20 @@ module('Integration | Component | authentication | login-or-register-oidc', func
       assert.ok(screen.getByRole('textbox', { name: t('pages.login-or-register-oidc.login-form.email') }));
       assert.ok(screen.getByRole('link', { name: t('pages.sign-in.forgotten-password') }));
       assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.login-form.button') }));
-      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`));
-      assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`));
+      assert.ok(
+        screen.getByText(
+          t('pages.login-or-register-oidc.register-form.first-name-label-and-value', {
+            firstName: 'Mélusine',
+          }),
+        ),
+      );
+      assert.ok(
+        screen.getByText(
+          t('pages.login-or-register-oidc.register-form.last-name-label-and-value', {
+            lastName: 'TITEGOUTTE',
+          }),
+        ),
+      );
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc-test.js
@@ -70,12 +70,8 @@ module('Integration | Component | authentication | login-or-register-oidc', func
         );
         assert.ok(screen.getByRole('button', { name: t('pages.login-or-register-oidc.register-form.button') }));
         assert.ok(screen.getByText('Partenaire OIDC'));
-        assert.ok(
-          screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`),
-        );
-        assert.ok(
-          screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`),
-        );
+        assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.firstName')} Mélusine`));
+        assert.ok(screen.getByText(`${t('pages.login-or-register-oidc.register-form.claims.lastName')} TITEGOUTTE`));
         assert.ok(screen.getByRole('checkbox', { name: t('common.cgu.label') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.cgu') }));
         assert.ok(screen.getByRole('link', { name: t('common.cgu.data-protection-policy') }));

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1612,14 +1612,14 @@
           "FrEduNumenHash": "Technical identifier",
           "discipline": "School subject",
           "employeeNumber": "Employee number",
-          "firstName": "First name:",
-          "lastName": "Last name:",
           "population": "Population",
           "rne": "Establishment of assignment",
           "title": "Title"
         },
         "description": "An account will be created based on the information sent by the organisation",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "First name: {firstName}",
+        "last-name-label-and-value": "Last name: {lastName}",
         "title": "Sign up"
       },
       "title": "Create your Account"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1608,15 +1608,15 @@
       "register-form": {
         "button": "Create my account",
         "claims": {
-          "FrEduFonctAdm": "Administrative function:",
+          "FrEduFonctAdm": "Administrative function",
           "FrEduNumenHash": "Technical identifier",
-          "discipline": "School subject:",
-          "employeeNumber": "Employee number:",
+          "discipline": "School subject",
+          "employeeNumber": "Employee number",
           "firstName": "First name:",
           "lastName": "Last name:",
-          "population": "Population:",
-          "rne": "Establishment of assignment:",
-          "title": "Title:"
+          "population": "Population",
+          "rne": "Establishment of assignment",
+          "title": "Title"
         },
         "description": "An account will be created based on the information sent by the organisation",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1607,19 +1607,19 @@
       },
       "register-form": {
         "button": "Create my account",
-        "description": "An account will be created based on the information sent by the organisation",
-        "information": {
+        "claims": {
           "FrEduFonctAdm": "Administrative function:",
           "FrEduNumenHash": "Technical identifier",
           "discipline": "School subject:",
           "employeeNumber": "Employee number:",
-          "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
           "firstName": "First name:",
           "lastName": "Last name:",
           "population": "Population:",
           "rne": "Establishment of assignment:",
           "title": "Title:"
         },
+        "description": "An account will be created based on the information sent by the organisation",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
         "title": "Sign up"
       },
       "title": "Create your Account"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1523,7 +1523,8 @@
       "register-form": {
         "button": "Creo una cuenta",
         "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "information": {
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "claims": {
           "family-name": "Apellidos: {familyName}",
           "given-name": "Nombre: {givenName}"
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1524,10 +1524,8 @@
         "button": "Creo una cuenta",
         "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "claims": {
-          "family-name": "Apellidos: {familyName}",
-          "given-name": "Nombre: {givenName}"
-        },
+        "last-name-label-and-value": "Apellidos: {lastName}",
+        "first-name-label-and-value": "Nombre: {firstName}",
         "title": "No tengo una cuenta Pix"
       },
       "title": "Crea una cuenta Pix"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1607,19 +1607,19 @@
       },
       "register-form": {
         "button": "Je crée mon compte",
-        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
-        "information": {
+        "claims": {
           "FrEduFonctAdm": "Fonction Administrative :",
           "FrEduNumenHash": "Identifiant technique",
           "discipline": "Discipline :",
           "employeeNumber": "Numéro d'employé :",
-          "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
           "firstName": "Prénom :",
           "lastName": "Nom :",
           "population": "Population :",
           "rne": "Etablissement d’affectation :",
           "title": "Fonction :"
         },
+        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
+        "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
         "title": "Je n’ai pas de compte Pix"
       },
       "title": "Créez votre compte Pix"
@@ -2006,7 +2006,6 @@
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser.",
         "notification": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. Vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilités par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
         "notification-with-auto-share": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
-
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1612,14 +1612,14 @@
           "FrEduNumenHash": "Identifiant technique",
           "discipline": "Discipline",
           "employeeNumber": "Numéro d'employé",
-          "firstName": "Prénom :",
-          "lastName": "Nom :",
           "population": "Population",
           "rne": "Etablissement d’affectation",
           "title": "Fonction"
         },
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
         "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
+        "first-name-label-and-value": "Prénom : {firstName}",
+        "last-name-label-and-value": "Nom : {lastName}",
         "title": "Je n’ai pas de compte Pix"
       },
       "title": "Créez votre compte Pix"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1608,15 +1608,15 @@
       "register-form": {
         "button": "Je crée mon compte",
         "claims": {
-          "FrEduFonctAdm": "Fonction Administrative :",
+          "FrEduFonctAdm": "Fonction Administrative",
           "FrEduNumenHash": "Identifiant technique",
-          "discipline": "Discipline :",
-          "employeeNumber": "Numéro d'employé :",
+          "discipline": "Discipline",
+          "employeeNumber": "Numéro d'employé",
           "firstName": "Prénom :",
           "lastName": "Nom :",
-          "population": "Population :",
-          "rne": "Etablissement d’affectation :",
-          "title": "Fonction :"
+          "population": "Population",
+          "rne": "Etablissement d’affectation",
+          "title": "Fonction"
         },
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
         "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1600,7 +1600,7 @@
       },
       "login-form": {
         "button": "Je me connecte",
-        "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
+        "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées.",
         "email": "Adresse e-mail",
         "password": "Mot de passe",
         "title": "J’ai déjà un compte Pix"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1527,10 +1527,8 @@
         "button": "Ik maak mijn account aan",
         "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "claims": {
-          "family-name": "Naam: {familyName}",
-          "given-name": "Voornaam : {givenName}"
-        },
+        "last-name-label-and-value": "Naam: {lastName}",
+        "first-name-label-and-value": "Voornaam: {firstName}",
         "title": "Ik heb geen Pix-account"
       },
       "title": "Maak je Pix-account aan"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1525,7 +1525,7 @@
       },
       "register-form": {
         "button": "Ik maak mijn account aan",
-        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt.",
+        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
         "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
         "claims": {
           "family-name": "Naam: {familyName}",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1518,7 +1518,7 @@
       },
       "login-form": {
         "button": "Inloggen",
-        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen",
+        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen.",
         "email": "E-mailadres",
         "password": "Wachtwoord",
         "title": "Ik heb al een Pix-account"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1526,7 +1526,8 @@
       "register-form": {
         "button": "Ik maak mijn account aan",
         "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt.",
-        "information": {
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "claims": {
           "family-name": "Naam: {familyName}",
           "given-name": "Voornaam : {givenName}"
         },


### PR DESCRIPTION
## 🔆 Problème

Actuellement au niveau de la double mire SSO on affiche la valeur de tous les claims to store. Or certaines de ces valeurs peuvent être très très longues (des identifiants techniques par exemple) ou bien être des valeurs binaires, etc.

## ⛱️ Proposition

S’aligner sur ce qui est fait dans les différentes interfaces utilisateurs actuelles en masquant les valeurs des données récupérées, mais bien sûr en affichant toujours quelles sont les données récupérées.

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Effectuer une authentification avec 1 SSO ayant des `claimsToStore`
2. Vérifier que pour le `Nom` et le `Prénom` les valeurs s’affichent bien, mais que pour d’autres claims comme `employeeNumber` la valeur n’est pas affichée
3. Changer les langues avec le languageSwitcher pour vérifier que toutes les traductions sont bien en place
4. Effectuer une authentification avec 1 SSO n’ayant pas de `claimsToStore`
5. Vérifier que pour le `Nom` et le `Prénom` les valeurs s’affichent bien (pour une vérification de non-régression)
6. Changer les langues avec le languageSwitcher pour vérifier que toutes les traductions sont bien en place
