### PR TITLE
[BUGFIX] Correction de l'affichage des badges d'orga "parent" /"enfant" (PIX-17879)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -60,10 +60,6 @@ export default class OrganizationInformationSection extends Component {
             </li>
           {{/each}}
         </ul>
-      {{else}}
-        <PixNotificationAlert class="organization-information-section__missing-tags-message" @type="information">Cette
-          organisation n'a pas de tags.
-        </PixNotificationAlert>
       {{/if}}
 
       {{#if this.hasChildren}}

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -6,7 +6,6 @@ import { concat, get } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import ENV from 'pix-admin/config/environment';
@@ -16,22 +15,6 @@ export default class OrganizationInformationSection extends Component {
   @service oidcIdentityProviders;
   @service accessControl;
   @service intl;
-  @tracked tags;
-  @tracked hasOrganizationChildren;
-
-  constructor() {
-    super(...arguments);
-    if (this.args.organization.tags) {
-      Promise.resolve(this.args.organization.tags).then((tags) => {
-        this.tags = tags;
-      });
-    }
-    if (this.args.organization.children) {
-      Promise.resolve(this.args.organization.children).then((children) => {
-        this.hasOrganizationChildren = children.length > 0;
-      });
-    }
-  }
 
   get isManagingStudentAvailable() {
     return (
@@ -55,11 +38,21 @@ export default class OrganizationInformationSection extends Component {
     return urlDashboardPrefix && urlDashboardPrefix + this.args.organization.id;
   }
 
+  get hasTags() {
+    const tags = this.args.organization.tags;
+    return tags?.length > 0;
+  }
+
+  get hasChildren() {
+    const children = this.args.organization.children;
+    return children?.length > 0;
+  }
+
   <template>
     <div class="organization__data">
       <h2 class="organization__name">{{@organization.name}}</h2>
 
-      {{#if this.tags}}
+      {{#if this.hasTags}}
         <ul class="organization-tags-list">
           {{#each @organization.tags as |tag|}}
             <li class="organization-tags-list__tag">
@@ -72,29 +65,26 @@ export default class OrganizationInformationSection extends Component {
           organisation n'a pas de tags.
         </PixNotificationAlert>
       {{/if}}
-      <div class="organization__network-label">
-        {{#if this.hasOrganizationChildren}}
-          <PixTag @color="success">{{t
-              "components.organizations.information-section-view.parent-organization"
-            }}</PixTag>
-        {{/if}}
-        {{#if @organization.parentOrganizationId}}
-          <ul>
-            <li>
-              <PixTag class="organization__child-tag" @color="success">{{t
-                  "components.organizations.information-section-view.child-organization"
-                }}</PixTag>
-            </li>
-            <li>
-              {{t "components.organizations.information-section-view.parent-organization"}}
-              :
-              <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
-                {{@organization.parentOrganizationName}}
-              </LinkTo>
-            </li>
-          </ul>
-        {{/if}}
-      </div>
+
+      {{#if this.hasChildren}}
+        <div class="organization__network-label">
+          <PixTag @color="success">
+            {{t "components.organizations.information-section-view.parent-organization"}}
+          </PixTag>
+        </div>
+      {{/if}}
+
+      {{#if @organization.parentOrganizationId}}
+        <div class="organization__network-label">
+          <PixTag class="organization__child-tag" @color="success">
+            {{t "components.organizations.information-section-view.child-organization"}}
+            <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+              {{@organization.parentOrganizationName}}
+            </LinkTo>
+          </PixTag>
+        </div>
+      {{/if}}
+
       {{#if @organization.isArchived}}
         <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
           Archivée le

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -42,7 +42,10 @@
     }
 
     .organization__child-tag{
-      margin-bottom: var(--pix-spacing-2x);
+      a {
+        color: var(--pix-success-700);
+        text-decoration: underline;
+      }
     }
 
     .organization__data {

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -9,10 +9,6 @@
     margin-bottom: 16px;
   }
 
-  &__missing-tags-message {
-    margin-bottom: 16px;
-  }
-
   &__details {
     &__list {
       margin-bottom: var(--pix-spacing-6x);

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -335,8 +335,8 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Organisation fille')).exists();
-        assert.dom(screen.getByText('Shibusen')).exists();
+        assert.dom(screen.getByText('Organisation fille de')).exists();
+        assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
       });
     });
 

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -261,23 +261,6 @@ module('Integration | Component | organizations/information-section-view', funct
       assert.dom(screen.getByText('AGRICULTURE')).exists();
     });
 
-    module('when organization has no tags', function () {
-      test('it should display an informative message', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const organization = store.createRecord('organization', {
-          archivedAt: null,
-          tags: [],
-        });
-
-        // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.getByText("Cette organisation n'a pas de tags.")).exists();
-      });
-    });
-
     module('when organization is archived', function () {
       test('it should display who archived it', async function (assert) {
         // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -502,7 +502,7 @@
         "table-name": "List of children organisations"
       },
       "information-section-view": {
-        "child-organization": "Child organization",
+        "child-organization": "Child organization of",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Automatic certificability",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -502,7 +502,7 @@
         "table-name": "Liste des organisations filles"
       },
       "information-section-view": {
-        "child-organization": "Organisation fille",
+        "child-organization": "Organisation fille de",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Certificabilité automatique",


### PR DESCRIPTION
## 🔆 Problème

Quand on navigue entre les organisations filles et parentes, les badges ne sont pas correctement rafraichis, on les voit en double.

**Scénario 1:** 
1. aller sur la fille
2. cliquer sur le nom de la mère (situé en haut de page, à coté du tag “orga fille”)
3. c’est là qu’on ne voit pas le tag “orga mère”
  a. NB: si on rafraichit la page, c’est OK ça revient.

**Scénario 2:** 
1. aller sur la mère
2. cliquer sur l’onglet “orgas filles”
3. cliquer sur une fille
4. c’est là qu’on voit les 2 tags 'orga mère” et “orga fille”, en haut de la page
  a. NB: si on rafraichit la page, on ne voit qu’un seul tag.

## ⛱️ Proposition

**Attendu :**
- Scénario 1: Quand je visualise une “orga mère”, je dois voir uniquement le tag “Organisation parente”
- Scénario 2: Quand je visualise une “orga fille”, je ne dois pas voir le tag “Organisation parente”.

**Bonus** - Amélioration de l'affichage du lien de l'organisation parent pour une organisation fille :
<img width="369" height="47" alt="image" src="https://github.com/user-attachments/assets/ae8c95c0-8b5a-4eb3-a8d8-2ece0258cbd8" />

## 🌊 Remarques

- **Un bug similaire présent sur l'affichage des tags** a également été corrigé.
- Suppression de la boîte d'information "Pas de tags sur l'orga" car non utile. 

## 🏄 Pour tester

**Quand je visualise une “orga mère”, je dois voir uniquement le tag “Organisation parente”**
1. Aller sur https://admin-pr12836.review.pix.fr/
2. Aller sur l'organisation : _Child of "Collège House of The Dragon"_ (fille)
3. Cliquer sur le nom de la mère situé dans le badge "Organisation fille de Collège House of The Dragon"
> Voir uniquement le badge "Organisation parente"
> NB: si on rafraichit la page, on voit également uniquement ce badge.

**Quand je visualise une “orga fille”, je ne dois pas voir le tag “Organisation parente”.**
1. Aller sur https://admin-pr12836.review.pix.fr/
2. Aller sur l'organisation : _Collège House of The Dragon_ (parente)
5. Cliquer sur l’onglet “Organisations filles”
6. Cliquer sur la l'organisation fille
> Voir uniquement le badge "Organisation fille de Collège House of The Dragon"
> NB: si on rafraichit la page, on voit également uniquement ce badge.