### PR TITLE
[FEATURE] Modifier les CTA Passer et Vérifier (PIX-18683)

### DIFF
--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -105,7 +105,7 @@ export default class ModuleQcm extends ModuleElement {
 
       {{#unless this.correction}}
         <PixButton
-          @variant="success"
+          @variant="primary"
           @type="submit"
           class="element-qcm__verify-button"
           @triggerAction={{this.onAnswer}}

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -109,7 +109,7 @@ export default class ModuleQcu extends ModuleElement {
 
       {{#unless this.correction}}
         <PixButton
-          @variant="success"
+          @variant="primary"
           @type="submit"
           class="element-qcu__verify-button"
           @triggerAction={{this.onAnswer}}

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -179,7 +179,7 @@ export default class ModuleQrocm extends ModuleElement {
 
       {{#unless this.correction}}
         <PixButton
-          @variant="success"
+          @variant="primary"
           @type="submit"
           class="element-qrocm__verify-button"
           @triggerAction={{this.onAnswer}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -252,7 +252,7 @@ export default class ModuleGrain extends Component {
 
         {{#if this.shouldDisplaySkipButton}}
           <footer class="grain-card__footer grain-card__footer__with-skip-button">
-            <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}}>
+            <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
               {{t "pages.modulix.buttons.grain.skip"}}
             </PixButton>
           </footer>

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -93,6 +93,6 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
 
     assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-    assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Passer l‘activité' })).exists();
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1659,7 +1659,7 @@
         },
         "grain": {
           "continue": "Continue",
-          "skip": "Skip",
+          "skip": "Skip activity",
           "terminate": "Terminate"
         },
         "stepper": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1645,7 +1645,7 @@
         },
         "grain": {
           "continue": "Continuar",
-          "skip": "Ir a",
+          "skip": "Ir a la actividad",
           "terminate": "Finalizar"
         },
         "stepper": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1659,7 +1659,7 @@
         },
         "grain": {
           "continue": "Continuer",
-          "skip": "Passer",
+          "skip": "Passer l‘activité",
           "terminate": "Terminer"
         },
         "stepper": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1648,7 +1648,7 @@
         },
         "grain": {
           "continue": "Ga verder met",
-          "skip": "Overslaan",
+          "skip": "Overslaan activiteit",
           "terminate": "Afwerking"
         },
         "stepper": {


### PR DESCRIPTION
## ⛱️ Proposition

CTA Vérifier
-  type : success > primary

CTA Passer
- wording : “Passer” > “Passer l’activité”
- ajout icone ‘arrowDown’

## 🌊 Remarques

- Les modifications concernant la position du bouton "Passer" n'ont pas été faites car elles impliquent de repenser l'agencement des composants Grain et QCU/QROCM/QCM dans notre page Module -> le bouton _Passer_ est donc placé en dessous du bouton _Vérifier_, et non à sa droite

## 🏄 Pour tester

- ouvrir le [bac à sable](https://app-pr12815.review.pix.fr/modules/bac-a-sable/details)
- Vérifier que pour un QCU/QCM/QROCM, le label du bouton "Vérifier" a été mis à jour
- Vérifier que le bouton "Passer" a été correctement modifié
