### PR TITLE
[TECH] Un peu de style dans la page organization de PixAdmin

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -123,44 +123,76 @@ export default class OrganizationInformationSection extends Component {
 }
 
 const OrganizationDescription = <template>
-  <ul class="organization-information-section__details__list">
-    <li>Type : {{@organization.type}}</li>
-    <li>Créée par : {{@organization.creatorFullName}} ({{@organization.createdBy}})</li>
-    <li>Créée le : {{@organization.createdAtFormattedDate}}</li>
+  <dl>
+    <div>
+      <dt>Type</dt>
+      <dd>{{@organization.type}}</dd>
+    </div>
+    <div>
+      <dt>Créée par</dt>
+      <dd>{{@organization.creatorFullName}} ({{@organization.createdBy}})</dd>
+    </div>
+    <div>
+      <dt>Créée le</dt>
+      <dd>{{@organization.createdAtFormattedDate}}</dd>
+    </div>
     {{#if @organization.externalId}}
-      <li>Identifiant externe : {{@organization.externalId}}</li>
+      <div>
+        <dt>Identifiant externe</dt>
+        <dd>{{@organization.externalId}}</dd>
+      </div>
     {{/if}}
     {{#if @organization.provinceCode}}
-      <li>Département : {{@organization.provinceCode}}</li>
+      <div>
+        <dt>Département</dt>
+        <dd>{{@organization.provinceCode}}</dd>
+      </div>
     {{/if}}
 
-    <br />
+    <div>
+      <dt>Nom du DPO</dt>
+      <dd>{{@organization.dataProtectionOfficerFullName}}</dd>
+    </div>
+    <div>
+      <dt>Adresse e-mail du DPO</dt>
+      <dd>{{@organization.dataProtectionOfficerEmail}}</dd>
+    </div>
 
-    <li>Nom du DPO : {{@organization.dataProtectionOfficerFullName}}</li>
-    <li>Adresse e-mail du DPO : {{@organization.dataProtectionOfficerEmail}}</li>
-    <br />
-    <li>Crédits : {{@organization.credit}}</li>
-    <li>Lien vers la documentation :
-      {{#if @organization.documentationUrl}}
-        <a
-          href="{{@organization.documentationUrl}}"
-          target="_blank"
-          rel="noopener noreferrer"
-        >{{@organization.documentationUrl}}</a>
-      {{else}}
-        Non spécifié
-      {{/if}}
-    </li>
-    <li>SSO : {{this.identityProviderName}}</li>
+    <div>
+      <dt>Crédits</dt>
+      <dd>{{@organization.credit}}</dd>
+    </div>
+    <div>
+      <dt>Lien vers la documentation</dt>
+      <dd>
+        {{#if @organization.documentationUrl}}
+          <a
+            href="{{@organization.documentationUrl}}"
+            target="_blank"
+            rel="noopener noreferrer"
+          >{{@organization.documentationUrl}}</a>
+        {{else}}
+          Non spécifié
+        {{/if}}
+      </dd>
+    </div>
+    <div>
+      <dt>SSO</dt>
+      <dd>{{this.identityProviderName}}</dd>
+    </div>
 
-    <br />
+    <div>
+      <dt>Adresse e-mail d'activation SCO</dt>
+      <dd>{{@organization.email}}</dd>
+    </div>
 
-    <li>Adresse e-mail d'activation SCO : {{@organization.email}}</li>
     {{#if @organization.code}}
-      <br />
-      <li>Code : {{@organization.code}}</li>
+      <div>
+        <dt>Code</dt>
+        <dd>{{@organization.code}}</dd>
+      </div>
     {{/if}}
-  </ul>
+  </dl>
 </template>;
 
 function keys(obj) {

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -92,44 +92,7 @@ export default class OrganizationInformationSection extends Component {
 
       <div class="organization-information-section__content">
         <div class="organization-information-section__details">
-          <ul class="organization-information-section__details__list">
-            <li>Type : {{@organization.type}}</li>
-            <li>Créée par : {{@organization.creatorFullName}} ({{@organization.createdBy}})</li>
-            <li>Créée le : {{@organization.createdAtFormattedDate}}</li>
-            {{#if @organization.externalId}}
-              <li>Identifiant externe : {{@organization.externalId}}</li>
-            {{/if}}
-            {{#if @organization.provinceCode}}
-              <li>Département : {{@organization.provinceCode}}</li>
-            {{/if}}
-
-            <br />
-
-            <li>Nom du DPO : {{@organization.dataProtectionOfficerFullName}}</li>
-            <li>Adresse e-mail du DPO : {{@organization.dataProtectionOfficerEmail}}</li>
-            <br />
-            <li>Crédits : {{@organization.credit}}</li>
-            <li>Lien vers la documentation :
-              {{#if @organization.documentationUrl}}
-                <a
-                  href="{{@organization.documentationUrl}}"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >{{@organization.documentationUrl}}</a>
-              {{else}}
-                Non spécifié
-              {{/if}}
-            </li>
-            <li>SSO : {{this.identityProviderName}}</li>
-
-            <br />
-
-            <li>Adresse e-mail d'activation SCO : {{@organization.email}}</li>
-            {{#if @organization.code}}
-              <br />
-              <li>Code : {{@organization.code}}</li>
-            {{/if}}
-          </ul>
+          <OrganizationDescription @organization={{@organization}} />
           <FeaturesSection @features={{@organization.features}} />
           {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
             <div class="form-actions">
@@ -158,6 +121,47 @@ export default class OrganizationInformationSection extends Component {
     </div>
   </template>
 }
+
+const OrganizationDescription = <template>
+  <ul class="organization-information-section__details__list">
+    <li>Type : {{@organization.type}}</li>
+    <li>Créée par : {{@organization.creatorFullName}} ({{@organization.createdBy}})</li>
+    <li>Créée le : {{@organization.createdAtFormattedDate}}</li>
+    {{#if @organization.externalId}}
+      <li>Identifiant externe : {{@organization.externalId}}</li>
+    {{/if}}
+    {{#if @organization.provinceCode}}
+      <li>Département : {{@organization.provinceCode}}</li>
+    {{/if}}
+
+    <br />
+
+    <li>Nom du DPO : {{@organization.dataProtectionOfficerFullName}}</li>
+    <li>Adresse e-mail du DPO : {{@organization.dataProtectionOfficerEmail}}</li>
+    <br />
+    <li>Crédits : {{@organization.credit}}</li>
+    <li>Lien vers la documentation :
+      {{#if @organization.documentationUrl}}
+        <a
+          href="{{@organization.documentationUrl}}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{{@organization.documentationUrl}}</a>
+      {{else}}
+        Non spécifié
+      {{/if}}
+    </li>
+    <li>SSO : {{this.identityProviderName}}</li>
+
+    <br />
+
+    <li>Adresse e-mail d'activation SCO : {{@organization.email}}</li>
+    {{#if @organization.code}}
+      <br />
+      <li>Code : {{@organization.code}}</li>
+    {{/if}}
+  </ul>
+</template>;
 
 function keys(obj) {
   return Object.keys(obj);

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { concat, get } from '@ember/helper';
@@ -218,7 +219,7 @@ function keys(obj) {
 }
 
 const FeaturesSection = <template>
-  <ul class="organization-information-section__details__list">
+  <ul class="organization-information-section__details__features">
     {{#each (keys Organization.featureList) as |feature|}}
       {{#let
         (get @features feature) (concat "components.organizations.information-section-view.features." feature)
@@ -250,20 +251,26 @@ const FeaturesSection = <template>
   </ul>
 </template>;
 
-function displayBooleanState(bool) {
-  return bool ? 'common.words.yes' : 'common.words.no';
-}
-
 const Feature = <template>
-  {{@label}}
-  :
-  {{#if (has-block)}}
-    {{#if @value}}
+  {{#if @value}}
+    <PixIcon
+      @name="checkCircle"
+      aria-label={{t "common.words.yes"}}
+      class="organization-information-section__details__features--enabled"
+    />
+    {{@label}}
+    {{#if (has-block)}}
+      :
       {{yield}}
-    {{else}}
-      {{t "common.words.no"}}
     {{/if}}
   {{else}}
-    {{t (displayBooleanState @value)}}
+    <PixIcon
+      @name="cancel"
+      aria-label={{t "common.words.no"}}
+      class="organization-information-section__details__features--disabled"
+    />
+    <span class="organization-information-section__details__features--disabled">
+      {{@label}}
+    </span>
   {{/if}}
 </template>;

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -12,7 +12,6 @@ import ENV from 'pix-admin/config/environment';
 import Organization from 'pix-admin/models/organization';
 
 export default class OrganizationInformationSection extends Component {
-  @service oidcIdentityProviders;
   @service accessControl;
   @service intl;
 
@@ -21,16 +20,6 @@ export default class OrganizationInformationSection extends Component {
       !this.args.organization.isLearnerImportEnabled &&
       (this.args.organization.isOrganizationSCO || this.args.organization.isOrganizationSUP)
     );
-  }
-
-  get identityProviderName() {
-    const GARIdentityProvider = { code: 'GAR', organizationName: 'GAR' };
-    const allIdentityProviderList = [...this.oidcIdentityProviders.list, GARIdentityProvider];
-    const identityProvider = allIdentityProviderList.find(
-      (identityProvider) => identityProvider.code === this.args.organization.identityProviderForCampaigns,
-    );
-    const identityProviderName = identityProvider?.organizationName;
-    return identityProviderName ?? 'Aucun';
   }
 
   get externalURL() {
@@ -122,78 +111,96 @@ export default class OrganizationInformationSection extends Component {
   </template>
 }
 
-const OrganizationDescription = <template>
-  <dl>
-    <div>
-      <dt>Type</dt>
-      <dd>{{@organization.type}}</dd>
-    </div>
-    <div>
-      <dt>Créée par</dt>
-      <dd>{{@organization.creatorFullName}} ({{@organization.createdBy}})</dd>
-    </div>
-    <div>
-      <dt>Créée le</dt>
-      <dd>{{@organization.createdAtFormattedDate}}</dd>
-    </div>
-    {{#if @organization.externalId}}
+class OrganizationDescription extends Component {
+  @service oidcIdentityProviders;
+
+  get identityProviderName() {
+    const GARIdentityProvider = { code: 'GAR', organizationName: 'GAR' };
+    const allIdentityProviderList = [...this.oidcIdentityProviders.list, GARIdentityProvider];
+    const identityProvider = allIdentityProviderList.find(
+      (identityProvider) => identityProvider.code === this.args.organization.identityProviderForCampaigns,
+    );
+    const identityProviderName = identityProvider?.organizationName;
+    return identityProviderName || 'Aucun';
+  }
+
+  <template>
+    <dl>
       <div>
-        <dt>Identifiant externe</dt>
-        <dd>{{@organization.externalId}}</dd>
+        <dt>Type</dt>
+        <dd>{{@organization.type}}</dd>
       </div>
-    {{/if}}
-    {{#if @organization.provinceCode}}
       <div>
-        <dt>Département</dt>
-        <dd>{{@organization.provinceCode}}</dd>
+        <dt>Créée par</dt>
+        <dd>{{@organization.creatorFullName}} ({{@organization.createdBy}})</dd>
       </div>
-    {{/if}}
-
-    <div>
-      <dt>Nom du DPO</dt>
-      <dd>{{@organization.dataProtectionOfficerFullName}}</dd>
-    </div>
-    <div>
-      <dt>Adresse e-mail du DPO</dt>
-      <dd>{{@organization.dataProtectionOfficerEmail}}</dd>
-    </div>
-
-    <div>
-      <dt>Crédits</dt>
-      <dd>{{@organization.credit}}</dd>
-    </div>
-    <div>
-      <dt>Lien vers la documentation</dt>
-      <dd>
-        {{#if @organization.documentationUrl}}
-          <a
-            href="{{@organization.documentationUrl}}"
-            target="_blank"
-            rel="noopener noreferrer"
-          >{{@organization.documentationUrl}}</a>
-        {{else}}
-          Non spécifié
-        {{/if}}
-      </dd>
-    </div>
-    <div>
-      <dt>SSO</dt>
-      <dd>{{this.identityProviderName}}</dd>
-    </div>
-
-    <div>
-      <dt>Adresse e-mail d'activation SCO</dt>
-      <dd>{{@organization.email}}</dd>
-    </div>
-
-    {{#if @organization.code}}
       <div>
-        <dt>Code</dt>
-        <dd>{{@organization.code}}</dd>
+        <dt>Créée le</dt>
+        <dd>{{@organization.createdAtFormattedDate}}</dd>
       </div>
-    {{/if}}
-  </dl>
-</template>;
+      {{#if @organization.externalId}}
+        <div>
+          <dt>Identifiant externe</dt>
+          <dd>{{@organization.externalId}}</dd>
+        </div>
+      {{/if}}
+      {{#if @organization.provinceCode}}
+        <div>
+          <dt>Département</dt>
+          <dd>{{@organization.provinceCode}}</dd>
+        </div>
+      {{/if}}
+
+      <div class="divider" />
+      <div>
+        <dt>Nom du DPO</dt>
+        <dd>{{@organization.dataProtectionOfficerFullName}}</dd>
+      </div>
+      <div>
+        <dt>Adresse e-mail du DPO</dt>
+        <dd>{{@organization.dataProtectionOfficerEmail}}</dd>
+      </div>
+      <div class="divider" />
+
+      <div>
+        <dt>Crédits</dt>
+        <dd>{{@organization.credit}}</dd>
+      </div>
+      <div>
+        <dt>Lien vers la documentation</dt>
+        <dd>
+          {{#if @organization.documentationUrl}}
+            <a
+              href="{{@organization.documentationUrl}}"
+              target="_blank"
+              rel="noopener noreferrer"
+            >{{@organization.documentationUrl}}</a>
+          {{else}}
+            Non spécifié
+          {{/if}}
+        </dd>
+      </div>
+      <div>
+        <dt>SSO</dt>
+        <dd>{{this.identityProviderName}}</dd>
+      </div>
+      <div class="divider" />
+
+      <div>
+        <dt>Adresse e-mail d'activation SCO</dt>
+        <dd>{{@organization.email}}</dd>
+      </div>
+
+      {{#if @organization.code}}
+        <div class="divider" />
+        <div>
+          <dt>Code</dt>
+          <dd>{{@organization.code}}</dd>
+        </div>
+      {{/if}}
+    </dl>
+  </template>
+}
 
 function keys(obj) {
   return Object.keys(obj);

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -39,36 +39,50 @@ export default class OrganizationInformationSection extends Component {
 
   <template>
     <div class="organization__data">
-      <h2 class="organization__name">{{@organization.name}}</h2>
+      <div class="organization__header">
+        <div class="organization__title">
+          <h2 class="organization__name">{{@organization.name}}</h2>
 
-      {{#if this.hasTags}}
-        <ul class="organization-tags-list">
-          {{#each @organization.tags as |tag|}}
-            <li class="organization-tags-list__tag">
-              <PixTag @color="purple-light">{{tag.name}}</PixTag>
-            </li>
-          {{/each}}
-        </ul>
-      {{/if}}
+          {{#if this.hasTags}}
+            <ul class="organization-tags-list">
+              {{#each @organization.tags as |tag|}}
+                <li class="organization-tags-list__tag">
+                  <PixTag @color="purple-light">{{tag.name}}</PixTag>
+                </li>
+              {{/each}}
+            </ul>
+          {{/if}}
 
-      {{#if this.hasChildren}}
-        <div class="organization__network-label">
-          <PixTag @color="success">
-            {{t "components.organizations.information-section-view.parent-organization"}}
-          </PixTag>
+          {{#if this.hasChildren}}
+            <div>
+              <PixTag @color="success">
+                {{t "components.organizations.information-section-view.parent-organization"}}
+              </PixTag>
+            </div>
+          {{/if}}
+
+          {{#if @organization.parentOrganizationId}}
+            <div>
+              <PixTag class="organization__child-tag" @color="success">
+                {{t "components.organizations.information-section-view.child-organization"}}
+                <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+                  {{@organization.parentOrganizationName}}
+                </LinkTo>
+              </PixTag>
+            </div>
+          {{/if}}
         </div>
-      {{/if}}
 
-      {{#if @organization.parentOrganizationId}}
-        <div class="organization__network-label">
-          <PixTag class="organization__child-tag" @color="success">
-            {{t "components.organizations.information-section-view.child-organization"}}
-            <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
-              {{@organization.parentOrganizationName}}
-            </LinkTo>
-          </PixTag>
-        </div>
-      {{/if}}
+        <PixButtonLink
+          @variant="secondary"
+          @href={{this.externalURL}}
+          @size="small"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Tableau de bord
+        </PixButtonLink>
+      </div>
 
       {{#if @organization.isArchived}}
         <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
@@ -79,33 +93,21 @@ export default class OrganizationInformationSection extends Component {
         </PixNotificationAlert>
       {{/if}}
 
-      <div class="organization-information-section__content">
-        <div class="organization-information-section__details">
-          <OrganizationDescription @organization={{@organization}} />
-          <FeaturesSection @features={{@organization.features}} />
-          {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
-            <div class="form-actions">
-              <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
-                {{t "common.actions.edit"}}
+      <div class="organization-information-section__details">
+        <OrganizationDescription @organization={{@organization}} />
+
+        {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+          <div class="form-actions">
+            <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>
+              {{t "common.actions.edit"}}
+            </PixButton>
+            {{#unless @organization.isArchived}}
+              <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
+                Archiver l'organisation
               </PixButton>
-              {{#unless @organization.isArchived}}
-                <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
-                  Archiver l'organisation
-                </PixButton>
-              {{/unless}}
-            </div>
-          {{/if}}
-        </div>
-        <div>
-          <PixButtonLink
-            @variant="secondary"
-            @href={{this.externalURL}}
-            @size="small"
-            target="_blank"
-            rel="noopener noreferrer"
-          >Tableau de bord
-          </PixButtonLink>
-        </div>
+            {{/unless}}
+          </div>
+        {{/if}}
       </div>
     </div>
   </template>
@@ -126,6 +128,7 @@ class OrganizationDescription extends Component {
 
   <template>
     <dl>
+      <div class="divider" />
       <div>
         <dt>Type</dt>
         <dd>{{@organization.type}}</dd>
@@ -160,8 +163,8 @@ class OrganizationDescription extends Component {
         <dt>Adresse e-mail du DPO</dt>
         <dd>{{@organization.dataProtectionOfficerEmail}}</dd>
       </div>
-      <div class="divider" />
 
+      <div class="divider" />
       <div>
         <dt>Crédits</dt>
         <dd>{{@organization.credit}}</dd>
@@ -184,8 +187,8 @@ class OrganizationDescription extends Component {
         <dt>SSO</dt>
         <dd>{{this.identityProviderName}}</dd>
       </div>
-      <div class="divider" />
 
+      <div class="divider" />
       <div>
         <dt>Adresse e-mail d'activation SCO</dt>
         <dd>{{@organization.email}}</dd>
@@ -198,6 +201,14 @@ class OrganizationDescription extends Component {
           <dd>{{@organization.code}}</dd>
         </div>
       {{/if}}
+
+      <div class="divider" />
+      <div>
+        <dt>{{t "components.organizations.information-section-view.features.title"}}</dt>
+        <dd><FeaturesSection @features={{@organization.features}} /></dd>
+      </div>
+
+      <div class="divider" />
     </dl>
   </template>
 }
@@ -207,11 +218,6 @@ function keys(obj) {
 }
 
 const FeaturesSection = <template>
-  <h3 class="page-section__title page-section__title--sub">{{t
-      "components.organizations.information-section-view.features.title"
-    }}
-    :
-  </h3>
   <ul class="organization-information-section__details__list">
     {{#each (keys Organization.featureList) as |feature|}}
       {{#let

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -255,7 +255,7 @@ const Feature = <template>
   {{#if @value}}
     <PixIcon
       @name="checkCircle"
-      aria-label={{t "common.words.yes"}}
+      aria-label={{concat @label " : " (t "common.words.yes")}}
       class="organization-information-section__details__features--enabled"
     />
     {{@label}}
@@ -266,7 +266,7 @@ const Feature = <template>
   {{else}}
     <PixIcon
       @name="cancel"
-      aria-label={{t "common.words.no"}}
+      aria-label={{concat @label " : " (t "common.words.no")}}
       class="organization-information-section__details__features--disabled"
     />
     <span class="organization-information-section__details__features--disabled">

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -37,10 +37,6 @@
       }
     }
 
-    .organization__network-label{
-      margin-bottom: var(--pix-spacing-6x);
-    }
-
     .organization__child-tag{
       a {
         color: var(--pix-success-700);
@@ -49,11 +45,22 @@
     }
 
     .organization__data {
-      max-width: 100%;
+      flex-grow: 1;
       overflow: hidden;
 
+      .organization__header {
+        display: flex;
+        align-items: flex-start;
+      }
+
+      .organization__title {
+        display: flex;
+        flex-direction: column;
+        gap: var(--pix-spacing-2x);
+        flex-grow: 1;
+      }
+
       .organization__name {
-        margin-bottom: 20px;
         font-weight: 600;
         font-size: 1.5rem;
       }
@@ -61,7 +68,6 @@
       .organization-tags-list {
         display: flex;
         flex-wrap: wrap;
-        margin-bottom: var(--pix-spacing-6x);
         padding: 0;
         list-style: none;
 

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -56,8 +56,8 @@
       .organization__title {
         display: flex;
         flex-direction: column;
-        gap: var(--pix-spacing-2x);
         flex-grow: 1;
+        gap: var(--pix-spacing-2x);
       }
 
       .organization__name {

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -1,21 +1,36 @@
+@use 'pix-design-tokens/typography';
+
 .organization-information-section {
   &__content {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
   }
 
   &__archived-message {
-    margin-bottom: 16px;
   }
 
   &__details {
-    &__list {
-      margin-bottom: var(--pix-spacing-6x);
-    }
+    dl {
+      display: flex;
+      flex-direction: column;
+      gap: var(--pix-spacing-1x);
 
-    .form-actions {
-      padding-bottom: 2px;
+      .divider {
+        border-top: 1px solid var(--pix-primary-100);
+        margin: var(--pix-spacing-3x) 0;
+      }
+
+      div {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--pix-spacing-3x);
+
+        dt {
+          @extend %pix-title-xxs;
+        }
+
+        dd {
+          grid-column: span 2 / span 2;
+        }
+      }
     }
   }
 }

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -9,11 +9,10 @@
     dl {
       display: flex;
       flex-direction: column;
-      gap: var(--pix-spacing-1x);
 
       .divider {
-        border-top: 1px solid var(--pix-primary-100);
         margin: var(--pix-spacing-3x) 0;
+        border-top: 1px solid var(--pix-primary-100);
       }
 
       div {
@@ -30,6 +29,34 @@
         dd {
           grid-column: span 2 / span 2;
         }
+      }
+    }
+
+    &__features {
+      display: flex;
+      flex-direction: column;
+      gap: var(--pix-spacing-1x);
+      padding: var(--pix-spacing-2x);
+      border: 1px solid var(--pix-primary-100);
+      border-radius: var(--pix-spacing-2x);
+
+      li {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--pix-spacing-2x);
+        align-items: center;
+      }
+
+      &--enabled {
+        color: var(--pix-success-300);
+      }
+
+      &--disabled {
+        /* stylelint-disable color-no-hex */
+
+        /* missing color tone in design system */
+        color: #abadb2;
+        /* stylelint-enable color-no-hex */
       }
     }
   }

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -1,10 +1,8 @@
 @use 'pix-design-tokens/typography';
 
 .organization-information-section {
-  &__content {
-  }
-
   &__archived-message {
+    margin-top: var(--pix-spacing-3x);
   }
 
   &__details {
@@ -19,12 +17,14 @@
       }
 
       div {
+        @extend %pix-body-m;
+
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: var(--pix-spacing-3x);
 
         dt {
-          @extend %pix-title-xxs;
+          font-weight: var(--pix-font-bold);
         }
 
         dd {

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -45,8 +45,8 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 2 })).exists();
-      assert.dom(screen.getByText('Nom du DPO : Bru No')).exists();
-      assert.dom(screen.getByText('Adresse e-mail du DPO : bru.no@example.net')).exists();
+      assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Bru No');
+      assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('bru.no@example.net');
     });
   });
 

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -78,12 +78,12 @@ module('Integration | Component | organizations/information-section', function (
 
       // then
       assert.dom(screen.getByRole('heading', { name: organization.name })).exists();
-      assert.dom(screen.getByText(`Identifiant externe : ${organization.externalId}`)).exists();
-      assert.dom(screen.getByText(`Département : ${organization.provinceCode}`)).exists();
+      assert.dom(screen.getByText('Identifiant externe').nextElementSibling).hasText(organization.externalId);
+      assert.dom(screen.getByText('Département').nextElementSibling).hasText(organization.provinceCode);
       assert.dom(screen.getByRole('link', { name: organization.documentationUrl })).exists();
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')} : ${t(
               'common.words.no',
             )}`,
@@ -92,14 +92,14 @@ module('Integration | Component | organizations/information-section', function (
         .exists();
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.SHOW_SKILLS')} : ${t('common.words.no')}`,
           ),
         )
         .exists();
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.MULTIPLE_SENDING_ASSESSMENT')} : ${t(
               'common.words.no',
             )}`,
@@ -136,7 +136,7 @@ module('Integration | Component | organizations/information-section', function (
 
       await fillIn(screen.getByLabelText('Nom *', { exact: false }), 'new name');
       await fillByLabel('Identifiant externe', 'new externalId');
-      await fillByLabel('Département (en 3 chiffres)', '   ');
+      await fillByLabel('Département (en 3 chiffres)', '');
       await fillByLabel('Crédits', 50);
       await clickByName("Gestion d'élèves/étudiants");
       await fillByLabel('Lien vers la documentation', 'https://pix.fr/');
@@ -152,12 +152,12 @@ module('Integration | Component | organizations/information-section', function (
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'new name' })).exists();
-      assert.dom(screen.getByText('Identifiant externe : new externalId')).exists();
-      assert.dom(screen.queryByText('Département : ')).doesNotExist();
-      assert.dom(screen.getByText('Crédits : 50')).exists();
+      assert.dom(screen.getByText('Identifiant externe').nextElementSibling).hasText('new externalId');
+      assert.dom(screen.queryByText('Département')).doesNotExist();
+      assert.dom(screen.getByText('Crédits').nextElementSibling).hasText('50');
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')} : ${t(
               'common.words.yes',
             )}`,
@@ -165,10 +165,10 @@ module('Integration | Component | organizations/information-section', function (
         )
         .exists();
       assert.dom(screen.getByRole('link', { name: 'https://pix.fr/' })).exists();
-      assert.dom(screen.getByText('SSO : organization 2')).exists();
+      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('organization 2');
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.MULTIPLE_SENDING_ASSESSMENT')} : ${t(
               'common.words.yes',
             )}`,
@@ -177,7 +177,7 @@ module('Integration | Component | organizations/information-section', function (
         .exists();
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.PLACES_MANAGEMENT')} : ${t(
               'common.words.yes',
             )}`,

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -65,21 +65,21 @@ module('Integration | Component | organizations/information-section-view', funct
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'SUPer Orga' })).exists();
-      assert.dom(screen.getByText('Type : SUP')).exists();
-      assert.dom(screen.getByText('Nom du DPO : Justin Ptipeu')).exists();
-      assert.dom(screen.getByText('Adresse e-mail du DPO : justin.ptipeu@example.net')).exists();
-      assert.dom(screen.getByText('Créée par : Gilles Parbal (1)')).exists();
-      assert.dom(screen.getByText('Créée le : 02/09/2022')).exists();
+      assert.dom(screen.getByText('Type').nextElementSibling).hasText('SUP');
+      assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Justin Ptipeu');
+      assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('justin.ptipeu@example.net');
+      assert.dom(screen.getByText('Créée par').nextElementSibling).hasText('Gilles Parbal (1)');
+      assert.dom(screen.getByText('Créée le').nextElementSibling).hasText('02/09/2022');
       assert
         .dom(
-          screen.getByText(
+          screen.getByLabelText(
             `${t('components.organizations.information-section-view.features.SHOW_SKILLS')} : ${t('common.words.yes')}`,
           ),
         )
         .exists();
-      assert.dom(screen.getByText('Crédits : 350')).exists();
-      assert.dom(screen.getByText('https://pix.fr')).exists();
-      assert.dom(screen.getByText('SSO : super-sso')).exists();
+      assert.dom(screen.getByText('Crédits').nextElementSibling).hasText('350');
+      assert.dom(screen.getByText('Lien vers la documentation').nextElementSibling).hasText('https://pix.fr');
+      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('super-sso');
     });
 
     test('it renders GAR identity provider correctly', async function (assert) {
@@ -108,7 +108,7 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByText('SSO : GAR')).exists();
+      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('GAR');
     });
 
     test('it generates correct external dashboard URL', async function (assert) {
@@ -154,39 +154,8 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Nom du DPO : Justin Ptipeu')).exists();
-        assert.dom(screen.getByText('Adresse e-mail du DPO : justin.ptipeu@example.net')).exists();
-      });
-
-      test('it renders partial DPO information', async function (assert) {
-        // given
-        class OidcIdentityProvidersStub extends Service {
-          list = [{ organizationName: 'super-sso', code: 'IDP' }];
-        }
-        this.owner.register('service:oidc-identity-providers', OidcIdentityProvidersStub);
-
-        const organization = {
-          type: 'SUP',
-          name: 'SUPer Orga',
-          credit: 350,
-          documentationUrl: 'https://pix.fr',
-          features: {
-            SHOW_SKILLS: { active: true },
-          },
-          createdBy: 1,
-          createdAtFormattedDate: '02/09/2022',
-          creatorFullName: 'Gilles Parbal',
-          identityProviderForCampaigns: 'IDP',
-          dataProtectionOfficerFullName: 'Ptipeu',
-          dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
-        };
-
-        // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
-
-        // then
-        assert.dom(screen.getByText('Nom du DPO : Ptipeu')).exists();
-        assert.dom(screen.getByText('Adresse e-mail du DPO : justin.ptipeu@example.net')).exists();
+        assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Justin Ptipeu');
+        assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('justin.ptipeu@example.net');
       });
 
       test('it renders without DPO information', async function (assert) {
@@ -214,8 +183,8 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Nom du DPO :')).exists();
-        assert.dom(screen.getByText('Adresse e-mail du DPO :')).exists();
+        assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('');
+        assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('');
       });
     });
 
@@ -239,7 +208,7 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByText('Lien vers la documentation : Non spécifié')).exists();
+      assert.dom(screen.getByText('Lien vers la documentation').nextElementSibling).hasText('Non spécifié');
     });
 
     test('it should display tags', async function (assert) {
@@ -355,7 +324,7 @@ module('Integration | Component | organizations/information-section-view', funct
 
         assert
           .dom(
-            screen.getByText(
+            screen.getByLabelText(
               `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')} : ${t(
                 'common.words.yes',
               )}`,
@@ -376,7 +345,7 @@ module('Integration | Component | organizations/information-section-view', funct
         // then
         assert
           .dom(
-            screen.getByText(
+            screen.getByLabelText(
               `${t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS')} : ${t(
                 'common.words.no',
               )}`,
@@ -418,7 +387,7 @@ module('Integration | Component | organizations/information-section-view', funct
             const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
             // then
             assert.ok(
-              screen.getByText(
+              screen.getByLabelText(
                 `${t(
                   'components.organizations.information-section-view.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
                 )} : ${t('common.words.yes')}`,
@@ -441,7 +410,7 @@ module('Integration | Component | organizations/information-section-view', funct
 
             // then
             assert.ok(
-              screen.getByText(
+              screen.getByLabelText(
                 `${t(
                   'components.organizations.information-section-view.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
                 )} : ${t('common.words.no')}`,
@@ -465,8 +434,10 @@ module('Integration | Component | organizations/information-section-view', funct
             const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
             // then
             assert.ok(
-              screen.getByText(
-                `${t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT')} : 6ème`,
+              screen.getByLabelText(
+                `${t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT')} : ${t(
+                  'common.words.yes',
+                )}`,
               ),
             );
           });
@@ -485,7 +456,7 @@ module('Integration | Component | organizations/information-section-view', funct
             const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
             // then
             assert.ok(
-              screen.getByText(
+              screen.getByLabelText(
                 `${t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT')} : ${t(
                   'common.words.no',
                 )}`,
@@ -511,7 +482,11 @@ module('Integration | Component | organizations/information-section-view', funct
 
             // then
             assert.ok(
-              screen.getByText(`${t('components.organizations.information-section-view.features.SHOW_NPS')} :`),
+              screen.getByLabelText(
+                `${t('components.organizations.information-section-view.features.SHOW_NPS')} : ${t(
+                  'common.words.yes',
+                )}`,
+              ),
             );
             assert.ok(screen.getByRole('link', { name: NPSUrl }));
           });
@@ -532,7 +507,7 @@ module('Integration | Component | organizations/information-section-view', funct
 
             // then
             assert.ok(
-              screen.getByText(
+              screen.getByLabelText(
                 `${t('components.organizations.information-section-view.features.SHOW_NPS')} : ${t('common.words.no')}`,
               ),
             );

--- a/admin/tests/unit/models/organization-test.js
+++ b/admin/tests/unit/models/organization-test.js
@@ -47,7 +47,7 @@ module('Unit | Model | organization', function (hooks) {
   });
 
   module('#dataProtectionOfficerFullName', function () {
-    test('it return the data protection officer full name', function (assert) {
+    test('it returns the data protection officer full name', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('organization', {
@@ -58,6 +58,18 @@ module('Unit | Model | organization', function (hooks) {
 
       // when & then
       assert.strictEqual(model.dataProtectionOfficerFullName, 'Justin Ptipeu');
+    });
+
+    test('it returns the data protection officer full name with partial information', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('organization', {
+        dataProtectionOfficerLastName: 'Ptipeu',
+        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+      });
+
+      // when & then
+      assert.strictEqual(model.dataProtectionOfficerFullName, 'Ptipeu');
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

L'affichage des attributs d'une organisation est très brut et manque de style 💄

## ⛱️ Proposition

Un peu de style, uniquement, sur la "section des attributs et features" d'une organisation :

<img width="2598" height="1282" alt="image" src="https://github.com/user-attachments/assets/6d85d3bc-04aa-41fe-939f-62d807915854" />

## 🌊 Remarques

Utilisation des [tags HTML "description lists"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl#wrapping_name-value_groups_in_div_elements)

## 🏄 Pour tester

Aller sur une page d'organisation dans PixAdmin.
