### PR TITLE
[FEATURE] Route de lecture de conversation de LLM de preview (PIX-18693)

### DIFF
--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -14,14 +14,6 @@ import * as toEventStream from '../../infrastructure/streaming/to-event-stream.j
 import { LLMChatDTO } from './models/LLMChatDTO.js';
 
 /**
- * @typedef LLMChatDTO
- * @type {object}
- * @property {string} id
- * @property {number} inputMaxPrompts
- * @property {number} inputMaxChars
- */
-
-/**
  * @function
  * @name startChat
  *

--- a/api/src/llm/application/llm-preview-controller.js
+++ b/api/src/llm/application/llm-preview-controller.js
@@ -1,5 +1,7 @@
 import { config } from '../../shared/config.js';
 import { usecases } from '../domain/usecases/index.js';
+import { chatRepository } from '../infrastructure/repositories/index.js';
+import * as chatSerializer from '../infrastructure/serializers/json/chat-serializer.js';
 import * as configurationSerializer from '../infrastructure/serializers/json/configuration-serializer.js';
 
 export const llmPreviewController = {
@@ -10,5 +12,9 @@ export const llmPreviewController = {
       .response()
       .header('Location', new URL(`/llm/preview/${chat.id}`, config.domain.pixApp).href)
       .code(201);
+  },
+  async getChat(request) {
+    const chat = await chatRepository.get(request.params.chatId);
+    return chatSerializer.serialize(chat);
   },
 };

--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -14,11 +14,7 @@ export async function register(server) {
           strategy: jwtApplicationAuthenticationStrategyName,
           access: { scope: 'llm-preview' },
         },
-        pre: [
-          {
-            method: checkLLMChatIsEnabled,
-          },
-        ],
+        pre: [{ method: checkLLMChatIsEnabled }],
         validate: {
           payload: Joi.object({
             configuration: Joi.object({
@@ -50,6 +46,22 @@ export async function register(server) {
           'Cette route est restreinte aux applications avec le scope llm-preview',
           'Elle permet de créer une discussion LLM avec la configuration en payload',
         ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/llm/preview/chats/{chatId}',
+      config: {
+        auth: false,
+        pre: [{ method: checkLLMChatIsEnabled }],
+        validate: {
+          params: Joi.object({
+            chatId: Joi.string().required(),
+          }).required(),
+        },
+        handler: llmPreviewController.getChat,
+        tags: ['api', 'llm', 'preview'],
+        notes: ['Cette route est publique', 'Elle permet de récupérer l’état d’une discussion LLM'],
       },
     },
   ]);

--- a/api/src/llm/infrastructure/repositories/prompt-repository.js
+++ b/api/src/llm/infrastructure/repositories/prompt-repository.js
@@ -3,11 +3,12 @@ import jwt from 'jsonwebtoken';
 import { config } from '../../../shared/config.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { LLMApiError } from '../../domain/errors.js';
+
 const logger = child('llm:api', { event: SCOPES.LLM });
 
 /**
- * @typedef {import('../../domain/Configuration').Configuration} Configuration
- * @typedef {import('../../domain/Chat').Chat} Chat
+ * @typedef {import('../../domain/models/Configuration').Configuration} Configuration
+ * @typedef {import('../../domain/models/Chat').Chat} Chat
  */
 
 /**
@@ -21,7 +22,7 @@ const logger = child('llm:api', { event: SCOPES.LLM });
  * @returns {Promise<ReadableStream>}
  */
 export async function prompt({ message, configuration, chat }) {
-  const messagesToForward = chat.messages.slice(-configuration.historySize).map(toHistoryMessage);
+  const messagesToForward = chat.messages.slice(-configuration.historySize).map((message) => message.toLLMHistory());
   const payload = JSON.stringify({
     prompt: message,
     configurationId: configuration.id,
@@ -64,12 +65,5 @@ async function handleFetchErrors(response) {
   return {
     status: response.status,
     err,
-  };
-}
-
-function toHistoryMessage(message) {
-  return {
-    content: message.content,
-    role: message.isFromUser ? 'user' : 'assistant',
   };
 }

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -1,0 +1,33 @@
+import { Message } from '../../../domain/models/Chat.js';
+
+/**
+ * @param {import('../../../domain/models/Chat').Chat} chat
+ */
+export function serialize({ id, configuration: { inputMaxChars, inputMaxPrompts, attachmentName }, messages }) {
+  messages = messages.filter(({ isAttachmentContent }) => !isAttachmentContent);
+
+  const notCountedAttachmentIndex = messages.findIndex(({ isAttachment, notCounted }) => isAttachment && notCounted);
+  if (notCountedAttachmentIndex !== -1) {
+    messages = messages.toSpliced(
+      notCountedAttachmentIndex,
+      2,
+      new Message({
+        content: messages[notCountedAttachmentIndex + 1].content,
+        attachmentName: messages[notCountedAttachmentIndex].attachmentName,
+        isFromUser: true,
+      }),
+    );
+  }
+
+  return {
+    id,
+    inputMaxChars,
+    inputMaxPrompts,
+    attachmentName,
+    messages: messages.map(({ content, attachmentName, isFromUser }) => ({
+      content,
+      attachmentName,
+      isFromUser,
+    })),
+  };
+}

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -498,7 +498,7 @@ function _mapToHttpError(error) {
   }
 
   if (error instanceof LLMDomainErrors.ChatNotFoundError) {
-    return new HttpErrors.BadRequestError(error.message, error.code);
+    return new HttpErrors.NotFoundError(error.message, error.code);
   }
 
   if (error instanceof LLMDomainErrors.NoUserIdProvidedError) {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -389,23 +389,13 @@ describe('Acceptance | Controller | passage-controller', function () {
               configurationId: 'uneConfigQuiExist',
               history: [
                 {
-                  content: `
-<system_notification>
-  L'utilisateur a téléversé une pièce jointe :
-  <attachment_name>
-    expected_file.pdf
-  </attachment_name>
-</system_notification>`,
+                  content:
+                    "<system_notification>L'utilisateur a téléversé une pièce jointe : <attachment_name>expected_file.pdf</attachment_name></system_notification>",
                   role: 'user',
                 },
                 {
-                  content: `
-<read_attachment_tool>
-  Lecture de la pièce jointe, expected_file.pdf :
-  <attachment_content>
-    some context
-  </attachment_content>
-</read_attachment_tool>`,
+                  content:
+                    '<read_attachment_tool>Lecture de la pièce jointe, expected_file.pdf : <attachment_content>some context</attachment_content></read_attachment_tool>',
                   role: 'assistant',
                 },
               ],

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -915,23 +915,13 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
               configurationId: 'uneConfigQuiExist',
               history: [
                 {
-                  content: `
-<system_notification>
-  L'utilisateur a téléversé une pièce jointe :
-  <attachment_name>
-    expected_file.pdf
-  </attachment_name>
-</system_notification>`,
+                  content:
+                    "<system_notification>L'utilisateur a téléversé une pièce jointe : <attachment_name>expected_file.pdf</attachment_name></system_notification>",
                   role: 'user',
                 },
                 {
-                  content: `
-<read_attachment_tool>
-  Lecture de la pièce jointe, expected_file.pdf :
-  <attachment_content>
-    some context
-  </attachment_content>
-</read_attachment_tool>`,
+                  content:
+                    '<read_attachment_tool>Lecture de la pièce jointe, expected_file.pdf : <attachment_content>some context</attachment_content></read_attachment_tool>',
                   role: 'assistant',
                 },
               ],

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -1,12 +1,7 @@
 import { CHAT_STORAGE_PREFIX } from '../../../../src/llm/infrastructure/repositories/chat-repository.js';
 import { featureToggles } from '../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
-import {
-  createServer,
-  databaseBuilder,
-  expect,
-  generateValidRequestAuthorizationHeaderForApplication,
-} from '../../../test-helper.js';
+import { createServer, expect, generateValidRequestAuthorizationHeaderForApplication } from '../../../test-helper.js';
 
 const chatTemporaryStorage = temporaryStorage.withPrefix(CHAT_STORAGE_PREFIX);
 
@@ -18,15 +13,11 @@ describe('Acceptance | Route | llm-preview', function () {
     await featureToggles.set('isEmbedLLMEnabled', true);
   });
 
+  afterEach(async function () {
+    await chatTemporaryStorage.flushAll();
+  });
+
   describe('POST /api/llm/preview/chats', function () {
-    beforeEach(async function () {
-      await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await chatTemporaryStorage.flushAll();
-    });
-
     context('when request is not authenticated', function () {
       it('should throw a 401', async function () {
         // when
@@ -163,6 +154,85 @@ describe('Acceptance | Route | llm-preview', function () {
         },
         hasAttachmentContextBeenAdded: false,
         messages: [],
+      });
+    });
+  });
+
+  describe('GET /api/llm/preview/chats/{chatId}', function () {
+    context('when chatId is unknown', function () {
+      it('returns status code 404', async function () {
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/llm/preview/chats/00000000-0000-0000-0000-000000000000',
+        });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    it('returns status code 200 and chat information', async function () {
+      // given
+      await chatTemporaryStorage.save({
+        key: '123e4567-e89b-12d3-a456-426614174000',
+        value: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          configuration: {
+            historySize: 10,
+            inputMaxChars: 500,
+            inputMaxPrompts: 4,
+            attachmentName: 'expected_file.txt',
+            attachmentContext: 'add me in the chat !',
+          },
+          hasAttachmentContextBeenAdded: true,
+          messages: [
+            { content: 'coucou user1', isFromUser: true, notCounted: false },
+            { content: 'coucou LLM1', isFromUser: false, notCounted: false },
+            {
+              attachmentName: 'expected_file.txt',
+              isFromUser: true,
+              notCounted: true,
+            },
+            {
+              attachmentName: 'expected_file.txt',
+              attachmentContext: 'add me in the chat !',
+              isFromUser: false,
+              notCounted: false,
+            },
+            { content: 'un message', isFromUser: true, notCounted: false },
+            {
+              content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
+              isFromUser: false,
+              notCounted: false,
+            },
+          ],
+        },
+      });
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/llm/preview/chats/123e4567-e89b-12d3-a456-426614174000',
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        inputMaxChars: 500,
+        inputMaxPrompts: 3,
+        attachmentName: 'expected_file.txt',
+        messages: [
+          { content: 'coucou user1', attachmentName: undefined, isFromUser: true },
+          { content: 'coucou LLM1', attachmentName: undefined, isFromUser: false },
+          { content: 'un message', attachmentName: 'expected_file.txt', isFromUser: true },
+          {
+            content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
+            attachmentName: undefined,
+            isFromUser: false,
+          },
+        ],
       });
     });
   });

--- a/api/tests/llm/integration/application/api/llm-api_test.js
+++ b/api/tests/llm/integration/application/api/llm-api_test.js
@@ -590,12 +590,12 @@ describe('LLM | Integration | Application | API | llm', function () {
                         { content: 'coucou LLM1', role: 'assistant' },
                         {
                           content:
-                            "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
+                            "<system_notification>L'utilisateur a téléversé une pièce jointe : <attachment_name>expected_file.txt</attachment_name></system_notification>",
                           role: 'user',
                         },
                         {
                           content:
-                            '\n<read_attachment_tool>\n  Lecture de la pièce jointe, expected_file.txt :\n  <attachment_content>\n    add me in the chat !\n  </attachment_content>\n</read_attachment_tool>',
+                            '<read_attachment_tool>Lecture de la pièce jointe, expected_file.txt : <attachment_content>add me in the chat !</attachment_content></read_attachment_tool>',
                           role: 'assistant',
                         },
                       ],
@@ -645,14 +645,13 @@ describe('LLM | Integration | Application | API | llm', function () {
                       { content: 'coucou user1', isFromUser: true, notCounted: false },
                       { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
-                        content:
-                          "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
+                        attachmentName: 'expected_file.txt',
                         isFromUser: true,
                         notCounted: true,
                       },
                       {
-                        content:
-                          '\n<read_attachment_tool>\n  Lecture de la pièce jointe, expected_file.txt :\n  <attachment_content>\n    add me in the chat !\n  </attachment_content>\n</read_attachment_tool>',
+                        attachmentName: 'expected_file.txt',
+                        attachmentContext: 'add me in the chat !',
                         isFromUser: false,
                         notCounted: false,
                       },
@@ -962,14 +961,13 @@ describe('LLM | Integration | Application | API | llm', function () {
                       { content: 'coucou user1', isFromUser: true, notCounted: false },
                       { content: 'coucou LLM1', isFromUser: false, notCounted: false },
                       {
-                        content:
-                          "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    expected_file.txt\n  </attachment_name>\n</system_notification>",
+                        attachmentName: 'expected_file.txt',
                         isFromUser: true,
                         notCounted: false,
                       },
                       {
-                        content:
-                          '\n<read_attachment_tool>\n  Lecture de la pièce jointe, expected_file.txt :\n  <attachment_content>\n    add me in the chat !\n  </attachment_content>\n</read_attachment_tool>',
+                        attachmentName: 'expected_file.txt',
+                        attachmentContext: 'add me in the chat !',
                         isFromUser: false,
                         notCounted: false,
                       },

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -21,11 +21,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(chat.toDTO()).to.have.deep.property('messages', [
         {
           content: 'some message',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: false,
           notCounted: false,
         },
         {
           content: 'un message pas vide',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: true,
           notCounted: false,
         },
@@ -50,6 +54,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(chat.toDTO()).to.have.deep.property('messages', [
         {
           content: 'some message',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: false,
           notCounted: false,
         },
@@ -75,11 +81,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(chat.toDTO()).to.have.deep.property('messages', [
         {
           content: 'some message',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: false,
           notCounted: false,
         },
         {
           content: 'un message pas vide',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: false,
           notCounted: false,
         },
@@ -104,6 +114,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(chat.toDTO()).to.have.deep.property('messages', [
         {
           content: 'some message',
+          attachmentName: undefined,
+          attachmentContext: undefined,
           isFromUser: false,
           notCounted: false,
         },
@@ -137,23 +149,29 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         expect(chatDTO).to.have.deep.property('messages', [
           {
             content: 'some message',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: true,
             notCounted: false,
           },
           {
             content: 'some answer',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: false,
             notCounted: false,
           },
           {
-            content:
-              "\n<system_notification>\n  L'utilisateur a téléversé une pièce jointe :\n  <attachment_name>\n    winter_lyrics.txt\n  </attachment_name>\n</system_notification>",
+            content: undefined,
+            attachmentName: 'winter_lyrics.txt',
+            attachmentContext: undefined,
             isFromUser: true,
             notCounted: false,
           },
           {
-            content:
-              "\n<read_attachment_tool>\n  Lecture de la pièce jointe, winter_lyrics.txt :\n  <attachment_content>\n    J'étais assise sur une pierre\nDes larmes coulaient sur mon visage\n  </attachment_content>\n</read_attachment_tool>",
+            content: undefined,
+            attachmentName: 'winter_lyrics.txt',
+            attachmentContext: "J'étais assise sur une pierre\nDes larmes coulaient sur mon visage",
             isFromUser: false,
             notCounted: false,
           },
@@ -184,11 +202,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         expect(chat.toDTO()).to.have.deep.property('messages', [
           {
             content: 'some message',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: true,
             notCounted: false,
           },
           {
             content: 'some answer',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: false,
             notCounted: false,
           },
@@ -316,11 +338,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         messages: [
           {
             content: 'message llm 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: false,
             notCounted: false,
           },
           {
             content: 'message user 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: true,
             notCounted: true,
           },
@@ -347,11 +373,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         messages: [
           {
             content: 'message llm 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: false,
             notCounted: false,
           },
           {
             content: 'message user 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
             isFromUser: true,
             notCounted: true,
           },

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -1,0 +1,129 @@
+import { Chat, Message } from '../../../../../src/llm/domain/models/Chat.js';
+import { Configuration } from '../../../../../src/llm/domain/models/Configuration.js';
+import { serialize } from '../../../../../src/llm/infrastructure/serializers/json/chat-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
+  describe('serialize', function () {
+    it('serializes Chat', function () {
+      // given
+      const chat = new Chat({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        configuration: new Configuration({
+          attachmentName: 'filename.txt',
+          inputMaxChars: 500,
+          inputMaxPrompts: 5,
+        }),
+        hasAttachmentContextBeenAdded: false,
+        messages: [
+          new Message({ content: 'Salut', isFromUser: true }),
+          new Message({ content: 'Bonjour comment puis-je vous aider ?', isFromUser: false }),
+        ],
+      });
+
+      // when
+      const payload = serialize(chat);
+
+      // then
+      expect(payload).to.deep.equal({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        attachmentName: 'filename.txt',
+        inputMaxChars: 500,
+        inputMaxPrompts: 4,
+        messages: [
+          { content: 'Salut', attachmentName: undefined, isFromUser: true },
+          { content: 'Bonjour comment puis-je vous aider ?', attachmentName: undefined, isFromUser: false },
+        ],
+      });
+    });
+
+    context('when messages contains an attachment not counted', function () {
+      it('serializes the attachment with the next message', function () {
+        // given
+        const chat = new Chat({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          configuration: new Configuration({
+            attachmentName: 'filename.txt',
+            inputMaxChars: 500,
+            inputMaxPrompts: 5,
+          }),
+          hasAttachmentContextBeenAdded: false,
+          messages: [
+            new Message({ content: 'Salut', isFromUser: true }),
+            new Message({ content: 'Bonjour comment puis-je vous aider ?', isFromUser: false }),
+            new Message({ attachmentName: 'chien.webp', isFromUser: true, notCounted: true }),
+            new Message({
+              attachmentName: 'chien.webp',
+              attachmentContext: 'c’est une photo d’un ours',
+              isFromUser: false,
+            }),
+            new Message({ content: 'Que contient ce fichier ?', isFromUser: true }),
+            new Message({ content: 'Le fichier contient la photo d’un ours', isFromUser: false }),
+          ],
+        });
+
+        // when
+        const payload = serialize(chat);
+
+        // then
+        expect(payload).to.deep.equal({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          attachmentName: 'filename.txt',
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          messages: [
+            { content: 'Salut', attachmentName: undefined, isFromUser: true },
+            { content: 'Bonjour comment puis-je vous aider ?', attachmentName: undefined, isFromUser: false },
+            { content: 'Que contient ce fichier ?', attachmentName: 'chien.webp', isFromUser: true },
+            { content: 'Le fichier contient la photo d’un ours', attachmentName: undefined, isFromUser: false },
+          ],
+        });
+      });
+    });
+
+    context('when messages contains an attachment counted', function () {
+      it('serializes the attachment with the next message', function () {
+        // given
+        const chat = new Chat({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          configuration: new Configuration({
+            attachmentName: 'filename.txt',
+            inputMaxChars: 500,
+            inputMaxPrompts: 5,
+          }),
+          hasAttachmentContextBeenAdded: false,
+          messages: [
+            new Message({ content: 'Salut', isFromUser: true }),
+            new Message({ content: 'Bonjour comment puis-je vous aider ?', isFromUser: false }),
+            new Message({ attachmentName: 'chien.webp', isFromUser: true, notCounted: false }),
+            new Message({
+              attachmentName: 'chien.webp',
+              attachmentContext: 'c’est une photo d’un ours',
+              isFromUser: false,
+            }),
+            new Message({ content: 'Que contient ce fichier ?', isFromUser: true }),
+            new Message({ content: 'Le fichier contient la photo d’un ours', isFromUser: false }),
+          ],
+        });
+
+        // when
+        const payload = serialize(chat);
+
+        // then
+        expect(payload).to.deep.equal({
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          attachmentName: 'filename.txt',
+          inputMaxChars: 500,
+          inputMaxPrompts: 4,
+          messages: [
+            { content: 'Salut', attachmentName: undefined, isFromUser: true },
+            { content: 'Bonjour comment puis-je vous aider ?', attachmentName: undefined, isFromUser: false },
+            { content: undefined, attachmentName: 'chien.webp', isFromUser: true },
+            { content: 'Que contient ce fichier ?', attachmentName: undefined, isFromUser: true },
+            { content: 'Le fichier contient la photo d’un ours', attachmentName: undefined, isFromUser: false },
+          ],
+        });
+      });
+    });
+  });
+});

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -109,14 +109,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('The configuration of id "someConfigId" does not exist');
     });
 
-    it('responds Bad Request when a LLMDomainErrors.ChatNotFoundError error occurs', async function () {
-      routeHandler.throws(new LLMDomainErrors.ChatNotFoundError('someChatId'));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal('The chat of id "someChatId" does not exist');
-    });
-
     it('responds Bad Request when a LLMDomainErrors.NoUserIdProvidedError error occurs', async function () {
       routeHandler.throws(new LLMDomainErrors.NoUserIdProvidedError());
       const response = await server.requestObject(request);
@@ -183,6 +175,18 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('User has not the right to use this chat');
+    });
+  });
+
+  context('404 Not found', function () {
+    const NOT_FOUND_ERROR = 404;
+
+    it('responds Not Found when a LLMDomainErrors.ChatNotFoundError error occurs', async function () {
+      routeHandler.throws(new LLMDomainErrors.ChatNotFoundError('someChatId'));
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
+      expect(responseDetail(response)).to.equal('The chat of id "someChatId" does not exist');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

L’embed LLM doit pouvoir charger une conversation par son identifiant.

## ⛱️ Proposition

Créer un endpoint permettant de lire une conversation par identifiant.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Non régression sur demo-llm.