### PR TITLE
[BUGFIX] Retrouver les challenges d'une certification complémentaire pour une simulation dédiée (PIX-18776).

### DIFF
--- a/api/src/certification/flash-certification/domain/usecases/index.js
+++ b/api/src/certification/flash-certification/domain/usecases/index.js
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
-import { complementaryCertificationRepository } from '../../../shared/infrastructure/repositories/complementary-certification-repository.js';
 import * as sharedFlashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as flashAlgorithmService from '../services/algorithm-methods/flash.js';
@@ -22,7 +21,6 @@ const dependencies = {
   challengeRepository,
   flashAlgorithmConfigurationRepository,
   sharedFlashAlgorithmConfigurationRepository,
-  complementaryCertificationRepository,
   flashAlgorithmService,
 };
 

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js
@@ -65,16 +65,13 @@ async function _simulateComplementaryCertificationScenario({
   variationPercent,
   challengeRepository,
   flashAlgorithmService,
-  complementaryCertificationRepository,
   sharedFlashAlgorithmConfigurationRepository,
   stopAtChallenge,
 }) {
-  const complementaryCertification = await complementaryCertificationRepository.getByKey(complementaryCertificationKey);
-
   const challenges = await _getChallenges({
     locale,
     challengeRepository,
-    complementaryCertification,
+    complementaryCertificationKey,
   });
 
   const mostRecentAlgorithmConfiguration = await sharedFlashAlgorithmConfigurationRepository.getMostRecent();
@@ -123,11 +120,11 @@ async function _simulateCoreCertificationScenario({
   });
 }
 
-function _getChallenges({ challengeRepository, locale, accessibilityAdjustmentNeeded, complementaryCertification }) {
+function _getChallenges({ challengeRepository, locale, accessibilityAdjustmentNeeded, complementaryCertificationKey }) {
   return challengeRepository.findActiveFlashCompatible({
     locale,
     accessibilityAdjustmentNeeded,
-    complementaryCertificationId: complementaryCertification?.id,
+    complementaryCertificationKey,
   });
 }
 

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -172,14 +172,14 @@ function _findChallengesForCoreCertification({ locale, accessibilityAdjustmentNe
 
 function decorateWithCertificationCalibration({ challengeDtos, complementaryCertificationChallenges }) {
   return challengeDtos.map((challenge) => {
-    const { alpha, delta } = complementaryCertificationChallenges.find(
+    const { discriminant, difficulty } = complementaryCertificationChallenges.find(
       ({ challengeId }) => challengeId === challenge.id,
     );
 
     return {
       ...challenge,
-      alpha,
-      delta,
+      alpha: discriminant,
+      delta: difficulty,
     };
   });
 }

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -232,5 +232,44 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
         expect(response).to.have.property('statusCode', 400);
       });
     });
+
+    describe('when simulating a complementary certification scenario', function () {
+      it('should return a report with the same number of simulation scenario reports as the number of challenges in the configuration', async function () {
+        // given
+        databaseBuilder.factory.buildComplementaryCertification({ key: 'DROIT' });
+        databaseBuilder.factory.buildComplementaryCertification({ key: 'EDU' });
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: 'DROIT',
+          challengeId: 'challenge1',
+        });
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: 'DROIT',
+          challengeId: 'challenge3',
+        });
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: 'EDU',
+          challengeId: 'challenge2',
+        });
+        await databaseBuilder.commit();
+        options.headers = adminAuthorizationHeaders;
+        options.payload = { ...validPayload, complementaryCertificationKey: 'DROIT' };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 200);
+        const parsedResponse = parseJsonStream(response);
+        expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
+        expect(parsedResponse[0].simulationReport[0].challengeId).to.exist;
+        expect(parsedResponse[0].simulationReport[0].capacity).to.exist;
+        expect(parsedResponse[0].simulationReport[0].difficulty).to.exist;
+        expect(parsedResponse[0].simulationReport[0].discriminant).to.exist;
+        expect(parsedResponse[0].simulationReport[0].reward).to.exist;
+        expect(parsedResponse[0].simulationReport[0].errorRate).to.exist;
+        expect(parsedResponse[0].simulationReport[0].answerStatus).to.exist;
+        expect(parsedResponse[0].simulationReport[0].numberOfAvailableChallenges).to.exist;
+      });
+    });
   });
 });

--- a/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -1,6 +1,7 @@
 import { simulateFlashAssessmentScenario } from '../../../../../../src/certification/flash-certification/domain/usecases/simulate-flash-assessment-scenario.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('#simulateFlashAssessmentScenario', function () {
   describe('when a complementary certification scenario is required', function () {
@@ -8,28 +9,20 @@ describe('#simulateFlashAssessmentScenario', function () {
       // given
       const locale = LOCALE.FRENCH_FRANCE;
       const accessibilityAdjustmentNeeded = false;
-      const complementaryCertification = domainBuilder.buildComplementaryCertification();
+      const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
       const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
-      const complementaryCertificationRepositoryStub = {
-        getByKey: sinon.stub().resolves(complementaryCertification),
-      };
 
       // when
       await catchErr(simulateFlashAssessmentScenario)({
         locale,
         accessibilityAdjustmentNeeded,
-        complementaryCertificationKey: complementaryCertification.key,
+        complementaryCertificationKey,
         challengeRepository: challengeRepositoryStub,
-        complementaryCertificationRepository: complementaryCertificationRepositoryStub,
       });
 
       // then
-      expect(complementaryCertificationRepositoryStub.getByKey).to.have.been.calledOnceWithExactly(
-        complementaryCertification.key,
-      );
-
       expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-        complementaryCertificationId: complementaryCertification.id,
+        complementaryCertificationKey,
         locale,
         accessibilityAdjustmentNeeded: undefined,
       });
@@ -42,9 +35,6 @@ describe('#simulateFlashAssessmentScenario', function () {
       const locale = LOCALE.FRENCH_FRANCE;
       const accessibilityAdjustmentNeeded = false;
       const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
-      const complementaryCertificationRepositoryStub = {
-        getByKey: sinon.stub(),
-      };
 
       // when
       await catchErr(simulateFlashAssessmentScenario)({
@@ -55,12 +45,10 @@ describe('#simulateFlashAssessmentScenario', function () {
       });
 
       // then
-      expect(complementaryCertificationRepositoryStub.getByKey).not.to.have.been.called;
-
       expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
         locale,
         accessibilityAdjustmentNeeded,
-        complementaryCertificationId: undefined,
+        complementaryCertificationKey: undefined,
       });
     });
   });

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1869,8 +1869,8 @@ describe('Integration | Repository | challenge-repository', function () {
 
         expect(flashCompatibleChallenges).to.have.lengthOf(1);
         expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[0].id);
-        expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.alpha);
-        expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.delta);
+        expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.difficulty);
+        expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.discriminant);
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

Lorsque l'on exécute une simulation de déroulé de certification complémentaire, nous ne retrouvions pas les challenges enregistrés dans la table `certification-frameworks-challenges` mais uniquement ceux issus du référentiel coeur.

Nous passions en effet le mauvais paramètre à la fonction de récupération des challenges.

Signature de la fonction `findActiveFlashCompatible` dans `api/src/shared/infrastructure/repositories/challenge-repository.js` 

```javascript
function findActiveFlashCompatible({
  locale,
  successProbabilityThreshold = config.features.successProbabilityThreshold,
  accessibilityAdjustmentNeeded = false,
  complementaryCertificationKey,
}) {}
```

Utilisation dans le code de simulateur de déroulé avant correctif :

```javascript
function _getChallenges({ challengeRepository, locale, accessibilityAdjustmentNeeded, complementaryCertificationKey }) {
  return challengeRepository.findActiveFlashCompatible({
    locale,
    accessibilityAdjustmentNeeded,
    complementaryCertificationId,
  });
}
```

Suite à #12740 , nous avons également renommé les colonnes `alpha` et `delta` de `certification-frameworks-challenges` en `difficulty` et `discriminant`. Renommage que nous n'avions pas reproduit dans le simulateur.

## ⛱️ Proposition

- Ajout d'un test d'acceptation pour nous couvrir
- Renommage de `alpha` et `delta`
- Utilisation du bon paramètre.
- Suppression d'un appel à un repository devenu non utile pour récupérer la certification complémentaire.


## 🌊 Remarques

Les seeds ne sont pas assez fournis pour tester le simulateur de déroulé de façon optimale dans le cadre d'une certification complémentaire. 
Nous rencontrons en effet un problème lié: 

- Au nombre de challenges enregistrés dans la table `certification-frameworks-challenges` (25 provenant de 3 sujets/tubes)
- Au fait que ces challenges soient tous liés à la même compétence

Ces deux critères "rentrent en conflit" avec les règles de la configuration de l'algorithme de sélection des questions enregistrée dans `flash-algorithm-configurations`. (`enablePassageByAllCompetences` et `limitToOneQuestionPerTube`)

Nous proposons de remonter les potentielles erreurs rencontrées lors d'une simulation, notamment l'erreur `throw new RangeError('No eligible challenges in referential');` liée au filtrage des questions effectué par `FlashAssessmentAlgorithmRuleEngine.js`.

## 🏄 Pour tester

⚠️ Il ne sera pas possible d'avoir plus de 3 challenges en sortie de simulation avec la configuration actuelle car les seeds contiennent des challenges de 3 sujets différents et la configuration demande à limiter à une seule question par sujet.
Nous ajoutons donc le paramètre `"stopAtChallenge": 3` dans le payload de la requête pour ne pas rencontrer d'erreurs.

```bash
TOKEN=$(curl --insecure 'https://admin-pr12872.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr12872.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "stopAtChallenge": 3, "complementaryCertificationKey": "DROIT", "locale": "fr-fr" }' | jq '.'
```
