### PR TITLE
[FEATURE] Permettre de re-scorer une certification dans Pix Admin (PIX-18192).

### DIFF
--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -33,6 +33,11 @@ export default class Certification extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/admin/complementary-certification-course-results`;
   }
 
+  rescoreCertification({ certificationCourseId }) {
+    const path = `${this.host}/${this.namespace}/admin/certifications/${certificationCourseId}/rescore`;
+    return this.ajax(path, 'POST');
+  }
+
   updateRecord(store, type, snapshot) {
     if (snapshot.adapterOptions.updateJuryComment) {
       const {

--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -147,6 +147,7 @@ export default class CertificationInformationGlobalActions extends Component {
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.certifications.global-actions.rescoring.success-message'),
       });
+      await this.args.certification.reload();
     } catch {
       this.pixToast.sendErrorNotification({
         message: this.intl.t('components.certifications.global-actions.rescoring.error-message'),

--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -5,11 +5,14 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 import ConfirmPopup from '../../../confirm-popup';
 
 export default class CertificationInformationGlobalActions extends Component {
   @service pixToast;
+  @service store;
+  @service intl;
 
   @tracked confirmAction = this.onCancelCertificationConfirmation;
   @tracked confirmErrorMessage = '';
@@ -39,6 +42,10 @@ export default class CertificationInformationGlobalActions extends Component {
 
   get displayUnrejectCertificationButton() {
     return this.args.certification.status === 'rejected' && this.args.certification.isRejectedForFraud;
+  }
+
+  get displayRescoringCertificationButton() {
+    return Boolean(!this.args.certification.isPublished && this.args.session.finalizedAt);
   }
 
   @action
@@ -130,6 +137,23 @@ export default class CertificationInformationGlobalActions extends Component {
     this.displayConfirm = true;
   }
 
+  @action
+  async rescoreCertification() {
+    try {
+      const adapter = this.store.adapterFor('certification');
+      await adapter.rescoreCertification({
+        certificationCourseId: this.args.certification.id,
+      });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.certifications.global-actions.rescoring.success-message'),
+      });
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.global-actions.rescoring.error-message'),
+      });
+    }
+  }
+
   <template>
     <PixButtonLink @route="authenticated.users.get" @size="small" @model={{@certification.userId}}>
       Voir les détails de l'utilisateur
@@ -175,6 +199,11 @@ export default class CertificationInformationGlobalActions extends Component {
             Rejeter la certification
           </PixButton>
         {{/if}}
+      {{/if}}
+      {{#if this.displayRescoringCertificationButton}}
+        <PixButton @size="small" @triggerAction={{this.rescoreCertification}}>
+          {{t "components.certifications.global-actions.rescoring.button"}}
+        </PixButton>
       {{/if}}
     </div>
 

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -409,6 +409,10 @@ function routes() {
   this.post('/admin/trainings/:id/duplicate', duplicateTraining);
 
   this.get('/admin/certifications/:id');
+  this.post('/admin/certifications/:id/rescore', () => {
+    return new Response(201);
+  });
+
   this.get('/admin/certifications/:id/certified-profile', (schema, request) => {
     const id = request.params.id;
     return schema.certifiedProfiles.find(id);

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -698,6 +698,40 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         });
       });
     });
+
+    module('Certification rescoring', function () {
+      module('when rescoring button is clicked', function () {
+        test('it displays a success notification', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          // when
+          const screen = await visit(`/certifications/${certification.id}`);
+          await click(screen.getByRole('button', { name: 'Re-scorer la certification' }));
+
+          // then
+          assert.dom(await screen.findByText('La certification a bien été rescorée.')).exists();
+        });
+
+        module('when an error occurred', function () {
+          test('it displays an error notification', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+            // when
+            const screen = await visit(`/certifications/${certification.id}`);
+            this.server.post(`/admin/certifications/${certification.id}/rescore`, () => ({}), 400);
+
+            await click(screen.getByRole('button', { name: 'Re-scorer la certification' }));
+
+            // then
+            assert
+              .dom(await screen.findByText('Une erreur est survenue lors du rescoring de la certification.'))
+              .exists();
+          });
+        });
+      });
+    });
   });
 });
 

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
 import CertificationInformationGlobalActions from 'pix-admin/components/certifications/certification/informations/global-actions';
 import { assessmentResultStatus } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
@@ -526,6 +527,77 @@ module('Integration | Component | Certifications | Certification | Information |
         assert.ok(currentCertification.save.notCalled);
         assert.ok(currentCertification.reload.notCalled);
         assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+      });
+    });
+  });
+
+  module('rescore button', function () {
+    module('when the certification is already published', function () {
+      test('should not display a rescoring button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          isPublished: true,
+        });
+        const session = store.createRecord('session', {});
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when the certification is not finalized', function () {
+      test('should not display a rescoring button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          isPublished: false,
+        });
+        const session = store.createRecord('session', { finalizedAt: null });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when the certification is finalized but not published yet', function () {
+      test('should display a rescoring button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          isPublished: false,
+        });
+        const session = store.createRecord('session', { finalizedAt: new Date('2020-01-01') });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+          .exists();
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -382,6 +382,13 @@
       "external-jury-select-options": {
         "REJECTED": "Rejected",
         "UNSET": "Waiting"
+      },
+      "global-actions": {
+        "rescoring": {
+          "button": "Rescore certification",
+          "error-message": "An error occurred during certification rescoring.",
+          "success-message": "Certification has successfully been rescored."
+        }
       }
     },
     "complementary-certifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -382,6 +382,13 @@
       "external-jury-select-options": {
         "REJECTED": "Rejetée",
         "UNSET": "En attente"
+      },
+      "global-actions": {
+        "rescoring": {
+          "button": "Re-scorer la certification",
+          "error-message": "Une erreur est survenue lors du rescoring de la certification.",
+          "success-message": "La certification a bien été rescorée."
+        }
       }
     },
     "complementary-certifications": {

--- a/api/src/certification/evaluation/application/certification-rescoring-route.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-route.js
@@ -13,10 +13,10 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -26,7 +26,7 @@ const register = async function (server) {
         handler: certificationRescoringController.rescoreCertification,
         tags: ['api', 'sessions', 'scoring'],
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle Super Admin**\n' +
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle Super Admin ou Certif**\n' +
             '- Elle permet de rescorer une certification',
         ],
       },


### PR DESCRIPTION
## 🔆 Problème
Actuellement sur Pix Admin, lorsque le métier à un besoin de rescorer une certification, il doit rejeter/dérejeter et ça c'est pas très propre.

## ⛱️ Proposition
Permettre de rescorer une certification avec un simple bouton ✨ 

## 🌊 Remarques

Ajout du rôle CERTIF pour donner l'accès au métier certif de rescorer.

## 🏄 Pour tester

- Se connecter sur Pix Admin
- Certification 7403 (`/sessions/7403/certifications`) , constater la présence d'un bouton "Re-scorer la certification" 
- Aller sur l'onglet Détails pour voir le score
- Avant de cliquer dessus, publier la session
- Constater que le bouton ne s'affiche plus
- Dé-publier la session puis cliquer sur ce beau bouton ✨ 
- (Si besoin de constater une diff de score, contacter un dev qui modifiera la conf en BDD ("`certification-scoring-configurations`")
- Constater la présence d'une notif vous indiquant que le scoring a été effectué 
- Aller sur l'onglet Détails pour voir le score.