### PR TITLE
[TECH] Supprimer le endpoint GET /api/assessments/{id}/next

### DIFF
--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -33,21 +33,6 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/assessments/{id}/next',
-      config: {
-        auth: false,
-        validate: {
-          params: Joi.object({
-            id: identifiersType.assessmentId,
-          }),
-        },
-        handler: assessmentController.getAssessmentWithNextChallenge,
-        notes: ["- Récupération de la question suivante pour l'évaluation donnée"],
-        tags: ['api'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/assessments/{id}',
       config: {
         auth: false,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -73,7 +73,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
     await mockLearningContent(learningContentObjects);
   });
 
-  describe('GET /api/assessments/:assessment_id/next', function () {
+  describe('GET /api/assessments/:assessment_id', function () {
     const assessmentId = 1;
     const userId = 1234;
 
@@ -117,7 +117,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-campai
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -76,7 +76,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
     await mockLearningContent(learningContentObjects);
   });
 
-  describe('GET /api/assessments/:assessment_id/next', function () {
+  describe('GET /api/assessments/:assessment_id', function () {
     const assessmentId = 1;
     const userId = 1234;
 
@@ -124,7 +124,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -191,7 +191,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -242,7 +242,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -298,7 +298,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -351,7 +351,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -74,7 +74,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
     await mockLearningContent(learningContentObjects);
   });
 
-  describe('GET /api/assessments/:assessment_id/next', function () {
+  describe('GET /api/assessments/:assessment_id', function () {
     const assessmentId = 1;
     const userId = 1234;
 
@@ -122,7 +122,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 
@@ -138,7 +138,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 
@@ -158,7 +158,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 
@@ -230,7 +230,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 
@@ -247,7 +247,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         // given
         const options = {
           method: 'GET',
-          url: `/api/assessments/${assessmentId}/next`,
+          url: `/api/assessments/${assessmentId}`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -51,7 +51,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
     await mockLearningContent(learningContentObjects);
   });
 
-  describe('(demo) GET /api/assessments/:assessment_id/next', function () {
+  describe('(demo) GET /api/assessments/:assessment_id', function () {
     const assessmentId = 1;
 
     context('when next challenge found', function () {
@@ -69,7 +69,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         // given
         const options = {
           method: 'GET',
-          url: '/api/assessments/' + assessmentId + '/next',
+          url: `/api/assessments/${assessmentId}`,
         };
 
         // when
@@ -99,7 +99,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         // given
         const options = {
           method: 'GET',
-          url: '/api/assessments/' + assessmentId + '/next',
+          url: `/api/assessments/${assessmentId}`,
         };
 
         // when
@@ -128,7 +128,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         // given
         const options = {
           method: 'GET',
-          url: '/api/assessments/' + assessmentId + '/next',
+          url: `/api/assessments/${assessmentId}`,
         };
 
         // when
@@ -156,7 +156,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo',
         // given
         const options = {
           method: 'GET',
-          url: '/api/assessments/' + assessmentId + '/next',
+          url: `/api/assessments/${assessmentId}`,
         };
 
         // when

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -63,7 +63,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
     server = await createServer();
   });
 
-  describe('GET /api/assessments/:assessment_id/next', function () {
+  describe('GET /api/assessments/:assessment_id', function () {
     const assessmentId = 1;
     const userId = 1234;
 
@@ -88,7 +88,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
           // given
           const options = {
             method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
+            url: `/api/assessments/${assessmentId}`,
             headers: generateAuthenticatedUserRequestHeaders({ userId, acceptLanguage: FRENCH_FRANCE }),
           };
 

--- a/api/tests/shared/unit/application/assessements/index_test.js
+++ b/api/tests/shared/unit/application/assessements/index_test.js
@@ -46,21 +46,6 @@ describe('Unit | Application | Router | assessment-router', function () {
     });
   });
 
-  describe('GET /api/assessments/{id}/next', function () {
-    it('should return 200', async function () {
-      // given
-      sinon.stub(assessmentController, 'getAssessmentWithNextChallenge').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/assessments/1/next');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('GET /api/assessments/{id}', function () {
     const method = 'GET';
     const url = '/api/assessments/1';


### PR DESCRIPTION
## 🔆 Problème
Le endpoint GET /api/assessments/{id}/next a été remplacé par le endpoint GET /api/assessments/{id} et n'est donc plus utilisé. 

## ⛱️ Proposition
Supprimer le endpoint GET /api/assessments/{id}/next

## 🏄 Pour tester
Les tests passent