### PR TITLE
[TECH] :art: Ajoute une fonction `getNextId()`  au `datamartBuffer`

### DIFF
--- a/api/datamart/datamart-builder/datamart-buffer.js
+++ b/api/datamart/datamart-builder/datamart-buffer.js
@@ -1,10 +1,16 @@
+const INITIAL_ID = 100000;
 const datamartBuffer = {
   objectsToInsert: [],
+  nextId: INITIAL_ID,
 
   pushInsertable({ tableName, values }) {
     this.objectsToInsert.push({ tableName, values });
 
     return values;
+  },
+
+  getNextId() {
+    return this.nextId++;
   },
 
   purge() {


### PR DESCRIPTION
## 🔆 Problème

Il n'est pas possible, pour les `datamartBuilder` du `datamart`, de bénéficier d'une fonction d'`id` incrémentale.

## ⛱️ Proposition

Ajout de la fonction `getNextId` dans le `datamartBuffer`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
