### PR TITLE
[TECH] :recycle: ajoute les secondes dans la version générée par le script de migration des challenges de référentiel de certification complémentaire (PIX-18694)

### DIFF
--- a/api/scripts/prod/certification-frameworks-challenges-version-migration.js
+++ b/api/scripts/prod/certification-frameworks-challenges-version-migration.js
@@ -17,12 +17,24 @@ class CertificationFrameworksChallengesVersionMigration extends Script {
     for (let i = 0; i < certificationFrameworksChallengesToUpdate.length; i++) {
       const certificationFrameworksChallenge = certificationFrameworksChallengesToUpdate[i];
       const createdAt = certificationFrameworksChallenge.createdAt;
-      const version = createdAt.toISOString().slice(0, 16).replace(/-|T|:/g, '');
+      const version = this.getVersionNumber(createdAt);
       await knex('certification-frameworks-challenges')
         .where({ id: certificationFrameworksChallenge.id })
         .update({ version });
     }
     logger.info(`${certificationFrameworksChallengesToUpdate.length} certification-frameworks-challenges rows updated`);
+  }
+
+  getVersionNumber(date) {
+    const pad = (n) => String(n).padStart(2, '0');
+    return (
+      date.getUTCFullYear().toString() +
+      pad(date.getUTCMonth() + 1) +
+      pad(date.getUTCDate()) +
+      pad(date.getUTCHours()) +
+      pad(date.getUTCMinutes()) +
+      pad(date.getSeconds())
+    );
   }
 }
 await ScriptRunner.execute(import.meta.url, CertificationFrameworksChallengesVersionMigration);


### PR DESCRIPTION
## 🔆 Problème

Le numéro de version dans le cas d'utilisation se construit avec des secondes (et de façon explicite dans le code).
Ces modifications n'ont pas été reportés dans le script de migration.

## ⛱️ Proposition

Faire en sorte que le script de migration des numéros de versions 
- sois plus explicite sur la construction du numéro de version
- utilise les secondes pour avoir moins de risque de chevauchement.

## 🌊 Remarques

:warning: Quand ce script sera en production, demander au Captain de l'executer.

## 🏄 Pour tester

- [ ] Avoir des enregistrements dans la table `certification-frameworks-challenges` avec une valeur dans la colonne `createdAt` et aucune valeur dans la colonne `version`.
- [ ] Exécuter le script de migration
- [ ] Constaté que le numéro de version est renseigné et construit à partir de la valeur de la colonne `createAt` de la ligne correspondante.

