### PR TITLE
[FEATURE] Ajustements sur la page de fin de parcours autonome (PIX-18613).

### DIFF
--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -144,9 +144,10 @@
 
 .evaluation-results-hero-details__actions {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   gap: var(--pix-spacing-6x);
-  align-items: center;
+  align-items: flex-start;
   margin-top: var(--pix-spacing-6x);
 }
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1379,12 +1379,12 @@
       "quit-results": {
         "send-result-modal": {
           "actions": {
-            "cancel-to-share": "Rester pour envoyer",
-            "quit-without-sharing": "Quitter sans envoyer"
+            "cancel-to-share": "Stay to send",
+            "quit-without-sharing": "Quit without sending"
           },
-          "content-information": "Envoyer vos résultats à l’organisateur du parcours est essentiel pour votre accompagnement. Restez sur cette page et cliquez sur ‘Envoyer mes résultats’ pour les transmettre.",
-          "content-instruction": "Voulez-vous vraiment quitter sans les envoyer ?",
-          "title": "Oups, vous n’avez pas encore envoyé vos résultats !"
+          "content-information": "Sending your results to the course organiser is essential for your support. Stay on this page and click on “Send my results” to send them.",
+          "content-instruction": "Do you really want to leave without sending them?",
+          "title": "Oops, you haven't sent your results yet!"
         }
       }
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1367,16 +1367,16 @@
       "first-title": "Oops, an error occurred!"
     },
     "evaluation-results": {
-      "leave-without-signup-modal": {
-        "actions": {
-          "cancel": "Cancel",
-          "leave": "Yes, leave the course"
-        },
-        "content-information": "If you leave this course without registering, you will not be able to keep your progress.",
-        "content-instruction": "Would you like to continue?",
-        "title": "Leave and return to Pix?"
-      },
       "quit-results": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Cancel",
+            "leave": "Yes, leave the course"
+          },
+          "content-information": "If you leave this course without registering, you will not be able to keep your progress.",
+          "content-instruction": "Would you like to continue?",
+          "title": "Leave and return to Pix?"
+        },
         "send-result-modal": {
           "actions": {
             "cancel-to-share": "Stay to send",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1372,7 +1372,7 @@
           "cancel": "Cancel",
           "leave": "Yes, leave the course"
         },
-        "content-information": "If you leave this course without registering, you will not be able to validate your progress.",
+        "content-information": "If you leave this course without registering, you will not be able to keep your progress.",
         "content-instruction": "Would you like to continue?",
         "title": "Leave and return to Pix?"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1368,7 +1368,7 @@
             "cancel": "Cancelar",
             "leave": "Sí, dejar el curso"
           },
-          "content-information": "Si abandona este curso sin inscribirse, no podrá validar su progreso.",
+          "content-information": "Si abandona este curso sin inscribirse, no podrá mantener su progreso.",
           "content-instruction": "¿Quiere continuar?",
           "title": "¿Salir y volver a Pix?"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1373,7 +1373,7 @@
             "cancel": "Annuler",
             "leave": "Oui, quitter le parcours"
           },
-          "content-information": "En quittant ce parcours sans vous inscrire, vous ne pourrez pas valider votre progression.",
+          "content-information": "En quittant ce parcours sans vous inscrire, vous ne pourrez pas conserver votre progression.",
           "content-instruction": "Voulez-vous continuer ?",
           "title": "Quitter et revenir sur pix.fr ?"
         },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1371,7 +1371,7 @@
             "cancel": "Annuleren",
             "leave": "Ja, verlaat de cursus"
           },
-          "content-information": "Als je deze cursus verlaat zonder je te registreren, kun je je voortgang niet valideren.",
+          "content-information": "Als je deze cursus verlaat zonder je te registreren, kun je je voortgang niet bijhouden.",
           "content-instruction": "Wil je doorgaan?",
           "title": "Vertrekken en terugkeren naar Pix?"
         },


### PR DESCRIPTION
## 🔆 Problème // Proposition
Quelques ajustement sont demandés sur page de fin d'un campagne à accès simplifié ou de parcours autonome.

## 🏄 Pour tester
- Activer le feature toggle upgradeToRealUserEnabled
- Lancer Pix App et se rendre sur la page de fin de parcours d'un parcours autonome (/campagnes/AUTOCOUR1 par exemple)
- En français, la modale pour quitter le parcours doit comporter la phrase "En quittant ce parcours sans vous inscrire, vous ne pourrez pas conserver votre progression."
- En anglais, le bouton Sign Up for Pix doit être sous le texte
- La modale pour quitter le parcours doit avoir des traductions fonctionnelles