### PR TITLE
[TECH] Déplacer les vidéos de modules vers des domaines Pix (PIX-18778)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -124,8 +124,12 @@
           "type": "element",
           "element": {
             "id": "fd39cc63-32f7-46eb-9f8a-55623878e0d1",
-            "type": "text",
-            "content": "<iframe title=\"Comment envoyer un mail ?\" width=\"560\" height=\"315\" src=\"https://tube-numerique-educatif.apps.education.fr/videos/embed/7d256f26-7777-4277-aa64-ca0084e1363b?title=0&amp;warningTitle=0&amp;peertubeLink=0&amp;p2p=0\" allowfullscreen=\"\" sandbox=\"allow-same-origin allow-scripts allow-popups allow-forms\"></iframe>"
+            "type": "video",
+            "title": "Comment envoyer un mail ?",
+            "url": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.mp4",
+            "poster": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.jpg",
+            "subtitles": "",
+            "transcription": ""
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -220,8 +220,12 @@
           "type": "element",
           "element": {
             "id": "8707010a-2068-470f-a007-77f0e82005c1",
-            "type": "text",
-            "content": "<iframe height=\"410\" src=\"https://www.youtube.com/embed/ikdJ-4ZVpOo?si=yjUOqKHdqafwbbh5\" title=\"Appliquer un tri multicritère dans un tableau\"></iframe>"
+            "type": "video",
+            "title": "Appliquer un tri multicritère dans un tableau",
+            "url": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.mp4",
+            "poster": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.jpg",
+            "subtitles": "",
+            "transcription": ""
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -552,7 +552,21 @@
                 {
                   "id": "734ef21d-3850-40db-840e-e16253d8817b",
                   "type": "text",
-                  "content": "<h3>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h3>\n<p> Ce clic gauche va faire démarrer la vidéo.</p><br><br><iframe height=\"410\" src=\"https://www.youtube.com/embed/czfvEpLfCV0?si=2Q1MBBnh2-c-0CmD\" title=\"Bravo\"></iframe>\n<p><br>Pour accéder à la suite, faites un clic gauche sur le bouton «&nbsp;Suivant&nbsp;».</p>"
+                  "content": "<h3>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h3><br><p> Ce clic gauche va faire démarrer la vidéo.</p>"
+                },
+                {
+                  "id": "b0f296c2-a295-4424-8eb1-76e3fbcc1ebb",
+                  "type": "video",
+                  "title": "Bravo, vous êtes sur internet",
+                  "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.mp4",
+                  "poster": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.jpg",
+                  "subtitles": "",
+                  "transcription": "<p>Bravo, vous êtes sur internet.</p><p>Vous allez voir c'est facile.</p>"
+                },
+                {
+                  "id": "06cd1e83-06ce-4ca2-a648-1184ca6700f3",
+                  "type": "text",
+                  "content": "<p>Pour accéder à la suite, faites un clic gauche sur le bouton «&nbsp;Suivant&nbsp;».</p>"
                 }
               ]
             },


### PR DESCRIPTION
## 🔆 Problème

On ne souhaite pas consommer de ressources externes à des domaines Pix.

## ⛱️ Proposition

Rapatrier des vidéos externes chez Pix.

## 🌊 Remarques

Il manque bien sûr les transcriptions/sous titres.

## 🏄 Pour tester

Vérifier que les vidéos dans les 3 modules suivants fonctionnent correctement : 
- https://app-pr12886.review.pix.fr/modules/comment-envoyer-un-mail/passage
- https://app-pr12886.review.pix.fr/modules/tri-multicritere-tableau/passage
- https://app-pr12886.review.pix.fr/modules/utiliser-souris-ordinateur-1/passage