### PR TITLE
[FEATURE] Indiquer à l'utilisateur qu'il peut retenter une campagne (PIX-18519)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -56,10 +56,18 @@ function _getQueryBuilder(callback) {
         deletedAt: 'campaign-participations.deletedAt',
         participationState: _computeCampaignParticipationState(),
         campaignId: 'campaigns.id',
+        isCampaignMultipleSendings: 'campaigns.multipleSendings',
+        isOrganizationLearnerDisabled: 'view-active-organization-learners.isDisabled',
+        campaignType: 'campaigns.type',
       })
         .from('campaign-participations')
         .join('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
         .join('organizations', 'organizations.id', 'campaigns.organizationId')
+        .leftJoin(
+          'view-active-organization-learners',
+          'view-active-organization-learners.id',
+          'campaign-participations.organizationLearnerId',
+        )
         .whereIn('campaigns.type', [CampaignTypes.ASSESSMENT, CampaignTypes.EXAM])
         .where('campaigns.isForAbsoluteNovice', false)
         .whereNot('organizations.id', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -21,6 +21,7 @@ const serialize = function (campaignParticipationOverview, meta) {
       'masteryRate',
       'validatedStagesCount',
       'totalStagesCount',
+      'canRetry',
     ],
     meta,
   }).serialize(campaignParticipationOverview);

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,5 +1,8 @@
 import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
-import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -22,6 +25,9 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
         masteryRate: 0.5,
         totalStagesCount: 3,
         validatedStagesCount: 2,
+        isCampaignMultipleSendings: true,
+        isOrganizationLearnerActive: true,
+        campaignType: CampaignTypes.ASSESSMENT,
       });
 
       expectedSerializedCampaignParticipationOverview = {
@@ -40,6 +46,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'mastery-rate': 0.5,
             'validated-stages-count': 2,
             'total-stages-count': 3,
+            'can-retry': false,
           },
         },
       };
@@ -51,6 +58,48 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
 
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipationOverview);
+    });
+
+    it('should serialize canRetry as true when retry is possible', function () {
+      // given
+      const campaignParticipationOverview = new CampaignParticipationOverview({
+        id: 6,
+        status: SHARED,
+        sharedAt: new Date('2018-01-01T14:12:44Z'), // Old enough
+        masteryRate: 0.7, // Less than 100%
+        isCampaignMultipleSendings: true,
+        isOrganizationLearnerActive: true,
+        campaignType: CampaignTypes.ASSESSMENT,
+        campaignArchivedAt: null,
+        deletedAt: null,
+      });
+
+      // when
+      const json = serializer.serialize(campaignParticipationOverview);
+
+      // then
+      expect(json.data.attributes['can-retry']).to.be.true;
+    });
+
+    it('should serialize canRetry as false when retry is not possible', function () {
+      // given
+      const campaignParticipationOverview = new CampaignParticipationOverview({
+        id: 7,
+        status: SHARED,
+        sharedAt: new Date('2018-01-01T14:12:44Z'),
+        masteryRate: 0.7,
+        isCampaignMultipleSendings: false, // Multiple sendings not allowed
+        isOrganizationLearnerActive: true,
+        campaignType: CampaignTypes.ASSESSMENT,
+        campaignArchivedAt: null,
+        deletedAt: null,
+      });
+
+      // when
+      const json = serializer.serialize(campaignParticipationOverview);
+
+      // then
+      expect(json.data.attributes['can-retry']).to.be.false;
     });
   });
 
@@ -70,6 +119,9 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           masteryRate: null,
           totalStagesCount: 0,
           validatedStagesCount: null,
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: true,
+          campaignType: CampaignTypes.ASSESSMENT,
         }),
 
         new CampaignParticipationOverview({
@@ -84,6 +136,9 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           masteryRate: null,
           totalStagesCount: 0,
           validatedStagesCount: null,
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: true,
+          campaignType: CampaignTypes.ASSESSMENT,
         }),
       ];
       const pagination = {
@@ -113,6 +168,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'disabled-at': null,
               'validated-stages-count': null,
               'total-stages-count': 0,
+              'can-retry': false,
             },
             id: '6',
             type: 'campaign-participation-overviews',
@@ -130,6 +186,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'disabled-at': null,
               'validated-stages-count': null,
               'total-stages-count': 0,
+              'can-retry': false,
             },
             id: '7',
             type: 'campaign-participation-overviews',

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
@@ -1,4 +1,4 @@
-import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 const { SHARED } = CampaignParticipationStatuses;
 
@@ -18,6 +18,11 @@ const buildCampaignParticipationOverview = function ({
   validatedStagesCount = 1,
   validatedSkillsCount = 1,
   disabledAt = null,
+  campaignArchivedAt = null,
+  deletedAt = null,
+  isCampaignMultipleSendings = false,
+  isOrganizationLearnerDisabled = false,
+  campaignType = CampaignTypes.ASSESSMENT,
 } = {}) {
   const isShared = status === SHARED;
   return new CampaignParticipationOverview({
@@ -37,6 +42,11 @@ const buildCampaignParticipationOverview = function ({
     totalStagesCount,
     validatedStagesCount,
     disabledAt,
+    campaignArchivedAt,
+    deletedAt,
+    isCampaignMultipleSendings,
+    isOrganizationLearnerDisabled,
+    campaignType,
   });
 };
 

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -38,10 +38,14 @@ export default class Ended extends Component {
         </div>
         <PixButton
           class="campaign-participation-overview-card-content__action"
-          @variant="secondary"
+          @variant={{if @model.canRetry "primary" "secondary"}}
           @triggerAction={{this.onClick}}
         >
-          {{t "pages.campaign-participation-overview.card.see-more"}}
+          {{#if @model.canRetry}}
+            {{t "pages.campaign-participation-overview.card.retry"}}
+          {{else}}
+            {{t "pages.campaign-participation-overview.card.see-more"}}
+          {{/if}}
         </PixButton>
       </section>
     </PixBlock>

--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -13,6 +13,7 @@ export default class CampaignParticipationOverviews extends Model {
   @attr('number') masteryRate;
   @attr('number') totalStagesCount;
   @attr('number') validatedStagesCount;
+  @attr('boolean') canRetry;
 
   get cardStatus() {
     if (this.isShared) return 'ENDED';

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
@@ -89,6 +89,54 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
       });
     });
 
+    module('when canRetry is true', function () {
+      test('should display retry button text', async function (assert) {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          isShared: true,
+          createdAt: '2020-12-10T15:16:20.109Z',
+          sharedAt: '2020-12-18T15:16:20.109Z',
+          status: 'SHARED',
+          campaignTitle: 'My campaign',
+          organizationName: 'My organization',
+          canRetry: true,
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        const screen = await render(
+          hbs`<CampaignParticipationOverview::Card::Ended @model={{this.campaignParticipationOverview}} />`,
+        );
+
+        // then
+        assert.ok(screen.getByText(t('pages.campaign-participation-overview.card.retry')));
+      });
+    });
+
+    module('when canRetry is false', function () {
+      test('should display see-more button text', async function (assert) {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          isShared: true,
+          createdAt: '2020-12-10T15:16:20.109Z',
+          sharedAt: '2020-12-18T15:16:20.109Z',
+          status: 'SHARED',
+          campaignTitle: 'My campaign',
+          organizationName: 'My organization',
+          canRetry: false,
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        const screen = await render(
+          hbs`<CampaignParticipationOverview::Card::Ended @model={{this.campaignParticipationOverview}} />`,
+        );
+
+        // then
+        assert.ok(screen.getByText(t('pages.campaign-participation-overview.card.see-more')));
+      });
+    });
+
     module('#onClick', function () {
       test('should push event on click', async function (assert) {
         // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -609,6 +609,7 @@
           "extra-information": "Resume the customised test {campaignTitle}",
           "information": "Resume"
         },
+        "retry": "Improve myself",
         "see-more": "See more",
         "send": "Submit my results",
         "stages": "{count} { count, plural, =0 {star} =1 {star} other {stars} } out of {total}",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -597,6 +597,7 @@
           "extra-information": "Retomar el test {campaignTitle}",
           "information": "Retomar"
         },
+        "retry": "Mejorarme a mí mismo",
         "see-more": "Ver el detalle",
         "send": "Enviar mis resultados",
         "stages": "{count} { count, plural, =0 {estrellas} =1 {estrella} other {estrellas} } de {total}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -609,6 +609,7 @@
           "extra-information": "Reprendre le parcours {campaignTitle}",
           "information": "Reprendre"
         },
+        "retry": "M'améliorer",
         "see-more": "Voir le détail",
         "send": "Envoyer mes résultats",
         "stages": "{count} { count, plural, =0 {étoile} =1 {étoile} other {étoiles} } sur {total}",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -597,6 +597,7 @@
           "extra-information": "Hervat de {campaignTitle} route",
           "information": "Overnemen"
         },
+        "retry": "Verbeter mezelf",
         "see-more": "Zie details",
         "send": "Stuur mijn resultaten",
         "stages": "{count} {count, plural, =0 {star} =1 {star} other {stars} } on {total}",


### PR DESCRIPTION
## 🔆 Problème

La feature "retenter le parcours" n'est pas assez utiliséee a notre gout.

## ⛱️ Proposition

Avant
<img width="1058" height="679" alt="image" src="https://github.com/user-attachments/assets/7d4f7a17-3995-40a2-9c0c-af034a76fed1" />

Apres
<img width="1068" height="584" alt="image" src="https://github.com/user-attachments/assets/33cdb447-5033-4af8-9ba9-6058a73b7466" />

Dans la liste des campagnes, changer le visuel du bouton pour indiquer à l'utilisateur qu'il peut retenter sa campagne.

## 🌊 Remarques

La logique pour déterminer si la campagne peut être retentée à été dupliquée depuis le model AssessmentResult. Il n'est évidemment pas souhaitable de répéter la même logique a deux endroits différents et nous allons traiter ce problème dans une prochaine fusiodemande.

## 🏄 Pour tester

Creer un parcours retentable, tu vois ce que je veux dire, ou utiliser PROASSMUL 🧑‍🏭  🍑 🫏 
Terminer le parcours 🔥. 
Revenir 4 jours plus tard 🤡 ( sinon vous pouvez aussi jouer avec la variable DAYS_BEFORE_RETRYING mais c'est moins drole )
Constater que le bouton dans la page des parcours a pris une jolie teinte violette.
