### PR TITLE
[FEATURE] Démarrer un parcours combiné (PIX-18121).

### DIFF
--- a/api/db/database-builder/factory/build-quest.js
+++ b/api/db/database-builder/factory/build-quest.js
@@ -3,6 +3,7 @@ import isUndefined from 'lodash/isUndefined.js';
 import { REWARD_TYPES } from '../../../src/quest/domain/constants.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildAttestation } from './build-attestation.js';
+import { buildOrganization } from './build-organization.js';
 
 const buildQuest = function ({
   id = databaseBuffer.getNextId(),
@@ -44,4 +45,15 @@ const buildQuest = function ({
   };
 };
 
-export { buildQuest };
+const buildQuestForCombinedCourse = function ({
+  code = 'COMBINIX1',
+  name = 'Mon parcours combiné',
+  organizationId,
+  ...args
+} = {}) {
+  organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
+
+  return buildQuest({ ...args, code, name, organizationId });
+};
+
+export { buildQuest, buildQuestForCombinedCourse };

--- a/api/db/database-builder/factory/combined-course-participation.js
+++ b/api/db/database-builder/factory/combined-course-participation.js
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+
+import { CombinedCourseParticipationStatuses } from '../../../src/prescription/shared/domain/constants.js';
+import { databaseBuffer } from '../database-buffer.js';
+import { buildOrganizationLearner } from './build-organization-learner.js';
+import { buildQuest } from './build-quest.js';
+
+const { STARTED } = CombinedCourseParticipationStatuses;
+
+const buildCombinedCourseParticipation = function ({
+  id = databaseBuffer.getNextId(),
+  questId,
+  organizationLearnerId,
+  status = STARTED,
+} = {}) {
+  organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
+  questId = _.isUndefined(questId) ? buildQuest().id : questId;
+
+  const values = {
+    id,
+    questId,
+    organizationLearnerId,
+    status,
+  };
+
+  databaseBuffer.pushInsertable({
+    tableName: 'quest_participations',
+    values,
+  });
+
+  return {
+    id,
+    questId,
+    organizationLearnerId,
+    status,
+  };
+};
+
+export { buildCombinedCourseParticipation };

--- a/api/db/migrations/20250715094708_add-quest-participation-constraint.js
+++ b/api/db/migrations/20250715094708_add-quest-participation-constraint.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'quest_participations';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.unique(['questId', 'organizationLearnerId']);
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropUnique(['questId', 'organizationLearnerId']);
+  });
+};
+
+export { down, up };

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -26,6 +26,7 @@ const OrganizationLearnerLoggerContext = {
 };
 
 const CombinedCourseParticipationStatuses = {
+  NOT_STARTED: 'not-started',
   STARTED: 'started',
   COMPLETED: 'completed',
 };

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -25,10 +25,16 @@ const OrganizationLearnerLoggerContext = {
   ANONYMIZATION: 'ORGANIZATION_LEARNER_ANONYMIZATION',
 };
 
+const CombinedCourseParticipationStatuses = {
+  STARTED: 'started',
+  COMPLETED: 'completed',
+};
+
 export {
   CampaignExternalIdTypes,
   CampaignParticipationLoggerContext,
   CampaignParticipationStatuses,
   CampaignTypes,
+  CombinedCourseParticipationStatuses,
   OrganizationLearnerLoggerContext,
 };

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -31,11 +31,18 @@ const CombinedCourseParticipationStatuses = {
   COMPLETED: 'completed',
 };
 
+const CombinedCourseStatuses = {
+  NOT_STARTED: 'NOT_STARTED',
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED',
+};
+
 export {
   CampaignExternalIdTypes,
   CampaignParticipationLoggerContext,
   CampaignParticipationStatuses,
   CampaignTypes,
   CombinedCourseParticipationStatuses,
+  CombinedCourseStatuses,
   OrganizationLearnerLoggerContext,
 };

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,0 +1,29 @@
+import { requestResponseUtils } from '../../shared/infrastructure/utils/request-response-utils.js';
+import { usecases } from '../domain/usecases/index.js';
+import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
+
+const getByCode = async function (request, _) {
+  const { code } = request.query.filter;
+
+  const combinedCourse = await usecases.getCombinedCourseByCode({ code });
+  return combinedCourseSerializer.serialize(combinedCourse);
+};
+
+const start = async function (request, h, dependencies = { requestResponseUtils }) {
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const code = request.params.code;
+
+  await usecases.startCombinedCourse({
+    userId,
+    code,
+  });
+
+  return h.response().code(204);
+};
+
+const combinedCourseController = {
+  getByCode,
+  start,
+};
+
+export { combinedCourseController };

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -2,10 +2,11 @@ import { requestResponseUtils } from '../../shared/infrastructure/utils/request-
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 
-const getByCode = async function (request, _) {
+const getByCode = async function (request, _, dependencies = { requestResponseUtils }) {
   const { code } = request.query.filter;
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
 
-  const combinedCourse = await usecases.getCombinedCourseByCode({ code });
+  const combinedCourse = await usecases.getCombinedCourseByCode({ userId, code });
   return combinedCourseSerializer.serialize(combinedCourse);
 };
 

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -1,0 +1,42 @@
+import Joi from 'joi';
+
+import { combinedCourseController } from './combined-course-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/combined-courses',
+      config: {
+        handler: combinedCourseController.getByCode,
+        validate: {
+          query: Joi.object({
+            filter: Joi.object({
+              code: Joi.string()
+                .regex(/^[a-zA-Z0-9]*$/)
+                .required(),
+            }).required(),
+          }),
+        },
+        notes: ['- Récupération du parcours combiné dont le code est spécifié dans les filtres de la requête'],
+        tags: ['api', 'quest'],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/api/combined-courses/{code}/start',
+      config: {
+        validate: {
+          params: Joi.object({
+            code: Joi.string().regex(/^[a-zA-Z0-9]*$/),
+          }),
+        },
+        handler: combinedCourseController.start,
+        notes: ["- Démarre un parcours combiné pour l'utilisateur connecté."],
+        tags: ['api', 'combined-courses'],
+      },
+    },
+  ]);
+};
+const name = 'combined-courses-api';
+export { name, register };

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -2,7 +2,6 @@ import { generateCSVTemplate } from '../../shared/infrastructure/serializers/csv
 import * as requestResponseUtils from '../../shared/infrastructure/utils/request-response-utils.js';
 import { QUEST_HEADER } from '../domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
-import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 import * as questResultSerializer from '../infrastructure/serializers/quest-result-serializer.js';
 
 const getQuestResults = async function (request, h, dependencies = { questResultSerializer, requestResponseUtils }) {
@@ -14,13 +13,6 @@ const getQuestResults = async function (request, h, dependencies = { questResult
   const serializedQuestResults = dependencies.questResultSerializer.serialize(questResults);
 
   return h.response(serializedQuestResults);
-};
-
-const getByCode = async function (request, _) {
-  const { code } = request.query.filter;
-
-  const combinedCourse = await usecases.getCombinedCourseByCode({ code });
-  return combinedCourseSerializer.serialize(combinedCourse);
 };
 
 const getTemplateForCreateOrUpdateQuestsInBatch = async function (request, h) {
@@ -51,7 +43,6 @@ const checkUserQuest = async function (request, h) {
 };
 
 const questController = {
-  getByCode,
   checkUserQuest,
   getQuestResults,
   createOrUpdateQuestsInBatch,

--- a/api/src/quest/application/quest-route.js
+++ b/api/src/quest/application/quest-route.js
@@ -14,24 +14,6 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/combined-courses',
-      config: {
-        handler: questController.getByCode,
-        validate: {
-          query: Joi.object({
-            filter: Joi.object({
-              code: Joi.string()
-                .regex(/^[a-zA-Z0-9]*$/)
-                .required(),
-            }).required(),
-          }),
-        },
-        notes: ['- Récupération du parcours combiné dont le code est spécifié dans les filtres de la requête'],
-        tags: ['api', 'quest'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/campaign-participations/{campaignParticipationId}/quest-results',
       config: {
         pre: [

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -1,11 +1,21 @@
-import { CombinedCourseParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
+import {
+  CombinedCourseParticipationStatuses,
+  CombinedCourseStatuses,
+} from '../../../prescription/shared/domain/constants.js';
 
 export class CombinedCourse {
-  constructor({ id, code, organizationId, name }) {
+  constructor({ id, code, organizationId, name }, participation) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
-    this.status = CombinedCourseParticipationStatuses.NOT_STARTED;
+    if (!participation) {
+      this.status = CombinedCourseStatuses.NOT_STARTED;
+    } else {
+      this.status =
+        participation.status === CombinedCourseParticipationStatuses.STARTED
+          ? CombinedCourseStatuses.STARTED
+          : CombinedCourseStatuses.COMPLETED;
+    }
   }
 }

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -1,8 +1,11 @@
+import { CombinedCourseParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
+
 export class CombinedCourse {
   constructor({ id, code, organizationId, name }) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
+    this.status = CombinedCourseParticipationStatuses.NOT_STARTED;
   }
 }

--- a/api/src/quest/domain/models/CombinedCourseParticipation.js
+++ b/api/src/quest/domain/models/CombinedCourseParticipation.js
@@ -1,0 +1,8 @@
+export class CombinedCourseParticipation {
+  constructor({ id, questId, organizationLearnerId, status }) {
+    this.id = id;
+    this.questId = questId;
+    this.organizationLearnerId = organizationLearnerId;
+    this.status = status;
+  }
+}

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -1,7 +1,22 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourse } from '../models/CombinedCourse.js';
 
-export async function getCombinedCourseByCode({ code, questRepository }) {
+export async function getCombinedCourseByCode({
+  userId,
+  code,
+  combinedCourseParticipationRepository,
+  questRepository,
+}) {
   const quest = await questRepository.getByCode({ code });
 
-  return new CombinedCourse(quest);
+  let participation = null;
+  try {
+    participation = await combinedCourseParticipationRepository.getByUserId({ questId: quest.id, userId });
+  } catch (err) {
+    if ((!err) instanceof NotFoundError) {
+      throw err;
+    }
+  }
+
+  return new CombinedCourse(quest, participation);
 }

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -17,7 +17,10 @@ const dependencies = {
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
   questRepository: repositories.questRepository,
+  combinedCourseParticipantRepository: repositories.combinedCourseParticipantRepository,
+  combinedCourseRepository: repositories.combinedCourseRepository,
   campaignRepository: repositories.campaignRepository,
+  userRepository: repositories.userRepository,
   logger,
 };
 

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
   questRepository: repositories.questRepository,
+  combinedCourseParticipationRepository: repositories.combinedCourseParticipationRepository,
   combinedCourseParticipantRepository: repositories.combinedCourseParticipantRepository,
   combinedCourseRepository: repositories.combinedCourseRepository,
   campaignRepository: repositories.campaignRepository,

--- a/api/src/quest/domain/usecases/start-combined-course.js
+++ b/api/src/quest/domain/usecases/start-combined-course.js
@@ -1,0 +1,19 @@
+export async function startCombinedCourse({
+  userId,
+  code,
+  combinedCourseParticipantRepository,
+  combinedCourseRepository,
+  questRepository,
+  userRepository,
+}) {
+  const quest = await questRepository.getByCode({ code });
+  const user = await userRepository.findById({ userId });
+
+  const organizationLearnerId = await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
+    userId,
+    organizationId: quest.organizationId,
+    organizationLearner: { firstName: user.firstName, lastName: user.lastName },
+  });
+
+  await combinedCourseRepository.save({ organizationLearnerId, questId: quest.id });
+}

--- a/api/src/quest/infrastructure/repositories/combined-course-participant-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participant-repository.js
@@ -1,0 +1,46 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { OrganizationLearnersCouldNotBeSavedError } from '../../../shared/domain/errors.js';
+import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
+
+export async function getOrCreateNewOrganizationLearner({ organizationLearner, userId, organizationId }) {
+  const knexConnection = DomainTransaction.getConnection();
+
+  const existingOrganizationLearner = await knexConnection('view-active-organization-learners')
+    .where({
+      userId,
+      organizationId,
+    })
+    .first();
+
+  if (existingOrganizationLearner) {
+    if (existingOrganizationLearner.isDisabled) {
+      await knexConnection('organization-learners')
+        .update({ isDisabled: false })
+        .where({ id: existingOrganizationLearner.id })
+        .returning('id');
+    }
+
+    return existingOrganizationLearner.id;
+  } else {
+    try {
+      const [{ id }] = await knexConnection('organization-learners').insert(
+        {
+          userId,
+          organizationId,
+          firstName: organizationLearner.firstName,
+          lastName: organizationLearner.lastName,
+        },
+        ['id'],
+      );
+      return id;
+    } catch (error) {
+      if (knexUtils.isUniqConstraintViolated(error) && error.constraint === 'one_active_organization_learner') {
+        throw new OrganizationLearnersCouldNotBeSavedError(
+          `User ${organizationLearner.userId} already inserted into ${organizationLearner.organizationId}`,
+        );
+      }
+
+      throw error;
+    }
+  }
+}

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -1,0 +1,32 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { CombinedCourseParticipation } from '../../domain/models/CombinedCourseParticipation.js';
+
+export const save = async function ({ organizationLearnerId, questId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  await knexConnection('quest_participations')
+    .insert({
+      questId,
+      organizationLearnerId,
+    })
+    .onConflict(['questId', 'organizationLearnerId'])
+    .ignore();
+};
+
+export const get = async function ({ organizationLearnerId, questId }) {
+  const knexConnection = DomainTransaction.getConnection();
+
+  const questParticipations = await knexConnection('quest_participations')
+    .select('id', 'questId', 'organizationLearnerId', 'status')
+    .where({
+      organizationLearnerId,
+      questId,
+    });
+  if (questParticipations.length === 0) {
+    throw new NotFoundError(
+      `CombinedCourseParticipation introuvable pour le couple organizationLearnerId=${organizationLearnerId}, questId=${questId}`,
+    );
+  }
+
+  return new CombinedCourseParticipation(questParticipations[0]);
+};

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -13,18 +13,24 @@ export const save = async function ({ organizationLearnerId, questId }) {
     .ignore();
 };
 
-export const get = async function ({ organizationLearnerId, questId }) {
+export const getByUserId = async function ({ userId, questId }) {
   const knexConnection = DomainTransaction.getConnection();
 
   const questParticipations = await knexConnection('quest_participations')
-    .select('id', 'questId', 'organizationLearnerId', 'status')
+    .select('quest_participations.id', 'questId', 'organizationLearnerId', 'quest_participations.status')
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.id',
+      '=',
+      'quest_participations.organizationLearnerId',
+    )
     .where({
-      organizationLearnerId,
+      'view-active-organization-learners.userId': userId,
       questId,
     });
   if (questParticipations.length === 0) {
     throw new NotFoundError(
-      `CombinedCourseParticipation introuvable pour le couple organizationLearnerId=${organizationLearnerId}, questId=${questId}`,
+      `CombinedCourseParticipation introuvable pour l'utilisateur d'id ${userId} et la quête d'id ${questId}`,
     );
   }
 

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -1,4 +1,5 @@
 import * as knowledgeElementsApi from '../../../evaluation/application/api/knowledge-elements-api.js';
+import * as userApi from '../../../identity-access-management/application/api/users-api.js';
 import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
 import * as campaignsApi from '../../../prescription/campaign/application/api/campaigns-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
@@ -14,6 +15,7 @@ import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
+import * as userRepository from './user-repository.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
@@ -25,6 +27,7 @@ const repositoriesWithoutInjectedDependencies = {
   campaignRepository,
   combinedCourseRepository,
   combinedCourseParticipantRepository,
+  userRepository,
 };
 
 const dependencies = {
@@ -36,6 +39,7 @@ const dependencies = {
   targetProfilesApi,
   profileRewardTemporaryStorage,
   rewardApi,
+  userApi,
 };
 
 const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -9,6 +9,7 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
+import * as combinedCourseRepository from './combined-course-participation-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';
@@ -22,6 +23,7 @@ const repositoriesWithoutInjectedDependencies = {
   rewardRepository,
   questRepository,
   campaignRepository,
+  combinedCourseRepository,
   combinedCourseParticipantRepository,
 };
 

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -10,6 +10,7 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
+import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
 import * as combinedCourseRepository from './combined-course-participation-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
@@ -27,6 +28,7 @@ const repositoriesWithoutInjectedDependencies = {
   campaignRepository,
   combinedCourseRepository,
   combinedCourseParticipantRepository,
+  combinedCourseParticipationRepository,
   userRepository,
 };
 

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -8,6 +8,7 @@ import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
+import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';
@@ -21,6 +22,7 @@ const repositoriesWithoutInjectedDependencies = {
   rewardRepository,
   questRepository,
   campaignRepository,
+  combinedCourseParticipantRepository,
 };
 
 const dependencies = {

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -33,7 +33,7 @@ const getByCode = async ({ code }) => {
     throw new NotFoundError(`La quête portant le code ${code} n'existe pas`);
   }
 
-  return new CombinedCourse({ id: quest.id, code: quest.code, organizationId: quest.organizationId, name: quest.name });
+  return new CombinedCourse(quest);
 };
 
 // envisager de mettre tableau vide en valeur par défaut des requirements si pas renseigné pour pas péter le code

--- a/api/src/quest/infrastructure/repositories/user-repository.js
+++ b/api/src/quest/infrastructure/repositories/user-repository.js
@@ -1,0 +1,4 @@
+export async function findById({ userId, userApi }) {
+  const users = await userApi.getActiveByUserIds({ userIds: [userId] });
+  return users ? users[0] : null;
+}

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourse) {
   return new Serializer('combined-courses', {
-    attributes: ['name', 'code', 'organizationId'],
+    attributes: ['name', 'code', 'organizationId', 'status'],
   }).serialize(combinedCourse);
 };
 

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,6 +1,7 @@
+import * as questParticipationRoute from './application/combined-course-route.js';
 import * as questRoute from './application/quest-route.js';
 import * as verifiedCodeRoute from './application/verified-code-route.js';
 
-const questRoutes = [questRoute, verifiedCodeRoute];
+const questRoutes = [questParticipationRoute, questRoute, verifiedCodeRoute];
 
 export { questRoutes };

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,7 +1,7 @@
-import * as questParticipationRoute from './application/combined-course-route.js';
+import * as combinedCourseRoute from './application/combined-course-route.js';
 import * as questRoute from './application/quest-route.js';
 import * as verifiedCodeRoute from './application/verified-code-route.js';
 
-const questRoutes = [questParticipationRoute, questRoute, verifiedCodeRoute];
+const questRoutes = [combinedCourseRoute, questRoute, verifiedCodeRoute];
 
 export { questRoutes };

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -1,0 +1,112 @@
+import { CombinedCourseParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+} from '../../../test-helper.js';
+
+describe('Quest | Acceptance | Application | Combined course Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/combined-courses', function () {
+    it('should return the combined course requested by code', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+
+      const { userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      const quest = databaseBuilder.factory.buildQuest({ code: 'SOMETHING', name: 'Mon parcours' });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/combined-courses/?filter[code]=${quest.code}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(Number(response.result.data.id)).to.equal(quest.id);
+      expect(response.result.data.attributes.name).to.equal('Mon parcours');
+    });
+
+    it('should return 404 when combined course with this code does not exist', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+
+      const { userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      const options = {
+        method: 'GET',
+        url: `/api/combined-courses/?filter[code]=NOTHINGTT`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+  });
+
+  describe('PUT /api/combined-course/{code}/start', function () {
+    it('should create a participation', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildQuest({ name: 'MA QUETE', organizationId, code: 'COMBINIX2' });
+
+      await databaseBuilder.commit();
+      const options = {
+        method: 'PUT',
+        url: '/api/combined-courses/COMBINIX2/start',
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 204 answer even if participation already exists', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const questId = databaseBuilder.factory.buildQuest({ name: 'MA QUETE', organizationId, code: 'COMBINIX2' }).id;
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId });
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        questId,
+        organizationLearnerId: organizationLearner.id,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'PUT',
+        url: '/api/combined-courses/COMBINIX2/start',
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/quest/acceptance/application/quest-route_test.js
+++ b/api/tests/quest/acceptance/application/quest-route_test.js
@@ -21,54 +21,6 @@ describe('Quest | Acceptance | Application | Quest Route ', function () {
     server = await createServer();
   });
 
-  describe('GET /api/combined-courses', function () {
-    it('should return the combined course requested by code', async function () {
-      // given
-      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
-
-      const { userId } = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      });
-
-      const quest = databaseBuilder.factory.buildQuest({ code: 'SOMETHING', name: 'Mon parcours' });
-
-      await databaseBuilder.commit();
-
-      const options = {
-        method: 'GET',
-        url: `/api/combined-courses/?filter[code]=${quest.code}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(Number(response.result.data.id)).to.equal(quest.id);
-      expect(response.result.data.attributes.name).to.equal('Mon parcours');
-    });
-    it('should return 404 when combined course with this code does not exist', async function () {
-      // given
-      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
-
-      const { userId } = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
-      });
-
-      const options = {
-        method: 'GET',
-        url: `/api/combined-courses/?filter[code]=NOTHINGTT`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(404);
-    });
-  });
   describe('GET /api/campaign-participations/{campaignParticipationId}/quest-results', function () {
     it('should return quest results for given campaignPaticipationId and userId', async function () {
       // given

--- a/api/tests/quest/acceptance/application/verified-code-route_test.js
+++ b/api/tests/quest/acceptance/application/verified-code-route_test.js
@@ -8,6 +8,18 @@ describe('Quest | Acceptance | Application | Verified Code Route ', function () 
   });
 
   describe('GET /api/verified-codes/{id}', function () {
+    it('should return 404 when the code does not exist', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/verified-codes/NOTHINGTT`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
     it('should return verified code with campaign link for given campaign', async function () {
       // given
       databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -1,3 +1,4 @@
+import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -6,14 +7,32 @@ import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code', function () {
   it('should return CombinedCourse for provided code', async function () {
     const code = 'SOMETHING';
-    const questId = databaseBuilder.factory.buildQuest({ code }).id;
+    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({ code });
+    const userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
 
-    const result = await usecases.getCombinedCourseByCode({ code });
+    const result = await usecases.getCombinedCourseByCode({ code, userId });
 
     expect(result).to.be.instanceOf(CombinedCourse);
     expect(result.id).to.equal(questId);
+    expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
   });
+
+  it('should return started combined course for given userId', async function () {
+    const code = 'SOMETHING';
+    const { id: questId, organizationId } = databaseBuilder.factory.buildQuestForCombinedCourse({ code });
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
+    databaseBuilder.factory.buildCombinedCourseParticipation({ questId, organizationLearnerId });
+    await databaseBuilder.commit();
+
+    const result = await usecases.getCombinedCourseByCode({ code, userId });
+
+    expect(result).to.be.instanceOf(CombinedCourse);
+    expect(result.id).to.equal(questId);
+    expect(result.status).to.equal(CombinedCourseStatuses.STARTED);
+  });
+
   it('should throw an error if CombinedCourse does not exist', async function () {
     const code = 'NOTHINGTT';
 

--- a/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
@@ -1,0 +1,67 @@
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, domainBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | start-combined-course', function () {
+  describe('when combined-course participation does not exist', function () {
+    it('should create combined-course participation', async function () {
+      //given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const questId = databaseBuilder.factory.buildQuest({ organizationId, code: 'COMBINIX8' }).id;
+      await databaseBuilder.commit();
+
+      //when
+      await usecases.startCombinedCourse({
+        userId: organizationLearner.userId,
+        code: 'COMBINIX8',
+      });
+
+      //then
+      const [participation] = await knex('quest_participations').where({
+        questId,
+        organizationLearnerId: organizationLearner.id,
+      });
+      expect(participation.id).to.be.finite;
+      expect(participation.questId).to.deep.equal(questId);
+      expect(participation.organizationLearnerId).to.deep.equal(organizationLearner.id);
+      expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+    });
+    describe('when organization learner does not exist', function () {
+      it('should also create organization learner', async function () {
+        //given
+        const user = databaseBuilder.factory.buildUser();
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const questId = databaseBuilder.factory.buildQuest({ organizationId, code: 'COMBINIX8' }).id;
+        await databaseBuilder.commit();
+
+        const organizationLearner = domainBuilder.buildOrganizationLearner({
+          firstName: user.firstName,
+          lastName: user.lastName,
+        });
+
+        //when
+        await usecases.startCombinedCourse({
+          userId: user.id,
+          code: 'COMBINIX8',
+        });
+
+        //then
+        const createdOrganizationLearner = await knex('organization-learners')
+          .where({ firstName: organizationLearner.firstName, lastName: organizationLearner.lastName })
+          .first();
+        expect(createdOrganizationLearner).not.to.be.undefined;
+
+        const [participation] = await knex('quest_participations').where({
+          questId,
+          organizationLearnerId: createdOrganizationLearner.id,
+        });
+
+        expect(participation.id).to.be.finite;
+        expect(participation.questId).to.deep.equal(questId);
+        expect(participation.organizationLearnerId).to.deep.equal(createdOrganizationLearner.id);
+        expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+      });
+    });
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
@@ -1,0 +1,44 @@
+import * as combinedCourseParticipantRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participant-repository.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Infrastructure | repositories | Combined Course Participant', function () {
+  describe('#getOrCreate', function () {
+    it('should get organization learner id if she exists', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
+        organizationLearner,
+        userId: organizationLearner.userId,
+        organizationId,
+      });
+      expect(result).to.be.equal(organizationLearner.id);
+    });
+    it('should create a new organization learner if organization learner does not exist', async function () {
+      const organizationLearner = { firstName: 'Sophie', lastName: 'Fonfek' };
+      const userId = databaseBuilder.factory.buildUser({
+        firstName: organizationLearner.firstName,
+        lastName: organizationLearner.lastName,
+      }).id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
+        organizationLearner,
+        userId,
+        organizationId,
+      });
+
+      //then
+      const learners = await knex('organization-learners').where({ organizationId });
+      expect(learners).to.have.lengthOf(1);
+      expect(learners[0].firstName).to.equal('Sophie');
+      expect(learners[0].lastName).to.equal('Fonfek');
+    });
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -1,0 +1,93 @@
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Infrastructure | repositories | Combined-Course-Participation', function () {
+  describe('#save', function () {
+    it('should insert combined course participation', async function () {
+      //given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const questId = databaseBuilder.factory.buildQuest().id;
+      await databaseBuilder.commit();
+
+      //when
+      await combinedCourseRepository.save({
+        organizationLearnerId,
+        questId,
+      });
+
+      //then
+      const [participation] = await knex('quest_participations').where({
+        organizationLearnerId,
+        questId,
+      });
+      expect(participation.id).to.be.finite;
+      expect(participation.questId).to.deep.equal(questId);
+      expect(participation.organizationLearnerId).to.deep.equal(organizationLearnerId);
+      expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+    });
+
+    it('should left intact combined course participation for given organization learner and quest ids', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const questId = databaseBuilder.factory.buildQuest().id;
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId,
+        questId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await combinedCourseRepository.save({ organizationLearnerId, questId });
+
+      // then
+      const [participation] = await knex('quest_participations').where({
+        organizationLearnerId,
+        questId,
+      });
+      expect(participation.id).to.be.finite;
+      expect(participation.questId).to.deep.equal(questId);
+      expect(participation.organizationLearnerId).to.deep.equal(organizationLearnerId);
+      expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
+    });
+  });
+  describe('#get', function () {
+    it('should return quest participation for given organization learner and quest ids', async function () {
+      // given
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const questId = databaseBuilder.factory.buildQuest().id;
+      databaseBuilder.factory.buildCombinedCourseParticipation({ organizationLearnerId, questId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseRepository.get({ organizationLearnerId, questId });
+
+      // then
+      const participations = await knex('quest_participations').where({
+        organizationLearnerId,
+        questId,
+      });
+      expect(participations).to.have.lengthOf(1);
+      expect(result.id).to.be.finite;
+      expect(result.questId).to.deep.equal(questId);
+      expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
+      expect(result.status).to.deep.equal(result.status);
+    });
+  });
+  it('should throw NotFound error when quest participation does not exist for given organization learner and quest ids', async function () {
+    // given
+    const organizationLearnerId = 1;
+    const questId = 2;
+
+    // when
+    const error = await catchErr(combinedCourseRepository.get)({ organizationLearnerId, questId });
+
+    // then
+    expect(error).to.be.instanceof(NotFoundError);
+    expect(error.message).to.equal(
+      `CombinedCourseParticipation introuvable pour le couple organizationLearnerId=${organizationLearnerId}, questId=${questId}`,
+    );
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -1,5 +1,5 @@
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
-import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
+import * as combinedCourseParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
@@ -8,11 +8,11 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should insert combined course participation', async function () {
       //given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuest().id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
       await databaseBuilder.commit();
 
       //when
-      await combinedCourseRepository.save({
+      await combinedCourseParticipationRepository.save({
         organizationLearnerId,
         questId,
       });
@@ -31,7 +31,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should left intact combined course participation for given organization learner and quest ids', async function () {
       // given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuest().id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
@@ -40,7 +40,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       await databaseBuilder.commit();
 
       // when
-      await combinedCourseRepository.save({ organizationLearnerId, questId });
+      await combinedCourseParticipationRepository.save({ organizationLearnerId, questId });
 
       // then
       const [participation] = await knex('quest_participations').where({
@@ -53,41 +53,42 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
     });
   });
-  describe('#get', function () {
-    it('should return quest participation for given organization learner and quest ids', async function () {
+  describe('#getByUserId', function () {
+    it('should return quest participation for given user and quest', async function () {
       // given
-      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuest().id;
-      databaseBuilder.factory.buildCombinedCourseParticipation({ organizationLearnerId, questId });
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId,
+        questId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+      });
       await databaseBuilder.commit();
 
       // when
-      const result = await combinedCourseRepository.get({ organizationLearnerId, questId });
+      const result = await combinedCourseParticipationRepository.getByUserId({ userId, questId });
 
       // then
-      const participations = await knex('quest_participations').where({
-        organizationLearnerId,
-        questId,
-      });
-      expect(participations).to.have.lengthOf(1);
       expect(result.id).to.be.finite;
       expect(result.questId).to.deep.equal(questId);
       expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
-      expect(result.status).to.deep.equal(result.status);
+      expect(result.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
     });
-  });
-  it('should throw NotFound error when quest participation does not exist for given organization learner and quest ids', async function () {
-    // given
-    const organizationLearnerId = 1;
-    const questId = 2;
 
-    // when
-    const error = await catchErr(combinedCourseRepository.get)({ organizationLearnerId, questId });
+    it('should throw NotFound error when quest participation does not exist for given user and quest', async function () {
+      // given
+      const userId = 1;
+      const questId = 2;
 
-    // then
-    expect(error).to.be.instanceof(NotFoundError);
-    expect(error.message).to.equal(
-      `CombinedCourseParticipation introuvable pour le couple organizationLearnerId=${organizationLearnerId}, questId=${questId}`,
-    );
+      // when
+      const error = await catchErr(combinedCourseParticipationRepository.getByUserId)({ userId, questId });
+
+      // then
+      expect(error).to.be.instanceof(NotFoundError);
+      expect(error.message).to.equal(
+        `CombinedCourseParticipation introuvable pour l'utilisateur d'id ${userId} et la quête d'id ${questId}`,
+      );
+    });
   });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -121,10 +121,11 @@ describe('Quest | Integration | Repository | quest', function () {
   });
 
   describe('#getByCode', function () {
-    it('should return a quest if quest exist', async function () {
+    it('should return a combined course if code exists', async function () {
       // given
       const code = 'SOMETHING';
-      const questId = databaseBuilder.factory.buildQuest({ code }).id;
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const questId = databaseBuilder.factory.buildQuest({ code, organizationId }).id;
       await databaseBuilder.commit();
 
       // when
@@ -132,7 +133,7 @@ describe('Quest | Integration | Repository | quest', function () {
 
       // then
       expect(quest).to.be.an.instanceof(CombinedCourse);
-      expect(quest.id).to.equal(questId);
+      expect(quest).to.deep.equal(new CombinedCourse({ ...quest, id: questId }));
     });
 
     it('should throw NotFoundError if quest does not exist', async function () {

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -1,3 +1,4 @@
+import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import * as combinedCourseSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-serializer.js';
 import { expect } from '../../../../test-helper.js';
@@ -17,7 +18,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           name: 'Mon parcours',
           code: 'COMBINIX1',
           'organization-id': 1,
-          status: 'not-started',
+          status: CombinedCourseStatuses.NOT_STARTED,
         },
         type: 'combined-courses',
         id: '1',

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -17,6 +17,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           name: 'Mon parcours',
           code: 'COMBINIX1',
           'organization-id': 1,
+          status: 'not-started',
         },
         type: 'combined-courses',
         id: '1',

--- a/mon-pix/app/adapters/combined-course.js
+++ b/mon-pix/app/adapters/combined-course.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class CombinedCourse extends ApplicationAdapter {
+  start(code) {
+    const url = `${this.host}/${this.namespace}/combined-courses/${code}/start`;
+    return this.ajax(url, 'PUT');
+  }
+}

--- a/mon-pix/app/adapters/combined-course.js
+++ b/mon-pix/app/adapters/combined-course.js
@@ -5,4 +5,9 @@ export default class CombinedCourse extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/combined-courses/${code}/start`;
     return this.ajax(url, 'PUT');
   }
+
+  urlForFindRecord(_, modelName, snapshot) {
+    const { code } = snapshot.record;
+    return `${this.urlForQueryRecord({ filter: { code } }, modelName)}?filter[code]=${code}`;
+  }
 }

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -7,7 +7,7 @@ import eq from 'ember-truth-helpers/helpers/eq';
 
 export default class CombinedCourses extends Component {
   <template>
-    {{#if (eq @combinedCourse.status "not-started")}}
+    {{#if (eq @combinedCourse.status "NOT_STARTED")}}
       <PixButton @type="submit" @triggerAction={{this.startQuestParticipation}} @loading-color="white" @size="large">{{t
           "pages.combined-courses.content.start-button"
         }}

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -1,0 +1,30 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import eq from 'ember-truth-helpers/helpers/eq';
+
+export default class CombinedCourses extends Component {
+  <template>
+    {{#if (eq @combinedCourse.status "not-started")}}
+      <PixButton @type="submit" @triggerAction={{this.startQuestParticipation}} @loading-color="white" @size="large">{{t
+          "pages.combined-courses.content.start-button"
+        }}
+      </PixButton>
+    {{/if}}
+  </template>
+
+  @service currentUser;
+  @service session;
+  @service featureToggles;
+  @service intl;
+  @service store;
+
+  @action
+  async startQuestParticipation() {
+    const combinedCourseAdapter = this.store.adapterFor('combined-course');
+    await combinedCourseAdapter.start(this.args.combinedCourse.code);
+    this.args.combinedCourse.reload();
+  }
+}

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -4,4 +4,5 @@ export default class CombinedCourse extends Model {
   @attr('string') name;
   @attr('string') code;
   @attr() organizationId;
+  @attr('string') status;
 }

--- a/mon-pix/app/templates/combined-courses.gjs
+++ b/mon-pix/app/templates/combined-courses.gjs
@@ -1,0 +1,3 @@
+import CombinedCourses from 'mon-pix/components/routes/combined-courses';
+
+<template><CombinedCourses @combinedCourse={{@model}} /></template>

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -1,0 +1,49 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering.js';
+
+module('Integration | Component | combined course', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when participation has not been started yet', function () {
+    test('should display start button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'not-started', code: 'COMBINIX9' });
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('pages.combined-courses.content.start-button') }));
+    });
+    test('when clicking start button, should create quest participation', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'not-started', code: 'COMBINIX9' });
+      sinon.stub(combinedCourse, 'reload').callsFake(() => {
+        combinedCourse.status = 'started';
+      });
+      this.setProperties({ combinedCourse });
+      sinon.stub(store, 'adapterFor');
+
+      store.adapterFor.withArgs('combined-course').returns({ start: sinon.stub().withArgs('COMBINIX9').resolves() });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      await click(screen.getByRole('button', { name: t('pages.combined-courses.content.start-button') }));
+
+      // then
+      assert.notOk(screen.queryByRole('button', { name: t('pages.combined-courses.content.start-button') }));
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -14,7 +14,7 @@ module('Integration | Component | combined course', function (hooks) {
     test('should display start button', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'not-started', code: 'COMBINIX9' });
+      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'NOT_STARTED', code: 'COMBINIX9' });
       this.setProperties({ combinedCourse });
 
       // when
@@ -27,9 +27,9 @@ module('Integration | Component | combined course', function (hooks) {
     test('when clicking start button, should create quest participation', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'not-started', code: 'COMBINIX9' });
+      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'NOT_STARTED', code: 'COMBINIX9' });
       sinon.stub(combinedCourse, 'reload').callsFake(() => {
-        combinedCourse.status = 'started';
+        combinedCourse.status = 'STARTED';
       });
       this.setProperties({ combinedCourse });
       sinon.stub(store, 'adapterFor');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1193,6 +1193,11 @@
         "end-of-assessment": "End of your assessment"
       }
     },
+    "combined-courses": {
+      "content": {
+        "start-button": "Start course"
+      }
+    },
     "comparison-window": {
       "results": {
         "a11y": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1188,6 +1188,11 @@
         "end-of-assessment": "Fin de la evaluación"
       }
     },
+    "combined-courses": {
+      "content": {
+        "start-button": "Iniciar el curso"
+      }
+    },
     "comparison-window": {
       "results": {
         "a11y": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1193,6 +1193,11 @@
         "end-of-assessment": "Fin de votre évaluation"
       }
     },
+    "combined-courses": {
+      "content": {
+        "start-button": "Commencer mon parcours"
+      }
+    },
     "comparison-window": {
       "results": {
         "a11y": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1191,6 +1191,11 @@
         "end-of-assessment": "Einde van je beoordeling"
       }
     },
+    "combined-courses": {
+      "content": {
+        "start-button": "Cursus starten"
+      }
+    },
     "comparison-window": {
       "results": {
         "a11y": {


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Actuellement, l'utilisateur ne peut pas démarrer un parcours combiné.

## ⛱️ Proposition

Ajout d'une page avec un bouton de démarrage du parcours combiné.
Côté backend, lors du démarrage du parcours combiné une "CombinedCourseParticipation" est créée afin de suivre l'avancement de l'utilisateur dans ce parcours combiné.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

La page est pour le moment vide (en dehors du bouton de démarrage).
Le contenu fera l'objet d'une PR dédiée.

Il y aura également une autre PR qui s'occupera de renommer la table `quest-participations` en `combined-courses-participations`.

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## 🏄 Pour tester

Se connecter avec `attestation-success@example.net` à Pix App.
Cliquer sur `J'ai un code`.
Saisir le code `COMBINIX1`.
Vérifier que le bouton `Démarrer le parcours combiné` s'affiche.
Cliquer sur le bouton.
Vérifier que le bouton ne s'affiche plus.
Vérifier qu'il n'y a pas de message d'erreur dans la console.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

