### PR TITLE
[BUGFIX] Rediriger vers la campagne autonome apres login (PIX-18614)

### DIFF
--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
@@ -7,6 +7,19 @@ import t from 'ember-intl/helpers/t';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 
 export default class LandingPageStartBlock extends Component {
+  @service session;
+  @service router;
+
+  get isUserConnected() {
+    return this.session.isAuthenticated;
+  }
+
+  @action
+  async redirectToSignin() {
+    const transition = this.args.startCampaignParticipation();
+    this.session.requireAuthenticationAndApprovedTermsOfService(transition);
+  }
+
   <template>
     <section class="autonomous-course-landing-page-start-block rounded-panel">
       <div class="autonomous-course-landing-page-start-block__logos">
@@ -16,9 +29,11 @@ export default class LandingPageStartBlock extends Component {
         {{t "pages.autonomous-course.landing-page.texts.title"}}<br />
         {{@campaign.title}}
       </h1>
+
       <div class="autonomous-course-landing-page-start-block__description">
         <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} @isInline={{true}} />
       </div>
+
       {{#if this.isUserConnected}}
         <PixButton
           id="autonomous-course-connected-start-button"
@@ -42,33 +57,16 @@ export default class LandingPageStartBlock extends Component {
             id="autonomous-course-sign-in-button"
             class="sign-in-button"
             type="button"
-            {{on "click" this.redirectToSigninIfUserIsAnonymous}}
+            {{on "click" this.redirectToSignin}}
           >
             {{t "pages.autonomous-course.landing-page.actions.sign-in"}}
           </button>
         </div>
       {{/if}}
+
       <p class="autonomous-course-landing-page-start-block__informations">
         {{t "pages.autonomous-course.landing-page.texts.legal-informations" htmlSafe=true}}
       </p>
     </section>
   </template>
-  @service session;
-  @service router;
-
-  get isUserConnected() {
-    return this.session.isAuthenticated;
-  }
-
-  @action
-  async redirectToSigninIfUserIsAnonymous(event) {
-    event.preventDefault();
-
-    if (this.isUserConnected) {
-      this.router.transitionTo('authenticated');
-    } else {
-      const transition = this.args.startCampaignParticipation();
-      this.session.requireAuthenticationAndApprovedTermsOfService(transition);
-    }
-  }
 }

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -46,6 +46,6 @@ export default class CampaignLandingPageController extends Controller {
 
   @action
   startCampaignParticipation() {
-    this.router.transitionTo('organizations.access', this.model.code);
+    return this.router.transitionTo('organizations.access', this.model.code);
   }
 }

--- a/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block-test.js
+++ b/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block-test.js
@@ -17,35 +17,18 @@ module('Unit | Component | Autonomous Course | Landing page start block', functi
     component.router.transitionTo = sinon.stub();
   });
 
-  module('#redirectToSigninIfUserIsAnonymous', function () {
-    module('when user is anonymous', function () {
-      test('should redirect to sign-in page on click', async function (assert) {
-        // given
-        const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
-        const event = { preventDefault: () => {} };
+  module('#redirectToSignin', function () {
+    test('should redirect to sign-in page on click', async function (assert) {
+      // given
+      const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
+      const event = { preventDefault: () => {} };
 
-        // when
-        await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);
+      // when
+      await component.actions.redirectToSignin.call(component, event);
 
-        // then
-        sinon.assert.calledWith(sessionService.requireAuthenticationAndApprovedTermsOfService, 'stubbed-transition');
-        assert.ok(true);
-      });
-    });
-
-    module('when user is authenticated', function () {
-      test('should redirect to next page', async function (assert) {
-        // given
-        stubSessionService(this.owner, { isAuthenticated: true });
-        const event = { preventDefault: () => {} };
-
-        // when
-        await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);
-
-        // then
-        sinon.assert.calledWith(component.router.transitionTo, 'authenticated');
-        assert.ok(true);
-      });
+      // then
+      sinon.assert.calledWith(sessionService.requireAuthenticationAndApprovedTermsOfService, 'stubbed-transition');
+      assert.ok(true);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Lors d'un parcours autonome, quand l'utilisateur clique sur "J'ai déjà un compte, je me connecte", il arrive sur la page de login. Mais suite à sa connexion, il n'est pas redirigé vers la campagne.

Comportement attendu: suite à sa connexion, il est redirigé vers la campagne autonome.

## ⛱️ Proposition

Ce petit bug semble être apparu suite à l'ajout de la gestion des parcours "combinix". **La transition (`attempted transition`) n'était plus retournée** par la fonction `startCampaignParticipation` dans le fichier `mon-pix/app/controllers/campaigns/campaign-landing-page.js`

`+` **Ajout d'un test d'acceptance** ajoutant le scénario concerné par le bug.

## 🌊 Remarques

Petit nettoyage et refactoring du composant `mon-pix/app/components/autonomous-course/landing-page-start-block.gjs` et son test unitaire.

## 🏄 Pour tester

1. Aller sur un parcours autonome : https://app-pr12834.review.pix.fr/campagnes/AUTOCOUR1
2. Cliquer sur _J'ai déjà un compte, je me connecte_
3. Se connecter avec un utilisateur existant
> L'utilisateur est redirigé sur le début de la campagne (dictaticiel)
