### PR TITLE
[FEATURE] Désactiver l'envoi automatique pour certaines organizations (PIX-18714).

### DIFF
--- a/mon-pix/app/routes/campaigns/assessment/results.js
+++ b/mon-pix/app/routes/campaigns/assessment/results.js
@@ -56,9 +56,13 @@ export default class ResultsRoute extends Route {
     if (!this.featureToggles.featureToggles?.isAutoShareEnabled) {
       return;
     }
+    if (model.campaignParticipationResult.isShared) {
+      return;
+    }
+    const disabledOrganizationIds = ENV.APP.AUTO_SHARE_DISABLED_ORGANIZATION_IDS.map(Number);
     if (
-      model.campaignParticipationResult.isShared ||
-      model.campaignParticipation.createdAt <= new Date(ENV.APP.AUTO_SHARE_AFTER_DATE)
+      model.campaignParticipation.createdAt <= new Date(ENV.APP.AUTO_SHARE_AFTER_DATE) ||
+      disabledOrganizationIds.includes(model.campaign.organizationId)
     ) {
       return;
     }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -120,6 +120,7 @@ module.exports = function (environment) {
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
+      AUTO_SHARE_DISABLED_ORGANIZATION_IDS: JSON.parse(process.env.AUTO_SHARE_DISABLED_ORGANIZATION_IDS || '[]'),
     },
 
     fontawesome: {

--- a/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/results-test.js
@@ -7,7 +7,7 @@ module('Unit | Route | Campaign | Assessment | Results', function (hooks) {
   setupTest(hooks);
 
   let route, modelForStub, transitionToStub, queryRecordStub, queryStub;
-  const campaign = { id: '123456', code: 'NEW_CODE' };
+  const campaign = { id: '123456', code: 'NEW_CODE', organizationId: '123456' };
   const questResults = [{ obtained: true, reward: { key: 'reward-key' } }];
   const campaignParticipation = { id: '1212', isShared: true, hasMany: sinon.stub() };
   const campaignParticipationResult = { id: campaignParticipation.id, campaignId: campaign.id };
@@ -127,6 +127,7 @@ module('Unit | Route | Campaign | Assessment | Results', function (hooks) {
         sinon.stub(store, 'adapterFor').withArgs('campaign-participation-result').returns({ share: shareSpy });
         // when
         await route.afterModel({
+          campaign,
           campaignParticipation: { createdAt: '2024-01-01' },
           campaignParticipationResult: { id: 123, isShared: false },
         });


### PR DESCRIPTION
## 🔆 Problème

Des organisations sont réticentes aux changements, ce qui est problématique dans un monde agile, où nous souhaitons faire disparaitre l'étape d'envoi des résultats. 

## ⛱️ Proposition

Ajouter une condition pour ne pas activer l'envoi automatique pour ces organisations. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Définir les variables d'environnement **front** : 
	- `AUTO_SHARE_DISABLED_ORGANIZATION_IDS=[1000]`
	- `AUTO_SHARE_AFTER_DATE=2024-01-01`
- Activer la feature : `isAutoSharedEnabled`
- Passer la campagne `PROASSMUL` constater que l'envoi ne se fait pas 