### PR TITLE
[FEATURE] Écran de preview du LLM (PIX-18711)

### DIFF
--- a/mon-pix/app/controllers/llm/preview.js
+++ b/mon-pix/app/controllers/llm/preview.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default class LLMPreviewController extends Controller {
+  get iframeSrc() {
+    const url = new URL('https://epreuves.pix.fr/pix-llm/pix-llm.html');
+    url.searchParams.set('chatId', this.model.chatId);
+    return url.href;
+  }
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -57,6 +57,7 @@ Router.map(function () {
   });
 
   this.route('challenge-preview', { path: '/challenges/:challenge_id/preview' });
+  this.route('llm.preview', { path: '/llm/preview/:chat_id' });
   this.route('courses.start', { path: '/courses/:course_id' });
 
   this.route('assessments', { path: '/assessments/:assessment_id' }, function () {

--- a/mon-pix/app/routes/llm/preview.js
+++ b/mon-pix/app/routes/llm/preview.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+
+export default class LLMPreviewRoute extends Route {
+  model(params) {
+    return {
+      chatId: params.chat_id,
+    };
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -72,6 +72,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use 'components/language-switcher' as *;
 @use 'components/learning-more-tutorial-panel' as *;
 @use 'components/levelup-notif' as *;
+@use 'components/llm/preview' as *;
 @use 'components/login-form' as *;
 @use 'components/login-or-register' as *;
 @use '../components/module/instruction/details' as *;

--- a/mon-pix/app/styles/components/llm/preview.scss
+++ b/mon-pix/app/styles/components/llm/preview.scss
@@ -1,0 +1,5 @@
+.llm-preview__iframe {
+  width: 100%;
+  height: 600px;
+  border: none;
+}

--- a/mon-pix/app/templates/llm/preview.gjs
+++ b/mon-pix/app/templates/llm/preview.gjs
@@ -1,0 +1,56 @@
+import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
+import pageTitle from 'ember-page-title/helpers/page-title';
+import PageTitle from 'mon-pix/components/ui/page-title';
+import modifierDidInsert from 'mon-pix/modifiers/modifier-did-insert';
+import { isEmbedAllowedOrigin } from 'mon-pix/utils/embed-allowed-origins';
+
+export default class LLMPreviewComponent extends Component {
+  @service
+  embedApiProxy;
+
+  @action
+  listenForInitMessage() {
+    window.addEventListener(
+      'message',
+      ({ origin, data, ports }) => {
+        if (!isEmbedAllowedOrigin(origin)) return;
+        if (!isInitMessage(data)) return;
+        if (!data.enableFetchFromApi) return;
+        const [requestsPort] = ports;
+        this.embedApiProxy.forwardForPreview(this, requestsPort);
+      },
+      { once: true },
+    );
+  }
+
+  <template>
+    {{pageTitle (t "pages.llm-preview.title")}}
+
+    <main class="main" role="main">
+      <PixBackgroundHeader id="main" class="certification-start-page__header">
+        <PageTitle>
+          <:title>{{t "pages.llm-preview.title"}}</:title>
+        </PageTitle>
+
+        <div>
+          <iframe
+            class="llm-preview__iframe"
+            src="{{@controller.iframeSrc}}"
+            title="{{t 'pages.llm-preview.title'}}"
+            frameBorder="0"
+            {{modifierDidInsert this.listenForInitMessage}}
+          ></iframe>
+        </div>
+      </PixBackgroundHeader>
+    </main>
+  </template>
+}
+
+function isInitMessage(data) {
+  if (typeof data !== 'object' || data === null) return false;
+  return data.from === 'pix' && data.type === 'init';
+}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1509,6 +1509,10 @@
     "levelup-notif": {
       "obtained-level": "Level { level } reached!"
     },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "ChatPix preview"
+    },
     "login-or-register": {
       "invitation": "{ organizationName }",
       "login-form": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1504,6 +1504,10 @@
     "levelup-notif": {
       "obtained-level": "¡Nivel { level } conseguido!"
     },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "Previsualización ChatPix"
+    },
     "login-or-register-oidc": {
       "error": {
         "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1509,6 +1509,10 @@
     "levelup-notif": {
       "obtained-level": "Niveau { level } gagné !"
     },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "Prévisualisation ChatPix"
+    },
     "login-or-register": {
       "invitation": "{ organizationName } vous invite à rejoindre Pix",
       "login-form": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1507,6 +1507,10 @@
     "levelup-notif": {
       "obtained-level": "Niveau {level} gewonnen!"
     },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "ChatPix voorbeeld"
+    },
     "login-or-register-oidc": {
       "error": {
         "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",


### PR DESCRIPTION
## 🔆 Problème

On souhaite faire les previews de LLM sur PixApp.

## ⛱️ Proposition

Créer un écran de preview du LLM dans PixApp.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Créer une conversation LLM avec les appels curl suivants :

```
ACCESS_TOKEN=$(curl -X POST -d 'grant_type=client_credentials&client_id=poc-llm&client_secret=<demander à Nico>&scope=llm-preview' https://api-pr12847.review.pix.fr/api/application/token | jq -r .access_token)
curl -v -H "Authorization: Bearer $ACCESS_TOKEN" -X POST -H 'Content-Type: application/json' --data '{"configuration":{"llm":{"model":"mistral-nemo-instruct-2407","environment":"SaaS","historySize":4,"temperature":0.4,"outputMaxToken":609},"name":"MODULIX PUBLIC TEST","challenge":{"tools":[],"description":"Cette configuration est mise à disposition publiquement. Ses capacités de raisonnement sont artificiellement réduites.","systemPrompt":"Tu t’appelles ChatPix.\nTu es un agent de conversation affable, dont le but est d’aider à la démonstration de ton intégration dans une application d’apprentissage en ligne.","inputMaxChars":128,"inputMaxPrompts":10,"victoryConditions":{"expectContainsAnswer":"ChatPix"}}}}' https://api-pr12847.review.pix.fr/api/llm/preview/chats
```

Peut aussi être testé via 1024pix/poc-llm#21