### PR TITLE
[BUGFIX] Corriger la sérialisation d'un assessment issu d'une campagne qui n'est pas de type assessment 

### DIFF
--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -69,6 +69,9 @@ const serialize = function (assessments) {
       ref: 'id',
       relationshipLinks: {
         related(record, current) {
+          if (!current) {
+            return null;
+          }
           return `/api/progressions/${current.id}`;
         },
       },

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -1,5 +1,5 @@
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
-import { Assessment } from '../../../../../../src/shared/domain/models/index.js';
+import { Assessment, CampaignTypes } from '../../../../../../src/shared/domain/models/index.js';
 import { CampaignAssessment } from '../../../../../../src/shared/domain/read-models/CampaignAssessment.js';
 import { CertificationAssessment } from '../../../../../../src/shared/domain/read-models/CertificationAssessment.js';
 import { CompetenceEvaluationAssessment } from '../../../../../../src/shared/domain/read-models/CompetenceEvaluationAssessment.js';
@@ -163,6 +163,26 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
 
       // then
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
+      expect(json.data.attributes['code-campaign']).to.equal('CAMPAGNE1');
+      expect(json.data.attributes['title']).to.equal('Parcours');
+    });
+
+    it('should convert an exam CampaignAssessment into JSON API data', function () {
+      //given
+      const assessment = domainBuilder.buildAssessment.ofTypeCampaign({
+        title: 'Parcours',
+        campaign: domainBuilder.buildCampaign({ title: 'Parcours', code: 'CAMPAGNE1', type: CampaignTypes.EXAM }),
+      });
+      const campaignAssessment = new CampaignAssessment(assessment);
+
+      const expectedProgressionJson = { data: null };
+
+      // when
+      const json = serializer.serialize(campaignAssessment);
+
+      // then
+      expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
+      expect(json.data.attributes['has-checkpoints']).to.be.false;
       expect(json.data.attributes['code-campaign']).to.equal('CAMPAGNE1');
       expect(json.data.attributes['title']).to.equal('Parcours');
     });


### PR DESCRIPTION
## 🔆 Problème
Suite à la PR https://github.com/1024pix/pix/pull/12789 un bug a été introduit. Nous retournons une erreur 500 lorsque nous voulons sérialiser un assessment issu d'une campagne qui n'est pas de type assessment. En effet, dans le cas de ces campagnes, il n'y a pas de relation progression à retourner mais le sérialiseur ne gère pas ce cas.  

## ⛱️ Proposition
Retourner null dans le sérialiseur lorsqu'il n'existe pas de progression pour l'assessment.

## 🏄 Pour tester
Créer une campagne de type collecte de profil ou exam, la passer et vérifier qu'il n'y a pas d'erreurs