### PR TITLE
[TECH] :card_file_box: Ajout le préfixe `data_` oublié à deux tables du `datamart`

### DIFF
--- a/api/datamart/migrations/20250704154900_update-active-calibrated-challenges-and-calibrations-tablenames.js
+++ b/api/datamart/migrations/20250704154900_update-active-calibrated-challenges-and-calibrations-tablenames.js
@@ -1,0 +1,24 @@
+const OLD_TABLE_NAME_CHALLENGES = 'active_calibrated_challenges';
+const NEW_TABLE_NAME_CHALLENGES = 'data_active_calibrated_challenges';
+const OLD_TABLE_NAME_CALIBRATIONS = 'calibrations';
+const NEW_TABLE_NAME_CALIBRATIONS = 'data_calibrations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.renameTable(OLD_TABLE_NAME_CHALLENGES, NEW_TABLE_NAME_CHALLENGES);
+  await knex.schema.renameTable(OLD_TABLE_NAME_CALIBRATIONS, NEW_TABLE_NAME_CALIBRATIONS);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.renameTable(NEW_TABLE_NAME_CHALLENGES, OLD_TABLE_NAME_CHALLENGES);
+  await knex.schema.renameTable(NEW_TABLE_NAME_CALIBRATIONS, OLD_TABLE_NAME_CALIBRATIONS);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous avons oublié le préfixe `data_` sur deux tables du datamart...

## ⛱️ Proposition

Ajouter le préfixe `data_` sur les deux tables du datamart.

## 🌊 Remarques

J'ai mis le tag `no-review-app`, mais peut-être qu'en fait, il faut le mettre ? 

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
