### PR TITLE
[TECH] Uniformiser les noms des méthodes et variables liées à la limite de places des orgas (PIX-18698).

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -265,13 +265,13 @@ const FeaturesForm = <template>
       {{#if (and (eq feature "PLACES_MANAGEMENT") @toggleLockPlaces)}}
         <div class="form-field">
           <PixCheckbox
-            @checked={{organizationFeature.params.enablePlacesThresholdLock}}
+            @checked={{organizationFeature.params.enableMaximumPlacesLimit}}
             {{on
               "change"
-              (fn @updateFormCheckBoxValue (concat "features." feature ".params.enablePlacesThresholdLock"))
+              (fn @updateFormCheckBoxValue (concat "features." feature ".params.enableMaximumPlacesLimit"))
             }}
           ><:label>{{t
-                "components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK"
+                "components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT"
               }}</:label></PixCheckbox>
         </div>
       {{/if}}

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -158,7 +158,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.notOk(
           screen.queryByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
           ),
         );
       });
@@ -167,7 +167,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         organization.features = {
           PLACES_MANAGEMENT: {
             active: true,
-            params: { enablePlacesThresholdLock: false },
+            params: { enableMaximumPlacesLimit: false },
           },
         };
 
@@ -179,7 +179,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.false(
           screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
           ).checked,
         );
       });
@@ -188,7 +188,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         organization.features = {
           PLACES_MANAGEMENT: {
             active: true,
-            params: { enablePlacesThresholdLock: true },
+            params: { enableMaximumPlacesLimit: true },
           },
         };
 
@@ -200,7 +200,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.true(
           screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LOCK'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
           ).checked,
         );
       });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -509,7 +509,7 @@
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",
-          "ORGANIZATION_PLACES_LOCK": "Block organization in case of places threshold exceeded",
+          "ORGANIZATION_PLACES_LOCK": "Block organization in case of places limit exceeded",
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -509,7 +509,7 @@
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",
-          "ORGANIZATION_PLACES_LOCK": "Block organization in case of places limit exceeded",
+          "ORGANIZATION_PLACES_LIMIT": "Block organization in case of places limit exceeded",
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -509,7 +509,7 @@
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Envoi multiple sur les campagnes d'évaluation",
-          "ORGANIZATION_PLACES_LOCK": "Blocage de l'organisation en cas de dépassement des places",
+          "ORGANIZATION_PLACES_LIMIT": "Blocage de l'organisation en cas de dépassement des places",
           "PLACES_MANAGEMENT": "Affichage de la page Places sur PixOrga",
           "SHOW_NPS": "Affichage du Net Promoter Score",
           "SHOW_SKILLS": "Affichage des acquis dans l'export de résultats",

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -371,7 +371,7 @@ function _paramsForFeature(importFormats, key, value) {
   }
 
   if (key === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key) {
-    return { enablePlacesThresholdLock: value.params?.enablePlacesThresholdLock || false };
+    return { enableMaximumPlacesLimit: value.params?.enableMaximumPlacesLimit || false };
   }
 }
 

--- a/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
@@ -46,7 +46,7 @@ export class PlaceStatistics {
     return this.#activePlacesLots.length;
   }
 
-  get hasReachMaximumPlacesWithThreshold() {
+  get hasReachedMaximumPlacesLimit() {
     if (!this.#isPlacesLockEnabled || this.occupied === 0) return false;
 
     const thresholdLock = config.features.organizationPlacesManagementThreshold;

--- a/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlaceStatistics.js
@@ -5,17 +5,17 @@ import { config } from '../../../../shared/config.js';
 export class PlaceStatistics {
   #placesLots;
   #placeRepartition;
-  #isPlacesLockEnabled;
+  #isMaximumPlacesLimitEnabled;
 
-  constructor({ placesLots = [], placeRepartition, organizationId, enablePlacesThresholdLock } = {}) {
+  constructor({ placesLots = [], placeRepartition, organizationId, enableMaximumPlacesLimit } = {}) {
     this.id = `${organizationId}_place_statistics`;
     this.#placesLots = placesLots;
     this.#placeRepartition = placeRepartition;
-    this.#isPlacesLockEnabled = enablePlacesThresholdLock;
+    this.#isMaximumPlacesLimitEnabled = enableMaximumPlacesLimit;
   }
 
-  static buildFrom({ placesLots, placeRepartition, organizationId, enablePlacesThresholdLock } = {}) {
-    return new PlaceStatistics({ placesLots, placeRepartition, organizationId, enablePlacesThresholdLock });
+  static buildFrom({ placesLots, placeRepartition, organizationId, enableMaximumPlacesLimit } = {}) {
+    return new PlaceStatistics({ placesLots, placeRepartition, organizationId, enableMaximumPlacesLimit });
   }
 
   get #activePlacesLots() {
@@ -47,7 +47,7 @@ export class PlaceStatistics {
   }
 
   get hasReachedMaximumPlacesLimit() {
-    if (!this.#isPlacesLockEnabled || this.occupied === 0) return false;
+    if (!this.#isMaximumPlacesLimitEnabled || this.occupied === 0) return false;
 
     const thresholdLock = config.features.organizationPlacesManagementThreshold;
     const maximumPlaces = this.total + this.total * thresholdLock;

--- a/api/src/prescription/organization-place/domain/usecases/get-organization-places-statistics.js
+++ b/api/src/prescription/organization-place/domain/usecases/get-organization-places-statistics.js
@@ -43,13 +43,13 @@ const getOrganizationPlacesStatistics = async function ({
   const placesManagementFeature = features.find(
     (feature) => feature.name === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
   );
-  const isPlacesThresholdLockEnabled = placesManagementFeature?.params?.enablePlacesThresholdLock;
+  const isMaximumPlacesLimitEnabled = placesManagementFeature?.params?.enableMaximumPlacesLimit;
 
   return PlaceStatistics.buildFrom({
     placesLots,
     placeRepartition,
     organizationId,
-    enablePlacesThresholdLock: isPlacesThresholdLockEnabled,
+    enableMaximumPlacesLimit: isMaximumPlacesLimitEnabled,
   });
 };
 

--- a/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
+++ b/api/src/prescription/organization-place/infrastructure/serializers/jsonapi/organization-places-statistics-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (places) {
   return new Serializer('organization-place-statistics', {
-    attributes: ['total', 'occupied', 'available', 'anonymousSeat', 'hasReachMaximumPlacesWithThreshold'],
+    attributes: ['total', 'occupied', 'available', 'anonymousSeat', 'hasReachedMaximumPlacesLimit'],
   }).serialize(places);
 };
 

--- a/api/src/shared/application/usecases/check-organization-access.js
+++ b/api/src/shared/application/usecases/check-organization-access.js
@@ -29,9 +29,9 @@ const execute = async function ({
   const placesManagementFeature = features.find(
     (feature) => feature.name === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
   );
-  const hasLockEnabled = placesManagementFeature?.params?.enablePlacesThresholdLock;
+  const hasMaximumPlacesLimitEnabled = placesManagementFeature?.params?.enableMaximumPlacesLimit;
 
-  if (!hasLockEnabled) return true;
+  if (!hasMaximumPlacesLimitEnabled) return true;
 
   const placesStatistics = await prescriptionUsecases.getOrganizationPlacesStatistics({
     organizationId: organizationIdToUse,

--- a/api/src/shared/application/usecases/check-organization-access.js
+++ b/api/src/shared/application/usecases/check-organization-access.js
@@ -37,7 +37,7 @@ const execute = async function ({
     organizationId: organizationIdToUse,
   });
 
-  if (placesStatistics.hasReachMaximumPlacesWithThreshold) {
+  if (placesStatistics.hasReachedMaximumPlacesLimit) {
     throw new ForbiddenAccess('Maximum places reached', 'MAXIMUM_PLACES_REACHED');
   }
 

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1196,7 +1196,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
               [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
               [ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key]: {
                 active: true,
-                params: { enablePlacesThresholdLock: true },
+                params: { enableMaximumPlacesLimit: true },
               },
             },
           });
@@ -1205,10 +1205,10 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           //then
           const enabledFeatures = await knex('organization-features');
           expect(enabledFeatures).lengthOf(1);
-          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: true });
+          expect(enabledFeatures[0].params).deep.equal({ enableMaximumPlacesLimit: true });
         });
 
-        it('by default, should insert new feature with falsy enablePlacesThresholdLock param', async function () {
+        it('by default, should insert new feature with falsy enableMaximumPlacesLimit param', async function () {
           // given && when
           const organizationToUpdate = new OrganizationForAdmin({
             id: organization.id,
@@ -1227,15 +1227,15 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           //then
           const enabledFeatures = await knex('organization-features');
           expect(enabledFeatures).lengthOf(1);
-          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: false });
+          expect(enabledFeatures[0].params).deep.equal({ enableMaximumPlacesLimit: false });
         });
 
-        it('should be possible to update enablePlacesThresholdLock param value', async function () {
+        it('should be possible to update enableMaximumPlacesLimit param value', async function () {
           // given && when
           databaseBuilder.factory.buildOrganizationFeature({
             featureId: placeManagementFeature.id,
             organizationId: organization.id,
-            params: { enablePlacesThresholdLock: false },
+            params: { enableMaximumPlacesLimit: false },
           });
 
           await databaseBuilder.commit();
@@ -1247,7 +1247,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
               [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
               [ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key]: {
                 active: true,
-                params: { enablePlacesThresholdLock: true },
+                params: { enableMaximumPlacesLimit: true },
               },
             },
           });
@@ -1257,7 +1257,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           //then
           const enabledFeatures = await knex('organization-features');
           expect(enabledFeatures).lengthOf(1);
-          expect(enabledFeatures[0].params).deep.equal({ enablePlacesThresholdLock: true });
+          expect(enabledFeatures[0].params).deep.equal({ enableMaximumPlacesLimit: true });
         });
       });
     });

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-organization-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-organization-places-statistics_test.js
@@ -70,12 +70,12 @@ describe('Integration | Domain | Use Cases | get-organization-places-statistics'
       expect(organizationPlacesStatistics.occupied).to.equal(2);
       expect(organizationPlacesStatistics.anonymousSeat).to.equal(1);
       expect(organizationPlacesStatistics.available).to.equal(0);
-      expect(organizationPlacesStatistics.hasReachMaximumPlacesWithThreshold).to.equal(true);
+      expect(organizationPlacesStatistics.hasReachedMaximumPlacesLimit).to.equal(true);
     });
   });
 
   describe('When organization does not have the blocking place feature', function () {
-    it('should return false on hasReachMaximumPlacesWithThreshold', async function () {
+    it('should return false on hasReachedMaximumPlacesLimit', async function () {
       // given
       databaseBuilder.factory.buildOrganizationPlace({
         organizationId,
@@ -91,7 +91,7 @@ describe('Integration | Domain | Use Cases | get-organization-places-statistics'
       });
 
       // then
-      expect(organizationPlacesStatistics.hasReachMaximumPlacesWithThreshold).to.equal(false);
+      expect(organizationPlacesStatistics.hasReachedMaximumPlacesLimit).to.equal(false);
     });
   });
 });

--- a/api/tests/prescription/organization-place/integration/domain/usecases/get-organization-places-statistics_test.js
+++ b/api/tests/prescription/organization-place/integration/domain/usecases/get-organization-places-statistics_test.js
@@ -48,7 +48,7 @@ describe('Integration | Domain | Use Cases | get-organization-places-statistics'
         organizationId,
         featureId: placesManagementFeatureId,
         params: {
-          enablePlacesThresholdLock: true,
+          enableMaximumPlacesLimit: true,
         },
       });
 

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -225,14 +225,14 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
   });
 
   describe('#hasReachedMaximumPlacesLimit', function () {
-    describe('When enablePlacesThresholdLock is activated', function () {
+    describe('When enableMaximumPlacesLimit is activated', function () {
       describe('when there is no occupied places', function () {
         it('should return false', function () {
           // when
           const statistics = new PlaceStatistics({
             placesLots: [{ count: 0, isActive: true }],
             placeRepartition: { totalUnRegisteredParticipant: 0, totalRegisteredParticipant: 0 },
-            enablePlacesThresholdLock: true,
+            enableMaximumPlacesLimit: true,
           });
 
           // then
@@ -249,7 +249,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
           const statistics = new PlaceStatistics({
             placesLots: [{ count: 100, isActive: true }],
             placeRepartition: { totalUnRegisteredParticipant: 10, totalRegisteredParticipant: 100 },
-            enablePlacesThresholdLock: true,
+            enableMaximumPlacesLimit: true,
           });
 
           // then
@@ -266,7 +266,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
           const statistics = new PlaceStatistics({
             placesLots: [{ count: 100, isActive: true }],
             placeRepartition: { totalUnRegisteredParticipant: 10, totalRegisteredParticipant: 99 },
-            enablePlacesThresholdLock: true,
+            enableMaximumPlacesLimit: true,
           });
 
           // then
@@ -275,7 +275,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
       });
     });
 
-    describe('When enablePlacesThresholdLock is deactivated and maximum places count is reached', function () {
+    describe('When enableMaximumPlacesLimit is deactivated and maximum places count is reached', function () {
       it('should return false', function () {
         // given
         sinon.stub(config.features, 'organizationPlacesManagementThreshold').value(0.1);
@@ -284,7 +284,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
         const statistics = new PlaceStatistics({
           placesLots: [{ count: 100, isActive: true }],
           placeRepartition: { totalUnRegisteredParticipant: 10, totalRegisteredParticipant: 100 },
-          enablePlacesThresholdLock: false,
+          enableMaximumPlacesLimit: false,
         });
 
         // then

--- a/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
+++ b/api/tests/prescription/organization-place/unit/domain/read-models/PlaceStatistics_test.js
@@ -224,7 +224,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
     });
   });
 
-  describe('#hasReachMaximumPlacesWithThreshold', function () {
+  describe('#hasReachedMaximumPlacesLimit', function () {
     describe('When enablePlacesThresholdLock is activated', function () {
       describe('when there is no occupied places', function () {
         it('should return false', function () {
@@ -236,7 +236,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
           });
 
           // then
-          expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.false;
+          expect(statistics.hasReachedMaximumPlacesLimit).to.be.false;
         });
       });
 
@@ -253,7 +253,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
           });
 
           // then
-          expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.true;
+          expect(statistics.hasReachedMaximumPlacesLimit).to.be.true;
         });
       });
 
@@ -270,7 +270,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
           });
 
           // then
-          expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.false;
+          expect(statistics.hasReachedMaximumPlacesLimit).to.be.false;
         });
       });
     });
@@ -288,7 +288,7 @@ describe('Unit | Domain | ReadModels | PlaceStatistics', function () {
         });
 
         // then
-        expect(statistics.hasReachMaximumPlacesWithThreshold).to.be.false;
+        expect(statistics.hasReachedMaximumPlacesLimit).to.be.false;
       });
     });
   });

--- a/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
+++ b/api/tests/prescription/organization-place/unit/infrastructure/serializers/jsonapi/organization-places-statistics-serializer_test.js
@@ -32,7 +32,7 @@ describe('Unit | Serializer | JSONAPI | organization-places-statistics-serialize
             occupied: 5,
             available: 5,
             'anonymous-seat': 3,
-            'has-reach-maximum-places-with-threshold': false,
+            'has-reached-maximum-places-limit': false,
           },
         },
       };

--- a/api/tests/shared/integration/domain/usecases/check-organization-access.test.js
+++ b/api/tests/shared/integration/domain/usecases/check-organization-access.test.js
@@ -36,7 +36,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
     });
 
     context('when the PLACE_MANAGEMENT organization feature is enabled', function () {
-      context('when threshold lock is disabled', function () {
+      context('when maximum places limit is disabled', function () {
         it('should not throw', async function () {
           // given
           const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -47,7 +47,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
             organizationId: organization.id,
             featureId: placeManagementFeature.id,
             params: {
-              enablePlacesThresholdLock: false,
+              enableMaximumPlacesLimit: false,
             },
           });
           await databaseBuilder.commit();
@@ -60,8 +60,8 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
         });
       });
 
-      context('when threshold lock is enabled', function () {
-        context('when the amount of maximum places if not reached', function () {
+      context('when maximum places limit is enabled', function () {
+        context('when the amount of maximum places is not reached', function () {
           it('should not throw', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -72,7 +72,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId: organization.id,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
             await databaseBuilder.commit();
@@ -85,7 +85,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
           });
         });
 
-        context('when the amount of maximum places if reached', function () {
+        context('when the amount of maximum places is reached', function () {
           it('should throw a forbidden access error', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -98,7 +98,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId: organization.id,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
 
@@ -153,7 +153,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
     });
 
     context('when the PLACE_MANAGEMENT organization feature is enabled', function () {
-      context('when threshold lock is disabled', function () {
+      context('when maximum places limit is disabled', function () {
         it('should not throw', async function () {
           // given
           const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -163,7 +163,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
             organizationId: organizationId,
             featureId: placeManagementFeature.id,
             params: {
-              enablePlacesThresholdLock: false,
+              enableMaximumPlacesLimit: false,
             },
           });
           await databaseBuilder.commit();
@@ -176,8 +176,8 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
         });
       });
 
-      context('when threshold lock is enabled', function () {
-        context('when the amount of maximum places if not reached', function () {
+      context('when maximum places limit is enabled', function () {
+        context('when the amount of maximum places is not reached', function () {
           it('should not throw', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -187,7 +187,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
             await databaseBuilder.commit();
@@ -200,7 +200,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
           });
         });
 
-        context('when the amount of maximum places if reached', function () {
+        context('when the amount of maximum places is reached', function () {
           it('should throw a forbidden access error', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -211,7 +211,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId: organizationId,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
 
@@ -264,7 +264,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
     });
 
     context('when the PLACE_MANAGEMENT organization feature is enabled', function () {
-      context('when threshold lock is disabled', function () {
+      context('when maximum places limit is disabled', function () {
         it('should not throw', async function () {
           // given
           const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -274,7 +274,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
             organizationId: organizationId,
             featureId: placeManagementFeature.id,
             params: {
-              enablePlacesThresholdLock: false,
+              enableMaximumPlacesLimit: false,
             },
           });
           await databaseBuilder.commit();
@@ -287,8 +287,8 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
         });
       });
 
-      context('when threshold lock is enabled', function () {
-        context('when the amount of maximum places if not reached', function () {
+      context('when maximum places limit is enabled', function () {
+        context('when the amount of maximum places is not reached', function () {
           it('should not throw', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -298,7 +298,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
             await databaseBuilder.commit();
@@ -311,7 +311,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
           });
         });
 
-        context('when the amount of maximum places if reached', function () {
+        context('when the amount of maximum places is reached', function () {
           it('should throw a forbidden access error', async function () {
             // given
             const placeManagementFeature = databaseBuilder.factory.buildFeature({
@@ -322,7 +322,7 @@ describe('Integration | Shared | Domain | UseCase | check-organization-access', 
               organizationId: organizationId,
               featureId: placeManagementFeature.id,
               params: {
-                enablePlacesThresholdLock: true,
+                enableMaximumPlacesLimit: true,
               },
             });
 

--- a/orga/app/components/banner/maximum-places-exceeded.gjs
+++ b/orga/app/components/banner/maximum-places-exceeded.gjs
@@ -8,7 +8,7 @@ export default class MaximumPlacesExceeded extends Component {
 
   get displayMaximumPlacesExceededBanner() {
     const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachMaximumPlacesWithThreshold;
+    return statistics?.hasReachedMaximumPlacesLimit;
   }
 
   <template>

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -17,7 +17,7 @@ export default class CampaignTabs extends Component {
 
   get hasReachedPlacesLimit() {
     const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachMaximumPlacesWithThreshold;
+    return statistics?.hasReachedMaximumPlacesLimit;
   }
 
   @action

--- a/orga/app/components/campaign/list-header.gjs
+++ b/orga/app/components/campaign/list-header.gjs
@@ -12,7 +12,7 @@ export default class List extends Component {
 
   get hasReachedPlacesLimit() {
     const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachMaximumPlacesWithThreshold;
+    return statistics?.hasReachedMaximumPlacesLimit;
   }
 
   get campaignCreationRoute() {

--- a/orga/app/models/organization-place-statistic.js
+++ b/orga/app/models/organization-place-statistic.js
@@ -5,7 +5,7 @@ export default class PlaceStatistics extends Model {
   @attr('number') total;
   @attr('number') occupied;
   @attr('number') anonymousSeat;
-  @attr('boolean') hasReachMaximumPlacesWithThreshold;
+  @attr('boolean') hasReachedMaximumPlacesLimit;
 
   get hasAnonymousSeat() {
     return this.anonymousSeat > 0;

--- a/orga/app/routes/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/analysis.js
@@ -9,7 +9,7 @@ export default class AnalysisRoute extends Route {
     const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -38,7 +38,7 @@ export default class AssessmentResultsRoute extends Route {
     const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -39,7 +39,7 @@ export default class ProfilesRoute extends Route {
     const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -16,7 +16,7 @@ export default class NewRoute extends Route {
   beforeModel() {
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns');
     }
   }

--- a/orga/app/routes/authenticated/campaigns/participant-assessment.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment.js
@@ -10,7 +10,7 @@ export default class AssessmentRoute extends Route {
     const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/analysis.js
@@ -8,7 +8,7 @@ export default class AnalysisRoute extends Route {
     const campaignId = transition.to.parent.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/results.js
@@ -8,7 +8,7 @@ export default class ResultsRoute extends Route {
     const campaignId = transition.to.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/participant-profile.js
+++ b/orga/app/routes/authenticated/campaigns/participant-profile.js
@@ -10,7 +10,7 @@ export default class ProfileRoute extends Route {
     const campaignId = transition.to.params.campaign_id;
     const places = this.modelFor('authenticated');
 
-    if (places?.hasReachMaximumPlacesWithThreshold) {
+    if (places?.hasReachedMaximumPlacesLimit) {
       this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
     }
   }

--- a/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
+++ b/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
@@ -28,7 +28,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
     module('when maximum places is not reached', function () {
       test('it should not display a banner', async function (assert) {
         // given
-        store.createRecord('organization-place-statistic', { hasReachMaximumPlacesWithThreshold: false });
+        store.createRecord('organization-place-statistic', { hasReachedMaximumPlacesLimit: false });
 
         // when
         const screen = await render(<template><MaximumPlacesExceeded /></template>);
@@ -41,7 +41,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
     module('when maximum places is reached', function () {
       test('it should display a banner', async function (assert) {
         // given
-        store.createRecord('organization-place-statistic', { hasReachMaximumPlacesWithThreshold: true });
+        store.createRecord('organization-place-statistic', { hasReachedMaximumPlacesLimit: true });
 
         // when
         const screen = await render(<template><MaximumPlacesExceeded /></template>);

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -113,11 +113,11 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
       );
     });
 
-    module('when has reach maximum places threshold is true', function (hooks) {
+    module('when has reached maximum places limit is true', function (hooks) {
       hooks.beforeEach(function () {
         const storeService = this.owner.lookup('service:store');
         sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
       });
 
       test('it should display disabled evaluation results item', async function (assert) {
@@ -136,7 +136,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         assert.dom(resultsLink).hasClass('disabled');
       });
 
-      test('it should disabled download campaign result', async function (assert) {
+      test('it should disable download campaign result button', async function (assert) {
         screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
         const downloadResultButton = screen.getByRole('button', { name: t('pages.campaign.actions.export-results') });
 
@@ -201,7 +201,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
       hooks.beforeEach(function () {
         const storeService = this.owner.lookup('service:store');
         sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
       });
 
       test('it should display disabled profile results item', async function (assert) {

--- a/orga/tests/integration/components/campaign/list-header-test.gjs
+++ b/orga/tests/integration/components/campaign/list-header-test.gjs
@@ -30,7 +30,7 @@ module('Integration | Component | Campaign | ListHeader', function (hooks) {
         // given
         const storeService = this.owner.lookup('service:store');
         sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: false }]);
+        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: false }]);
 
         // when
         const screen = await render(<template><ListHeader /></template>);
@@ -45,7 +45,7 @@ module('Integration | Component | Campaign | ListHeader', function (hooks) {
         // given
         const storeService = this.owner.lookup('service:store');
         sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachMaximumPlacesWithThreshold: true }]);
+        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
 
         // when
         const screen = await render(<template><ListHeader /></template>);

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/analysis-test.js
@@ -59,7 +59,7 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel({
@@ -89,7 +89,7 @@ module('Unit | Route | authenticated/campaigns/campaign/analysis', function (hoo
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel({

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results-test.js
@@ -156,14 +156,14 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
     });
 
     module('When places limit is reached', function () {
-      test('should redirect on main campaign page', function (assert) {
+      test('should redirect to main campaign page', function (assert) {
         //given
         const campaignId = Symbol('CampaignId');
 
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel({
@@ -189,7 +189,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel({

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results-test.js
@@ -103,14 +103,14 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     });
 
     module('When places limit is reached', function () {
-      test('should redirect on main campaign page', function (assert) {
+      test('should redirect to main campaign page', function (assert) {
         //given
         const campaignId = Symbol('CampaignId');
 
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel({
@@ -129,14 +129,14 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     });
 
     module('When places limit is not reached', function () {
-      test('should not redirect on main campaign page', function (assert) {
+      test('should not redirect to main campaign page', function (assert) {
         //given
         const campaignId = Symbol('CampaignId');
 
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel({

--- a/orga/tests/unit/routes/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-test.js
@@ -290,7 +290,7 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel();
@@ -306,7 +306,7 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel();

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment-test.js
@@ -19,7 +19,7 @@ module('Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaign
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel({
@@ -46,7 +46,7 @@ module('Unit | Route | authenticated/campaigns/{campaignId}/evaluation/{campaign
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel({

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/analysis-test.js
@@ -21,7 +21,7 @@ module(
           const modelForStub = sinon.stub(route, 'modelFor');
           const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+          modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
           //when
           route.beforeModel({
@@ -48,7 +48,7 @@ module(
           const modelForStub = sinon.stub(route, 'modelFor');
           const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+          modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
           //when
           route.beforeModel({

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-assessment/results-test.js
@@ -21,7 +21,7 @@ module(
           const modelForStub = sinon.stub(route, 'modelFor');
           const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+          modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
           //when
           route.beforeModel({ to: { params: { campaign_id: campaignId } } });
@@ -40,7 +40,7 @@ module(
           const modelForStub = sinon.stub(route, 'modelFor');
           const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-          modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+          modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
           //when
           route.beforeModel({ to: { params: { campaign_id: campaignId } } });

--- a/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/participant-profile-test.js
@@ -19,7 +19,7 @@ module('Unit | Route | authenticated/campaigns/{campaignId}/profils/{campaignPar
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: true });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: true });
 
         //when
         route.beforeModel({ to: { params: { campaign_id: campaignId } } });
@@ -38,7 +38,7 @@ module('Unit | Route | authenticated/campaigns/{campaignId}/profils/{campaignPar
         const modelForStub = sinon.stub(route, 'modelFor');
         const replaceWithStub = sinon.stub(route.router, 'replaceWith');
 
-        modelForStub.withArgs('authenticated').returns({ hasReachMaximumPlacesWithThreshold: false });
+        modelForStub.withArgs('authenticated').returns({ hasReachedMaximumPlacesLimit: false });
 
         //when
         route.beforeModel({ to: { params: { campaign_id: campaignId } } });


### PR DESCRIPTION
## 🔆 Problème
Durant les PR, nous avons utilisé différents termes pour parler de la limite maxium du nombre de places d'une organisation.

## ⛱️ Proposition
Par souci de lisibilité et de pérennité, homogénéiser ces noms de méthodes et variables.

## 🏄 Pour tester
- Lancer Pix Admin
- Aller sur l'organisation Pro Classic
- Activer le blocage des places
- Supprimer les places présentes et n'en créer que 2
- Lancer Pix Orga avec admin-orga
- Aller sur l'orga Pro Classic
- Constater que le bandeau de manque de place est présent, et que les actions sont bloquées
- Désactiver la feature sur Pix Admin et vérifier que les actions re-fonctionnent sur Pix Orga
