### PR TITLE
[FEATURE] Ajouter des événements Plausible lors de l'enrichissement d'un utilisateur anonyme (PIX-18522).

### DIFF
--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -33,6 +33,7 @@ export default class SignupForm extends Component {
   @service url;
   @service errorMessages;
   @service featureToggles;
+  @service pixMetrics;
 
   @tracked isLoading = false;
   @tracked globalError = null;
@@ -91,6 +92,7 @@ export default class SignupForm extends Component {
       const wasAnonymousBeforeSaving = user.isAnonymous;
       await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
       if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && wasAnonymousBeforeSaving) {
+        this.pixMetrics.trackEvent({ 'pix-event-name': 'SignUpFromAnonymousUserDone' });
         this.session.set('skipRedirectAfterSessionInvalidation', true);
         await this.session.invalidate();
       }

--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
@@ -7,8 +7,9 @@ import t from 'ember-intl/helpers/t';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 
 export default class LandingPageStartBlock extends Component {
-  @service session;
+  @service pixMetrics;
   @service router;
+  @service session;
 
   get isUserConnected() {
     return this.session.isAuthenticated;
@@ -18,6 +19,12 @@ export default class LandingPageStartBlock extends Component {
   async redirectToSignin() {
     const transition = this.args.startCampaignParticipation();
     this.session.requireAuthenticationAndApprovedTermsOfService(transition);
+  }
+
+  @action
+  async startCampaignParticipationAsAnonymous() {
+    this.pixMetrics.trackEvent({ 'pix-event-name': 'StartAutonomousCourseAsAnonymousClick' });
+    this.args.startCampaignParticipation();
   }
 
   <template>
@@ -48,7 +55,7 @@ export default class LandingPageStartBlock extends Component {
           <PixButton
             id="autonomous-course-start-anonymously-button"
             class="start-anonymously-button"
-            @triggerAction={{@startCampaignParticipation}}
+            @triggerAction={{this.startCampaignParticipationAsAnonymous}}
           >
             {{t "pages.autonomous-course.landing-page.actions.start-anonymously"}}
           </PixButton>

--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -64,6 +64,7 @@ export default class CampaignStartBlock extends Component {
   @service session;
   @service featureToggles;
   @service intl;
+  @service pixMetrics;
 
   get showWarningMessage() {
     return this.session.isAuthenticated && !this.currentUser.user.isAnonymous;
@@ -109,6 +110,13 @@ export default class CampaignStartBlock extends Component {
   }
 
   @action
+  trackAccessForUser() {
+    if (this.args.campaign.isSimplifiedAccess && !this.session.isAuthenticated) {
+      this.pixMetrics.trackEvent({ 'pix-event-name': 'StartSimplifiedAccessCampaignAsAnonymousClick' });
+    }
+  }
+
+  @action
   disconnect() {
     this.session.invalidate();
   }
@@ -116,6 +124,7 @@ export default class CampaignStartBlock extends Component {
   @action
   start(event) {
     event.preventDefault();
+    this.trackAccessForUser();
     this.args.startCampaignParticipation();
   }
 }

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -26,7 +26,7 @@ dayjs.extend(CustomParseFormat);
 export default class EvaluationResultsHero extends Component {
   @service currentUser;
 
-  @service metrics;
+  @service pixMetrics;
   @service router;
   @service store;
   @service tabManager;
@@ -70,12 +70,6 @@ export default class EvaluationResultsHero extends Component {
     return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous;
   }
 
-  get dynamicRoute() {
-    return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous
-      ? 'inscription'
-      : 'authentication.login';
-  }
-
   get hasQuestResults() {
     return this.args.questResults && this.args.questResults.length > 0;
   }
@@ -106,7 +100,7 @@ export default class EvaluationResultsHero extends Component {
       const adapter = this.store.adapterFor('campaign-participation-result');
       await adapter.beginImprovement(campaignParticipationResult.id);
 
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Amélioration des résultats',
@@ -137,7 +131,7 @@ export default class EvaluationResultsHero extends Component {
       });
       this.args.onResultsShared();
 
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Envoi des résultats',
@@ -157,7 +151,7 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   handleBackToHomepageDisplay() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Sortie de parcours',
@@ -167,12 +161,17 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   handleBackToHomepageClick() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Sortie de parcours',
       'pix-event-name': "Clic sur le bouton 'Revenir à la page d'accueil'",
     });
+  }
+
+  @action
+  handleSignUpClick() {
+    this.pixMetrics.trackEvent({ 'pix-event-name': 'CampaignResultSignUpFromAnonymousUserClick' });
   }
 
   <template>
@@ -252,7 +251,7 @@ export default class EvaluationResultsHero extends Component {
             {{#if @campaignParticipationResult.isShared}}
               {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
                 <p>{{t "pages.sign-up.save-progress-message"}}</p>
-                <PixButtonLink @route="inscription" @size="large">
+                <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
                   {{t "pages.sign-up.actions.sign-up-on-pix"}}
                 </PixButtonLink>
               {{/if}}
@@ -295,13 +294,13 @@ export default class EvaluationResultsHero extends Component {
             {{/if}}
           {{else}}
             {{#unless @campaign.hasCustomResultPageButton}}
-              {{this.handleBackToHomepageDisplay}}
               {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
                 <p>{{t "pages.sign-up.save-progress-message"}}</p>
-                <PixButtonLink @route={{this.dynamicRoute}} @size="large" onclick={{this.handleBackToHomepageClick}}>
+                <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
                   {{t "pages.sign-up.actions.sign-up-on-pix"}}
                 </PixButtonLink>
               {{else}}
+                {{this.handleBackToHomepageDisplay}}
                 <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
                   {{t "navigation.back-to-homepage"}}
                 </PixButtonLink>

--- a/mon-pix/app/services/pix-metrics.js
+++ b/mon-pix/app/services/pix-metrics.js
@@ -17,7 +17,11 @@ export default class PixMetricsService extends Service {
   getRedactedPageUrl() {
     const params = extractParamsFromRouteInfo(this.router.currentRoute);
     const currentUrl = this.router.currentURL;
+    if (!currentUrl) return null;
+
     const [base, queryParams] = currentUrl.split('?');
+    if (!base) return null;
+
     const redactedUrl = base
       .split('/')
       .map((token) => {


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre de cette Epix, nous avons besoin de pouvoir [identifier les utilisateurs qui se sont créé un compte Pix ](https://1024pix.atlassian.net/wiki/spaces/DA/pages/5086576645/Donner+la+possibilit+d+un+utilisateur+anonyme+de+se+lier+un+compte#:~:text=Voir%20comment%20identifier%20si%20les%20utilisateurs%20ont%20%C3%A9t%C3%A9%20cr%C3%A9%C3%A9s%20via%20une%20inscription%20suite%20%C3%A0%20un%20parcours%20autonome%20(anonyme%20dans%20le%20pass%C3%A9)%20dans%20le%20but%20d%E2%80%99analyse%20des%20donn%C3%A9es.)à partir d’un compte anonyme. 


Cette fonctionnalité est importante pour : 

Déterminer le nombre de bénéficiaires de cette fonctionnalité et justifier les fonds que nous recevons

Déterminer le taux de conversion (nombre de comptes anonymes crées / nombre d’utilisateurs qui se sont crées un compte à partir d’un compte anonyme).

## ⛱️ Proposition
Ajouter des événements Plausible sur la conversion d'un utilisateur anonyme en utilisateur "normal" et sur l'entrée en parcours autonome anonyme. 

## 🏄 Pour tester

**Test à réaliser sur la RA (FT et WebAnalytics configurés)**

:warning: **Attention** votre navigateur (ou adblock) ne doit pas bloquer les requêtes pour tester.

1. Réaliser un parcours autonome https://app-pr12866.review.pix.fr/campagnes/AUTOCOUR1 en créant un compte en fin de parcours
> Vérifier que les évènements sont bien envoyés (voir requêtes réseaux: `/event`)
> - `StartAutonomousCourseAsAnonymousClick`
> - `CampaignResultSignUpFromAnonymousUserClick`
> - `SignUpFromAnonymousUserDone`

2. Réaliser un parcours accès simplifié https://app-pr12866.review.pix.fr/campagnes/EVALSTAG1 en créant un compte en fin de parcours
> Vérifier que les évènements sont bien envoyés (voir requêtes réseaux: `/event`)
> - `StartSimplifiedAccessCampaignAsAnonymousClick`
> - `CampaignResultSignUpFromAnonymousUserClick`
> - `SignUpFromAnonymousUserDone`

