### PR TITLE
[FEATURE] Modifier affichage des éléments interactifs (PIX-18690)(PIX-18652)

### DIFF
--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -1,5 +1,24 @@
-@use 'pix-design-tokens/colors';
+@use 'pix-design-tokens/typography';
+
 
 message-conversation::part(conversation) {
   background-color: var(--pix-primary-10);
+}
+
+.element-custom {
+  fieldset {
+    padding: var(--pix-spacing-2x);
+    border: 2px dashed rgb(var(--pix-tertiary-900-inline), 0.6);
+    border-radius: var(--pix-spacing-2x);
+  }
+
+  legend {
+    @extend %pix-body-s;
+
+    display: inline-flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    padding: 0 var(--pix-spacing-2x);
+    color: var(--pix-tertiary-900);
+  }
 }

--- a/mon-pix/app/components/module/element/_text.scss
+++ b/mon-pix/app/components/module/element/_text.scss
@@ -1,11 +1,6 @@
-.element-text {
-  iframe {
-    width: 100%;
-    padding: var(--pix-spacing-2x);
-    border: 2px dashed rgb(var(--pix-tertiary-500-inline), 0.6);
-    border-radius: var(--pix-spacing-2x);
-  }
+@use 'pix-design-tokens/typography';
 
+.element-text {
   table {
     width: 100%;
     background: var(--pix-neutral-0);
@@ -39,5 +34,21 @@
     th, td {
       padding: 0.75rem;
     }
+  }
+
+  fieldset {
+    padding: var(--pix-spacing-2x);
+    border: 2px dashed rgb(var(--pix-tertiary-900-inline), 0.6);
+    border-radius: var(--pix-spacing-2x);
+  }
+
+  legend {
+    @extend %pix-body-s;
+
+    display: inline-flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    padding: 0 var(--pix-spacing-2x);
+    color: var(--pix-tertiary-900);
   }
 }

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -1,4 +1,6 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
+import { t } from 'ember-intl';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 import ModuleElement from './module-element';
@@ -11,5 +13,15 @@ export default class ModulixCustomElement extends ModuleElement {
     container.append(customElement);
   }
 
-  <template><div class="element-custom" {{didInsert this.mountCustomElement}} /></template>
+  <template>
+    <div class="element-custom">
+      <fieldset>
+        <legend>
+          <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
+          <span>{{t "pages.modulix.interactiveElement.label"}}</span>
+        </legend>
+        <div {{didInsert this.mountCustomElement}} />
+      </fieldset>
+    </div>
+  </template>
 }

--- a/mon-pix/app/components/module/element/text.gjs
+++ b/mon-pix/app/components/module/element/text.gjs
@@ -1,7 +1,29 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
-<template>
-  <div class="element-text">
-    {{htmlUnsafe @text.content}}
-  </div>
-</template>
+import ModuleElement from './module-element';
+
+export default class ModulixText extends ModuleElement {
+  get contentWithIframe() {
+    const expression = /^<iframe/;
+    const regExp = new RegExp(expression);
+    return regExp.test(this.args.text.content);
+  }
+
+  <template>
+    <div class="element-text">
+      {{#if this.contentWithIframe}}
+        <fieldset>
+          <legend>
+            <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
+            <span>{{t "pages.modulix.interactiveElement.label"}}</span>
+          </legend>
+          {{htmlUnsafe @text.content}}
+        </fieldset>
+      {{else}}
+        {{htmlUnsafe @text.content}}
+      {{/if}}
+    </div>
+  </template>
+}

--- a/mon-pix/tests/integration/components/module/text_test.gjs
+++ b/mon-pix/tests/integration/components/module/text_test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { findAll } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModuleElementText from 'mon-pix/components/module/element/text';
 import { module, test } from 'qunit';
 
@@ -19,5 +20,22 @@ module('Integration | Component | Module | Text', function (hooks) {
     assert.ok(screen);
     assert.strictEqual(findAll('.element-text').length, 1);
     assert.ok(screen.getByText('toto'));
+  });
+
+  module('when text content contains an iframe tag', function () {
+    test('should display a legend above', async function (assert) {
+      // given
+      const textElement = {
+        content: '<iframe src="https://my-source.org" height="400"></iframe>',
+        type: 'text',
+      };
+
+      //  when
+      const screen = await render(<template><ModuleElementText @text={{textElement}} /></template>);
+
+      // then
+      assert.ok(screen);
+      assert.dom(screen.getByRole('group', { name: t('pages.modulix.interactiveElement.label') })).exists();
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1722,6 +1722,9 @@
           "summary": "Summary"
         }
       },
+      "interactiveElement": {
+        "label": "Interactive element"
+      },
       "modals": {
         "alternativeText": {
           "title": "Alternative text"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1708,6 +1708,9 @@
           "summary": "Recapitular"
         }
       },
+      "interactiveElement": {
+        "label": "Elemento interactivo"
+      },
       "modals": {
         "alternativeText": {
           "title": "Texto alternativo"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1722,6 +1722,9 @@
           "summary": "Récap'"
         }
       },
+      "interactiveElement": {
+        "label": "Élément interactif"
+      },
       "modals": {
         "alternativeText": {
           "title": "Alternative textuelle"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1711,6 +1711,9 @@
           "summary": "Recap"
         }
       },
+      "interactiveElement": {
+        "label": "Interactief element"
+      },
       "modals": {
         "alternativeText": {
           "title": "Tekst alternatief"


### PR DESCRIPTION
## ⛱️ Proposition

Ajout encadré hachuré “Elément interactif” pour les éléments `text` (qui contiennent une `iframe`) et `custom` :
- Ajustements sur les espaces des pointillés
- Ajout du titre et icône (voir [maquette](https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R-D-DevComp?node-id=9556-43577&m=dev))

## 🌊 Remarques

RAS

## 🏄 Pour tester
- Ouvrir le [module bac-a-sable](https://app-pr12858.review.pix.fr/modules/bac-a-sable/passage)
- Parcourir le module jusqu'à afficher un élément text avec iframe, et un élément custom
- Vérifier que ceux-ci ont bien l'encadré avec la mention "élément interactif"
