### PR TITLE
[FEATURE] Afficher les certifications passées par un utilisateur sur PixAdmin (PIX-18691).

### DIFF
--- a/admin/app/adapters/user-certification-course.js
+++ b/admin/app/adapters/user-certification-course.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class UserCertificationCourseAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForQuery({ userId }) {
+    return `${this.host}/${this.namespace}/users/${Number(userId)}/certification-courses`;
+  }
+}

--- a/admin/app/components/users/user-certification-courses.gjs
+++ b/admin/app/components/users/user-certification-courses.gjs
@@ -1,0 +1,91 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import { t } from 'ember-intl';
+
+export default class UserCertificationCourses extends Component {
+  @service intl;
+  @service router;
+  @service store;
+
+  @tracked userCertificationCourses = [];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadUserCertificationCourses();
+  }
+
+  async loadUserCertificationCourses() {
+    const userId = this.router.currentRoute.parent.params.user_id;
+    this.userCertificationCourses = await this.store.query('user-certification-course', { userId });
+  }
+
+  <template>
+    <header class="page-section__header">
+      <h2 class="page-section__title">
+        {{t "components.users.certification-centers.certification-courses.section-title"}}
+      </h2>
+    </header>
+
+    {{#if this.userCertificationCourses.length}}
+      <PixTable
+        @variant="admin"
+        @data={{this.userCertificationCourses}}
+        @caption={{t "components.users.certification-centers.certification-courses.table-caption"}}
+      >
+        <:columns as |certificationCourse context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.users.certification-centers.certification-courses.table-headers.id"}}
+            </:header>
+            <:cell>
+              <LinkTo
+                @route="authenticated.certifications.certification.informations"
+                @model={{certificationCourse.id}}
+              >
+                {{certificationCourse.id}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.users.certification-centers.certification-courses.table-headers.created-at"}}
+            </:header>
+            <:cell>
+              {{dayjsFormat certificationCourse.createdAt "DD/MM/YYYY"}}
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.users.certification-centers.certification-courses.table-headers.session-id"}}
+            </:header>
+            <:cell>
+              <LinkTo @route="authenticated.sessions.session.informations" @model={{certificationCourse.sessionId}}>
+                {{certificationCourse.sessionId}}
+              </LinkTo>
+            </:cell>
+          </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.users.certification-centers.certification-courses.table-headers.session-status"}}
+            </:header>
+            <:cell>
+              {{#if certificationCourse.isPublished}}
+                {{t "pages.certifications.session-state.published"}}
+              {{else}}
+                {{t "pages.certifications.session-state.not-published"}}
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <div class="table__empty">{{t "components.users.certification-centers.certification-courses.empty-table"}}</div>
+    {{/if}}
+  </template>
+}

--- a/admin/app/models/user-certification-course.js
+++ b/admin/app/models/user-certification-course.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class UserCertificationCourse extends Model {
+  @attr('date') createdAt;
+  @attr('boolean') isPublished;
+  @attr() sessionId;
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -54,12 +54,11 @@ export default class User extends Model {
   get organizationMembershipCount() {
     return this.organizationMemberships.length;
   }
-  get certificationCenterMembershipCount() {
-    return this.certificationCenterMemberships.length;
-  }
+
   get participationCount() {
     return this.participations.length;
   }
+
   get authenticationMethodCount() {
     return this.username && this.email ? this.authenticationMethods.length + 1 : this.authenticationMethods.length;
   }

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -68,6 +68,7 @@ Router.map(function () {
         this.route('campaign-participations', { path: '/participations' });
         this.route('organizations');
         this.route('certification-center-memberships');
+        this.route('certification-courses', { path: '/certifications' });
         this.route('cgu');
       });
     });

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -39,10 +39,13 @@
 
     <LinkTo
       @route="authenticated.users.get.certification-center-memberships"
-      aria-label="Centres de certification auxquels appartient l´utilisateur"
+      aria-label={{t "pages.user-details.navbar.certification-centers-list-aria-label"}}
     >
       {{t "pages.user-details.navbar.certification-centers-list"}}
-      ({{@model.certificationCenterMembershipCount}})
+    </LinkTo>
+
+    <LinkTo @route="authenticated.users.get.certification-courses">
+      {{t "pages.user-details.navbar.certification-courses"}}
     </LinkTo>
 
     <LinkTo

--- a/admin/app/templates/authenticated/users/get/certification-courses.hbs
+++ b/admin/app/templates/authenticated/users/get/certification-courses.hbs
@@ -1,0 +1,1 @@
+<Users::UserCertificationCourses />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -332,6 +332,10 @@ function routes() {
     return certificationCenterMembership;
   });
 
+  this.get('/admin/users/:id/certification-courses', () => {
+    return { data: [] };
+  });
+
   this.post('/admin/memberships', createOrganizationMembership);
   this.patch('/admin/memberships/:id', (schema, request) => {
     const organizationMembershipId = request.params.id;

--- a/admin/tests/integration/components/users/user-certification-courses-test.gjs
+++ b/admin/tests/integration/components/users/user-certification-courses-test.gjs
@@ -1,0 +1,87 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import dayjs from 'dayjs';
+import { t } from 'ember-intl/test-support';
+import UserCertificationCourses from 'pix-admin/components/users/user-certification-courses';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Users | User certification courses', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store;
+  const userId = 1;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+
+    const serviceRouter = this.owner.lookup('service:router');
+    sinon.stub(serviceRouter, 'currentRoute').value({ parent: { params: { user_id: userId } } });
+  });
+
+  module('When user has no certification course', function () {
+    test('displays a title and an info', async function (assert) {
+      // given
+      sinon.stub(store, 'query').resolves([]);
+
+      // when
+      const screen = await render(<template><UserCertificationCourses /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.users.certification-centers.certification-courses.section-title'),
+          }),
+        )
+        .exists();
+
+      assert
+        .dom(screen.getByText(t('components.users.certification-centers.certification-courses.empty-table')))
+        .exists();
+    });
+  });
+
+  module('When user has certification courses', function () {
+    test('displays a table with a table of certification courses', async function (assert) {
+      // given
+      const certificationCourse = store.createRecord('user-certification-course', {
+        id: 1,
+        sessionId: 23,
+        createdAt: new Date('2025-04-01'),
+        isPublished: true,
+      });
+      const certificationCourse2 = store.createRecord('user-certification-course', {
+        isPublished: false,
+      });
+
+      sinon.stub(store, 'query').resolves([certificationCourse, certificationCourse2]);
+
+      // when
+      const screen = await render(<template><UserCertificationCourses /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.users.certification-centers.certification-courses.section-title'),
+          }),
+        )
+        .exists();
+
+      const idCell = screen.getByRole('cell', { name: certificationCourse.id });
+      assert.dom(within(idCell).getByRole('link', { name: certificationCourse.id })).exists();
+
+      assert
+        .dom(screen.getByRole('cell', { name: dayjs(certificationCourse.createdAt).format('DD/MM/YYYY') }))
+        .exists();
+
+      const sessionIdCell = screen.getByRole('cell', { name: certificationCourse.sessionId });
+      assert.dom(within(sessionIdCell).getByRole('link', { name: certificationCourse.sessionId })).exists();
+
+      assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.published') })).exists();
+      assert.dom(screen.getByRole('cell', { name: t('pages.certifications.session-state.not-published') })).exists();
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -567,6 +567,17 @@
         }
       },
       "certification-centers": {
+        "certification-courses": {
+          "empty-table": "This user has no certification course.",
+          "section-title": "Certification courses",
+          "table-caption": "List of certifications passed by the user. Contains ID, creation date, session ID and status.",
+          "table-headers": {
+            "created-at": "Creation date",
+            "id": "ID",
+            "session-id": "Session ID",
+            "session-status": "Session status"
+          }
+        },
         "memberships": {
           "caption": "Liste des centres de certification dont l'utilisateur est membre. Contient l'identifiant en tant que membre, l'identifiant, le nom, l'identifiant externe et le type du centre, et enfin le rôle du membre. Plusieurs actions permettent de changer le rôle du membre et de le désactiver du centre.",
           "empty-table": "There is no certification center",
@@ -583,7 +594,7 @@
             }
           },
           "no-last-connection-date-info": "Has not been connected since 03/2025",
-          "section-title": "User Certification Centres",
+          "section-title": "Certification centers memberships",
           "table-headers": {
             "actions-label": "Actions",
             "center-external-id": "External ID",
@@ -1144,7 +1155,9 @@
     },
     "user-details": {
       "navbar": {
-        "certification-centers-list": "Pix Certif",
+        "certification-centers-list": "Certification centers",
+        "certification-centers-list-aria-label": "Lists of certifications held by the user and the certification centres to which he/she belongs",
+        "certification-courses": "Certifications",
         "cgu": "Terms of service",
         "cgu-aria-label": "Terms of service",
         "connections": "Connections",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -567,6 +567,17 @@
         }
       },
       "certification-centers": {
+        "certification-courses": {
+          "empty-table": "Cet utilisateur n'a passé aucune certification",
+          "section-title": "Certifications passées par l'utilisateur",
+          "table-caption": "Liste des certifications passées par l'utilisateur. Contient l'ID, la date de création, l'ID ainsi que le statut de la session.",
+          "table-headers": {
+            "created-at": "Date de création",
+            "id": "ID",
+            "session-id": "Session ID",
+            "session-status": "Statut de la session"
+          }
+        },
         "memberships": {
           "caption": "Liste des centres de certification dont l'utilisateur est membre. Contient l'identifiant en tant que membre, l'identifiant, le nom, l'identifiant externe et le type du centre, et enfin le rôle du membre. Plusieurs actions permettent de changer le rôle du membre et de le désactiver du centre.",
           "empty-table": "Aucun centre de certification",
@@ -583,7 +594,7 @@
             }
           },
           "no-last-connection-date-info": "Non connecté depuis 03/2025",
-          "section-title": "Centres de certification de l’utilisateur",
+          "section-title": "Accès aux centres de certification",
           "table-headers": {
             "actions-label": "Actions",
             "center-external-id": "Identifiant externe",
@@ -1144,7 +1155,9 @@
     },
     "user-details": {
       "navbar": {
-        "certification-centers-list": "Pix Certif",
+        "certification-centers-list": "Centres de certif",
+        "certification-centers-list-aria-label": "Listes des certifications passées par l'utilisateur et des centres de certifs auxquels il/elle appartient",
+        "certification-courses": "Certifications",
         "cgu": "CGU",
         "cgu-aria-label": "Conditions générales d'utilisation",
         "connections": "Connexions",

--- a/api/src/certification/results/application/user-controller.js
+++ b/api/src/certification/results/application/user-controller.js
@@ -1,0 +1,20 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as userCertificationCoursesSerializer from '../infrastructure/serializers/user-certification-courses-serializer.js';
+
+const findAllCertificationCourses = async function (
+  request,
+  h,
+  dependencies = {
+    userCertificationCoursesSerializer,
+  },
+) {
+  const userId = request.params.userId;
+  const userCertificationCourses = await usecases.findUserCertificationCourses({ userId });
+  return dependencies.userCertificationCoursesSerializer.serialize(userCertificationCourses);
+};
+
+const userController = {
+  findAllCertificationCourses,
+};
+
+export { userController };

--- a/api/src/certification/results/application/user-route.js
+++ b/api/src/certification/results/application/user-route.js
@@ -1,0 +1,41 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { userController } from './user-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/users/{userId}/certification-courses',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+          }),
+        },
+        handler: userController.findAllCertificationCourses,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés sur PixAdmin avec le rôle Super Admin, Certif et Support',
+          "- Récupération de liste des passages en certification d'un utilisateur spécifique",
+        ],
+        tags: ['api', 'admin', 'user', 'certification-courses'],
+      },
+    },
+  ]);
+};
+
+const name = 'certification-results-user-api';
+export { name, register };

--- a/api/src/certification/results/domain/usecases/find-user-certification-courses.js
+++ b/api/src/certification/results/domain/usecases/find-user-certification-courses.js
@@ -1,0 +1,10 @@
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {import('./index.js').certificationCourseRepository} params.certificationCourseRepository
+ **/
+const findUserCertificationCourses = async function ({ userId, certificationCourseRepository }) {
+  return certificationCourseRepository.findAllByUserId({ userId });
+};
+
+export { findUserCertificationCourses };

--- a/api/src/certification/results/infrastructure/serializers/user-certification-courses-serializer.js
+++ b/api/src/certification/results/infrastructure/serializers/user-certification-courses-serializer.js
@@ -1,0 +1,14 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (userCertificationCourses) {
+  return new Serializer('user-certification-course', {
+    transform(currentCertificationCourse) {
+      return currentCertificationCourse.toDTO();
+    },
+    attributes: ['id', 'createdAt', 'isPublished', 'sessionId'],
+  }).serialize(userCertificationCourses);
+};
+
+export { serialize };

--- a/api/src/certification/results/routes.js
+++ b/api/src/certification/results/routes.js
@@ -3,6 +3,7 @@ import * as certificationReports from './application/certification-reports-route
 import * as certificationResults from './application/certification-results-route.js';
 import * as livretScolaire from './application/livret-scolaire-route.js';
 import * as organization from './application/organization-route.js';
+import * as user from './application/user-route.js';
 
 const certificationResultRoutes = [
   certificationReports,
@@ -10,6 +11,7 @@ const certificationResultRoutes = [
   certificate,
   livretScolaire,
   organization,
+  user,
 ];
 
 export { certificationResultRoutes };

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -182,6 +182,24 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
   });
 }
 
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @returns {Promise<Array<CertificationCourse>>}
+ */
+async function findAllByUserId({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const certificationCourses = await knexConn('certification-courses')
+    .select('*')
+    .where({ userId })
+    .orderBy('createdAt', 'desc');
+
+  return certificationCourses.map((certificationCourseDTO) => {
+    return _toDomain({ certificationCourseDTO });
+  });
+}
+
 async function update({ certificationCourse, noTransaction = false }) {
   const knexConn = noTransaction ? knex : DomainTransaction.getConnection();
 
@@ -221,6 +239,7 @@ async function findCertificationCoursesBySessionId({ sessionId }) {
 }
 
 export {
+  findAllByUserId,
   findCertificationCoursesBySessionId,
   findOneCertificationCourseByUserIdAndSessionId,
   get,

--- a/api/tests/certification/results/acceptance/application/user-route_test.js
+++ b/api/tests/certification/results/acceptance/application/user-route_test.js
@@ -1,0 +1,54 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+} from '../../../../test-helper.js';
+
+describe('Certification | Results | Acceptance | Routes | User', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/users/{userId}/certification-courses', function () {
+    it('should return a 200 status code response with JSON API serialized content', async function () {
+      // given
+      const superAdminUser = databaseBuilder.factory.buildUser.withRole();
+
+      const userWithCertificationCourses = databaseBuilder.factory.buildUser();
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        userId: userWithCertificationCourses.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/users/${userWithCertificationCourses.id}/certification-courses`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdminUser.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: [
+          {
+            attributes: {
+              id: certificationCourse.id,
+              'created-at': certificationCourse.createdAt,
+              'is-published': certificationCourse.isPublished,
+              'session-id': certificationCourse.sessionId,
+            },
+            id: String(certificationCourse.id),
+            type: 'user-certification-courses',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/certification/results/unit/application/user-controller_test.js
+++ b/api/tests/certification/results/unit/application/user-controller_test.js
@@ -1,0 +1,38 @@
+import { userController } from '../../../../../src/certification/results/application/user-controller.js';
+import { usecases } from '../../../../../src/certification/results/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Application | Controller | user-controller', function () {
+  describe('#findAllCertificationCourses', function () {
+    it('should return serialized data', async function () {
+      // given
+      const findUserCertificationCoursesStub = sinon.stub(usecases, 'findUserCertificationCourses');
+
+      const serializedResponse = Symbol('serialized-content');
+
+      const dependencies = {
+        userCertificationCoursesSerializer: {
+          serialize: sinon.stub().returns(serializedResponse),
+        },
+      };
+
+      const request = {
+        params: {
+          userId: Symbol('userId'),
+        },
+      };
+
+      // when
+      const serializedUserCertificationCourses = await userController.findAllCertificationCourses(
+        request,
+        hFake,
+        dependencies,
+      );
+
+      // then
+      expect(findUserCertificationCoursesStub.calledOnceWithExactly({ userId: request.params.userId })).to.be.true;
+      expect(dependencies.userCertificationCoursesSerializer.serialize.called).to.be.true;
+      expect(serializedUserCertificationCourses).to.equal(serializedResponse);
+    });
+  });
+});

--- a/api/tests/certification/results/unit/application/user-route_test.js
+++ b/api/tests/certification/results/unit/application/user-route_test.js
@@ -1,0 +1,55 @@
+import { userController } from '../../../../../src/certification/results/application/user-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/results/application/user-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Router | user', function () {
+  describe('GET /api/admin/users/{userId}/certification-courses', function () {
+    it('should return OK when everything does as expected', async function () {
+      // given
+      sinon.stub(userController, 'findAllCertificationCourses').returns('ok');
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      /// when
+      const response = await httpTestServer.request('GET', '/api/admin/users/123/certification-courses');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should reject when admin user role is not accepted', async function () {
+      // given
+      sinon.stub(userController, 'findAllCertificationCourses').returns('ok');
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
+        h
+          .response({ errors: new Error('') })
+          .code(403)
+          .takeover(),
+      );
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      /// when
+      const response = await httpTestServer.request('GET', '/api/admin/users/123/certification-courses');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should reject an invalid user id', async function () {
+      //given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/users/invalid/certification-courses');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/api/tests/certification/results/unit/domain/usecases/find-user-certification-courses_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/find-user-certification-courses_test.js
@@ -1,0 +1,22 @@
+import { findUserCertificationCourses } from '../../../../../../src/certification/results/domain/usecases/find-user-certification-courses.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Results | UseCases | find-user-certification-courses', function () {
+  it('should call findAllByUserId repository method', async function () {
+    // given
+    const userId = Symbol('userId');
+
+    const certificationCourseRepository = {
+      findAllByUserId: sinon.stub(),
+    };
+
+    // when
+    await findUserCertificationCourses({
+      userId,
+      certificationCourseRepository,
+    });
+
+    // then
+    expect(certificationCourseRepository.findAllByUserId.calledOnceWithExactly({ userId })).to.be.true;
+  });
+});

--- a/api/tests/certification/results/unit/infrastructure/serializers/user-certification-courses-serializer_test.js
+++ b/api/tests/certification/results/unit/infrastructure/serializers/user-certification-courses-serializer_test.js
@@ -1,0 +1,50 @@
+import * as serializer from '../../../../../../src/certification/results/infrastructure/serializers/user-certification-courses-serializer.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Results | Unit | Serializer | user-certification-courses-serializer', function () {
+  describe('#serialize()', function () {
+    it('should format certification courses model into into JSON API data', function () {
+      // given
+      const userCertificationCourse1 = domainBuilder.buildCertificationCourse({
+        id: 1,
+        createdAt: new Date('2020-01-01'),
+        isPublished: true,
+        sessionId: 1,
+      });
+      const userCertificationCourse2 = domainBuilder.buildCertificationCourse({
+        id: 2,
+        createdAt: new Date('2024-12-01'),
+        sessionId: 3,
+      });
+
+      // when
+      const json = serializer.serialize([userCertificationCourse1, userCertificationCourse2]);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            attributes: {
+              id: userCertificationCourse1.toDTO().id,
+              'created-at': userCertificationCourse1.toDTO().createdAt,
+              'is-published': userCertificationCourse1.toDTO().isPublished,
+              'session-id': userCertificationCourse1.toDTO().sessionId,
+            },
+            id: String(userCertificationCourse1.toDTO().id),
+            type: 'user-certification-courses',
+          },
+          {
+            attributes: {
+              id: userCertificationCourse2.toDTO().id,
+              'created-at': userCertificationCourse2.toDTO().createdAt,
+              'is-published': userCertificationCourse2.toDTO().isPublished,
+              'session-id': userCertificationCourse2.toDTO().sessionId,
+            },
+            id: String(userCertificationCourse2.toDTO().id),
+            type: 'user-certification-courses',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Sur PixAdmin, pour trouver un ID d'une certification-course d'un utilisateur spécifique, le métier était obligé de passer par un outil externe.

## ⛱️ Proposition

Afficher la liste des certifications d'un utilisateur dans l'onglet "Certif" du détail de cet user.

<img width="1001" height="333" alt="image" src="https://github.com/user-attachments/assets/50351e1d-b980-426f-965a-19e00f32492a" />

## 🌊 Remarques

Le compteur présent sur l'onglet n'a plus vraiment de sens.

Le fait que "certification-centers" soit le parent de mon composant non plus.
Mais je ne voulais pas partir sur un gros refacto dans cette PR.

## 🏄 Pour tester

- Visualiser [l'utilisateur 7101](https://admin-pr12824.review.pix.fr/users/7101/certifications) sur PixAdmin en RA.
- Un tableau avec 2 entrées de certif courses devrait être affiché.
- Visualiser que pour [un autre utilisateur](https://admin-pr12824.review.pix.fr/users/1000/certifications), on ne voit pas le tableau.
