### PR TITLE
[TECH] :card_file_box: Modifie des colonnes de `complementary-certifications` pour les rendre `nullable`

### DIFF
--- a/api/db/migrations/20250716135747_alter-columns-to-nullable-into-complementary-certifications.js
+++ b/api/db/migrations/20250716135747_alter-columns-to-nullable-into-complementary-certifications.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'complementary-certifications';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer('certificationExtraTime').nullable().alter();
+    table.decimal('minimumReproducibilityRate').nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer('certificationExtraTime').notNullable().alter();
+    table.decimal('minimumReproducibilityRate').notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Trois colonnes ne sont plus utilisées dans la nouvelle version de certification.

## ⛱️ Proposition

rentre `nullable` les trois colonnes

- `minimumReproducibilityRateLowerLevel`
- `certificationExtraTime`
- `minimumReproducibilityRate`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
