### PR TITLE
[FEATURE] Afficher une catégorie de temps estimé de passage d'un profil cible dans PixAdmin (Pix-18697).

### DIFF
--- a/admin/app/components/target-profiles/target-profile.gjs
+++ b/admin/app/components/target-profiles/target-profile.gjs
@@ -59,6 +59,23 @@ export default class TargetProfile extends Component {
     return urlDashboardPrefix && `${urlDashboardPrefix}?id=${this.args.model.id}`;
   }
 
+  get estimatedTimeLabel() {
+    const estimatedTime = this.args.model.estimatedTime;
+
+    if (!estimatedTime) return this.intl.t('pages.target-profiles.estimated-range.unavailable');
+    const ranges = [
+      { max: 900, key: 'fifteen' },
+      { max: 1800, key: 'thirty' },
+      { max: 2700, key: 'fortyfive' },
+      { max: 3600, key: 'sixty' },
+      { max: 5400, key: 'ninety' },
+      { max: 7200, key: 'one-hundred-twenty' },
+      { max: 10800, key: 'one-hundred-eighty' },
+    ];
+    const found = ranges.find((range) => estimatedTime <= range.max);
+    return this.intl.t(`pages.target-profiles.estimated-range.${found?.key ?? 'one-hundred-eighty-one'}`);
+  }
+
   displayBooleanState = (bool) => {
     const yes = this.intl.t('common.words.yes');
     const no = this.intl.t('common.words.no');
@@ -191,6 +208,8 @@ export default class TargetProfile extends Component {
             <li><span class="bold">ID&#x20;:&#x20;</span>{{@model.id}}</li>
             <li><span class="bold">Nom interne&#x20;:&#x20;</span>{{@model.internalName}}</li>
             <li><span class="bold">Nom externe&#x20;:&#x20;</span>{{@model.name}}</li>
+            <li><span class="bold">{{t "pages.target-profiles.label.estimated-time"}}</span>{{this.estimatedTimeLabel}}
+              {{t "pages.target-profiles.label.estimated-time-experimental"}}</li>
             <li><span class="bold">Organisation de référence&#x20;:&#x20;</span><LinkTo
                 @route="authenticated.organizations.get"
                 @model={{@model.ownerOrganizationId}}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -35,6 +35,7 @@ export default class TargetProfile extends Model {
   @attr('boolean') hasLinkedAutonomousCourse;
   @attr('number') maxLevel;
   @attr('number') tubesCount;
+  @attr('number') estimatedTime;
   @attr() cappedTubes;
 
   @hasMany('badge', { async: true, inverse: null }) badges;

--- a/admin/tests/integration/components/target-profiles/target-profile-test.gjs
+++ b/admin/tests/integration/components/target-profiles/target-profile-test.gjs
@@ -25,6 +25,7 @@ module('Integration | Component | TargetProfile', function (hooks) {
     hasLinkedAutonomousCourse: false,
     id: 666,
     isSimplifiedAccess: false,
+    estimatedTime: 1800,
     maxLevel: 7,
     name: 'Dummy target-profile',
     outdated: false,
@@ -44,6 +45,14 @@ module('Integration | Component | TargetProfile', function (hooks) {
         // then
         assert.ok(_findByListItemText(screen, `ID : ${model.id}`));
         assert.ok(_findByListItemText(screen, `Organisation de référence : ${model.ownerOrganizationId}`));
+        assert.ok(
+          _findByListItemText(
+            screen,
+            `${t('pages.target-profiles.label.estimated-time')}${t('pages.target-profiles.estimated-range.thirty')} ${t(
+              'pages.target-profiles.label.estimated-time-experimental',
+            )}`,
+          ),
+        );
         assert.ok(_findByListItemText(screen, 'Date de création : 01/03/2024'));
         assert.ok(_findByListItemText(screen, 'Obsolète : Non'));
         assert.ok(_findByListItemText(screen, 'Parcours Accès Simplifié : Non'));
@@ -120,7 +129,12 @@ module('Integration | Component | TargetProfile', function (hooks) {
 function _findByListItemText(screen, text) {
   return (
     screen.getAllByRole('listitem').find((listitem) => {
-      const cleanListItemText = listitem.textContent.replace(/(\r\n|\n|\r)/gm, '').trim();
+      const cleanListItemText = listitem.textContent
+        .replace(/(\r\n|\n|\r)/gm, '')
+        .trim()
+        .replace(/  +/g, ' ');
+      console.log(text);
+      console.log(cleanListItemText);
       return cleanListItemText === text;
     }) || null
   );

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1066,6 +1066,17 @@
           "success": "The target profile has been duplicated."
         }
       },
+      "estimated-range": {
+        "fifteen": "0 - 15mn",
+        "fortyfive": "31 - 45mn",
+        "ninety": "1H01 - 1H30",
+        "one-hundred-eighty": "2H01 - 3H",
+        "one-hundred-eighty-one": "3H+",
+        "one-hundred-twenty": "1H31 - 2H",
+        "sixty": "46mn - 1H",
+        "thirty": "16 - 30mn",
+        "unavailable": "Not available"
+      },
       "filters": {
         "aria-label": "Target profile filters",
         "count": "{count, plural, =0 {0 target profile} =1 {1 target profile} other {{count} target profiles}}",
@@ -1077,6 +1088,10 @@
           "aria-label": "Filter target profiles by internal name",
           "label": "Internal name"
         }
+      },
+      "label": {
+        "estimated-time": "Estimated time: ",
+        "estimated-time-experimental": "(experimental data based on the relativity of time)"
       },
       "resettable-checkbox": {
         "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1066,6 +1066,17 @@
           "success": "Le profil cible a bien été copié."
         }
       },
+      "estimated-range": {
+        "fifteen": "0 - 15min",
+        "fortyfive": "31 - 45min",
+        "ninety": "1h01 - 1h30",
+        "one-hundred-eighty": "2h01 - 3h",
+        "one-hundred-eighty-one": "3h+",
+        "one-hundred-twenty": "1h31 - 2h",
+        "sixty": "46min - 1h",
+        "thirty": "16 - 30min",
+        "unavailable": "Non disponible"
+      },
       "filters": {
         "aria-label": "Filtres sur les profils cibles",
         "count": "{count, plural, =0 {0 profil cible} =1 {1 profil cible} other {{count} profils cibles}}",
@@ -1077,6 +1088,10 @@
           "aria-label": "Filtrer les profils cible par le nom interne",
           "label": "Nom interne"
         }
+      },
+      "label": {
+        "estimated-time": "Temps estimé : ",
+        "estimated-time-experimental": "(données expérimentales basées sur la relativité du temps)"
       },
       "resettable-checkbox": {
         "label": "Permettre la remise à zéro des acquis du profil cible"

--- a/api/datamart/datamart-builder/datamart-builder.js
+++ b/api/datamart/datamart-builder/datamart-builder.js
@@ -49,6 +49,7 @@ class DatamartBuilder {
       'organizations_cover_rates',
       'data_active_calibrated_challenges',
       'data_calibrations',
+      'target_profiles_course_duration',
     ].forEach((tableName) => {
       rawQuery += `DELETE FROM ${tableName};`;
     });

--- a/api/src/prescription/target-profile/domain/models/TargetProfileForAdmin.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileForAdmin.js
@@ -25,6 +25,7 @@ class TargetProfileForAdmin {
     thematics = [],
     tubes = [],
     skills = [],
+    estimatedTime = null,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -57,6 +58,7 @@ class TargetProfileForAdmin {
         }),
     );
     this.tubesCount = tubes.length;
+    this.estimatedTime = estimatedTime;
   }
 
   get cappedTubes() {

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -47,6 +47,7 @@ const serialize = function ({ targetProfile, filter }) {
       'maxLevel',
       'tubesCount',
       'cappedTubes',
+      'estimatedTime',
     ],
     badges: {
       ref: 'id',

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -205,6 +205,7 @@ describe('Acceptance | TargetProfile | Application | Route | admin-target-profil
         category: 'TEST',
         'tubes-count': 1,
         comment: 'Un beau profil cible',
+        'estimated-time': null,
         description: 'Une description',
         'created-at': new Date('2020-01-01'),
         'has-linked-campaign': true,

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-administration-repository_test.js
@@ -7,6 +7,7 @@ import { TargetProfile } from '../../../../../../src/shared/domain/models/index.
 import {
   catchErr,
   databaseBuilder,
+  datamartBuilder,
   domainBuilder,
   expect,
   knex,
@@ -125,7 +126,6 @@ describe('Integration | Repository | Target-profile', function () {
         // given
         databaseBuilder.factory.buildOrganization({ id: 66 });
         const targetProfileDB = databaseBuilder.factory.buildTargetProfile({
-          id: 1,
           name: 'Mon Super Profil Cible qui déchire',
           internalName: 'Mon Super Profil Cible qui déchire en interne',
           outdated: false,
@@ -138,6 +138,7 @@ describe('Integration | Repository | Target-profile', function () {
           isSimplifiedAccess: true,
           areKnowledgeElementsResettable: true,
         });
+
         databaseBuilder.factory.buildTargetProfileTube({
           targetProfileId: targetProfileDB.id,
           tubeId: 'recTube1',
@@ -203,6 +204,16 @@ describe('Integration | Repository | Target-profile', function () {
           ]),
         });
         await databaseBuilder.commit();
+
+        datamartBuilder.factory.buildTargetProfileCourseDuration({
+          targetProfileId: targetProfileDB.id,
+          median: 125,
+          quantile_75: 150,
+          quantile_95: 190,
+        });
+
+        await datamartBuilder.commit();
+
         const learningContent = {
           areas: [
             {
@@ -356,7 +367,7 @@ describe('Integration | Repository | Target-profile', function () {
         await mockLearningContent(learningContent);
 
         // when
-        const actualTargetProfile = await targetProfileAdministrationRepository.get({ id: 1 });
+        const actualTargetProfile = await targetProfileAdministrationRepository.get({ id: targetProfileDB.id });
 
         // then
         const skill1_tube1_themA_compA_areaA = {
@@ -477,6 +488,7 @@ describe('Integration | Repository | Target-profile', function () {
           thematics: [themA_compA_areaA, themB_compA_areaA, themC_compB_areaA],
           tubes: [tube1_themA_compA_areaA, tube2_themB_compA_areaA, tube3_themC_compB_areaA],
           skills: [skill1_tube1_themA_compA_areaA, skill2_tube2_themB_compA_areaA],
+          estimatedTime: 150,
         });
         expect(actualTargetProfile).to.deepEqualInstance(expectedTargetProfile);
       });

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -93,6 +93,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
       });
       const targetProfile = new TargetProfileForAdmin({
         id: 132,
+        estimatedTime: 150,
         name: 'Mon Super profil cible',
         internalName: 'Mon Super profil cible interne',
         outdated: true,
@@ -191,6 +192,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
           attributes: {
             category: 'OTHER',
             comment: 'commentaire',
+            'estimated-time': 150,
             'created-at': new Date('2021-03-02'),
             description: 'Un super profil cible',
             'image-url': 'some/image/url',

--- a/api/tests/shared/acceptance/application/healthcheck.route.test.js
+++ b/api/tests/shared/acceptance/application/healthcheck.route.test.js
@@ -1,9 +1,7 @@
-import { databaseConnection } from '../../../../datamart/knex-database-connection.js';
 import { createServer, expect } from '../../../test-helper.js';
 
 describe('Acceptance | Shared | Application | Route | healthcheck', function () {
   let server;
-
   beforeEach(async function () {
     server = await createServer();
   });
@@ -40,24 +38,6 @@ describe('Acceptance | Shared | Application | Route | healthcheck', function () 
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.message).to.equal('Connection to databases ok');
-    });
-
-    it('returns an HTTP status code 503 when at least one database is not available', async function () {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/healthcheck/db',
-      };
-      await databaseConnection.disconnect();
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(503);
-      expect(response.result.message).to.equal(
-        'Connection to databases failed: Connection to database datamart not available.',
-      );
     });
   });
 });

--- a/api/tests/shared/integration/healthcheck.route.test.js
+++ b/api/tests/shared/integration/healthcheck.route.test.js
@@ -1,0 +1,27 @@
+import { databaseConnections } from '../../../db/database-connections.js';
+import { createServer, expect, sinon } from '../../test-helper.js';
+
+describe('Integration | Shared | Application | Route | healthcheck', function () {
+  let server;
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/healthcheck/db', function () {
+    it('returns an HTTP status code 503 database is not available given database error message', async function () {
+      sinon.stub(databaseConnections, 'checkStatuses').throws({ message: 'database error.' });
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/healthcheck/db',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(503);
+      expect(response.result.message).to.equal('Connection to databases failed: database error.');
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Il est difficile actuellement de savoir le temps qu'un profil cible met à être joué. 

## ⛱️ Proposition

Maintenant que nous avons de la DATA, nous remontons cette informations dans le detail d'un profil cible sur PixAdmin actuellement en mentionnant que c'est une EXPERIMENTATION OK ?

## 🏄 Pour tester

Aller sur PixAdmin, vérifier que sur le ProfilCible `Pix (Niv1 ~ 5) - Badges - Stages` . nous voyons bien le temps estimé. Sur un autre profil cible non renseigné nous souhaitons voir non disponible ( en français dans le texte )