### PR TITLE
[TECH] :sparkles: Ajout de la clef de complémentaire `EDU_CPE` (PIX-18722)

### DIFF
--- a/api/src/certification/shared/domain/models/ComplementaryCertificationKeys.js
+++ b/api/src/certification/shared/domain/models/ComplementaryCertificationKeys.js
@@ -8,5 +8,6 @@ export const ComplementaryCertificationKeys = Object.freeze({
   CLEA: 'CLEA',
   PIX_PLUS_EDU_1ER_DEGRE: 'EDU_1ER_DEGRE',
   PIX_PLUS_EDU_2ND_DEGRE: 'EDU_2ND_DEGRE',
+  PIX_PLUS_EDU_CPE: 'EDU_CPE',
   PIX_PLUS_PRO_SANTE: 'PRO_SANTE',
 });


### PR DESCRIPTION
## 🔆 Problème

Une nouvelle complémentaire va faire son entrée à l'inventaire...

## ⛱️ Proposition

ajouter la nouvelle clef dans l'ENUM

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
