### PR TITLE
[TECH] Linter tous les fichiers de traduction de Pix App

### DIFF
--- a/mon-pix/eslint.config.mjs
+++ b/mon-pix/eslint.config.mjs
@@ -14,7 +14,7 @@ const compiledOutputFiles = ['dist/*', 'tmp/*'];
 const dependenciesFiles = ['bower_components/*', 'node_modules/*'];
 const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache'];
 const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];
-const nonPhraseGeneratedFiles = ['translations/*.json'];
+const translationFiles = ['translations/*.json'];
 
 const nodeFiles = [
   'eslint.config.cjs',
@@ -136,7 +136,7 @@ export default [
     },
   },
   {
-    files: nonPhraseGeneratedFiles,
+    files: translationFiles,
     plugins: { 'i18n-json': i18nJsonPlugin },
     processor: {
       meta: { name: '.json' },

--- a/mon-pix/eslint.config.mjs
+++ b/mon-pix/eslint.config.mjs
@@ -14,7 +14,7 @@ const compiledOutputFiles = ['dist/*', 'tmp/*'];
 const dependenciesFiles = ['bower_components/*', 'node_modules/*'];
 const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache'];
 const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];
-const nonPhraseGeneratedFiles = ['translations/en.json', 'translations/fr.json'];
+const nonPhraseGeneratedFiles = ['translations/*.json'];
 
 const nodeFiles = [
   'eslint.config.cjs',

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1078,7 +1078,7 @@
       "is-focused-challenge": {
         "info-alert": {
           "adjusted-course-title": "Responde a esta pregunta sin utilizar Internet ni ninguna aplicación.",
-          "subtitle": " ",
+          "subtitle": "Si cambia de página o de pestaña durante una prueba de certificación, su respuesta no será validada.",
           "title": "Responde a esta pregunta sin buscar en internet ni utilizar ningún programa informático."
         }
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -112,7 +112,6 @@
       "nl": "Holandés"
     },
     "level": "nivel",
-    "no-level": "No nivel",
     "loading": {
       "default": "Cargando",
       "results": "Preparación de tus resultados",
@@ -121,6 +120,7 @@
     "new-information-banner": {
       "close-label": "Cerrar el banner"
     },
+    "no-level": "No nivel",
     "or": "o",
     "pagination": {
       "action": {
@@ -359,21 +359,17 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Página de inicio de Pix.{ tld }",
-    "user-logged-menu": {
-      "details": "Consultar mis datos"
-    },
     "user": {
       "account": "Mi cuenta",
       "certifications": "Mis certificaciones",
       "sign-out": "Desconectarse",
       "tests": "Mis tests"
+    },
+    "user-logged-menu": {
+      "details": "Consultar mis datos"
     }
   },
   "pages": {
-    "attestations": {
-      "title": "Mis títulos",
-      "subtitle": "Acceda a todos sus certificados Pix y descárguelos."
-    },
     "account-recovery": {
       "errors": {
         "account-exists": "Ya existe una cuenta con esta dirección de correo electrónico.",
@@ -525,6 +521,10 @@
       },
       "title": "Fin de la prueba"
     },
+    "attestations": {
+      "subtitle": "Acceda a todos sus certificados Pix y descárguelos.",
+      "title": "Mis títulos"
+    },
     "authentication": {
       "login": {
         "signup-button": "Regístrate"
@@ -554,6 +554,15 @@
           "legal-informations": "Con o sin cuenta Pix, la información relativa a tu progreso en el test nos llegará a nosotros.'<br>'Esta información la utiliza Pix para mejorar el servicio.",
           "title": "Empieza el test:"
         }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "El test no está accesible para ti.",
+        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
+        "existing-participation-user-info": "Hay una participación asociada a nombre de ",
+        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
+        "not-accessible": "Uy, la página solicitada no está disponible."
       }
     },
     "campaign-landing": {
@@ -589,6 +598,9 @@
       "warning-message": "¿No eres { firstName } { lastName }?",
       "warning-message-logout": "Desconectarse"
     },
+    "campaign-participation": {
+      "title": "Test"
+    },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Finalizado el {date}",
@@ -613,34 +625,14 @@
       },
       "title": "Test"
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
-    "campaign": {
-      "errors": {
-        "existing-participation": "El test no está accesible para ti.",
-        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
-        "existing-participation-user-info": "Hay una participación asociada a nombre de ",
-        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
-        "not-accessible": "Uy, la página solicitada no está disponible."
-      }
-    },
     "certificate": {
-      "congratulations": "¡Felicidades!",
-      "global": {
-        "explanation": {
-          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
-          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
-        },
-        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
-        "labels": {
-          "advanced": "Advanced",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Independent",
-          "level": "Your level"
-        }
-      },
+      "attestation": "Descargar mi certificado",
+      "back-link": "Volver a mis certificaciones",
+      "candidate": "Candidato :",
+      "candidate-birth": "Nacido/a el {birthdate}",
+      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
+      "certification-center": "Centro de certificación :",
+      "certification-date": "Fecha de examen :",
       "certification-value": {
         "paragraphs": {
           "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
@@ -648,48 +640,56 @@
           "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
         }
       },
-      "attestation": "Descargar mi certificado",
-      "back-link": "Volver a mis certificaciones",
-      "candidate-birth": "Nacido/a el {birthdate}",
-      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
-      "certification-center": "Centro de certificación :",
+      "competences": {
+        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
+      },
+      "complementary": {
+        "alternative": "Certificación complementaria",
+        "clea": "Certificación CléA Numérique by Pix",
+        "title": "No hay ninguna certificación obtenida"
+      },
+      "congratulations": "¡Felicidades!",
       "delivered-at": "Fecha de emisión :",
-      "subtitle": "(niveles de {maxReachableLevel})",
       "details": {
         "competences": {
           "description": "Tu puntuación Pix da una estimación de tu nivel en las 16 competencias digitales.",
           "title": "Su perfil de competencias digitales"
         }
       },
-      "certification-date": "Fecha de examen :",
-      "candidate": "Candidato :",
-      "competences": {
-        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
-      },
-      "complementary": {
-        "alternative": "Certificación complementaria",
-        "title": "No hay ninguna certificación obtenida",
-        "clea": "Certificación CléA Numérique by Pix"
-      },
       "exam-date": "Fecha de presentación:",
+      "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        },
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+      },
       "hexagon-score": {
         "certified": "certificados"
       },
       "issued-on": "Entregado el",
       "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
       "jury-title": "Observaciones del tribunal",
+      "learn-about-certification-results": "¿Cómo interpretar los resultados?",
       "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
+      "subtitle": "(niveles de {maxReachableLevel})",
       "title": "Certificado Pix",
       "verification-code": {
-        "share": "Share your certificate",
-        "information": "Your unique verification code",
         "alt": "Copiar",
         "copied": "¡Código copiado!",
         "copy": "Copiar el código",
+        "information": "Your unique verification code",
+        "share": "Share your certificate",
         "title": "Código de comprobación",
         "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
-      },
-      "learn-about-certification-results": "¿Cómo interpretar los resultados?"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -825,9 +825,6 @@
         "actions": {
           "submit": "Continuar"
         },
-        "fields-validation": {
-          "session-number-error": "El número de sesión se compone únicamente de dígitos."
-        },
         "fields": {
           "birth-date": "Fecha de nacimiento",
           "birth-day": "día de nacimiento (DD)",
@@ -837,6 +834,9 @@
           "first-name": "Nombre",
           "session-number": "Número de sesión",
           "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+        },
+        "fields-validation": {
+          "session-number-error": "El número de sesión se compone únicamente de dígitos."
         },
         "placeholders": {
           "birth-day": "DD",
@@ -900,25 +900,25 @@
       "title": "Unirse a una sesión de certificación"
     },
     "certifications-list": {
-      "comment": "Comentario:",
-      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
-      "no-certification": {
-        "text": "Aún no tienes Pix certificación"
-      },
       "buttons": {
         "details": "Ver detalles",
-        "download-certificate": "Descargar certificado",
-        "download-attestation": "Descargar certificado"
+        "download-attestation": "Descargar certificado",
+        "download-certificate": "Descargar certificado"
       },
-      "statuses": {
-        "cancelled": "Cancelado",
-        "rejected": "No obtenido",
-        "not-published": "Resultados pendientes",
-        "validated": "Obtenido"
-      },
+      "comment": "Comentario:",
+      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
       "information": {
         "certification-center": "Centro de certificación :",
         "date": "Fecha del examen :"
+      },
+      "no-certification": {
+        "text": "Aún no tienes Pix certificación"
+      },
+      "statuses": {
+        "cancelled": "Cancelado",
+        "not-published": "Resultados pendientes",
+        "rejected": "No obtenido",
+        "validated": "Obtenido"
       },
       "title": "Mis certificaciones"
     },
@@ -957,15 +957,6 @@
         },
         "placeholder": "Cargando la aplicación"
       },
-      "feedback-panel-v3": {
-        "actions": {
-          "no-send-feedback": "No, vuelvo a la prueba",
-          "open-close": "Informar de un problema con la pregunta",
-          "send-feedback": "Sí, estoy seguro/a"
-        },
-        "description": "¿Estás seguro/a de que quieres informar de un problema?",
-        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
-      },
       "feedback-panel": {
         "actions": {
           "open-close": "Informar de un problema con la pregunta"
@@ -980,12 +971,12 @@
             "category-selection": {
               "label": "Tengo un problema con",
               "options": {
-                "other": "Otro",
                 "accessibility": "La accesibilidad a la prueba",
                 "answer": "La respuesta",
                 "download": "El archivo que se debe descargar",
                 "embed": "El simulador/la aplicación",
                 "link": "El enlace indicado en la pregunta",
+                "other": "Otro",
                 "picture": "La imagen",
                 "question": "La pregunta",
                 "tutorial": "El tutorial"
@@ -1000,7 +991,6 @@
                 "answer-not-accepted": "Mi respuesta es correcta, pero no ha sido validada",
                 "answer-not-agreed": "No estoy de acuerdo con la respuesta",
                 "download": {
-                  "other": "Tengo otro problema con el archivo",
                   "edit-failure": {
                     "label": "No puedo modificar el archivo",
                     "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
@@ -1012,7 +1002,8 @@
                   "open-failure": {
                     "label": "No puedo abrir el archivo en un ordenador",
                     "solution": "Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas."
-                  }
+                  },
+                  "other": "Tengo otro problema con el archivo"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "En un ordenador, aparece el simulador, pero tiene un problema",
@@ -1065,6 +1056,15 @@
           "content": "'<p><strong>'¿Estás seguro de que deseas informar de este problema?'</strong></p><p>'Gracias por tu informe, que será revisado cuidadosamente por el equipo de Pix. Tenemos en cuenta todos los comentarios para mejorar continuamente nuestros servicios y la experiencia del usuario. No podremos darte una respuesta personalizada. Gracias por tu colaboración.'</p>'",
           "title": "Confirmación del aviso"
         }
+      },
+      "feedback-panel-v3": {
+        "actions": {
+          "no-send-feedback": "No, vuelvo a la prueba",
+          "open-close": "Informar de un problema con la pregunta",
+          "send-feedback": "Sí, estoy seguro/a"
+        },
+        "description": "¿Estás seguro/a de que quieres informar de un problema?",
+        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
       },
       "has-focused-out-of-window": {
         "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor y responde a la pregunta en su presencia.",
@@ -1504,32 +1504,6 @@
     "levelup-notif": {
       "obtained-level": "¡Nivel { level } conseguido!"
     },
-    "login-or-register-oidc": {
-      "error": {
-        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
-        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
-        "error-message": "Debes aceptar las condiciones de uso de Pix.",
-        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
-        "invalid-email": "Tu dirección de correo electrónico no es válida.",
-        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
-      },
-      "login-form": {
-        "button": "Iniciar sesión",
-        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
-        "email": "Dirección de correo electrónico",
-        "password": "Contraseña",
-        "title": "Ya tengo una cuenta Pix"
-      },
-      "register-form": {
-        "button": "Creo una cuenta",
-        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "last-name-label-and-value": "Apellidos: {lastName}",
-        "first-name-label-and-value": "Nombre: {firstName}",
-        "title": "No tengo una cuenta Pix"
-      },
-      "title": "Crea una cuenta Pix"
-    },
     "login-or-register": {
       "invitation": "{ organizationName } te invita a unirte a Pix",
       "login-form": {
@@ -1609,6 +1583,32 @@
         "title": "Crear cuenta"
       },
       "title": "Conectarse a Pix"
+    },
+    "login-or-register-oidc": {
+      "error": {
+        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
+        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
+        "error-message": "Debes aceptar las condiciones de uso de Pix.",
+        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
+        "invalid-email": "Tu dirección de correo electrónico no es válida.",
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
+      },
+      "login-form": {
+        "button": "Iniciar sesión",
+        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
+        "email": "Dirección de correo electrónico",
+        "password": "Contraseña",
+        "title": "Ya tengo una cuenta Pix"
+      },
+      "register-form": {
+        "button": "Creo una cuenta",
+        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "Nombre: {firstName}",
+        "last-name-label-and-value": "Apellidos: {lastName}",
+        "title": "No tengo una cuenta Pix"
+      },
+      "title": "Crea una cuenta Pix"
     },
     "modulix": {
       "beta-banner": "Este módulo está en versión beta. Puede enviarnos sus comentarios al final de este módulo para ayudarnos a mejorarlo.",
@@ -1690,8 +1690,8 @@
         },
         "direction": "Busca la respuesta y gira la tarjeta",
         "navigation": {
-          "shortCurrentStep": "{current}/{total}",
-          "longCurrentStep": "{current} Paso a paso {total}"
+          "longCurrentStep": "{current} Paso a paso {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "{currentCardPosition}Tarjeta /{totalCards}"
       },
@@ -1737,8 +1737,8 @@
       },
       "recap": {
         "backToModuleDetails": "Volver a los detalles del módulo",
-        "goToHomepage": "Continuar mi experiencia Pix",
         "goToForm": "Responder al cuestionario",
+        "goToHomepage": "Continuar mi experiencia Pix",
         "subtitle": "Has alcanzado los siguientes objetivos:",
         "title": "¡Enhorabuena! Módulo completado"
       },
@@ -1777,18 +1777,6 @@
     "password-reset-demand": {
       "title": "¿Olvidaste tu contraseña?"
     },
-    "profile-already-shared": {
-      "actions": {
-        "continue": "Continúa tu experiencia Pix"
-      },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
-      "first-title": "Ha habido un imprevisto",
-      "retry": {
-        "button": "Reenviar mi perfil",
-        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
-      },
-      "title": "Perfil ya enviado"
-    },
     "profile": {
       "accessibility": {
         "title": "Tu perfil Pix",
@@ -1804,6 +1792,7 @@
           "no-level": "Competencia sin empezar"
         }
       },
+      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix.",
       "first-title": "Tienes 16 competencias en las que hacer pruebas. '<br>'¡Concéntrate y a por ello!",
       "resume-campaign-banner": {
         "accessibility": {
@@ -1825,8 +1814,19 @@
         "icon": "Información sobre los pix",
         "label": "Abrir la información emergente",
         "title": "¿Por qué 1024 pix?"
+      }
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Continúa tu experiencia Pix"
       },
-      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix."
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "first-title": "Ha habido un imprevisto",
+      "retry": {
+        "button": "Reenviar mi perfil",
+        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
+      },
+      "title": "Perfil ya enviado"
     },
     "reset-password": {
       "error": {
@@ -1886,8 +1886,8 @@
     "sign-up": {
       "actions": {
         "login": "Iniciar sesión",
-        "submit": "Crear cuenta",
-        "sign-up-on-pix": "Crear cuenta en Pix"
+        "sign-up-on-pix": "Crear cuenta en Pix",
+        "submit": "Crear cuenta"
       },
       "errors": {
         "invalid-locale-format": "Tu configuración local «{invalidLocale}» tiene un formato incorrecto.",
@@ -1986,14 +1986,12 @@
         },
         "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
         "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
-
       },
       "retry": {
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
         "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
         "notification-with-auto-share": "Repita las preguntas fallidas para mejorar su resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
-
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {
@@ -2026,7 +2024,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Cerrar y volver a los resultados",
-            "subtitle": "¿Listo para desarrollar tus habilidades? \uD83C\uDF93",
+            "subtitle": "¿Listo para desarrollar tus habilidades? 🎓",
             "title": "Resultados compartidos"
           },
           "tab-label": "Formación",
@@ -2069,13 +2067,9 @@
         "webinaire": "Webinario"
       }
     },
-    "tutorial-panel": {
-      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
-      "title": "Para tener éxito la próxima vez"
-    },
     "tutorial": {
-      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dot-action-description": "Acceder al paso {stepNumber} en {stepsCount}",
+      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dots-nav-label": "Pasos del tutorial",
       "next": "Siguiente",
       "next-title": "Mostrar siguiente paso",
@@ -2106,6 +2100,10 @@
       "start": "Comenzar el test",
       "title": "Tutorial de la campaña"
     },
+    "tutorial-panel": {
+      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+      "title": "Para tener éxito la próxima vez"
+    },
     "update-expired-password": {
       "button": "Restablecer",
       "fields": {
@@ -2120,6 +2118,31 @@
       "validation": "Tu contraseña ha sido actualizada."
     },
     "user-account": {
+      "account-update-email": {
+        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
+        "fields": {
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "new-email-confirmation": {
+            "label": "Confirmación de la dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "password-information": "Introduce tu contraseña para confirmar",
+        "save-button": "Confirmar",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
       "account-update-email-with-validation": {
         "fields": {
           "errors": {
@@ -2138,31 +2161,6 @@
           }
         },
         "save-button": "Recibir un código de comprobación",
-        "title": "Cambio de la dirección de correo electrónico"
-      },
-      "account-update-email": {
-        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
-        "fields": {
-          "errors": {
-            "empty-password": "Tu contraseña no puede estar vacía.",
-            "invalid-password": "La contraseña que has introducido no es válida.",
-            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
-            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
-          },
-          "new-email-confirmation": {
-            "label": "Confirmación de la dirección de correo electrónico"
-          },
-          "new-email": {
-            "label": "Nueva dirección de correo electrónico"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "password-information": "Introduce tu contraseña para confirmar",
-        "save-button": "Confirmar",
         "title": "Cambio de la dirección de correo electrónico"
       },
       "connexion-methods": {
@@ -2226,8 +2224,6 @@
       "title": "Mi cuenta"
     },
     "user-tests": {
-      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
-      "title": "Mis tests",
       "anonymised-participations": {
         "course": "Recorrido",
         "states": {
@@ -2235,7 +2231,9 @@
           "started": "comenzado"
         },
         "title": "rutas desactivadas"
-      }
+      },
+      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
+      "title": "Mis tests"
     },
     "user-trainings": {
       "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -585,7 +585,7 @@
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
         "legal-with-autoshare": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
-        "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
+        "title-with-username": "'<span>'¿{userFirstName},'</span><br>'Listo para evaluar tus habilidades?"
       },
       "profiles-collection": {
         "action": "¡Empecemos!",
@@ -804,7 +804,7 @@
         "message": "Enhorabuena {fullName}, tu perfil Pix se puede certificar."
       },
       "error-messages": {
-        "candidate-not-eligible": "<strong>La cuenta con la que ha iniciado sesión actualmente no es elegible para esta sesión de certificación.</strong> <br>' La información introducida corresponde a un candidato registrado para la sesión en certificación complementaria únicamente. <br>' Compruebe que ha iniciado sesión con la cuenta elegible para realizar la certificación complementaria únicamente.",
+        "candidate-not-eligible": "'<strong>'La cuenta con la que ha iniciado sesión actualmente no es elegible para esta sesión de certificación.'</strong>' '<br>' La información introducida corresponde a un candidato registrado para la sesión en certificación complementaria únicamente. '<br>' Compruebe que ha iniciado sesión con la cuenta elegible para realizar la certificación complementaria únicamente.",
         "generic": {
           "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de inscripción.",
           "check-session-number": "Comprueba el número de sesión.",
@@ -1358,7 +1358,7 @@
       "title": "Descargar los resultados de la sesión"
     },
     "error": {
-      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
+      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>'Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
       "first-title": "¡Uy, se ha producido un error!"
     },
     "evaluation-results": {
@@ -1820,7 +1820,7 @@
       "actions": {
         "continue": "Continúa tu experiencia Pix"
       },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization},'<br>'lo hiciste el {date} a las {hour,time,hhmm}",
       "first-title": "Ha habido un imprevisto",
       "retry": {
         "button": "Reenviar mi perfil",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -112,7 +112,6 @@
       "nl": "Nederlands"
     },
     "level": "niveau",
-    "no-level": "Geen niveau",
     "loading": {
       "default": "Bezig met laden",
       "results": "Je resultaten voorbereiden",
@@ -121,6 +120,7 @@
     "new-information-banner": {
       "close-label": "Sluit de banner"
     },
+    "no-level": "Geen niveau",
     "or": "of",
     "pagination": {
       "action": {
@@ -359,21 +359,17 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Startpagina Pix.{ tld }",
-    "user-logged-menu": {
-      "details": "Mijn informatie bekijken"
-    },
     "user": {
       "account": "Mijn account",
       "certifications": "Mijn certificaten",
       "sign-out": "Uitloggen",
       "tests": "Mijn tests"
+    },
+    "user-logged-menu": {
+      "details": "Mijn informatie bekijken"
     }
   },
   "pages": {
-    "attestations": {
-      "title": "Mijn getuigschriften",
-      "subtitle": "Krijg toegang tot al je Pix-certificaten en download ze."
-    },
     "account-recovery": {
       "errors": {
         "account-exists": "Er bestaat al een account met dit e-mailadres.",
@@ -525,6 +521,10 @@
       },
       "title": "Einde test"
     },
+    "attestations": {
+      "subtitle": "Krijg toegang tot al je Pix-certificaten en download ze.",
+      "title": "Mijn getuigschriften"
+    },
     "authentication": {
       "login": {
         "signup-button": "Registreren"
@@ -554,6 +554,15 @@
           "legal-informations": "Of je nu een Pix-account hebt of niet, de gegevens over je voortgang worden naar ons verstuurd.'<br>'Deze informatie wordt door Pix gebruikt om de service te verbeteren.",
           "title": "Start de test:"
         }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "De cursus is niet toegankelijk voor jou.",
+        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
+        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van",
+        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
+        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
       }
     },
     "campaign-landing": {
@@ -589,6 +598,9 @@
       "warning-message": "Ben jij niet {firstName} {lastName }?",
       "warning-message-logout": "Uitloggen"
     },
+    "campaign-participation": {
+      "title": "Test"
+    },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Voltooid op {date}",
@@ -613,38 +625,18 @@
       },
       "title": "Test"
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
-    "campaign": {
-      "errors": {
-        "existing-participation": "De cursus is niet toegankelijk voor jou.",
-        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
-        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van",
-        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
-        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
-      }
-    },
     "certificate": {
       "actions": {
         "download-attestation": "Mijn certificaat downloaden",
         "download-certificate": "Mijn certificaat downloaden"
       },
-      "congratulations": "Gefeliciteerd!",
-      "progressbar-explanation": "oortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, i.e. level {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
-      "global": {
-        "labels": {
-          "advanced": "Geavanceerd",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Onafhankelijk",
-          "level": "Jouw niveau"
-        },
-        "explanation": {
-          "default": "Je hebt het {globalLevelLabel} niveau van Pix Certification bereikt!",
-          "pre-beginner-level": "Je hebt je Pix-certificeringstest afgerond, maar je resultaten staan je niet toe om het eerste niveau te behalen."
-        }
-      },
+      "attestation": "Mijn certificaat downloaden",
+      "back-link": "Terug naar mijn certificaten",
+      "candidate": "Kandidaat :",
+      "candidate-birth": "Geboren op {birthdate}",
+      "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}",
+      "certification-center": "Certificeringscentrum :",
+      "certification-date": "Examendatum :",
       "certification-value": {
         "paragraphs": {
           "1": "Pix certificering is officieel erkend en getuigt van je beheersing van digitale vaardigheden. Je wordt lid van een gemeenschap van miljoenen gecertificeerde gebruikers. Gefeliciteerd met deze belangrijke stap in je carrière!",
@@ -652,47 +644,55 @@
           "3": "Op de dag van je certificering was het mogelijk om niveau 7 en maximaal 895 pix te bereiken (niveau Expert 1)."
         }
       },
-      "attestation": "Mijn certificaat downloaden",
-      "back-link": "Terug naar mijn certificaten",
-      "candidate-birth": "Geboren op {birthdate}",
-      "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}",
-      "certification-center": "Certificeringscentrum :",
-      "delivered-at": "Datum van uitgifte :",
-      "certification-date": "Examendatum :",
-      "candidate": "Kandidaat :",
       "competences": {
         "information": "Je gecertificeerde score is berekend op basis van je antwoorden tijdens het certificeringsproces. Deze kan daarom afwijken van het aantal Pix dat wordt weergegeven in je profiel. Op de dag van je certificering was het mogelijk om het {maxReachableLevelOnCertificationDate} vaardigheidsniveau en {maxReachablePixCountOnCertificationDate} pix maximaal te behalen."
       },
+      "complementary": {
+        "alternative": "Aanvullende certificering",
+        "clea": "Certificering CléA Numérique by Pix",
+        "title": "Andere behaalde certificering"
+      },
+      "congratulations": "Gefeliciteerd!",
+      "delivered-at": "Datum van uitgifte :",
       "details": {
         "competences": {
           "description": "Je Pix-score geeft een schatting van je niveau in de 16 digitale vaardigheden.",
           "title": "Je digitale vaardigheidsprofiel"
         }
       },
-      "complementary": {
-        "alternative": "Aanvullende certificering",
-        "title": "Andere behaalde certificering",
-        "clea": "Certificering CléA Numérique by Pix"
-      },
       "exam-date": "Datum bezoek :",
+      "global": {
+        "explanation": {
+          "default": "Je hebt het {globalLevelLabel} niveau van Pix Certification bereikt!",
+          "pre-beginner-level": "Je hebt je Pix-certificeringstest afgerond, maar je resultaten staan je niet toe om het eerste niveau te behalen."
+        },
+        "labels": {
+          "advanced": "Geavanceerd",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Onafhankelijk",
+          "level": "Jouw niveau"
+        }
+      },
       "hexagon-score": {
         "certified": "gecertificeerd"
       },
       "issued-on": "Uitgegeven op",
       "jury-info": "De opmerkingen van de jury worden niet gedeeld op de verificatiepagina van je certificaat.",
       "jury-title": "Commentaar van de jury",
+      "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?",
       "professionalizing-warning": "Het Pix-certificaat wordt door France Compétences erkend als een professionele kwalificatie zodra een minimale score van 120 pix is behaald.",
+      "progressbar-explanation": "oortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, i.e. level {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
       "title": "Pix-certificaat",
       "verification-code": {
-        "share": "Deel uw certificaat",
-        "information": "Je unieke verificatiecode",
         "alt": "Kopieer",
         "copied": "Code gekopieerd!",
         "copy": "Kopieer de code",
+        "information": "Je unieke verificatiecode",
+        "share": "Deel uw certificaat",
         "title": "Verificatie code",
         "tooltip": "Geef deze code om een derde partij de echtheid van je certificaat te laten controleren"
-      },
-      "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -828,9 +828,6 @@
         "actions": {
           "submit": "Ga verder met"
         },
-        "fields-validation": {
-          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
-        },
         "fields": {
           "birth-date": "Geboortedatum",
           "birth-day": "geboortedag (DD)",
@@ -840,6 +837,9 @@
           "first-name": "Voornaam",
           "session-number": "Sessienummer",
           "session-number-information": "Alleen meegedeeld door de surveillant aan het begin van de sessie"
+        },
+        "fields-validation": {
+          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
         },
         "placeholders": {
           "birth-day": "DD",
@@ -903,25 +903,25 @@
       "title": "Doe mee aan een certificeringssessie"
     },
     "certifications-list": {
-      "comment": "Opmerking :",
-      "description": "Krijg toegang tot al je Pix-certificaten. Bekijk details en download je certificaten.",
-      "no-certification": {
-        "text": "Je hebt nog geen Pix-certificering"
-      },
       "buttons": {
         "details": "Zie details",
-        "download-certificate": "Het certificaat downloaden",
-        "download-attestation": "Het certificaat downloaden"
+        "download-attestation": "Het certificaat downloaden",
+        "download-certificate": "Het certificaat downloaden"
       },
-      "statuses": {
-        "cancelled": "Geannuleerd",
-        "rejected": "Niet verkregen",
-        "not-published": "In afwachting van resultaten",
-        "validated": "Verkregen"
-      },
+      "comment": "Opmerking :",
+      "description": "Krijg toegang tot al je Pix-certificaten. Bekijk details en download je certificaten.",
       "information": {
         "certification-center": "Certificeringscentrum :",
         "date": "Datum bezoek :"
+      },
+      "no-certification": {
+        "text": "Je hebt nog geen Pix-certificering"
+      },
+      "statuses": {
+        "cancelled": "Geannuleerd",
+        "not-published": "In afwachting van resultaten",
+        "rejected": "Niet verkregen",
+        "validated": "Verkregen"
       },
       "title": "Mijn certificaten"
     },
@@ -960,15 +960,6 @@
         },
         "placeholder": "De huidige toepassing laden"
       },
-      "feedback-panel-v3": {
-        "actions": {
-          "no-send-feedback": "Nee, ik kom terug op de test",
-          "open-close": "Een probleem met de vraag melden",
-          "send-feedback": "Ja, ik weet het zeker"
-        },
-        "description": "Weet je zeker dat je een probleem wilt melden?",
-        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren."
-      },
       "feedback-panel": {
         "actions": {
           "open-close": "Een probleem met de vraag melden"
@@ -983,12 +974,12 @@
             "category-selection": {
               "label": "Ik heb een probleem met",
               "options": {
-                "other": "Overig",
                 "accessibility": "Toegankelijkheid van de test",
                 "answer": "Het antwoord",
                 "download": "Het te downloaden bestand",
                 "embed": "De simulator/toepassing",
                 "link": "De link in de vraag",
+                "other": "Overig",
                 "picture": "De afbeelding",
                 "question": "De vraag",
                 "tutorial": "De handleiding"
@@ -1003,7 +994,6 @@
                 "answer-not-accepted": "Mijn antwoord is correct, maar niet gevalideerd",
                 "answer-not-agreed": "Ik ben het niet eens met het antwoord",
                 "download": {
-                  "other": "Ik heb een ander probleem met de",
                   "edit-failure": {
                     "label": "Ik kan de",
                     "solution": "Het bestand staat waarschijnlijk open in \"Alleen lezen\" of \"Beveiligde modus\". '<br>'Klik op \"Bewerken inschakelen\" of \"Document bewerken\" op de banner bovenaan het bestand als deze verschijnt. '<br>'Sla anders het bestand op onder een andere naam en open dit nieuwe bestand."
@@ -1015,7 +1005,8 @@
                   "open-failure": {
                     "label": "Ik kan het bestand niet openen op een computer",
                     "solution": "Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen."
-                  }
+                  },
+                  "other": "Ik heb een ander probleem met de"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "Op een computer wordt de simulator weergegeven, maar er is een probleem",
@@ -1068,6 +1059,15 @@
           "content": "'<p><strong>'Weet je zeker dat je dit probleem wilt melden?'</strong></p><p>'Bedankt voor je melding, die zorgvuldig zal worden bekeken door het Pix-team. We houden rekening met al je feedback om onze diensten en gebruikerservaring voortdurend te verbeteren. We kunnen je geen persoonlijk antwoord geven. Hartelijk dank voor je medewerking.'</p>'",
           "title": "Bevestiging van waarschuwing"
         }
+      },
+      "feedback-panel-v3": {
+        "actions": {
+          "no-send-feedback": "Nee, ik kom terug op de test",
+          "open-close": "Een probleem met de vraag melden",
+          "send-feedback": "Ja, ik weet het zeker"
+        },
+        "description": "Weet je zeker dat je een probleem wilt melden?",
+        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren."
       },
       "has-focused-out-of-window": {
         "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend. Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
@@ -1507,32 +1507,6 @@
     "levelup-notif": {
       "obtained-level": "Niveau {level} gewonnen!"
     },
-    "login-or-register-oidc": {
-      "error": {
-        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
-        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
-        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
-        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
-        "invalid-email": "Je e-mailadres is ongeldig.",
-        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist."
-      },
-      "login-form": {
-        "button": "Inloggen",
-        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen.",
-        "email": "E-mailadres",
-        "password": "Wachtwoord",
-        "title": "Ik heb al een Pix-account"
-      },
-      "register-form": {
-        "button": "Ik maak mijn account aan",
-        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "last-name-label-and-value": "Naam: {lastName}",
-        "first-name-label-and-value": "Voornaam: {firstName}",
-        "title": "Ik heb geen Pix-account"
-      },
-      "title": "Maak je Pix-account aan"
-    },
     "login-or-register": {
       "invitation": "{ organizationName } nodigt je uit om je aan te sluiten bij Pix",
       "login-form": {
@@ -1612,6 +1586,32 @@
         "title": "Ik wil me registreren"
       },
       "title": "Verbinding maken met Pix"
+    },
+    "login-or-register-oidc": {
+      "error": {
+        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
+        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
+        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
+        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
+        "invalid-email": "Je e-mailadres is ongeldig.",
+        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist."
+      },
+      "login-form": {
+        "button": "Inloggen",
+        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen.",
+        "email": "E-mailadres",
+        "password": "Wachtwoord",
+        "title": "Ik heb al een Pix-account"
+      },
+      "register-form": {
+        "button": "Ik maak mijn account aan",
+        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "Voornaam: {firstName}",
+        "last-name-label-and-value": "Naam: {lastName}",
+        "title": "Ik heb geen Pix-account"
+      },
+      "title": "Maak je Pix-account aan"
     },
     "modulix": {
       "beta-banner": "Deze module is in bètaversie. Je kunt ons feedback sturen aan het einde van deze module om ons te helpen deze te verbeteren.",
@@ -1693,8 +1693,8 @@
         },
         "direction": "Zoek het antwoord en draai de sitemap om",
         "navigation": {
-          "shortCurrentStep": "{current}/{total}",
-          "longCurrentStep": "{current} Stap op {total}"
+          "longCurrentStep": "{current} Stap op {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "{currentCardPosition}sitemap /{totalCards}"
       },
@@ -1740,8 +1740,8 @@
       },
       "recap": {
         "backToModuleDetails": "Terug naar moduledetails",
-        "goToHomepage": "Mijn Pix-ervaring voortzetten",
         "goToForm": "Beantwoord de vragenlijst",
+        "goToHomepage": "Mijn Pix-ervaring voortzetten",
         "subtitle": "Je hebt de volgende doelen bereikt:",
         "title": "Gefeliciteerd! Module voltooid"
       },
@@ -1779,18 +1779,6 @@
     },
     "password-reset-demand": {
       "title": "Wachtwoord vergeten?"
-    },
-    "profile-already-shared": {
-      "actions": {
-        "continue": "Zet je Pix-ervaring voort"
-      },
-      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
-      "first-title": "Niet alles gaat volgens plan",
-      "retry": {
-        "button": "Mijn profiel opnieuw verzenden",
-        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
-      },
-      "title": "Profiel al verzonden"
     },
     "profile": {
       "accessibility": {
@@ -1830,6 +1818,18 @@
         "label": "Tooltip openen",
         "title": "Waarom 1024 pix?"
       }
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Zet je Pix-ervaring voort"
+      },
+      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
+      "first-title": "Niet alles gaat volgens plan",
+      "retry": {
+        "button": "Mijn profiel opnieuw verzenden",
+        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
+      },
+      "title": "Profiel al verzonden"
     },
     "reset-password": {
       "error": {
@@ -1889,8 +1889,8 @@
     "sign-up": {
       "actions": {
         "login": "Inloggen",
-        "submit": "Registreren",
-        "sign-up-on-pix": "Inschrijven bij Pix"
+        "sign-up-on-pix": "Inschrijven bij Pix",
+        "submit": "Registreren"
       },
       "errors": {
         "invalid-locale-format": "Uw locale \"{invalidLocale}\" heeft de verkeerde indeling.",
@@ -1989,7 +1989,6 @@
         },
         "notification": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen.",
         "notification-with-auto-share": "Herhaal mislukte vragen of stel in op nul om het opnieuw te proberen. De organisator blijft toegang houden tot je eerder ingediende resultaten."
-
       },
       "retry": {
         "button": "Mijn reis naspelen",
@@ -2028,7 +2027,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Sluiten en terugkeren naar resultaten",
-            "subtitle": "Klaar om je vaardigheden te ontwikkelen? \uD83C\uDF93",
+            "subtitle": "Klaar om je vaardigheden te ontwikkelen? 🎓",
             "title": "Verdeelde resultaten!"
           },
           "tab-label": "Training",
@@ -2071,13 +2070,9 @@
         "webinaire": "Webinar"
       }
     },
-    "tutorial-panel": {
-      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
-      "title": "Om de volgende keer te slagen"
-    },
     "tutorial": {
-      "dot-action-title": "Stap {stepNumber} van {stepsCount}",
       "dot-action-description": "Ga naar stap {stepNumber} op {stepsCount}",
+      "dot-action-title": "Stap {stepNumber} van {stepsCount}",
       "dots-nav-label": "Stappen uit de tutorial",
       "next": "Volgende",
       "next-title": "Volgende stap tonen",
@@ -2108,6 +2103,10 @@
       "start": "Begin mijn reis",
       "title": "Campagne handleiding"
     },
+    "tutorial-panel": {
+      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
+      "title": "Om de volgende keer te slagen"
+    },
     "update-expired-password": {
       "button": "Reset",
       "fields": {
@@ -2122,6 +2121,31 @@
       "validation": "Je wachtwoord is bijgewerkt."
     },
     "user-account": {
+      "account-update-email": {
+        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
+        "fields": {
+          "errors": {
+            "empty-password": "Je wachtwoord mag niet leeg zijn.",
+            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
+            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
+            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
+            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
+            "wrong-email-format": "Je e-mailadres is ongeldig."
+          },
+          "new-email": {
+            "label": "Nieuw e-mailadres"
+          },
+          "new-email-confirmation": {
+            "label": "Bevestiging van e-mailadres"
+          },
+          "password": {
+            "label": "Wachtwoord"
+          }
+        },
+        "password-information": "Voer uw wachtwoord in om te bevestigen",
+        "save-button": "Bevestig",
+        "title": "Je e-mailadres wijzigen"
+      },
       "account-update-email-with-validation": {
         "fields": {
           "errors": {
@@ -2140,31 +2164,6 @@
           }
         },
         "save-button": "Een verificatiecode ontvangen",
-        "title": "Je e-mailadres wijzigen"
-      },
-      "account-update-email": {
-        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
-        "fields": {
-          "errors": {
-            "empty-password": "Je wachtwoord mag niet leeg zijn.",
-            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
-            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
-            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
-            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
-            "wrong-email-format": "Je e-mailadres is ongeldig."
-          },
-          "new-email-confirmation": {
-            "label": "Bevestiging van e-mailadres"
-          },
-          "new-email": {
-            "label": "Nieuw e-mailadres"
-          },
-          "password": {
-            "label": "Wachtwoord"
-          }
-        },
-        "password-information": "Voer uw wachtwoord in om te bevestigen",
-        "save-button": "Bevestig",
         "title": "Je e-mailadres wijzigen"
       },
       "connexion-methods": {
@@ -2228,8 +2227,6 @@
       "title": "Mijn account"
     },
     "user-tests": {
-      "title": "Mijn tests",
-      "description": "Bekijk je Pix-trajecten, volg je voortgang en ga eenvoudig verder waar je was gebleven.",
       "anonymised-participations": {
         "course": "Route",
         "states": {
@@ -2237,7 +2234,9 @@
           "started": "begonnen"
         },
         "title": "Uitgeschakelde trajecten"
-      }
+      },
+      "description": "Bekijk je Pix-trajecten, volg je voortgang en ga eenvoudig verder waar je was gebleven.",
+      "title": "Mijn tests"
     },
     "user-trainings": {
       "description": "Blijf vooruitgang boeken dankzij de trainingen die aan het einde van je assessment worden aanbevolen.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1333,7 +1333,7 @@
           "text": "Om er meer over te weten",
           "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
         },
-        "message": "<h2>Welkom bij Pix in het Nederlands!</h2><p>De vertaling van al onze vaardigheden is binnenkort beschikbaar. '<'a href=\"https://pix.org/nl-be/de-planning-voor-de-uitrol-van-pix-in-het-nederlan\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer informatie'</a>'</p></p>"
+        "message": "'<h2>'Welkom bij Pix in het Nederlands!'</h2><p>'De vertaling van al onze vaardigheden is binnenkort beschikbaar. '<a href=\"https://pix.org/nl-be/de-planning-voor-de-uitrol-van-pix-in-het-nederlan\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'Meer informatie'</a></p>'"
       },
       "recommended-competences": {
         "extra-information": "Toegang tot alle aanbevolen vaardigheden",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -585,7 +585,7 @@
         "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Als je aan het einde van de cursus op de knop \"Stuur mijn resultaten\" klikt, worden je resultaten naar de organisator gestuurd.",
         "legal-with-auto-share": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
         "title": "Begin je Pix-reis",
-        "title-with-username": "<span>{userFirstName},</span><br> ben je klaar om je vaardigheden te testen?"
+        "title-with-username": "'<span>'{userFirstName},'</span><br>' ben je klaar om je vaardigheden te testen?"
       },
       "profiles-collection": {
         "action": "Laten we gaan!",
@@ -807,7 +807,7 @@
         "message": "Gefeliciteerd {fullName}, je Pix-profiel is certificeerbaar."
       },
       "error-messages": {
-        "candidate-not-eligible": "<strong>Het account waarmee u op dit moment bent ingelogd komt niet in aanmerking voor deze certificeringssessie.</strong> '<br>' De ingevoerde informatie komt overeen met een kandidaat die alleen is geregistreerd voor de sessie aanvullende certificering. '<br>' Controleer of u bent ingelogd op het account dat in aanmerking komt om alleen de aanvullende certificering te volgen.",
+        "candidate-not-eligible": "'<strong>'Het account waarmee u op dit moment bent ingelogd komt niet in aanmerking voor deze certificeringssessie.'</strong>' '<br>' De ingevoerde informatie komt overeen met een kandidaat die alleen is geregistreerd voor de sessie aanvullende certificering. '<br>' Controleer of u bent ingelogd op het account dat in aanmerking komt om alleen de aanvullende certificering te volgen.",
         "generic": {
           "check-personal-info": "Controleer bij de supervisor of je persoonlijke gegevens overeenkomen met die op het inschrijfformulier.",
           "check-session-number": "Controleer het sessienummer.",


### PR DESCRIPTION
## 🔆 Problème

Seuls les fichiers de traduction `fr.json` et `en.json` de Pix App sont lintés. En effet les fichiers pour les autres langues étant anciennement gérés dans _Phrase_ ils étaient volontairement ignorés.

Les règles appliquées sont principalement de l'ordre du style pour trier par ordre alphabétique mais aussi pour éviter quelques erreurs.

## ⛱️ Proposition

Linter tous les fichiers de trad.

## 🌊 Remarques

Il faudrait vérifier les autres apps.

## 🏄 Pour tester

* CI ✅ 
* Modifier l’ordre de quelques traductions dans chacun des fichiers `*.json`
* Exécuter la commande `npm run lint:fix` et constater que les traductions ont été retriées par ordre alphabétique