### PR TITLE
[TECH] Rendre l'utilitaire "fetchPage" du knex-utils "transaction compliant"

### DIFF
--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -21,7 +21,10 @@ const findBySessionId = async function ({ sessionId }) {
 const findBySessionIdPaginated = async function ({ page, sessionId }) {
   const query = _getCertificationCoursesIdBySessionIdQuery(sessionId);
 
-  const { results: orderedCertificationCourseIdsInObjects, pagination } = await fetchPage(query, page);
+  const { results: orderedCertificationCourseIdsInObjects, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
 
   const orderedCertificationCourseIds = orderedCertificationCourseIdsInObjects.map((obj) => obj.id);
   const orderedResults = await _getByCertificationCourseIds(orderedCertificationCourseIds);

--- a/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
@@ -54,7 +54,7 @@ const findPaginatedFiltered = async function ({ filters, page }) {
     .orderByRaw('?? ASC', 'finalizedAt')
     .orderBy('id');
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const jurySessions = results.map(_toDomain);
 
   return {

--- a/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
@@ -34,7 +34,11 @@ const findPaginatedByCertificationCenterId = async function ({ certificationCent
 
   const countQuery = knex('sessions').count('*', { as: 'rowCount' }).where({ certificationCenterId });
 
-  const { results, pagination } = await fetchPage(query, page, null, countQuery);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+    countQueryBuilder: countQuery,
+  });
   const hasSessions = Boolean(pagination.rowCount);
 
   const sessionSummaries = results.map((result) => SessionSummary.from(result));

--- a/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
@@ -32,7 +32,7 @@ const findPaginatedByCertificationCenterId = async function ({ certificationCent
     .orderBy('sessions.time', 'DESC')
     .orderBy('sessions.id', 'ASC');
 
-  const countQuery = knex('sessions').count('*', { as: 'rowCount' }).where({ certificationCenterId });
+  const countQuery = knex('sessions').count('*', { as: 'row_count' }).where({ certificationCenterId });
 
   const { results, pagination } = await fetchPage({
     queryBuilder: query,

--- a/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-summary-repository.js
@@ -34,7 +34,7 @@ const findPaginatedByCertificationCenterId = async function ({ certificationCent
 
   const countQuery = knex('sessions').count('*', { as: 'rowCount' }).where({ certificationCenterId });
 
-  const { results, pagination } = await fetchPage(query, page, countQuery);
+  const { results, pagination } = await fetchPage(query, page, null, countQuery);
   const hasSessions = Boolean(pagination.rowCount);
 
   const sessionSummaries = results.map((result) => SessionSummary.from(result));

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -61,7 +61,10 @@ async function findPaginatedSummaries({ filter, page }) {
     )
     .orderBy('trainings.id', 'asc')
     .modify(_applyFilters, filter);
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
 
   const trainingTriggers = await knexConn('training-triggers').whereIn(
     'trainingId',
@@ -94,7 +97,7 @@ async function findPaginatedSummariesByTargetProfileId({ targetProfileId, page }
     .where({ 'target-profile-trainings.targetProfileId': targetProfileId })
     .orderBy('id', 'asc');
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const trainingTriggers = await knexConn('training-triggers').whereIn(
     'trainingId',
@@ -182,7 +185,7 @@ async function findPaginatedByUserId({ userId, locale, page }) {
     .join(USER_RECOMMENDED_TRAININGS_TABLE_NAME, 'trainings.id', 'trainingId')
     .where({ userId, locale, isDisabled: false })
     .orderBy('id', 'asc');
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const userRecommendedTrainings = results.map(
     (userRecommendedTraining) => new UserRecommendedTraining(userRecommendedTraining),

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -179,7 +179,10 @@ const findPaginatedFiltered = async function ({ filter, page, queryType = QUERY_
   const query = knex('users')
     .where((qb) => _setSearchFiltersForQueryBuilder(filter, qb, queryType))
     .orderBy([{ column: 'firstName', order: 'asc' }, { column: 'lastName', order: 'asc' }, { column: 'id' }]);
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
 
   const users = results.map((userDTO) => new User(userDTO));
   return { models: users, pagination };

--- a/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/certification-center.repository.js
@@ -62,7 +62,10 @@ export const findPaginatedFiltered = async ({ filter, page }) => {
     })
     .orderBy('id');
 
-  const { results: certificationCenters, pagination } = await fetchPage(query, page);
+  const { results: certificationCenters, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
 
   return { models: certificationCenters.map((certificationCenter) => _toDomain({ certificationCenter })), pagination };
 };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -256,7 +256,10 @@ const findPaginatedFiltered = async function ({ filter, page }) {
     .modify(_setSearchFiltersForQueryBuilder, filter)
     .orderBy('name', 'ASC');
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
   const organizations = results.map((model) => _toDomain(model));
   return { models: organizations, pagination };
 };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -14,7 +14,10 @@ const findByUserIdWithFilters = async function ({ userId, states, page }) {
     _filterByStates(queryBuilder, states);
   }
 
-  const { results, pagination } = await fetchPage(queryBuilder, page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder,
+    paginationParams: page,
+  });
   return {
     campaignParticipationOverviews: results.map(
       (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -180,7 +180,10 @@ const findInfoByCampaignId = async function ({ campaignId, page, since }) {
     });
   }
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: query,
+    paginationParams: page,
+  });
 
   return { models: results.map(_rowToResult), meta: pagination };
 };

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -41,7 +41,7 @@ const findPaginatedParticipationsForCampaignManagement = async function ({ campa
     .where('campaignId', campaignId)
     .orderBy(['lastName', 'firstName'], ['asc', 'asc']);
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const participationsForCampaignManagement = results.map(
     (attributes) => new ParticipationForCampaignManagement(attributes),

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -16,7 +16,10 @@ export const findPaginatedByCampaignId = async ({
   dependencies = { stageCollectionRepository },
 }) => {
   const stageCollection = await dependencies.stageCollectionRepository.findStageCollection({ campaignId });
-  const { results, pagination } = await fetchPage(getParticipantsResultList(campaignId, filters), page);
+  const { results, pagination } = await fetchPage({
+    queryBuilder: getParticipantsResultList(campaignId, filters),
+    paginationParams: page,
+  });
   const participations = await buildCampaignAssessmentParticipationResultList(results, stageCollection);
 
   return {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
@@ -86,7 +86,7 @@ const findPaginatedCampaignManagements = async function ({ organizationId, page 
     .where('organizationId', organizationId)
     .orderBy('campaigns.createdAt', 'DESC');
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const campaignManagement = results.map((attributes) => new CampaignManagement(attributes));
   return { models: campaignManagement, meta: { ...pagination } };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -12,7 +12,7 @@ const campaignParticipantActivityRepository = {
       .from('campaign_participants_activities_ordered')
       .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 
-    const { results, pagination } = await fetchPage(query, page);
+    const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
     const campaignParticipantsActivities = results.map((result) => {
       return new CampaignParticipantActivity(result);

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -34,7 +34,7 @@ async function findPaginatedByCampaignId(campaignId, page = {}, filters = {}) {
 
 function _getResultListPaginated(campaignId, filters, page) {
   const query = _getParticipantsResultList(campaignId, filters);
-  return fetchPage(query, page);
+  return fetchPage({ queryBuilder: query, paginationParams: page });
 }
 
 function _getParticipantsResultList(campaignId, filters) {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -126,7 +126,7 @@ const findPaginatedFilteredByOrganizationId = async function ({ organizationId, 
     .modify(_setSearchFiltersForQueryBuilder, filter, userId)
     .orderBy('campaigns.createdAt', 'DESC');
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const atLeastOneCampaign = await knex('campaigns')
     .select('id')
     .where({ organizationId })

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -110,7 +110,7 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
     }
   }
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const learners = results.map((learner) => new OrganizationLearner(learner));
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
@@ -17,7 +17,7 @@ async function findPaginatedFilteredParticipants({ organizationId, page, filters
     sort,
     withImport: false,
   });
-  const { results, pagination } = await fetchPage(organizationLearnerQuery, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: organizationLearnerQuery, paginationParams: page });
   const organizationParticipants = results.map((rawParticipant) => new OrganizationParticipant(rawParticipant));
   return { organizationParticipants, meta: { ...pagination, participantCount: totalParticipants } };
 }
@@ -40,7 +40,7 @@ async function findPaginatedFilteredImportedParticipants({
     sort,
     withImport: true,
   });
-  const { results, pagination } = await fetchPage(organizationLearnerQuery, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: organizationLearnerQuery, paginationParams: page });
   const organizationParticipants = results.map((rawParticipant) => new OrganizationParticipant(rawParticipant));
   return { organizationParticipants, meta: { ...pagination, participantCount: totalParticipants } };
 }

--- a/api/src/prescription/organization-learner/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/sco-organization-participant-repository.js
@@ -206,7 +206,7 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     .modify(_setFilters, filter)
     .orderBy(orderByClause);
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const scoOrganizationParticipants = results.map((result) => {
     return new ScoOrganizationParticipant({

--- a/api/src/prescription/organization-learner/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/sup-organization-participant-repository.js
@@ -160,7 +160,7 @@ const findPaginatedFilteredSupParticipants = async function ({ organizationId, f
     .orderBy(orderByClause)
     .modify(_setFilters, filter);
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const supOrganizationParticipants = results.map((result) => {
     return new SupOrganizationParticipant({ ...result });
   });

--- a/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -10,7 +10,7 @@ const findPaginatedFiltered = async function ({ filter, page }) {
     .orderBy('internalName', 'ASC')
     .modify(_applyFilters, filter);
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   const targetProfileSummaries = results.map((attributes) => new TargetProfileSummaryForAdmin(attributes));
   return { models: targetProfileSummaries, meta: { ...pagination } };

--- a/api/src/shared/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-learner-repository.js
@@ -40,7 +40,7 @@ const findByOrganizationIdAndUpdatedAtOrderByDivision = async function ({ organi
     query.whereIn('division', filter.divisions);
   }
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
 
   return {
     data: results.map((result) => new OrganizationLearner(result)),

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -103,7 +103,7 @@ const findPaginatedFilteredByTargetProfile = async function ({ targetProfileId, 
     .where({ 'target-profile-shares.targetProfileId': targetProfileId })
     .modify(_setSearchFiltersForQueryBuilder, filter);
 
-  const { results, pagination } = await fetchPage(query, page);
+  const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const organizations = results.map((model) => _toDomain(model));
   return { models: organizations, pagination };
 };

--- a/api/src/shared/infrastructure/utils/knex-utils.js
+++ b/api/src/shared/infrastructure/utils/knex-utils.js
@@ -65,19 +65,4 @@ function foreignKeyConstraintViolated(err) {
   return err.code === PGSQL_FK_CONSTRAINT;
 }
 
-function getChunkSizeForParameterBinding(objectAboutToBeBinded) {
-  // PostgreSQL allows a maximum of 65536 binded parameters in prepared statements
-  const MAX_BINDED_PARAMS_PG = 65536;
-  if (objectAboutToBeBinded) {
-    return Math.floor(MAX_BINDED_PARAMS_PG / Object.keys(objectAboutToBeBinded).length);
-  }
-  return MAX_BINDED_PARAMS_PG;
-}
-
-export {
-  DEFAULT_PAGINATION,
-  fetchPage,
-  foreignKeyConstraintViolated,
-  getChunkSizeForParameterBinding,
-  isUniqConstraintViolated,
-};
+export { DEFAULT_PAGINATION, fetchPage, foreignKeyConstraintViolated, isUniqConstraintViolated };

--- a/api/src/shared/infrastructure/utils/knex-utils.js
+++ b/api/src/shared/infrastructure/utils/knex-utils.js
@@ -7,24 +7,25 @@ const DEFAULT_PAGINATION = {
 
 /**
  * Paginate a knex query with given page parameters
- * @param {*} queryBuilder - a knex query builder
- * @param {Object} page - page parameters
- * @param {Number} page.number - the page number to retrieve
- * @param {Number} page.size - the size of the page
- * @param {object|null|undefined} queryBuilder - a knex query builder that counts the total number of rows, when one do not want to use the default one
- * @param {object|null|undefined} trx - transaction to use, possibly null
+ * @param {object} params
+ * @param {object} params.queryBuilder - a knex query builder
+ * @param {object} params.paginationParams
+ * @param {Number} params.paginationParams.number - the page number to retrieve
+ * @param {Number} params.paginationParams.size - the size of the page
+ * @param {object|null} params.trx - transaction to use
+ * @param {object|null} params.countQueryBuilder - a knex query builder that counts the total number of rows, bypassing the default one
  */
-const fetchPage = async (
+const fetchPage = async ({
   queryBuilder,
-  { number = DEFAULT_PAGINATION.PAGE, size = DEFAULT_PAGINATION.PAGE_SIZE } = {},
-  trx,
-  countRequestBuilder = undefined,
-) => {
+  paginationParams: { number = DEFAULT_PAGINATION.PAGE, size = DEFAULT_PAGINATION.PAGE_SIZE } = {},
+  trx = null,
+  countQueryBuilder = null,
+}) => {
   const page = number < 1 ? 1 : number;
   const offset = (page - 1) * size;
 
-  const countExecutor = countRequestBuilder
-    ? countRequestBuilder
+  const countExecutor = countQueryBuilder
+    ? countQueryBuilder
     : trx
       ? trx.count('*', { as: 'rowCount' }).from(queryBuilder.clone().as('query_all_results'))
       : knex.count('*', { as: 'rowCount' }).from(queryBuilder.clone().as('query_all_results'));

--- a/api/src/shared/infrastructure/utils/knex-utils.js
+++ b/api/src/shared/infrastructure/utils/knex-utils.js
@@ -47,7 +47,7 @@ const fetchPage = async ({
     pagination: {
       page,
       pageSize: size,
-      rowCount: rowCount,
+      rowCount,
       pageCount: Math.ceil(rowCount / size),
     },
   };

--- a/api/src/team/infrastructure/repositories/membership.repository.js
+++ b/api/src/team/infrastructure/repositories/membership.repository.js
@@ -116,7 +116,10 @@ export const findPaginatedFiltered = async function ({ organizationId, filter, p
   queryBuilder.innerJoin('users', 'memberships.userId', 'users.id');
   queryBuilder.orderByRaw('"organizationRole" ASC, LOWER(users."lastName") ASC, LOWER(users."firstName") ASC');
 
-  const result = await fetchPage(queryBuilder, { number: pageNumber, size: pageSize });
+  const result = await fetchPage({
+    queryBuilder,
+    paginationParams: { number: pageNumber, size: pageSize },
+  });
   const memberships = result.results.map(
     (membership) =>
       new Membership({

--- a/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/knex-utils_test.js
@@ -13,7 +13,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
       // when
       const query = knex.select('name').from('campaigns').orderBy('name', 'ASC');
-      const { results, pagination } = await fetchPage(query, { number: 2, size: 2 });
+      const { results, pagination } = await fetchPage({
+        queryBuilder: query,
+        paginationParams: { number: 2, size: 2 },
+      });
 
       // then
       expect(results).to.have.lengthOf(2);
@@ -36,7 +39,9 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
       // when
       const query = knex.distinct('name').from('campaigns');
-      const { results, pagination } = await fetchPage(query);
+      const { results, pagination } = await fetchPage({
+        queryBuilder: query,
+      });
 
       // then
       expect(results).to.have.lengthOf(2);
@@ -55,7 +60,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -72,7 +80,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.be.empty;
@@ -89,7 +100,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -105,7 +119,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -124,7 +141,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.have.lengthOf(pageSize);
@@ -141,7 +161,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.have.lengthOf(total);
@@ -158,7 +181,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.be.empty;
@@ -174,7 +200,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber },
+        });
 
         // then
         expect(results).to.have.lengthOf(pagination.pageSize);
@@ -193,7 +222,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -210,7 +242,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.be.empty;
@@ -229,7 +264,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -246,7 +284,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.not.be.empty;
@@ -263,7 +304,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('name').from('campaigns');
-        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: pageNumber, size: pageSize },
+        });
 
         // then
         expect(results).to.be.empty;
@@ -292,7 +336,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
               },
             ]);
             const query = knex.select('key').from('features');
-            const { results, pagination } = await fetchPage(query, { number: 3, size: 5 }, trx);
+            const { results, pagination } = await fetchPage({
+              queryBuilder: query,
+              paginationParams: { number: 3, size: 5 },
+              trx,
+            });
             expect(results, 'results within the transaction, before rollback').to.have.length(3);
             expect(pagination).to.deep.equal({
               page: 3,
@@ -311,7 +359,10 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
 
         // when
         const query = knex.select('key').from('features');
-        const { results, pagination } = await fetchPage(query, { number: 3, size: 5 });
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: 3, size: 5 },
+        });
 
         // then
         expect(results, 'results outside the transaction').to.be.empty;
@@ -336,7 +387,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', function () {
         // when
         const query = knex.select('key').from('features').orderBy('key');
         const countQuery = knex('organizations').count('*', { as: 'rowCount' });
-        const { results, pagination } = await fetchPage(query, { number: 1, size: 5 }, null, countQuery);
+        const { results, pagination } = await fetchPage({
+          queryBuilder: query,
+          paginationParams: { number: 1, size: 5 },
+          countQueryBuilder: countQuery,
+        });
 
         // then
         expect(results).to.deep.equal([


### PR DESCRIPTION
## 🔆 Problème

On généralise l'usage du DomainTransaction.getConnection() pour récupérer la transaction ouverte en cours dans le contexte de la requête client.
Malheureusement, l'utilitaire fetchPage du fichier knex-utils ne permet pas de passer une transaction.

## ⛱️ Proposition

Permettre à l'utilitaire de recevoir une transaction

## 🌊 Remarques

Ajout d'un test manquant pour l'attribut countQueryBuilder

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
