### PR TITLE
[TECH] Corriger le test e2e flaky sur les résultats de campagne

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-orga/PixOrgaPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-orga/PixOrgaPage.ts
@@ -29,6 +29,21 @@ export class PixOrgaPage {
     } while (inProgress);
   }
 
+  async waitForParticipationScoreComputed(score: string, page: Page) {
+    let masteryPercentageVisible = await page
+      .getByRole('definition')
+      .filter({ hasText: `${score} %` })
+      .isVisible();
+    while (!masteryPercentageVisible) {
+      await page.reload({ waitUntil: 'load' });
+      await page.getByRole('definition').filter({ hasText: `%` }).waitFor();
+      masteryPercentageVisible = await page
+        .getByRole('definition')
+        .filter({ hasText: `${score} %` })
+        .isVisible();
+    }
+  }
+
   async createEvaluationCampaign({
     campaignName,
     targetProfileName,

--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -90,11 +90,14 @@ test('Assessment campaign', async ({ page }) => {
       page.getByRole('region').filter({ hasText: 'Total de participants' }).getByRole('definition'),
     ).toBeVisible();
 
-    await page.getByRole('cell', { name: 'Voir les résultats de Buffy' }).click();
-    await expect(page.getByLabel('Résultat', { exact: true }).getByText(`${globalMasteryPercentage} %`)).toBeVisible();
-
-    await page.getByRole('link', { name: 'campagne pro', exact: true }).click();
     await page.getByRole('link', { name: 'Résultats (1)' }).click();
+    await expect(page.getByRole('definition').filter({ hasText: `%` })).toBeVisible();
+
+    await orgaPage.waitForParticipationScoreComputed(globalMasteryPercentage, page);
+
     await expect(page.getByRole('definition').filter({ hasText: `${globalMasteryPercentage} %` })).toBeVisible();
+
+    await page.getByRole('cell', { name: 'Buffy' }).click();
+    await expect(page.getByLabel('Résultat', { exact: true }).getByText(`${globalMasteryPercentage} %`)).toBeVisible();
   });
 });


### PR DESCRIPTION
## 🔆 Problème

On a flaky sur la récupération du score dans pixOrga qui est calculé dans un job asynchrone.
Il arrive qu'on affiche alors un score de `0%` alors qu'on a un score supérieur (car on utilise un stratégie de réponse un coup juste, un coup faux ce qui donne un score autour de 50%.

## ⛱️ Proposition

On ajoute un rechargement de page dans le test tant qu'on a pas un score supérieur à `0` qui s'affiche.

## 🌊 Remarques
RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
RAS
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
