### PR TITLE
[FEATURE] Route de création de conversation LLM de preview (PIX-18670)

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -23,6 +23,7 @@ import { evaluationRoutes } from './src/evaluation/routes.js';
 import { identityAccessManagementRoutes } from './src/identity-access-management/application/routes.js';
 import * as serverAuthentication from './src/identity-access-management/infrastructure/server-authentication.js';
 import { learningContentRoutes } from './src/learning-content/routes.js';
+import { llmRoutes } from './src/llm/routes.js';
 import { Metrics } from './src/monitoring/infrastructure/metrics.js';
 import { organizationalEntitiesRoutes } from './src/organizational-entities/application/routes.js';
 import { campaignRoutes } from './src/prescription/campaign/routes.js';
@@ -237,6 +238,7 @@ const setupRoutesAndPlugins = async function (server) {
     ...certificationRoutes,
     ...prescriptionRoutes,
     bannerRoutes,
+    llmRoutes,
     {
       name: 'root',
       register: async function (server) {

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -44,12 +44,6 @@ export async function startChat({ configId, userId }) {
 }
 
 /**
- * @typedef LLMChatResponseDTO
- * @type {object}
- * @property {string} message
- */
-
-/**
  * @function
  * @name prompt
  *

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   ChatForbiddenError,
   ChatNotFoundError,
@@ -32,7 +34,7 @@ import { LLMChatDTO } from './models/LLMChatDTO.js';
  * @param {string} params.userId
  * @returns {Promise<LLMChatDTO>}
  */
-export async function startChat({ configId, userId }) {
+export async function startChat({ configId, userId }, { generateId = randomUUID } = {}) {
   if (!configId) {
     throw new ConfigurationNotFoundError('null id provided');
   }
@@ -40,7 +42,7 @@ export async function startChat({ configId, userId }) {
     throw new NoUserIdProvidedError();
   }
   const configuration = await configurationRepository.get(configId);
-  const chatId = generateId(userId);
+  const chatId = generateId();
   const newChat = new Chat({
     id: chatId,
     userId,
@@ -116,11 +118,6 @@ export async function prompt({ chatId, userId, message, attachmentName }) {
     onLLMResponseReceived: addMessagesToChat(chat, message, chatRepository),
     shouldSendAttachmentEventMessage: Boolean(attachmentName),
   });
-}
-
-function generateId(userId) {
-  const nowMs = new Date().getMilliseconds();
-  return `${userId}-${nowMs}`;
 }
 
 function addMessagesToChat(chat, prompt, chatRepository) {

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -43,6 +43,7 @@ export async function startChat({ configId, userId }) {
   const chatId = generateId(userId);
   const newChat = new Chat({
     id: chatId,
+    userId,
     configuration: configuration,
     hasAttachmentContextBeenAdded: false,
     messages: [],
@@ -82,7 +83,7 @@ export async function prompt({ chatId, userId, message, attachmentName }) {
   }
 
   const chat = await chatRepository.get(chatId);
-  if (!userId || !chat.id.startsWith(userId)) {
+  if (!userId || userId !== chat.userId) {
     throw new ChatForbiddenError();
   }
 

--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -43,7 +43,7 @@ export async function startChat({ configId, userId }) {
   const chatId = generateId(userId);
   const newChat = new Chat({
     id: chatId,
-    configurationId: configuration.id,
+    configuration: configuration,
     hasAttachmentContextBeenAdded: false,
     messages: [],
   });
@@ -77,14 +77,16 @@ export async function prompt({ chatId, userId, message, attachmentName }) {
   if (!chatId) {
     throw new ChatNotFoundError('null id provided');
   }
+  if (!attachmentName && !message) {
+    throw new NoAttachmentNorMessageProvidedError();
+  }
+
   const chat = await chatRepository.get(chatId);
   if (!userId || !chat.id.startsWith(userId)) {
     throw new ChatForbiddenError();
   }
-  if (!attachmentName && !message) {
-    throw new NoAttachmentNorMessageProvidedError();
-  }
-  const configuration = await configurationRepository.get(chat.configurationId);
+
+  const { configuration } = chat;
   if (attachmentName && !configuration.hasAttachment) {
     throw new NoAttachmentNeededError();
   }

--- a/api/src/llm/application/llm-preview-controller.js
+++ b/api/src/llm/application/llm-preview-controller.js
@@ -1,0 +1,14 @@
+import { config } from '../../shared/config.js';
+import { usecases } from '../domain/usecases/index.js';
+import * as configurationSerializer from '../infrastructure/serializers/json/configuration-serializer.js';
+
+export const llmPreviewController = {
+  async startChat(request, h) {
+    const configuration = configurationSerializer.deserialize(request.payload.configuration);
+    const chat = await usecases.startChat({ configuration });
+    return h
+      .response()
+      .header('Location', new URL(`/llm/preview/${chat.id}`, config.domain.pixApp).href)
+      .code(201);
+  },
+};

--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -1,0 +1,58 @@
+import Joi from 'joi';
+
+import { jwtApplicationAuthenticationStrategyName } from '../../shared/infrastructure/authentication-strategy-names.js';
+import { llmPreviewController } from './llm-preview-controller.js';
+import { checkLLMChatIsEnabled } from './pre-handlers/index.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/llm/preview/chats',
+      config: {
+        auth: {
+          strategy: jwtApplicationAuthenticationStrategyName,
+          access: { scope: 'llm-preview' },
+        },
+        pre: [
+          {
+            method: checkLLMChatIsEnabled,
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            configuration: Joi.object({
+              llm: Joi.object({
+                historySize: Joi.number().required(),
+              })
+                .required()
+                .unknown(true),
+              challenge: Joi.object({
+                inputMaxChars: Joi.number().required(),
+                inputMaxPrompts: Joi.number().required(),
+              })
+                .required()
+                .unknown(true),
+              attachment: Joi.object({
+                name: Joi.string().optional(),
+                context: Joi.string().optional(),
+              })
+                .optional()
+                .unknown(true),
+            })
+              .required()
+              .unknown(true),
+          }).required(),
+        },
+        handler: llmPreviewController.startChat,
+        tags: ['api', 'llm', 'preview'],
+        notes: [
+          'Cette route est restreinte aux applications avec le scope llm-preview',
+          'Elle permet de créer une discussion LLM avec la configuration en payload',
+        ],
+      },
+    },
+  ]);
+}
+
+export const name = 'llm-preview-api';

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -1,15 +1,17 @@
+import { Configuration } from './Configuration.js';
+
 export class Chat {
   /**
    * @constructor
    * @param {Object} params
    * @param {string} params.id
-   * @param {string} params.configurationId
+   * @param {import('./Configuration').Configuration} params.configuration
    * @param {Boolean} params.hasAttachmentContextBeenAdded
    * @param {Array<Message>} params.messages
    */
-  constructor({ id, configurationId, hasAttachmentContextBeenAdded, messages = [] }) {
+  constructor({ id, configuration, hasAttachmentContextBeenAdded, messages = [] }) {
     this.id = id;
-    this.configurationId = configurationId;
+    this.configuration = configuration;
     this.hasAttachmentContextBeenAdded = hasAttachmentContextBeenAdded;
     this.messages = messages;
   }
@@ -75,10 +77,18 @@ export class Chat {
   toDTO() {
     return {
       id: this.id,
-      configurationId: this.configurationId,
+      configuration: this.configuration.toDTO(),
       hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,
       messages: this.messages.map((message) => message.toDTO()),
     };
+  }
+
+  static fromDTO(chatDTO) {
+    return new Chat({
+      ...chatDTO,
+      configuration: Configuration.fromDTO(chatDTO.configuration),
+      messages: chatDTO.messages.map((messageDTO) => new Message(messageDTO)),
+    });
   }
 }
 

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -5,12 +5,14 @@ export class Chat {
    * @constructor
    * @param {Object} params
    * @param {string} params.id
+   * @param {number} params.userId
    * @param {import('./Configuration').Configuration} params.configuration
    * @param {Boolean} params.hasAttachmentContextBeenAdded
    * @param {Array<Message>} params.messages
    */
-  constructor({ id, configuration, hasAttachmentContextBeenAdded, messages = [] }) {
+  constructor({ id, userId, configuration, hasAttachmentContextBeenAdded, messages = [] }) {
     this.id = id;
+    this.userId = userId;
     this.configuration = configuration;
     this.hasAttachmentContextBeenAdded = hasAttachmentContextBeenAdded;
     this.messages = messages;
@@ -77,6 +79,7 @@ export class Chat {
   toDTO() {
     return {
       id: this.id,
+      userId: this.userId,
       configuration: this.configuration.toDTO(),
       hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,
       messages: this.messages.map((message) => message.toDTO()),
@@ -86,6 +89,7 @@ export class Chat {
   static fromDTO(chatDTO) {
     return new Chat({
       ...chatDTO,
+      userId: chatDTO.userId ?? parseInt(chatDTO.id.split('-')[0]),
       configuration: Configuration.fromDTO(chatDTO.configuration),
       messages: chatDTO.messages.map((messageDTO) => new Message(messageDTO)),
     });

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -87,4 +87,8 @@ export class Configuration {
       attachmentContext: this.#attachmentContext,
     };
   }
+
+  static fromDTO(configurationDTO) {
+    return new Configuration(configurationDTO);
+  }
 }

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -79,7 +79,6 @@ export class Configuration {
    */
   toDTO() {
     return {
-      version: 1,
       id: this.id,
       historySize: this.#historySize,
       inputMaxChars: this.#inputMaxChars,

--- a/api/src/llm/domain/usecases/index.js
+++ b/api/src/llm/domain/usecases/index.js
@@ -1,0 +1,20 @@
+import { randomUUID } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as repositories from '../../infrastructure/repositories/index.js';
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const dependencies = {
+  ...repositories,
+  randomUUID,
+};
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+};
+
+export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/llm/domain/usecases/start-chat.js
+++ b/api/src/llm/domain/usecases/start-chat.js
@@ -1,11 +1,16 @@
-import { ConfigurationNotFoundError } from '../errors.js';
 import { Chat } from '../models/Chat.js';
 
-export async function startChat({ configId, userId, chatRepository, configurationRepository, randomUUID }) {
-  if (!configId) {
-    throw new ConfigurationNotFoundError('null id provided');
+export async function startChat({
+  configuration,
+  configId,
+  userId,
+  chatRepository,
+  configurationRepository,
+  randomUUID,
+}) {
+  if (!configuration) {
+    configuration = await configurationRepository.get(configId);
   }
-  const configuration = await configurationRepository.get(configId);
   const chatId = randomUUID();
   const newChat = new Chat({
     id: chatId,

--- a/api/src/llm/domain/usecases/start-chat.js
+++ b/api/src/llm/domain/usecases/start-chat.js
@@ -1,0 +1,19 @@
+import { ConfigurationNotFoundError } from '../errors.js';
+import { Chat } from '../models/Chat.js';
+
+export async function startChat({ configId, userId, chatRepository, configurationRepository, randomUUID }) {
+  if (!configId) {
+    throw new ConfigurationNotFoundError('null id provided');
+  }
+  const configuration = await configurationRepository.get(configId);
+  const chatId = randomUUID();
+  const newChat = new Chat({
+    id: chatId,
+    userId,
+    configuration,
+    hasAttachmentContextBeenAdded: false,
+    messages: [],
+  });
+  await chatRepository.save(newChat);
+  return newChat;
+}

--- a/api/src/llm/infrastructure/repositories/chat-repository.js
+++ b/api/src/llm/infrastructure/repositories/chat-repository.js
@@ -4,7 +4,9 @@ import { ChatNotFoundError } from '../../domain/errors.js';
 import { Chat } from '../../domain/models/Chat.js';
 import * as configurationRepository from './configuration-repository.js';
 
-export const CHAT_STORAGE_PREFIX = 'llm-chats';
+export const OLD_CHAT_STORAGE_PREFIX = 'llm-chats';
+const oldChatsTemporaryStorage = temporaryStorage.withPrefix(OLD_CHAT_STORAGE_PREFIX);
+export const CHAT_STORAGE_PREFIX = 'llm-chats:';
 const chatsTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
 
 /**
@@ -34,7 +36,11 @@ export async function save(chat) {
  * @returns {Promise<Chat>}
  */
 export async function get(id) {
-  const chatDTO = await chatsTemporaryStorage.get(id);
+  let chatDTO = await chatsTemporaryStorage.get(id);
+  // backward compatibility, may be removed after some time
+  if (!chatDTO) {
+    chatDTO = await oldChatsTemporaryStorage.get(id);
+  }
   if (!chatDTO) {
     throw new ChatNotFoundError(id);
   }

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -26,7 +26,7 @@ const logger = child('llm:api', { event: SCOPES.LLM });
 export async function get(id) {
   const cachedConfiguration = await configurationTemporaryStorage.get(id);
   if (cachedConfiguration) {
-    return toDomainFromCache(cachedConfiguration);
+    return Configuration.fromDTO(cachedConfiguration);
   }
   const url = config.llm.getConfigurationUrl + '/' + id;
   let response;
@@ -88,8 +88,4 @@ function toDomainFromLLMApi(id, configurationDTO) {
     attachmentName: configurationDTO?.attachment?.name ?? null,
     attachmentContext: configurationDTO?.attachment?.context ?? null,
   });
-}
-
-function toDomainFromCache(configurationDTO) {
-  return new Configuration(configurationDTO);
 }

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -18,6 +18,9 @@ const logger = child('llm:api', { event: SCOPES.LLM });
  * @returns {Promise<Configuration>}
  */
 export async function get(id) {
+  if (!id) {
+    throw new ConfigurationNotFoundError(id);
+  }
   const url = config.llm.getConfigurationUrl + '/' + id;
   let response;
   try {

--- a/api/src/llm/infrastructure/repositories/configuration-repository.js
+++ b/api/src/llm/infrastructure/repositories/configuration-repository.js
@@ -26,7 +26,7 @@ const logger = child('llm:api', { event: SCOPES.LLM });
 export async function get(id) {
   const cachedConfiguration = await configurationTemporaryStorage.get(id);
   if (cachedConfiguration) {
-    return toDomainFromCache(id, cachedConfiguration);
+    return toDomainFromCache(cachedConfiguration);
   }
   const url = config.llm.getConfigurationUrl + '/' + id;
   let response;
@@ -90,7 +90,6 @@ function toDomainFromLLMApi(id, configurationDTO) {
   });
 }
 
-function toDomainFromCache(id, configurationDTO) {
-  if (configurationDTO.version === 1) return new Configuration(configurationDTO);
-  return toDomainFromLLMApi(id, configurationDTO);
+function toDomainFromCache(configurationDTO) {
+  return new Configuration(configurationDTO);
 }

--- a/api/src/llm/infrastructure/repositories/index.js
+++ b/api/src/llm/infrastructure/repositories/index.js
@@ -1,0 +1,3 @@
+export * as chatRepository from './chat-repository.js';
+export * as configurationRepository from './configuration-repository.js';
+export * as promptRepository from './prompt-repository.js';

--- a/api/src/llm/infrastructure/serializers/json/configuration-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/configuration-serializer.js
@@ -1,0 +1,11 @@
+import { Configuration } from '../../../domain/models/Configuration.js';
+
+export function deserialize(payload) {
+  return new Configuration({
+    historySize: payload.llm.historySize,
+    inputMaxChars: payload.challenge.inputMaxChars,
+    inputMaxPrompts: payload.challenge.inputMaxPrompts,
+    attachmentName: payload.attachment?.name,
+    attachmentContext: payload.attachment?.context,
+  });
+}

--- a/api/src/llm/routes.js
+++ b/api/src/llm/routes.js
@@ -1,0 +1,3 @@
+import * as llmPreviewRoute from './application/llm-preview-route.js';
+
+export const llmRoutes = [llmPreviewRoute];

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -370,7 +370,8 @@ describe('Acceptance | Controller | passage-controller', function () {
         it('should receive LLM response as stream', async function () {
           // given
           const chat = new Chat({
-            id: `${user.id}-someChatId123456789`,
+            id: 'someChatId123456789',
+            userId: user.id,
             configuration: new Configuration({
               id: 'uneConfigQuiExist',
               historySize: 123,
@@ -383,7 +384,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             messages: [],
           });
           await chatTemporaryStorage.save({
-            key: `${user.id}-someChatId123456789`,
+            key: 'someChatId123456789',
             value: chat.toDTO(),
             expirationDelaySeconds: ms('24h'),
           });
@@ -419,7 +420,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           // when
           const response = await server.inject({
             method: 'POST',
-            url: `/api/passages/111/embed/llm/chats/${user.id}-someChatId123456789/messages`,
+            url: '/api/passages/111/embed/llm/chats/someChatId123456789/messages',
             payload: { prompt: 'Quelle est la recette de la ratatouille ?', attachmentName: 'expected_file.pdf' },
             headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
           });

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -5,7 +5,6 @@ import ms from 'ms';
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { CHAT_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/chat-repository.js';
-import { CONFIGURATION_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/configuration-repository.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
 import {
@@ -19,7 +18,6 @@ import {
 } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
-const configurationTemporaryStorage = temporaryStorage.withPrefix(CONFIGURATION_STORAGE_PREFIX);
 
 describe('Acceptance | Controller | passage-controller', function () {
   let server;
@@ -239,7 +237,6 @@ describe('Acceptance | Controller | passage-controller', function () {
     afterEach(async function () {
       clock.restore();
       await chatTemporaryStorage.flushAll();
-      await configurationTemporaryStorage.flushAll();
     });
 
     context('when user is not authenticated', function () {
@@ -331,7 +328,6 @@ describe('Acceptance | Controller | passage-controller', function () {
 
     afterEach(async function () {
       await chatTemporaryStorage.flushAll();
-      await configurationTemporaryStorage.flushAll();
     });
 
     context('when user is not authenticated', function () {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -14,7 +14,6 @@ import {
   generateAuthenticatedUserRequestHeaders,
   knex,
   nock,
-  sinon,
 } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
@@ -224,18 +223,15 @@ describe('Acceptance | Controller | passage-controller', function () {
   });
 
   describe('POST /api/passages/{passageId}/embed/llm/chats', function () {
-    let clock, now, user;
+    let user;
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildPassage({ id: 111, userId: user.id }).id;
-      now = new Date('2023-10-05T18:02:00Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       await databaseBuilder.commit();
     });
 
     afterEach(async function () {
-      clock.restore();
       await chatTemporaryStorage.flushAll();
     });
 
@@ -287,12 +283,12 @@ describe('Acceptance | Controller | passage-controller', function () {
 
           // then
           expect(response.statusCode).to.equal(201);
-          expect(response.result).to.deep.equal({
-            chatId: `${user.id}-${now.getMilliseconds()}`,
+          expect(response.result).to.contain({
             inputMaxChars: 456,
             inputMaxPrompts: 788,
             attachmentName: 'file.txt',
           });
+          expect(response.result).to.have.property('chatId').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
         });
       });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -27,7 +27,6 @@ import {
   learningContentBuilder,
   mockLearningContent,
   nock,
-  sinon,
 } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
@@ -750,18 +749,15 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   });
 
   describe('POST /api/assessments/{assessmentId}/embed/llm/chats', function () {
-    let clock, now, user;
+    let user;
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildAssessment({ id: 111, userId: user.id });
-      now = new Date('2023-10-05T18:02:00Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       await databaseBuilder.commit();
     });
 
     afterEach(async function () {
-      clock.restore();
       await chatTemporaryStorage.flushAll();
     });
 
@@ -813,12 +809,12 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
 
           // then
           expect(response.statusCode).to.equal(201);
-          expect(response.result).to.deep.equal({
-            chatId: `${user.id}-${now.getMilliseconds()}`,
+          expect(response.result).to.contain({
             inputMaxChars: 456,
             inputMaxPrompts: 788,
             attachmentName: 'file.txt',
           });
+          expect(response.result).to.have.property('chatId').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
         });
       });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -9,7 +9,6 @@ import * as badgeAcquisitionRepository from '../../../../../src/evaluation/infra
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { CHAT_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/chat-repository.js';
-import { CONFIGURATION_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/configuration-repository.js';
 import {
   CRITERION_COMPARISONS,
   REQUIREMENT_COMPARISONS,
@@ -32,7 +31,6 @@ import {
 } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
-const configurationTemporaryStorage = temporaryStorage.withPrefix(CONFIGURATION_STORAGE_PREFIX);
 
 describe('Acceptance | Controller | assessment-controller-complete-assessment', function () {
   let options;
@@ -765,7 +763,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     afterEach(async function () {
       clock.restore();
       await chatTemporaryStorage.flushAll();
-      await configurationTemporaryStorage.flushAll();
     });
 
     context('when user is not authenticated', function () {
@@ -857,7 +854,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
 
     afterEach(async function () {
       await chatTemporaryStorage.flushAll();
-      await configurationTemporaryStorage.flushAll();
     });
 
     context('when user is not authenticated', function () {

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -7,6 +7,7 @@ import { USER_RECOMMENDED_TRAININGS_TABLE_NAME } from '../../../../../db/migrati
 import { CertificationCompletedJob } from '../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
 import * as badgeAcquisitionRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-acquisition-repository.js';
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { CHAT_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/chat-repository.js';
 import { CONFIGURATION_STORAGE_PREFIX } from '../../../../../src/llm/infrastructure/repositories/configuration-repository.js';
 import {
@@ -900,7 +901,14 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           // given
           const chat = new Chat({
             id: `${user.id}-someChatId123456789`,
-            configurationId: 'uneConfigQuiExist',
+            configuration: new Configuration({
+              id: 'uneConfigQuiExist',
+              historySize: 123,
+              inputMaxChars: 999,
+              inputMaxPrompts: 999,
+              attachmentName: 'expected_file.pdf',
+              attachmentContext: 'some context',
+            }),
             hasAttachmentContextBeenAdded: false,
             messages: [],
           });
@@ -909,21 +917,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
             value: chat.toDTO(),
             expirationDelaySeconds: ms('24h'),
           });
-          const getConfigScope = nock('https://llm-test.pix.fr/api')
-            .get('/configurations/uneConfigQuiExist')
-            .reply(200, {
-              llm: {
-                historySize: 123,
-              },
-              challenge: {
-                inputMaxChars: 999,
-                inputMaxPrompts: 999,
-              },
-              attachment: {
-                name: 'expected_file.pdf',
-                context: 'some context',
-              },
-            });
           const promptLlmScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configurationId: 'uneConfigQuiExist',
@@ -964,7 +957,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           // then
           expect(response.statusCode).to.equal(201);
           expect(response.result).to.deep.equal("event: attachment\ndata: \n\ndata: coucou c'est super\n\n");
-          expect(getConfigScope.isDone()).to.be.true;
           expect(promptLlmScope.isDone()).to.be.true;
         });
       });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -896,7 +896,8 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         it('should receive LLM response as stream', async function () {
           // given
           const chat = new Chat({
-            id: `${user.id}-someChatId123456789`,
+            id: 'someChatId123456789',
+            userId: user.id,
             configuration: new Configuration({
               id: 'uneConfigQuiExist',
               historySize: 123,
@@ -909,7 +910,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
             messages: [],
           });
           await chatTemporaryStorage.save({
-            key: `${user.id}-someChatId123456789`,
+            key: 'someChatId123456789',
             value: chat.toDTO(),
             expirationDelaySeconds: ms('24h'),
           });
@@ -945,7 +946,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           // when
           const response = await server.inject({
             method: 'POST',
-            url: `/api/assessments/111/embed/llm/chats/${user.id}-someChatId123456789/messages`,
+            url: '/api/assessments/111/embed/llm/chats/someChatId123456789/messages',
             payload: { prompt: 'Quelle est la recette de la ratatouille ?', attachmentName: 'expected_file.pdf' },
             headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
           });

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -1,0 +1,169 @@
+import { CHAT_STORAGE_PREFIX } from '../../../../src/llm/infrastructure/repositories/chat-repository.js';
+import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
+import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeaderForApplication,
+} from '../../../test-helper.js';
+
+const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
+
+describe('Acceptance | Route | llm-preview', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+    await featureToggles.set('isEmbedLLMEnabled', true);
+  });
+
+  describe('POST /api/llm/preview/chats', function () {
+    beforeEach(async function () {
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await chatTemporaryStorage.flushAll();
+    });
+
+    context('when request is not authenticated', function () {
+      it('should throw a 401', async function () {
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/llm/preview/chats',
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    context('when application token does not have llm-preview scope', function () {
+      it('should throw a 403', async function () {
+        // given
+        const token = generateValidRequestAuthorizationHeaderForApplication('pix-llm', 'Pix LLM', 'wrong-scope');
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/llm/preview/chats',
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when payload’s configuration is not valid', function () {
+      it('should throw a 400', async function () {
+        // given
+        const token = generateValidRequestAuthorizationHeaderForApplication('pix-llm', 'Pix LLM', 'llm-preview');
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/llm/preview/chats',
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          payload: {
+            configuration: {
+              name: 'Config de test',
+              challenge: {
+                inputMaxChars: 1024,
+                inputMaxPrompts: 5,
+              },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when isEmbedLLMEnabled feature toggle is false', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isEmbedLLMEnabled', false);
+      });
+
+      it('should throw a 503', async function () {
+        // given
+        const token = generateValidRequestAuthorizationHeaderForApplication('pix-llm', 'Pix LLM', 'llm-preview');
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/llm/preview/chats',
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          payload: {
+            configuration: {
+              name: 'Config de test',
+              llm: {
+                historySize: 10,
+              },
+              challenge: {
+                inputMaxChars: 1024,
+                inputMaxPrompts: 5,
+              },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(503);
+      });
+    });
+
+    it('should throw a 201', async function () {
+      // given
+      const token = generateValidRequestAuthorizationHeaderForApplication('pix-llm', 'Pix LLM', 'llm-preview');
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/llm/preview/chats',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+        payload: {
+          configuration: {
+            name: 'Config de test',
+            llm: {
+              historySize: 10,
+            },
+            challenge: {
+              inputMaxChars: 1024,
+              inputMaxPrompts: 5,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.headers)
+        .to.have.property('location')
+        .that.matches(
+          /^https:\/\/test\.app\.pix\/llm\/preview\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+
+      expect(await chatTemporaryStorage.get(response.headers.location.split('/').at(-1))).to.deep.contain({
+        configuration: {
+          historySize: 10,
+          inputMaxChars: 1024,
+          inputMaxPrompts: 5,
+        },
+        hasAttachmentContextBeenAdded: false,
+        messages: [],
+      });
+    });
+  });
+});

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -27,15 +27,10 @@ describe('LLM | Integration | Application | API | llm', function () {
   });
 
   describe('#startChat', function () {
-    let clock, now;
+    let generateId;
 
     beforeEach(async function () {
-      now = new Date('2023-10-05T18:02:00Z');
-      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-    });
-
-    afterEach(async function () {
-      clock.restore();
+      generateId = sinon.stub().returns('123e4567-e89b-12d3-a456-426614174000');
     });
 
     context('when no config id provided', function () {
@@ -85,18 +80,18 @@ describe('LLM | Integration | Application | API | llm', function () {
 
         it('should return the newly created chat with attachment info, diminushing inputMaxPrompts by one', async function () {
           // when
-          const chat = await startChat({ configId, userId });
+          const chat = await startChat({ configId, userId }, { generateId });
 
           // then
           expect(chat).to.deep.equal({
-            id: `123456-${now.getMilliseconds()}`,
+            id: '123e4567-e89b-12d3-a456-426614174000',
             attachmentName: 'file.txt',
             inputMaxChars: 456,
             inputMaxPrompts: 788,
           });
           expect(llmApiScope.isDone()).to.be.true;
-          expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({
-            id: `123456-${now.getMilliseconds()}`,
+          expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
+            id: '123e4567-e89b-12d3-a456-426614174000',
             userId: 123456,
             configuration: {
               id: 'uneConfigQuiExist',
@@ -130,18 +125,18 @@ describe('LLM | Integration | Application | API | llm', function () {
 
         it('should return the newly created chat with attachment info', async function () {
           // when
-          const chat = await startChat({ configId, userId });
+          const chat = await startChat({ configId, userId }, { generateId });
 
           // then
           expect(chat).to.deep.equal({
-            id: `123456-${now.getMilliseconds()}`,
+            id: '123e4567-e89b-12d3-a456-426614174000',
             attachmentName: null,
             inputMaxChars: 456,
             inputMaxPrompts: 789,
           });
           expect(llmApiScope.isDone()).to.be.true;
-          expect(await chatTemporaryStorage.get(`123456-${now.getMilliseconds()}`)).to.deep.equal({
-            id: `123456-${now.getMilliseconds()}`,
+          expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
+            id: '123e4567-e89b-12d3-a456-426614174000',
             userId: 123456,
             configuration: {
               id: 'uneConfigQuiExist',

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -1,10 +1,9 @@
-import { ConfigurationNotFoundError } from '../../../../../src/llm/domain/errors.js';
 import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
 import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { startChat } from '../../../../../src/llm/domain/usecases/start-chat.js';
 import { chatRepository, configurationRepository } from '../../../../../src/llm/infrastructure/repositories/index.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { catchErr, expect, nock, sinon } from '../../../../test-helper.js';
+import { expect, nock, sinon } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(chatRepository.CHAT_STORAGE_PREFIX);
 
@@ -20,18 +19,47 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
       randomUUID = sinon.stub().returns('123e4567-e89b-12d3-a456-426614174000');
     });
 
-    context('when no config id provided', function () {
-      it('should throw a ConfigurationNotFoundError', async function () {
+    context('when config object provided', function () {
+      let configuration;
+
+      beforeEach(function () {
+        configuration = new Configuration({
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: 'file.txt',
+          attachmentContext: '**coucou**',
+        });
+      });
+
+      it('should return the newly created chat', async function () {
         // when
-        const err = await catchErr(startChat)({ configId: null, userId: 12345 });
+        const chat = await startChat({ configuration, randomUUID, chatRepository });
 
         // then
-        expect(err).to.be.instanceOf(ConfigurationNotFoundError);
-        expect(err.message).to.equal('The configuration of id "null id provided" does not exist');
+        expect(chat).to.deepEqualInstance(
+          new Chat({
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            configuration: new Configuration({}), // Configuration’s properties are not enumerable
+            hasAttachmentContextBeenAdded: false,
+          }),
+        );
+        expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          configuration: {
+            historySize: 123,
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+            attachmentName: 'file.txt',
+            attachmentContext: '**coucou**',
+          },
+          hasAttachmentContextBeenAdded: false,
+          messages: [],
+        });
       });
     });
 
-    context('when config id provided', function () {
+    context('when config object not provided', function () {
       let configId, userId, llmApiScope, config;
 
       beforeEach(function () {

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -1,0 +1,87 @@
+import { ConfigurationNotFoundError } from '../../../../../src/llm/domain/errors.js';
+import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
+import { startChat } from '../../../../../src/llm/domain/usecases/start-chat.js';
+import { chatRepository, configurationRepository } from '../../../../../src/llm/infrastructure/repositories/index.js';
+import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { catchErr, expect, nock, sinon } from '../../../../test-helper.js';
+
+const chatTemporaryStorage = temporaryStorage.withPrefix(chatRepository.CHAT_STORAGE_PREFIX);
+
+describe('LLM | Integration | Domain | UseCases | start-chat', function () {
+  afterEach(async function () {
+    await chatTemporaryStorage.flushAll();
+  });
+
+  describe('#startChat', function () {
+    let randomUUID;
+
+    beforeEach(async function () {
+      randomUUID = sinon.stub().returns('123e4567-e89b-12d3-a456-426614174000');
+    });
+
+    context('when no config id provided', function () {
+      it('should throw a ConfigurationNotFoundError', async function () {
+        // when
+        const err = await catchErr(startChat)({ configId: null, userId: 12345 });
+
+        // then
+        expect(err).to.be.instanceOf(ConfigurationNotFoundError);
+        expect(err.message).to.equal('The configuration of id "null id provided" does not exist');
+      });
+    });
+
+    context('when config id provided', function () {
+      let configId, userId, llmApiScope, config;
+
+      beforeEach(function () {
+        configId = 'uneConfigQuiExist';
+        userId = 123456;
+        config = {
+          llm: {
+            historySize: 123,
+          },
+          challenge: {
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+          },
+          attachment: {
+            name: 'file.txt',
+            context: '**coucou**',
+          },
+        };
+        llmApiScope = nock('https://llm-test.pix.fr/api').get('/configurations/uneConfigQuiExist').reply(200, config);
+      });
+
+      it('should return the newly created chat', async function () {
+        // when
+        const chat = await startChat({ configId, userId, randomUUID, chatRepository, configurationRepository });
+
+        // then
+        expect(chat).to.deepEqualInstance(
+          new Chat({
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            userId: 123456,
+            configuration: new Configuration({}), // Configuration’s properties are not enumerable
+            hasAttachmentContextBeenAdded: false,
+          }),
+        );
+        expect(llmApiScope.isDone()).to.be.true;
+        expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          userId: 123456,
+          configuration: {
+            id: 'uneConfigQuiExist',
+            historySize: 123,
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+            attachmentName: 'file.txt',
+            attachmentContext: '**coucou**',
+          },
+          hasAttachmentContextBeenAdded: false,
+          messages: [],
+        });
+      });
+    });
+  });
+});

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -1,22 +1,30 @@
 import { ChatNotFoundError } from '../../../../../src/llm/domain/errors.js';
 import { Chat, Message } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { CHAT_STORAGE_PREFIX, get, save } from '../../../../../src/llm/infrastructure/repositories/chat-repository.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { catchErr, expect } from '../../../../test-helper.js';
+import { catchErr, expect, nock } from '../../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
 
 describe('LLM | Integration | Infrastructure | Repositories | chat', function () {
-  describe('#save', function () {
-    afterEach(async function () {
-      await chatTemporaryStorage.flushAll();
-    });
+  afterEach(async function () {
+    await chatTemporaryStorage.flushAll();
+  });
 
+  describe('#save', function () {
     it('should persist the chat in cache', async function () {
       // given
       const chat = new Chat({
         id: 'someChatId',
-        configurationId: 'someConfigurationId',
+        configuration: new Configuration({
+          id: 'some-config-id',
+          historySize: 10,
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          attachmentName: 'test.csv',
+          attachmentContext: 'le contexte',
+        }),
         hasAttachmentContextBeenAdded: false,
         messages: [
           new Message({ content: 'je suis user', isFromUser: true }),
@@ -30,7 +38,14 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
       // then
       expect(await chatTemporaryStorage.get('someChatId')).to.deep.equal({
         id: 'someChatId',
-        configurationId: 'someConfigurationId',
+        configuration: {
+          id: 'some-config-id',
+          historySize: 10,
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          attachmentName: 'test.csv',
+          attachmentContext: 'le contexte',
+        },
         hasAttachmentContextBeenAdded: false,
         messages: [
           { content: 'je suis user', isFromUser: true, notCounted: false },
@@ -41,24 +56,29 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
   });
 
   describe('#get', function () {
-    afterEach(async function () {
-      await chatTemporaryStorage.flushAll();
-    });
-
     context('error cases', function () {
       context('when chat does not exist', function () {
         it('should throw a ChatNotFoundError', async function () {
           // given
-          const chat = new Chat({
-            id: 'someChatId',
-            configurationId: 'someConfigurationId',
-            hasAttachmentContextBeenAdded: false,
-            messages: [
-              new Message({ content: 'je suis user', isFromUser: true, notCounted: false }),
-              new Message({ content: 'je suis LLM', isFromUser: false, notCounted: false }),
-            ],
+          await chatTemporaryStorage.save({
+            key: 'someChatId',
+            value: {
+              id: 'someChatId',
+              configuration: {
+                id: 'some-config-id',
+                historySize: 10,
+                inputMaxChars: 500,
+                inputMaxPrompts: 4,
+                attachmentName: 'test.csv',
+                attachmentContext: 'le contexte',
+              },
+              hasAttachmentContextBeenAdded: false,
+              messages: [
+                { content: 'je suis user', isFromUser: true, notCounted: false },
+                { content: 'je suis LLM', isFromUser: false, notCounted: false },
+              ],
+            },
           });
-          await save(chat);
 
           // when
           const err = await catchErr(get)('unChatQuiNexistePas');
@@ -73,22 +93,97 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
     context('success cases', function () {
       it('should return the chat', async function () {
         // given
-        const chat = new Chat({
-          id: 'someChatId',
-          configurationId: 'someConfigurationId',
-          hasAttachmentContextBeenAdded: false,
-          messages: [
-            new Message({ content: 'je suis user', isFromUser: true, notCounted: false }),
-            new Message({ content: 'je suis LLM', isFromUser: false, notCounted: false }),
-          ],
+        await chatTemporaryStorage.save({
+          key: 'someChatId',
+          value: {
+            id: 'someChatId',
+            configuration: {
+              id: 'some-config-id',
+              historySize: 10,
+              inputMaxChars: 500,
+              inputMaxPrompts: 4,
+              attachmentName: 'test.csv',
+              attachmentContext: 'le contexte',
+            },
+            hasAttachmentContextBeenAdded: false,
+            messages: [
+              { content: 'je suis user', isFromUser: true, notCounted: false },
+              { content: 'je suis LLM', isFromUser: false, notCounted: false },
+            ],
+          },
         });
-        await save(chat);
 
         // when
         const actualChat = await get('someChatId');
 
         // then
-        expect(actualChat).to.deepEqualInstance(chat);
+        expect(actualChat).to.deepEqualInstance(
+          new Chat({
+            id: 'someChatId',
+            configuration: new Configuration({
+              id: 'some-config-id',
+              historySize: 10,
+              inputMaxChars: 500,
+              inputMaxPrompts: 4,
+              attachmentName: 'test.csv',
+              attachmentContext: 'le contexte',
+            }),
+            hasAttachmentContextBeenAdded: false,
+            messages: [
+              new Message({ content: 'je suis user', isFromUser: true }),
+              new Message({ content: 'je suis LLM', isFromUser: false }),
+            ],
+          }),
+        );
+      });
+
+      context('when chat does not contain configuration', function () {
+        it('should load configuration and return chat with configuration', async function () {
+          // given
+          await chatTemporaryStorage.save({
+            key: 'someChatId',
+            value: {
+              id: 'someChatId',
+              configurationId: 'some-config-id',
+              hasAttachmentContextBeenAdded: false,
+              messages: [
+                { content: 'je suis user', isFromUser: true, notCounted: false },
+                { content: 'je suis LLM', isFromUser: false, notCounted: false },
+              ],
+            },
+          });
+          const llmApiScope = nock('https://llm-test.pix.fr/api')
+            .get('/configurations/some-config-id')
+            .reply(200, {
+              llm: { historySize: 1 },
+              challenge: { inputMaxChars: 2, inputMaxPrompts: 3 },
+              attachment: { name: 'some_attachment_name', context: 'some attachment context' },
+            });
+
+          // when
+          const actualChat = await get('someChatId');
+
+          // then
+          expect(actualChat).to.deepEqualInstance(
+            new Chat({
+              id: 'someChatId',
+              configuration: new Configuration({
+                id: 'some-config-id',
+                historySize: 1,
+                inputMaxChars: 2,
+                inputMaxPrompts: 3,
+                attachmentName: 'some_attachment_name',
+                attachmentContext: 'some attachment context',
+              }),
+              hasAttachmentContextBeenAdded: false,
+              messages: [
+                new Message({ content: 'je suis user', isFromUser: true }),
+                new Message({ content: 'je suis LLM', isFromUser: false }),
+              ],
+            }),
+          );
+          expect(llmApiScope.isDone()).to.be.true;
+        });
       });
     });
   });

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -17,6 +17,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
       // given
       const chat = new Chat({
         id: 'someChatId',
+        userId: 123,
         configuration: new Configuration({
           id: 'some-config-id',
           historySize: 10,
@@ -38,6 +39,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
       // then
       expect(await chatTemporaryStorage.get('someChatId')).to.deep.equal({
         id: 'someChatId',
+        userId: 123,
         configuration: {
           id: 'some-config-id',
           historySize: 10,
@@ -64,6 +66,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
             key: 'someChatId',
             value: {
               id: 'someChatId',
+              userId: 123,
               configuration: {
                 id: 'some-config-id',
                 historySize: 10,
@@ -97,6 +100,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           key: 'someChatId',
           value: {
             id: 'someChatId',
+            userId: 123,
             configuration: {
               id: 'some-config-id',
               historySize: 10,
@@ -120,6 +124,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         expect(actualChat).to.deepEqualInstance(
           new Chat({
             id: 'someChatId',
+            userId: 123,
             configuration: new Configuration({
               id: 'some-config-id',
               historySize: 10,
@@ -144,6 +149,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
             key: 'someChatId',
             value: {
               id: 'someChatId',
+              userId: 123,
               configurationId: 'some-config-id',
               hasAttachmentContextBeenAdded: false,
               messages: [
@@ -167,6 +173,7 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           expect(actualChat).to.deepEqualInstance(
             new Chat({
               id: 'someChatId',
+              userId: 123,
               configuration: new Configuration({
                 id: 'some-config-id',
                 historySize: 1,

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -115,41 +115,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
           expect(llmApiScopeShouldBeCalled.isDone()).to.be.true;
           expect(llmApiScopeShouldNOTBeCalled.isDone()).to.be.false;
         });
-        context('when cached configuration is not versioned', function () {
-          it('should return the configuration from the cache in new version format', async function () {
-            // given
-            await configurationTemporaryStorage.save({
-              key: 'unIdDeConfiguration',
-              value: {
-                llm: { historySize: 1 },
-                challenge: { inputMaxChars: 2, inputMaxPrompts: 3 },
-                attachment: { name: 'some_attachment_name', context: 'some attachment context' },
-              },
-            });
-
-            const llmApiScopeShouldNOTBeCalled = nock('https://llm-test.pix.fr/api')
-              .get('/configurations/unIdDeConfiguration')
-              .twice()
-              .reply(500, { err: 'I SHOULD NOT BE CALLED' });
-
-            // when
-            const configurationCached = await get('unIdDeConfiguration');
-
-            // then
-            const expectedConfiguration = new Configuration({
-              id: 'unIdDeConfiguration',
-              historySize: 1,
-              inputMaxChars: 2,
-              inputMaxPrompts: 3,
-              attachmentName: 'some_attachment_name',
-              attachmentContext: 'some attachment context',
-            });
-
-            expect(configurationCached).to.deepEqualInstance(expectedConfiguration);
-            expect(configurationCached.toDTO()).to.deep.equal(expectedConfiguration.toDTO());
-            expect(llmApiScopeShouldNOTBeCalled.isDone()).to.be.false;
-          });
-        });
       });
     });
   });

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -6,6 +6,17 @@ import { catchErr, expect, nock } from '../../../../test-helper.js';
 describe('LLM | Integration | Infrastructure | Repositories | configuration', function () {
   describe('#get', function () {
     context('error cases', function () {
+      context('when no config id provided', function () {
+        it('should throw a ConfigurationNotFoundError', async function () {
+          // when
+          const err = await catchErr(get)(null);
+
+          // then
+          expect(err).to.be.instanceOf(ConfigurationNotFoundError);
+          expect(err.message).to.equal('The configuration of id "null" does not exist');
+        });
+      });
+
       context('when configuration does not exist', function () {
         it('should throw a ConfigurationNotFoundError', async function () {
           // given

--- a/api/tests/llm/unit/application/api/llm-api_test.js
+++ b/api/tests/llm/unit/application/api/llm-api_test.js
@@ -1,0 +1,57 @@
+import * as llmApi from '../../../../../src/llm/application/api/llm-api.js';
+import { LLMChatDTO } from '../../../../../src/llm/application/api/models/LLMChatDTO.js';
+import { NoUserIdProvidedError } from '../../../../../src/llm/domain/errors.js';
+import { Chat } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
+import { usecases } from '../../../../../src/llm/domain/usecases/index.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('LLM | Unit | Application | API | llm', function () {
+  describe('#startChat', function () {
+    context('when no user id provided', function () {
+      it('should throw a NoUserIdProvidedError', async function () {
+        // when
+        const err = await catchErr(llmApi.startChat)({ configId: 'someConfig', userId: null });
+
+        // then
+        expect(err).to.be.instanceOf(NoUserIdProvidedError);
+        expect(err.message).to.equal('Must provide a user ID to use LLM API');
+      });
+    });
+
+    context('when user id provided', function () {
+      let startChat, newChat;
+
+      beforeEach(function () {
+        newChat = new Chat({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          configuration: new Configuration({
+            attachmentName: 'file.txt',
+            inputMaxChars: 456,
+            inputMaxPrompts: 789,
+          }),
+        });
+        startChat = sinon.stub(usecases, 'startChat').resolves(newChat);
+      });
+
+      it('should return the newly created chat with attachment info, diminushing inputMaxPrompts by one', async function () {
+        const configId = 'abc123';
+        const userId = 123;
+
+        // when
+        const chat = await llmApi.startChat({ configId, userId });
+
+        // then
+        expect(chat).to.deepEqualInstance(
+          new LLMChatDTO({
+            id: newChat.id,
+            attachmentName: newChat.configuration.attachmentName,
+            inputMaxChars: newChat.configuration.inputMaxChars,
+            inputMaxPrompts: newChat.configuration.inputMaxPrompts,
+          }),
+        );
+        expect(startChat).to.have.been.calledOnceWithExactly({ configId, userId });
+      });
+    });
+  });
+});

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -281,6 +281,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
+        userId: 123,
         configuration: new Configuration({
           id: 'some-config-id',
           historySize: 10,
@@ -302,6 +303,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       // then
       expect(dto).to.deep.equal({
         id: 'some-chat-id',
+        userId: 123,
         configuration: {
           id: 'some-config-id',
           historySize: 10,
@@ -332,6 +334,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       // given
       const dto = {
         id: 'some-chat-id',
+        userId: 123,
         configuration: {
           id: 'some-config-id',
           historySize: 10,
@@ -362,6 +365,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(chat).to.deepEqualInstance(
         new Chat({
           id: 'some-chat-id',
+          userId: 123,
           configuration: new Configuration({
             id: 'some-config-id',
             historySize: 10,
@@ -377,6 +381,32 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           ],
         }),
       );
+    });
+
+    context('when DTO does not contain userId', function () {
+      it('should extract userId from chatId', function () {
+        // given
+        const dto = {
+          id: '123-456',
+          configuration: {},
+          hasAttachmentContextBeenAdded: false,
+          messages: [],
+        };
+
+        // when
+        const chat = Chat.fromDTO(dto);
+
+        // then
+        expect(chat).to.deepEqualInstance(
+          new Chat({
+            id: '123-456',
+            userId: 123,
+            configuration: new Configuration({}),
+            hasAttachmentContextBeenAdded: false,
+            messages: [],
+          }),
+        );
+      });
     });
   });
 });

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -1,4 +1,5 @@
 import { Chat, Message } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('LLM | Unit | Domain | Models | Chat', function () {
@@ -8,7 +9,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       const message = 'un message pas vide';
       const chat = new Chat({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
         hasAttachmentContextBeenAdded: false,
         messages: [new Message({ content: 'some message', isFromUser: false })],
       });
@@ -17,30 +18,25 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       chat.addUserMessage(message);
 
       // then
-      expect(chat.toDTO()).to.deep.equal({
-        id: 'some-chat-id',
-        configurationId: 'some-config-id',
-        hasAttachmentContextBeenAdded: false,
-        messages: [
-          {
-            content: 'some message',
-            isFromUser: false,
-            notCounted: false,
-          },
-          {
-            content: 'un message pas vide',
-            isFromUser: true,
-            notCounted: false,
-          },
-        ],
-      });
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some message',
+          isFromUser: false,
+          notCounted: false,
+        },
+        {
+          content: 'un message pas vide',
+          isFromUser: true,
+          notCounted: false,
+        },
+      ]);
     });
 
     it('should not append anything when message has no content', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
         hasAttachmentContextBeenAdded: false,
         messages: [new Message({ content: 'some message', isFromUser: false })],
       });
@@ -51,18 +47,13 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       chat.addUserMessage();
 
       // then
-      expect(chat.toDTO()).to.deep.equal({
-        id: 'some-chat-id',
-        configurationId: 'some-config-id',
-        hasAttachmentContextBeenAdded: false,
-        messages: [
-          {
-            content: 'some message',
-            isFromUser: false,
-            notCounted: false,
-          },
-        ],
-      });
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some message',
+          isFromUser: false,
+          notCounted: false,
+        },
+      ]);
     });
   });
 
@@ -72,7 +63,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       const message = 'un message pas vide';
       const chat = new Chat({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
         hasAttachmentContextBeenAdded: false,
         messages: [new Message({ content: 'some message', isFromUser: false })],
       });
@@ -81,30 +72,25 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       chat.addLLMMessage(message);
 
       // then
-      expect(chat.toDTO()).to.deep.equal({
-        id: 'some-chat-id',
-        configurationId: 'some-config-id',
-        hasAttachmentContextBeenAdded: false,
-        messages: [
-          {
-            content: 'some message',
-            isFromUser: false,
-            notCounted: false,
-          },
-          {
-            content: 'un message pas vide',
-            isFromUser: false,
-            notCounted: false,
-          },
-        ],
-      });
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some message',
+          isFromUser: false,
+          notCounted: false,
+        },
+        {
+          content: 'un message pas vide',
+          isFromUser: false,
+          notCounted: false,
+        },
+      ]);
     });
 
     it('should not append anything when message has no content', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
         hasAttachmentContextBeenAdded: false,
         messages: [new Message({ content: 'some message', isFromUser: false })],
       });
@@ -115,18 +101,13 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       chat.addLLMMessage();
 
       // then
-      expect(chat.toDTO()).to.deep.equal({
-        id: 'some-chat-id',
-        configurationId: 'some-config-id',
-        hasAttachmentContextBeenAdded: false,
-        messages: [
-          {
-            content: 'some message',
-            isFromUser: false,
-            notCounted: false,
-          },
-        ],
-      });
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some message',
+          isFromUser: false,
+          notCounted: false,
+        },
+      ]);
     });
   });
 
@@ -136,7 +117,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configurationId: 'some-config-id',
+          configuration: new Configuration({ id: 'some-config-id' }),
           hasAttachmentContextBeenAdded: false,
           messages: [
             new Message({ content: 'some message', isFromUser: true }),
@@ -151,44 +132,41 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         );
 
         // then
-        expect(chat.toDTO()).to.deep.equal({
-          id: 'some-chat-id',
-          configurationId: 'some-config-id',
-          hasAttachmentContextBeenAdded: true,
-          messages: [
-            {
-              content: 'some message',
-              isFromUser: true,
-              notCounted: false,
-            },
-            {
-              content: 'some answer',
-              isFromUser: false,
-              notCounted: false,
-            },
-            {
-              content:
-                "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    winter_lyrics.txt\n  </attachment_name>\n</system_notification>",
-              isFromUser: true,
-              notCounted: false,
-            },
-            {
-              content:
-                "\n<read_attachment_tool>\n  Lecture de la pièce jointe, winter_lyrics.txt :\n  <attachment_content>\n    J'étais assise sur une pierre\nDes larmes coulaient sur mon visage\n  </attachment_content>\n</read_attachment_tool>",
-              isFromUser: false,
-              notCounted: false,
-            },
-          ],
-        });
+        const chatDTO = chat.toDTO();
+        expect(chatDTO).to.have.property('hasAttachmentContextBeenAdded', true);
+        expect(chatDTO).to.have.deep.property('messages', [
+          {
+            content: 'some message',
+            isFromUser: true,
+            notCounted: false,
+          },
+          {
+            content: 'some answer',
+            isFromUser: false,
+            notCounted: false,
+          },
+          {
+            content:
+              "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    winter_lyrics.txt\n  </attachment_name>\n</system_notification>",
+            isFromUser: true,
+            notCounted: false,
+          },
+          {
+            content:
+              "\n<read_attachment_tool>\n  Lecture de la pièce jointe, winter_lyrics.txt :\n  <attachment_content>\n    J'étais assise sur une pierre\nDes larmes coulaient sur mon visage\n  </attachment_content>\n</read_attachment_tool>",
+            isFromUser: false,
+            notCounted: false,
+          },
+        ]);
       });
     });
 
-    context('when attachment context has not already been added', function () {
+    context('when attachment context has already been added', function () {
       it('should do nothing', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configurationId: 'some-config-id',
+          configuration: new Configuration({ id: 'some-config-id' }),
           hasAttachmentContextBeenAdded: true,
           messages: [
             new Message({ content: 'some message', isFromUser: true }),
@@ -203,23 +181,18 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         );
 
         // then
-        expect(chat.toDTO()).to.deep.equal({
-          id: 'some-chat-id',
-          configurationId: 'some-config-id',
-          hasAttachmentContextBeenAdded: true,
-          messages: [
-            {
-              content: 'some message',
-              isFromUser: true,
-              notCounted: false,
-            },
-            {
-              content: 'some answer',
-              isFromUser: false,
-              notCounted: false,
-            },
-          ],
-        });
+        expect(chat.toDTO()).to.have.deep.property('messages', [
+          {
+            content: 'some message',
+            isFromUser: true,
+            notCounted: false,
+          },
+          {
+            content: 'some answer',
+            isFromUser: false,
+            notCounted: false,
+          },
+        ]);
       });
     });
   });
@@ -230,16 +203,13 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configurationId: 'some-config-id',
+          configuration: new Configuration({ id: 'some-config-id' }),
           hasAttachmentContextBeenAdded: false,
           messages: [],
         });
 
-        // when
-        const currentPromptsCount = chat.currentPromptsCount;
-
         // then
-        expect(currentPromptsCount).to.equal(0);
+        expect(chat).to.have.property('currentPromptsCount', 0);
       });
     });
 
@@ -253,11 +223,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           messages: [new Message({ content: 'some message', isFromUser: false })],
         });
 
-        // when
-        const currentPromptsCount = chat.currentPromptsCount;
-
         // then
-        expect(currentPromptsCount).to.equal(0);
+        expect(chat).to.have.property('currentPromptsCount', 0);
       });
     });
 
@@ -266,7 +233,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configurationId: 'some-config-id',
+          configuration: new Configuration({ id: 'some-config-id' }),
           hasAttachmentContextBeenAdded: false,
           messages: [
             new Message({ content: 'message llm 1', isFromUser: false }),
@@ -276,11 +243,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           ],
         });
 
-        // when
-        const currentPromptsCount = chat.currentPromptsCount;
-
         // then
-        expect(currentPromptsCount).to.equal(2);
+        expect(chat).to.have.property('currentPromptsCount', 2);
       });
     });
 
@@ -289,7 +253,14 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configurationId: 'some-config-id',
+          configuration: new Configuration({
+            id: 'some-config-id',
+            historySize: 10,
+            inputMaxChars: 500,
+            inputMaxPrompts: 4,
+            attachmentName: 'test.csv',
+            attachmentContext: 'le contexte',
+          }),
           hasAttachmentContextBeenAdded: false,
           messages: [
             new Message({ content: 'message llm 1', isFromUser: false }),
@@ -299,11 +270,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           ],
         });
 
-        // when
-        const currentPromptsCount = chat.currentPromptsCount;
-
         // then
-        expect(currentPromptsCount).to.equal(1);
+        expect(chat).to.have.property('currentPromptsCount', 1);
       });
     });
   });
@@ -313,7 +281,14 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: new Configuration({
+          id: 'some-config-id',
+          historySize: 10,
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          attachmentName: 'test.csv',
+          attachmentContext: 'le contexte',
+        }),
         hasAttachmentContextBeenAdded: false,
         messages: [
           new Message({ content: 'message llm 1', isFromUser: false }),
@@ -327,7 +302,14 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       // then
       expect(dto).to.deep.equal({
         id: 'some-chat-id',
-        configurationId: 'some-config-id',
+        configuration: {
+          id: 'some-config-id',
+          historySize: 10,
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          attachmentName: 'test.csv',
+          attachmentContext: 'le contexte',
+        },
         hasAttachmentContextBeenAdded: false,
         messages: [
           {
@@ -342,6 +324,59 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           },
         ],
       });
+    });
+  });
+
+  describe('#fromDTO', function () {
+    it('should return the DTO version of the Chat model', function () {
+      // given
+      const dto = {
+        id: 'some-chat-id',
+        configuration: {
+          id: 'some-config-id',
+          historySize: 10,
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          attachmentName: 'test.csv',
+          attachmentContext: 'le contexte',
+        },
+        hasAttachmentContextBeenAdded: false,
+        messages: [
+          {
+            content: 'message llm 1',
+            isFromUser: false,
+            notCounted: false,
+          },
+          {
+            content: 'message user 1',
+            isFromUser: true,
+            notCounted: true,
+          },
+        ],
+      };
+
+      // when
+      const chat = Chat.fromDTO(dto);
+
+      // then
+      expect(chat).to.deepEqualInstance(
+        new Chat({
+          id: 'some-chat-id',
+          configuration: new Configuration({
+            id: 'some-config-id',
+            historySize: 10,
+            inputMaxChars: 500,
+            inputMaxPrompts: 4,
+            attachmentName: 'test.csv',
+            attachmentContext: 'le contexte',
+          }),
+          hasAttachmentContextBeenAdded: false,
+          messages: [
+            new Message({ content: 'message llm 1', isFromUser: false }),
+            new Message({ content: 'message user 1', isFromUser: true, notCounted: true }),
+          ],
+        }),
+      );
     });
   });
 });

--- a/api/tests/llm/unit/domain/models/Configuration_test.js
+++ b/api/tests/llm/unit/domain/models/Configuration_test.js
@@ -2,8 +2,8 @@ import { Configuration } from '../../../../../src/llm/domain/models/Configuratio
 import { expect } from '../../../../test-helper.js';
 
 describe('LLM | Unit | Domain | Models | Configuration', function () {
-  describe('#get id', function () {
-    it('should return the id of the Configuration', function () {
+  describe('simple property getters', function () {
+    it('should return property values', function () {
       // given
       const configuration = new Configuration({
         id: 'some-config-id',
@@ -14,167 +14,84 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
         attachmentContext: 'some-attachment-context',
       });
 
-      // when
-      const id = configuration.id;
-
       // then
-      expect(id).to.equal('some-config-id');
-    });
-  });
-
-  describe('#get historySize', function () {
-    it('should return the historySize of the Configuration', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
-      });
-
-      // when
-      const historySize = configuration.historySize;
-
-      // then
-      expect(historySize).to.equal(123);
-    });
-  });
-
-  describe('#get inputMaxChars', function () {
-    it('should return the inputMaxChars of the Configuration', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
-      });
-
-      // when
-      const inputMaxChars = configuration.inputMaxChars;
-
-      // then
-      expect(inputMaxChars).to.equal(456);
+      expect(configuration).to.have.property('id', 'some-config-id');
+      expect(configuration).to.have.property('historySize', 123);
+      expect(configuration).to.have.property('inputMaxChars', 456);
+      expect(configuration).to.have.property('attachmentName', 'some-attachment-name');
+      expect(configuration).to.have.property('attachmentContext', 'some-attachment-context');
     });
   });
 
   describe('#get inputMaxPrompts', function () {
-    it('should return the inputMaxPrompts of the Configuration as the original when configuration has no attachment', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: null,
-        attachmentContext: null,
+    context('when configuration has no attachment', function () {
+      it('should return the inputMaxPrompts of the Configuration', function () {
+        // given
+        const configuration = new Configuration({
+          id: 'some-config-id',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: null,
+          attachmentContext: null,
+        });
+
+        // then
+        expect(configuration).to.have.property('inputMaxPrompts', 789);
       });
-
-      // when
-      const inputMaxPrompts = configuration.inputMaxPrompts;
-
-      // then
-      expect(inputMaxPrompts).to.equal(789);
     });
 
-    it('should return the inputMaxPrompts of the Configuration as the original minus one when configuration has an attachment', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
+    context('when configuration has an attachment', function () {
+      it('should return the inputMaxPrompts of the Configuration minus one', function () {
+        // given
+        const configuration = new Configuration({
+          id: 'some-config-id',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: 'some-attachment-name',
+          attachmentContext: 'some-attachment-context',
+        });
+
+        // then
+        expect(configuration).to.have.property('inputMaxPrompts', 788);
       });
-
-      // when
-      const inputMaxPrompts = configuration.inputMaxPrompts;
-
-      // then
-      expect(inputMaxPrompts).to.equal(788);
-    });
-  });
-
-  describe('#get attachmentName', function () {
-    it('should return the attachmentName of the Configuration', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
-      });
-
-      // when
-      const attachmentName = configuration.attachmentName;
-
-      // then
-      expect(attachmentName).to.equal('some-attachment-name');
     });
   });
 
   describe('#get hasAttachment', function () {
-    it('should return true when attachmentName is not empty', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
+    context('when attachmentName is not empty', function () {
+      it('should return true', function () {
+        // given
+        const configuration = new Configuration({
+          id: 'some-config-id',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: 'some-attachment-name',
+          attachmentContext: 'some-attachment-context',
+        });
+
+        // then
+        expect(configuration).to.have.property('hasAttachment', true);
       });
-
-      // when
-      const hasAttachment = configuration.hasAttachment;
-
-      // then
-      expect(hasAttachment).to.be.true;
     });
 
-    it('should return false when attachmentName is empty', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: null,
-        attachmentContext: null,
+    context('when attachmentName is empty', function () {
+      it('should return false', function () {
+        // given
+        const configuration = new Configuration({
+          id: 'some-config-id',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: null,
+          attachmentContext: null,
+        });
+
+        // then
+        expect(configuration).to.have.property('hasAttachment', false);
       });
-
-      // when
-      const hasAttachment = configuration.hasAttachment;
-
-      // then
-      expect(hasAttachment).to.be.false;
-    });
-  });
-
-  describe('#get attachmentContext', function () {
-    it('should return the attachmentContext of the Configuration', function () {
-      // given
-      const configuration = new Configuration({
-        id: 'some-config-id',
-        historySize: 123,
-        inputMaxChars: 456,
-        inputMaxPrompts: 789,
-        attachmentName: 'some-attachment-name',
-        attachmentContext: 'some-attachment-context',
-      });
-
-      // when
-      const attachmentContext = configuration.attachmentContext;
-
-      // then
-      expect(attachmentContext).to.equal('some-attachment-context');
     });
   });
 
@@ -202,6 +119,35 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
         attachmentName: 'some-attachment-name',
         attachmentContext: 'some-attachment-context',
       });
+    });
+  });
+
+  describe('#fromDTO', function () {
+    it('should return the DTO version of the Configuration model', function () {
+      // given
+      const dto = {
+        id: 'some-config-id',
+        historySize: 123,
+        inputMaxChars: 456,
+        inputMaxPrompts: 789,
+        attachmentName: 'some-attachment-name',
+        attachmentContext: 'some-attachment-context',
+      };
+
+      // when
+      const configuration = Configuration.fromDTO(dto);
+
+      // then
+      expect(configuration).to.deepEqualInstance(
+        new Configuration({
+          id: 'some-config-id',
+          historySize: 123,
+          inputMaxChars: 456,
+          inputMaxPrompts: 789,
+          attachmentName: 'some-attachment-name',
+          attachmentContext: 'some-attachment-context',
+        }),
+      );
     });
   });
 });

--- a/api/tests/llm/unit/domain/models/Configuration_test.js
+++ b/api/tests/llm/unit/domain/models/Configuration_test.js
@@ -195,7 +195,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
 
       // then
       expect(dto).to.deep.equal({
-        version: 1,
         id: 'some-config-id',
         historySize: 123,
         inputMaxChars: 456,


### PR DESCRIPTION
## 🔆 Problème

On a besoin d’une route de création de conversation LLM de preview :
 - cette route est à l’usage de POC LLM, donc sécurisée par JWT applicatif
 - elle renvoie une URL Pix App où la conversation sera disponible

## ⛱️ Proposition

Plusieurs refactorings :
 - le chat ID devient un UUID et ne contient plus le userId, le userId est stocké dans l’objet Chat
 - on stocke la configuration LLM dans l’objet Chat et on ne la met plus en cache (elle est téléchargée ou reçue quand on créé la conversation)

Le nouveau endpoint permet de créer une conversation en fournissant la configuration en payload de requête.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Non régression sur le LLM dans les modules.