### PR TITLE
[TECH] :truck: Déplace un modèle en lecture seul vers son contexte métier

### DIFF
--- a/api/src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js
@@ -1,4 +1,4 @@
-import { config } from '../../config.js';
+import { config } from '../../../shared/config.js';
 
 const { features } = config;
 class AllowedCertificationCenterAccess {

--- a/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 
 import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { AllowedCertificationCenterAccess } from '../../../shared/domain/read-models/AllowedCertificationCenterAccess.js';
 import { CertificationPointOfContact } from '../../../shared/domain/read-models/CertificationPointOfContact.js';
+import { AllowedCertificationCenterAccess } from '../../domain/read-models/AllowedCertificationCenterAccess.js';
 
 const CERTIFICATION_CENTER_MEMBERSHIPS_TABLE_NAME = 'certification-center-memberships';
 

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
@@ -1,9 +1,9 @@
 import * as centerRepository from '../../../../src/certification/enrolment/infrastructure/repositories/center-repository.js';
+import { AllowedCertificationCenterAccess } from '../../../../src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js';
 import * as certificationPointOfContactRepository from '../../../../src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js';
 import { Organization } from '../../../../src/organizational-entities/domain/models/Organization.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { CertificationCenter } from '../../../../src/shared/domain/models/CertificationCenter.js';
-import { AllowedCertificationCenterAccess } from '../../../../src/shared/domain/read-models/AllowedCertificationCenterAccess.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | Identity Access Management |  Repository | CertificationPointOfContact', function () {

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -1,4 +1,4 @@
-import { AllowedCertificationCenterAccess } from '../../../../src/shared/domain/read-models/AllowedCertificationCenterAccess.js';
+import { AllowedCertificationCenterAccess } from '../../../../src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js';
 
 const ALLOWED_CERTIFICATION_CENTER_ACCESS_BUILDER_DEFAULT_ID = 123;
 


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seul `AllowedCertificationCenterAccess` est dans le répertoire partagé `src/shared/` alors qu'il n'est utilisé que dans le contexte `identity-access-management`.

## ⛱️ Proposition

Déplacer le modèle en lecture seul vers son contexte métier

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
