### PR TITLE
[TECH] Migrer les tests e2E de campagnes vers playwright

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+
+import { buildFreshPixOrgaUser } from '../../helpers/db.ts';
+import { expect, test } from '../../helpers/fixtures.ts';
+import { rightWrongAnswerCycle } from '../../helpers/utils.ts';
+import { CampaignResultsPage } from '../../pages/pix-app/CampaignResultsPage.ts';
+import { ChallengePage } from '../../pages/pix-app/ChallengePage.ts';
+import { FinalCheckpointPage } from '../../pages/pix-app/FinalCheckpointPage.ts';
+import { IntermediateCheckpointPage } from '../../pages/pix-app/IntermediateCheckpointPage.ts';
+import { LoginPage } from '../../pages/pix-app/LoginPage.ts';
+import { StartCampaignPage } from '../../pages/pix-app/StartCampaignPage.ts';
+import { PixOrgaPage } from '../../pages/pix-orga/PixOrgaPage.ts';
+
+let uid: string;
+
+test.beforeEach(async () => {
+  uid = randomUUID().slice(-8);
+  await buildFreshPixOrgaUser('Adi', 'Minh', `admin-${uid}@example.net`, 'pix123', 'ADMIN', {
+    type: 'PRO',
+    externalId: `PRO_MANAGING-${uid}`,
+    isManagingStudents: false,
+  });
+});
+
+test('Assessment campaign', async ({ page }) => {
+  let campaignCode: string;
+  let globalMasteryPercentage: string;
+
+  const orgaPage = new PixOrgaPage(page);
+
+  await test.step('Login to pixOrga', async () => {
+    await page.goto(process.env.PIX_ORGA_URL as string);
+    await orgaPage.login(`admin-${uid}@example.net`, 'pix123');
+    await page.getByRole('button').filter({ hasText: 'Je me connecte' }).waitFor({ state: 'detached' });
+    await orgaPage.acceptCGU();
+  });
+
+  await test.step('Create a campaign', async () => {
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'Créer une campagne' }).click();
+    await orgaPage.createEvaluationCampaign({
+      campaignName: 'campagne pro',
+      targetProfileName: 'PC pour Playwright',
+    });
+    campaignCode = (await page.locator('dd.campaign-header-title__campaign-code > span').textContent()) ?? '';
+  });
+
+  await test.step('plays campaign', async function () {
+    await page.goto(process.env.PIX_APP_URL as string);
+    const loginPage = new LoginPage(page);
+    await loginPage.signup('Buffy', 'Summers', `buffy.summers.${uid}@example.net`, 'Coucoulesdevs66');
+    const rightWrongAnswerCycleIter = rightWrongAnswerCycle({ numRight: 1, numWrong: 1 });
+
+    await page.getByRole('link', { name: "J'ai un code" }).click();
+    const startCampaignPage = new StartCampaignPage(page);
+    await startCampaignPage.goToFirstChallenge(campaignCode);
+
+    await test.step(`answering right or wrong according to pattern`, async () => {
+      while (!page.url().endsWith('/checkpoint?finalCheckpoint=true')) {
+        const challengePage = new ChallengePage(page);
+        await challengePage.setRightOrWrongAnswer(rightWrongAnswerCycleIter.next().value as boolean);
+        await challengePage.validateAnswer();
+        if (page.url().includes('/checkpoint') && !page.url().includes('finalCheckpoint=true')) {
+          const checkpointPage = new IntermediateCheckpointPage(page);
+          await checkpointPage.goNext();
+        }
+      }
+    });
+
+    await test.step(`campaign results`, async () => {
+      const finalCheckpointPage = new FinalCheckpointPage(page);
+      await finalCheckpointPage.goToResults();
+
+      const campaignResultsPage = new CampaignResultsPage(page);
+      globalMasteryPercentage = await campaignResultsPage.getGlobalMasteryPercentage();
+      await campaignResultsPage.sendResults();
+      await expect(page.getByRole('paragraph').filter({ hasText: 'Vos résultats ont été envoyés' })).toBeVisible();
+    });
+  });
+
+  await test.step('view campaign results', async function () {
+    await page.goto(process.env.PIX_ORGA_URL as string);
+
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'campagne pro', exact: true }).click();
+    await expect(
+      page.getByRole('region').filter({ hasText: 'Résultats reçus Retrouvez ici' }).getByRole('definition'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('region').filter({ hasText: 'Total de participants' }).getByRole('definition'),
+    ).toBeVisible();
+
+    await page.getByRole('cell', { name: 'Voir les résultats de Buffy' }).click();
+    await expect(page.getByLabel('Résultat', { exact: true }).getByText(`${globalMasteryPercentage} %`)).toBeVisible();
+
+    await page.getByRole('link', { name: 'campagne pro', exact: true }).click();
+    await page.getByRole('link', { name: 'Résultats (1)' }).click();
+    await expect(page.getByRole('definition').filter({ hasText: `${globalMasteryPercentage} %` })).toBeVisible();
+  });
+});

--- a/high-level-tests/e2e-playwright/tests/pix-orga/campaign-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/campaign-management.test.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto';
+
+import { buildFreshPixOrgaUser } from '../../helpers/db.ts';
+import { expect, test } from '../../helpers/fixtures.ts';
+import { PixOrgaPage } from '../../pages/pix-orga/PixOrgaPage.ts';
+
+let uid: string;
+
+test.beforeEach(async () => {
+  uid = randomUUID().slice(-8);
+  await buildFreshPixOrgaUser('Adi', 'Minh', `admin-${uid}@example.net`, 'pix123', 'ADMIN', {
+    type: 'PRO',
+    externalId: `PRO_MANAGING-${uid}`,
+    isManagingStudents: false,
+  });
+});
+
+test('Assessment campaign', async ({ page }) => {
+  const orgaPage = new PixOrgaPage(page);
+
+  await test.step('Login to pixOrga', async () => {
+    await page.goto(process.env.PIX_ORGA_URL as string);
+    await orgaPage.login(`admin-${uid}@example.net`, 'pix123');
+    await page.getByRole('button').filter({ hasText: 'Je me connecte' }).waitFor({ state: 'detached' });
+    await orgaPage.acceptCGU();
+  });
+
+  await test.step('Create a campaign', async () => {
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'Créer une campagne' }).click();
+    await orgaPage.createEvaluationCampaign({
+      campaignName: 'campagne pro',
+      targetProfileName: 'PC pour Playwright',
+    });
+  });
+
+  await test.step('Duplicate campaign details', async () => {
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'campagne pro' }).click();
+    await page.getByRole('link', { name: 'Paramètres' }).click();
+    await page.getByRole('link', { name: 'Dupliquer' }).click();
+    await page.getByRole('button', { name: 'Créer la campagne' }).click();
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await expect(page.getByRole('link', { name: 'Copie de campagne pro' })).toBeVisible();
+  });
+
+  await test.step('Update campaign details', async () => {
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'Copie de campagne pro' }).click();
+    await page.getByRole('link', { name: 'Paramètres' }).click();
+    await page.getByRole('link', { name: 'Modifier' }).click();
+    await page.getByRole('textbox', { name: 'Nom de la campagne *' }).fill('campagne pro 2');
+    await page.getByRole('button', { name: 'Modifier' }).click();
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await expect(page.getByRole('link', { name: 'campagne pro 2' })).toBeVisible();
+  });
+
+  await test.step('Archive/unarchive campaign', async function () {
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await page.getByRole('link', { name: 'campagne pro 2' }).click();
+    await page.getByRole('link', { name: 'Paramètres' }).click();
+    await page.getByRole('button', { name: 'Archiver' }).click();
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await expect(page.getByRole('link', { name: 'campagne pro 2' })).not.toBeVisible();
+    await page.getByRole('button', { name: 'Afficher les campagnes' }).click();
+    await expect(page.getByRole('link', { name: 'campagne pro' })).toBeVisible();
+    await page.getByRole('link', { name: 'campagne pro' }).click();
+    await page.getByRole('button', { name: 'Désarchiver la campagne' }).click();
+    await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
+    await expect(page.getByRole('link', { name: 'campagne pro 2' })).toBeVisible();
+  });
+});

--- a/high-level-tests/e2e-playwright/tests/pix-orga/migration.md
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/migration.md
@@ -5,7 +5,7 @@
 **Homepage**
 
 - [ ] (NEW) Changer d'organisation
-- [ ] Logout
+- [x] Logout
 
 **Onboarding**
 
@@ -24,9 +24,9 @@
 
 **campaign-evaluation**
 
-- [ ] Création d'une campagne d'évaluation
-- [ ] Modification d'une campagne d'évaluation
-- [ ] Je consulte le détail d'une campagne d'évaluation
+- [x] Création d'une campagne d'évaluation
+- [x] Modification d'une campagne d'évaluation
+- [x] Je consulte le détail d'une campagne d'évaluation
 
 **campaign-profile**
 
@@ -36,8 +36,8 @@
 
 **campaign-management**
 
-- [ ] Duplication
-- [ ] Archivage / désarchivage
+- [x] Duplication
+- [x] Archivage / désarchivage
 
 **member-management**
 

--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -5,35 +5,6 @@ Fonctionnalité: Gestion des Campagnes
     Étant donné que je vais sur Pix Orga
     Et que les données de test sont chargées
 
-  Scénario: Je consulte le détail d'une campagne d'évaluation
-    Étant donné que je suis connecté à Pix Orga
-    Alors je vois 3 campagnes
-    Lorsque je recherche une campagne avec le nom "néra"
-    Alors je vois 1 campagne
-    Lorsque je clique sur "Campagne de la Néra"
-    Alors je vois le détail de la campagne "Campagne de la Néra"
-    Lorsque je clique sur "Activité"
-    Alors je vois 4 participants
-    Lorsque je clique sur "Cersei"
-    Alors je vois "50 %" comme "Avancement"
-    Alors je vois 0 résultats par compétence
-    Lorsque je reviens en arrière
-    Et je clique sur "Tyrion"
-    Alors je vois 2 résultats par compétence
-    Lorsque je clique sur "Analyse"
-    Alors je vois 2 sujets
-    Et je vois que le sujet "Capitales" est "Très recommandé"
-    Et je vois que le sujet "Philosophes" est "Assez recommandé"
-    Lorsque je clique sur "Campagne de la Néra"
-    Et je clique sur "Résultats (1)"
-    Alors je vois la moyenne des résultats à 50%
-    Lorsque je clique sur "Analyse"
-    Alors je vois 2 sujets
-    Et je vois que le sujet "Capitales" est "Très recommandé"
-    Et je vois que le sujet "Philosophes" est "Assez recommandé"
-    Lorsque j'ouvre le sujet "Capitales"
-    Alors je vois 1 tutoriel
-
   Scénario: Je consulte le détail d'une campagne de collecte de profils
     Étant donné que je suis connecté à Pix Orga
     Lorsque je clique sur "Envoi profils Lannister"
@@ -42,18 +13,6 @@ Fonctionnalité: Gestion des Campagnes
     Alors je vois 2 participants
     Lorsque je clique sur "Résultats (0)"
     Alors je vois 0 profils
-
-  Scénario: Je créé une campagne d'évaluation
-    Étant donné que je suis connecté à Pix Orga
-    Lorsque je clique sur "Créer une campagne"
-    Alors je suis redirigé vers la page "creation"
-    Lorsque je saisis "Campagne du Nord" dans le champ "Nom de la campagne"
-    Et je clique sur "Évaluer les participants"
-    Et je saisis "Compétences pour un M" dans le champ "Que souhaitez-vous tester ?"
-    Et je clique sur "Compétences pour un Mestre"
-    Et je clique sur "Non"
-    Et je clique sur "Créer la campagne"
-    Alors je vois le détail de la campagne "Campagne du Nord"
 
   Scénario: Je créé une campagne de collecte de profils
     Étant donné que je suis connecté à Pix Orga
@@ -64,39 +23,3 @@ Fonctionnalité: Gestion des Campagnes
     Et je clique sur "Non"
     Et je clique sur "Créer la campagne"
     Alors je vois le détail de la campagne "Campagne de l'Ouest"
-
-  Scénario: Je duplique une campagne d'évaluation
-    Étant donné que je suis connecté à Pix Orga
-    Et je clique sur "Campagne de la Néra"
-    Et je clique sur "Paramètres"
-    Lorsque je clique sur "Dupliquer"
-    Alors je suis redirigé vers la page "creation"
-    Et je clique sur "Créer la campagne"
-    Alors je vois le détail de la campagne "Copie de Campagne de la Néra"
-
-  Scénario: J'archive et je désarchive une campagne
-    Étant donné que je suis connecté à Pix Orga
-    Et je clique sur "Campagne du Mur"
-    Et je clique sur "Paramètres"
-    Lorsque je clique sur "Archiver"
-    Et que je clique sur "Campagnes"
-    Et que je clique sur "Archivées"
-    Alors je vois 1 campagne
-    Lorsque je clique sur "Campagne du Mur"
-    Et je clique sur "Paramètres"
-    Et que je clique sur "Désarchiver la campagne"
-    Et que je clique sur "Campagnes"
-    Et que je clique sur "Archivées"
-    Alors je vois 0 campagne
-
-  Scénario: Je modifie une campagne
-    Étant donné que je suis connecté à Pix Orga
-    Et je clique sur "Campagne du Mur"
-    Et je clique sur "Paramètres"
-    Lorsque je clique sur "Modifier"
-    Alors je suis redirigé vers la page "modification"
-    Lorsque je saisis "Parcours pour les marcheurs blancs" dans le champ "Titre du parcours"
-    Et que je clique sur "Modifier"
-    Et que je clique sur "Paramètres"
-    Alors je vois le détail de la campagne "Campagne du Mur"
-    Et je vois "Parcours pour les marcheurs blancs" comme "Titre du parcours"


### PR DESCRIPTION
## :christmas_tree: Problème
On veut plus de cypress pour les tests e2e
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## :gift: Proposition
on migre les tests d'orga pour les campagne d'évaluation et les tests de gestion des campagnes vers playwright
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :socks: Remarques
On a pas testé la partie analyse qui av changer très prochainement
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester
RAS
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
