### PR TITLE
[FEATURE] Supprimer le message 'message de votre organisation' sur la page de fin de parcours  (PIX-18676).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -2,7 +2,6 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { t } from 'ember-intl';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
 
@@ -47,9 +46,6 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   <template>
     <div class="evaluation-results-hero__organization-block">
-      <h3 class="evaluation-results-hero-organization-block__title">
-        {{t "pages.skill-review.organization-message"}}
-      </h3>
       {{#if @campaign.customResultPageText}}
         <MarkdownToHtml
           class="evaluation-results-hero-organization-block__message"

--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -215,12 +215,6 @@
   border-top: 1px solid var(--pix-neutral-100);
 }
 
-.evaluation-results-hero-organization-block__title {
-  @extend %pix-title-s;
-
-  margin-bottom: var(--pix-spacing-2x);
-}
-
 .evaluation-results-hero-organization-block__link {
   display: inline-flex;
   margin-top: var(--pix-spacing-4x);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/custom-organization-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/custom-organization-block-test.js
@@ -1,6 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
@@ -9,19 +8,6 @@ module(
   'Integration | Components | Campaigns | Assessment | Results | Evaluation Results Hero | Custom Organization Block',
   function (hooks) {
     setupIntlRenderingTest(hooks);
-
-    test('displays the block title', async function (assert) {
-      // given
-      this.set('campaign', {});
-
-      // when
-      const screen = await render(
-        hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::CustomOrganizationBlock @campaign={{this.campaign}} />`,
-      );
-
-      // then
-      assert.dom(screen.getByText(t('pages.skill-review.organization-message'))).exists();
-    });
 
     module('custom text', function () {
       module('when organization custom text is defined', function () {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -1069,7 +1069,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           );
 
           // then
-          assert.dom(screen.getByText(t('pages.skill-review.organization-message'))).exists();
           assert.dom(screen.getByText('My custom result page text')).exists();
         });
       });
@@ -1095,7 +1094,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           );
 
           // then
-          assert.dom(screen.getByText(t('pages.skill-review.organization-message'))).exists();
           assert.dom(screen.getByRole('link', { name: 'Custom result page button text' })).exists();
         });
       });
@@ -1115,7 +1113,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           );
 
           // then
-          assert.dom(screen.queryByText(t('pages.skill-review.organization-message'))).doesNotExist();
           assert.dom(screen.queryByText('My custom result page text')).doesNotExist();
         });
       });
@@ -1137,7 +1134,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           );
 
           // then
-          assert.dom(screen.queryByText(t('pages.skill-review.organization-message'))).doesNotExist();
           assert.dom(screen.queryByText('My custom result page text')).doesNotExist();
         });
       });
@@ -1162,7 +1158,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             );
 
             // then
-            assert.dom(screen.getByText(t('pages.skill-review.organization-message'))).exists();
             assert.dom(screen.getByText('My custom result page text')).exists();
           });
         });
@@ -1188,7 +1183,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             );
 
             // then
-            assert.dom(screen.getByText(t('pages.skill-review.organization-message'))).exists();
             assert.dom(screen.getByRole('link', { name: 'Custom result page button text' })).exists();
           });
         });
@@ -1208,7 +1202,6 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
             );
 
             // then
-            assert.dom(screen.queryByText(t('pages.skill-review.organization-message'))).doesNotExist();
             assert.dom(screen.queryByText('My custom result page text')).doesNotExist();
           });
         });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1992,7 +1992,6 @@
         "title": "Your opinion counts!"
       },
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
-      "organization-message": "Message of your organization",
       "reset": {
         "button": "Reset and restart from the beginning",
         "modal": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1979,7 +1979,6 @@
         "title": "¡Tu opinión cuenta!"
       },
       "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
-      "organization-message": "Mensaje de tu organización",
       "reset": {
         "button": "Poner a cero y volver a intentarlo todo",
         "modal": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1992,7 +1992,6 @@
         "title": "Votre avis compte !"
       },
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
-      "organization-message": "Message de votre organisation",
       "reset": {
         "button": "Remettre à zéro et tout retenter",
         "modal": {
@@ -2001,7 +2000,6 @@
         },
         "notification": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
         "notification-with-auto-share": "Repassez les questions échouées ou remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
-      
       },
       "retry": {
         "button": "Repasser mon parcours",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1982,7 +1982,6 @@
         "title": "Jouw mening telt!"
       },
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
-      "organization-message": "Bericht van uw organisatie",
       "reset": {
         "button": "Reset en probeer opnieuw",
         "modal": {


### PR DESCRIPTION
## 🔆 Problème

Un titre avec "message de votre organisation apparaît" avant les messages / boutons  modifables d'une campagne. ce qui peut générer des incohérences avec le message du dessous dans le cas où ce ne sont pas des organisations qui souhaitent porter le message.

## ⛱️ Proposition

Supprimer ce titre qui ne sert à R et voir les retours.

## 🏄 Pour tester

Ajouter une campagne avec un message de fin de parcours custom et un bouton, aller en fin de parcours et vérifier la disparition du titre. 