### PR TITLE
[TECH] :truck: Déplace le modèle en lecture seul `CpfCertificationResult` vers le contexte `/src/certification/session-management`

### DIFF
--- a/api/src/certification/session-management/domain/read-models/CpfCertificationResult.js
+++ b/api/src/certification/session-management/domain/read-models/CpfCertificationResult.js
@@ -1,4 +1,4 @@
-import { EuropeanNumericLevelFactory } from './EuropeanNumericLevelFactory.js';
+import { EuropeanNumericLevelFactory } from '../../../../shared/domain/read-models/EuropeanNumericLevelFactory.js';
 
 class CpfCertificationResult {
   constructor({

--- a/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
-import { CpfCertificationResult } from '../../../../shared/domain/read-models/CpfCertificationResult.js';
 import { CpfImportStatus } from '../../domain/models/CpfImportStatus.js';
+import { CpfCertificationResult } from '../../domain/read-models/CpfCertificationResult.js';
 
 const findByBatchId = async function (batchId) {
   const cpfCertificationResults = await _selectCpfCertificationResults()

--- a/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
@@ -1,4 +1,4 @@
-import { CpfCertificationResult } from '../../../../src/shared/domain/read-models/CpfCertificationResult.js';
+import { CpfCertificationResult } from '../../../../src/certification/session-management/domain/read-models/CpfCertificationResult.js';
 
 const buildCpfCertificationResult = function ({
   id = 1234,


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seul `CpfCertificationResult` est dans `/src/shared` mais n'est utilisé que dans le contexte `/src/certification/session-management`.

## ⛱️ Proposition

Déplacer le modèle en lecture seul `CpfCertificationResult` vers le contexte `/src/certification/session-management`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
