### PR TITLE
[FEATURE] Afficher les tags Découverte et Activité (PIX-18657)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -104,6 +104,10 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   }
 }
 
+.grain-card-tag {
+  margin-bottom: var(--pix-spacing-1x);
+}
+
 // stylelint-disable-next-line no-duplicate-selectors
 .grain--active:focus-visible {
   .grain__card {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -12,6 +13,7 @@ import { TrackedSet } from 'tracked-built-ins';
 
 export default class ModuleGrain extends Component {
   @service modulixAutoScroll;
+  @service intl;
   @tracked answeredElements = new TrackedSet();
 
   grain = this.args.grain;
@@ -191,8 +193,16 @@ export default class ModuleGrain extends Component {
     return this.args.grain.type === 'summary';
   }
 
+  get isGrainTypeWithTag() {
+    return this.args.grain.type === 'activity' || this.args.grain.type === 'discovery';
+  }
+
   get emojiGrain() {
     return '📌';
+  }
+
+  get tagText() {
+    return this.intl.t(`pages.modulix.grain.tag.${this.args.grain.type}`);
   }
 
   <template>
@@ -208,6 +218,11 @@ export default class ModuleGrain extends Component {
           total=@totalSteps
         }}</h2>
       <div class="grain__card grain-card--{{this.grainType}}">
+        {{#if this.isGrainTypeWithTag}}
+          <PixTag class="grain-card-tag" @color="grey">
+            {{this.tagText}}
+          </PixTag>
+        {{/if}}
         {{#if this.isGrainTypeSummary}}
           <p class="grain-card-icon">{{this.emojiGrain}}</p>
         {{/if}}

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -627,8 +627,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       await render(
         hbs`
           <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                         @onGrainContinue={{this.onGrainContinue}} @onGrainSkip={{this.onGrainSkip}}
-                         @passage={{this.passage}} />`,
+                                @onGrainContinue={{this.onGrainContinue}} @onGrainSkip={{this.onGrainSkip}}
+                                @passage={{this.passage}} />`,
       );
       await clickByName(t('pages.modulix.buttons.grain.skip'));
 
@@ -1595,6 +1595,55 @@ module('Integration | Component | Module | Grain', function (hooks) {
           assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.continue') })).doesNotExist();
         });
       });
+    });
+  });
+
+  module('when grain has type ‘Discovery‘', function () {
+    test('should display the corresponding tag', async function (assert) {
+      // given
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = {
+        id: '12345-abcdef',
+        type: 'discovery',
+        components: [{ type: 'element', element: textElement }],
+      };
+
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+          <Module::Grain::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.dom(screen.getByText('Découverte')).exists();
+    });
+  });
+
+  module('when grain has type ‘Activity‘', function () {
+    test('should display the corresponding tag', async function (assert) {
+      // given
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = {
+        id: '12345-abcdef',
+        type: 'activity',
+        components: [{ type: 'element', element: textElement }],
+      };
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+          <Module::Grain::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.dom(screen.getByText('Activité')).exists();
     });
   });
 });


### PR DESCRIPTION
## ⛱️ Proposition

Pour les grains de type "discovery" et "activity", afficher un tag contenant le type de grain à l'utilisateur.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Ouvrir le [module bac-a-sable](https://app-pr12807.review.pix.fr/modules/bac-a-sable/details)
- Démarrer
- Le premier grain est de type "discovery", donc un tag doit être présent au début du grain
