### PR TITLE
[FEATURE] Enlever titres Fiche Recap et A Retenir (PIX-18679)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -14,7 +14,7 @@
   "grains": [
     {
       "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
-      "type": "lesson",
+      "type": "summary",
       "title": "test table",
       "components": [
         {

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -88,8 +88,8 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   }
 }
 
-.grain-card-title {
-  @extend %pix-title-s;
+.grain-card-icon {
+  @extend %pix-title-m;
 
   margin-bottom: var(--pix-spacing-4x);
 }

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -187,19 +187,12 @@ export default class ModuleGrain extends Component {
     return `grain_${this.args.grain.id}`;
   }
 
-  get isGrainTypeWithTitle() {
-    return this.args.grain.type === 'lesson' || this.args.grain.type === 'summary';
+  get isGrainTypeSummary() {
+    return this.args.grain.type === 'summary';
   }
 
-  get grainTitle() {
-    switch (this.args.grain.type) {
-      case 'lesson':
-        return 'A retenir';
-      case 'summary':
-        return 'Fiche récap';
-      default:
-        return '';
-    }
+  get emojiGrain() {
+    return '📌';
   }
 
   <template>
@@ -215,8 +208,8 @@ export default class ModuleGrain extends Component {
           total=@totalSteps
         }}</h2>
       <div class="grain__card grain-card--{{this.grainType}}">
-        {{#if this.isGrainTypeWithTitle}}
-          <h2 class="grain-card-title">{{this.grainTitle}}</h2>
+        {{#if this.isGrainTypeSummary}}
+          <p class="grain-card-icon">{{this.emojiGrain}}</p>
         {{/if}}
         <div class="grain-card__content">
           <!-- eslint-disable-next-line no-unused-vars -->


### PR DESCRIPTION
## ⛱️ Proposition

Ne plus afficher les titres "Fiche Recap" et "A retenir", et mettre une icône pour les recap.

## 🌊 Remarques

- Dans `grain.gjs`, obligée d'utiliser un getter pour renvoyer l'emoji afin qu'il s'affiche correctement et sans erreur du linter sur le besoin de traduction d'une chaîne de caractères

## 🏄 Pour tester

- [Ouvrir le bac-a-sable](https://app-pr12814.review.pix.fr/modules/bac-a-sable/passage)
- Afficher le premier grain
- L'icône Pin doit apparaître, sans titre sur le grain
- Les titres "A retenir" ont disparu des grains "lesson"
