### PR TITLE
[BUGFIX] Utiliser les url complètes pour le suivi plausible (PIX-18165)

### DIFF
--- a/mon-pix/app/services/pix-metrics.js
+++ b/mon-pix/app/services/pix-metrics.js
@@ -24,7 +24,8 @@ export default class PixMetricsService extends Service {
         return params.includes(token) ? '_ID_' : token;
       })
       .join('/');
-    return queryParams ? `${redactedUrl}?${queryParams}` : redactedUrl;
+    const baseUrl = new URL(window.location).origin;
+    return queryParams ? `${baseUrl}${redactedUrl}?${queryParams}` : `${baseUrl}${redactedUrl}`;
   }
 }
 

--- a/mon-pix/tests/acceptance/application-test.js
+++ b/mon-pix/tests/acceptance/application-test.js
@@ -39,7 +39,7 @@ module('Acceptance | Application', function (hooks) {
       // then
       assert.ok(
         metricService.trackPage.calledOnceWithExactly({
-          plausibleAttributes: { u: '/accueil' },
+          plausibleAttributes: { u: `${new URL(window.location).origin}/accueil` },
         }),
       );
     });
@@ -70,7 +70,7 @@ module('Acceptance | Application', function (hooks) {
       const metricService = this.owner.lookup('service:metrics');
       await visit('/assessments/1/challenges/0');
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/assessments/_ID_/challenges/_ID_' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/assessments/_ID_/challenges/_ID_` },
       });
       assert.ok(true);
     });
@@ -83,7 +83,7 @@ module('Acceptance | Application', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/connexion' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/connexion` },
       });
 
       assert.ok(true);
@@ -103,7 +103,7 @@ module('Acceptance | Application', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/assessments/_ID_/challenges/_ID_?id=1' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/assessments/_ID_/challenges/_ID_?id=1` },
       });
 
       assert.ok(true);

--- a/mon-pix/tests/unit/services/pix-metrics-test.js
+++ b/mon-pix/tests/unit/services/pix-metrics-test.js
@@ -44,7 +44,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
-        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
         params: 1,
       });
       assert.ok(true);
@@ -76,7 +76,9 @@ module('Unit | Service | PixMetrics', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
-        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
         params: 1,
       });
       assert.ok(true);
@@ -110,7 +112,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
         eventName: 'mon-event',
-        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
         params: 1,
       });
       assert.ok(true);
@@ -144,7 +146,9 @@ module('Unit | Service | PixMetrics', function (hooks) {
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
         eventName: 'mon-event',
-        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
         params: 1,
       });
       assert.ok(true);

--- a/orga/app/services/pix-metrics.js
+++ b/orga/app/services/pix-metrics.js
@@ -24,7 +24,9 @@ export default class PixMetricsService extends Service {
         return params.includes(token) ? '_ID_' : token;
       })
       .join('/');
-    return queryParams ? `${redactedUrl}?${queryParams}` : redactedUrl;
+
+    const baseUrl = new URL(window.location).origin;
+    return queryParams ? `${baseUrl}${redactedUrl}?${queryParams}` : `${baseUrl}${redactedUrl}`;
   }
 }
 

--- a/orga/tests/acceptance/application-test.js
+++ b/orga/tests/acceptance/application-test.js
@@ -38,7 +38,7 @@ module('Application', function (hooks) {
       // then
       assert.ok(
         metricService.trackPage.calledOnceWithExactly({
-          plausibleAttributes: { u: '/campagnes/les-miennes' },
+          plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/les-miennes` },
         }),
       );
     });
@@ -75,7 +75,7 @@ module('Application', function (hooks) {
 
       await visit('/campagnes/1/parametres');
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/campagnes/_ID_/parametres' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/parametres` },
       });
       assert.ok(true);
     });
@@ -88,7 +88,7 @@ module('Application', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/connexion' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/connexion` },
       });
 
       assert.ok(true);
@@ -115,7 +115,9 @@ module('Application', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricService.trackPage, {
-        plausibleAttributes: { u: '/campagnes/_ID_/resultats-evaluation?groups=["1ere A"]' },
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/campagnes/_ID_/resultats-evaluation?groups=["1ere A"]`,
+        },
       });
 
       assert.ok(true);

--- a/orga/tests/unit/services/pix-metrics-test.js
+++ b/orga/tests/unit/services/pix-metrics-test.js
@@ -17,6 +17,10 @@ module('Unit | Service | PixMetrics', function (hooks) {
     sinon.stub(metricsService, 'trackEvent');
   });
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('trackPage', function () {
     test('it should redact id from url', function (assert) {
       // given
@@ -44,7 +48,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
-        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
         params: 1,
       });
       assert.ok(true);
@@ -76,7 +80,9 @@ module('Unit | Service | PixMetrics', function (hooks) {
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
-        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
         params: 1,
       });
       assert.ok(true);
@@ -110,7 +116,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
         eventName: 'mon-event',
-        plausibleAttributes: { u: '/campagnes/_ID_/presentation' },
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
         params: 1,
       });
       assert.ok(true);
@@ -144,7 +150,9 @@ module('Unit | Service | PixMetrics', function (hooks) {
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
         eventName: 'mon-event',
-        plausibleAttributes: { u: '/assessments/_ID_/checkpoint?finalCheckpoint=true' },
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
         params: 1,
       });
       assert.ok(true);


### PR DESCRIPTION
## 🔆 Problème
Le tracking ne fonctionne pas correctement dans plausible. Plausible permet de filtrer les domaines autorisés à envoyer des évènements.
Malheureusement, nous n'envoyons pas d'url complète dans nos évènements plausible.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition
On rajoute le host dans l'url des évènements plausible
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

ras
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

activement le tracking dans la review-app
se ballader sur le site et voir qu'on a pas de x-plausible-dropped dans les header des réponses renvoyées par plausible

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
