### PR TITLE
[FEATURE] Afficher le référentiel cadre actuel d'une complémentaire (PIX-18346).

### DIFF
--- a/admin/app/adapters/certification-consolidated-framework.js
+++ b/admin/app/adapters/certification-consolidated-framework.js
@@ -19,4 +19,10 @@ export default class CertificationConsolidatedFrameworkAdapter extends Applicati
 
     return this.ajax(url, 'POST', payload);
   }
+
+  findRecord(store, type, complementaryCertificationKey) {
+    const url = `${this.buildURL('complementary-certifications', complementaryCertificationKey)}/current-consolidated-framework`;
+
+    return this.ajax(url, 'GET');
+  }
 }

--- a/admin/app/components/complementary-certifications/item/framework.gjs
+++ b/admin/app/components/complementary-certifications/item/framework.gjs
@@ -1,11 +1,57 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-<template>
-  <PixButtonLink
-    class="framework__creation-button"
-    @route="authenticated.complementary-certifications.item.framework.new"
-  >
-    {{t "components.complementary-certifications.item.framework.create-button"}}
-  </PixButtonLink>
-</template>
+import FrameworkDetails from './framework/framework-details';
+
+export default class ComplementaryCertificationFramework extends Component {
+  @service store;
+  @service router;
+  @tracked currentConsolidatedFramework;
+
+  constructor() {
+    super(...arguments);
+
+    this.#onMount();
+  }
+
+  async #onMount() {
+    const routeParams = this.router.currentRoute.parent.parent.params;
+
+    const complementaryCertification = await this.store.peekRecord(
+      'complementary-certification',
+      routeParams.complementary_certification_id,
+    );
+
+    this.currentConsolidatedFramework = await this.store.findRecord(
+      'certification-consolidated-framework',
+      complementaryCertification.key,
+    );
+  }
+
+  <template>
+    <PixBlock @variant="admin">
+      {{#unless this.currentConsolidatedFramework}}
+        <PixNotificationAlert @withIcon={{true}} class="framework__no-current">
+          {{t "components.complementary-certifications.item.framework.no-current-framework"}}
+        </PixNotificationAlert>
+        <br />
+      {{/unless}}
+
+      <PixButtonLink
+        class="framework__creation-button"
+        @route="authenticated.complementary-certifications.item.framework.new"
+      >
+        {{t "components.complementary-certifications.item.framework.create-button"}}
+      </PixButtonLink>
+    </PixBlock>
+
+    {{#if this.currentConsolidatedFramework}}
+      <FrameworkDetails @currentConsolidatedFramework={{this.currentConsolidatedFramework}} />
+    {{/if}}
+  </template>
+}

--- a/admin/app/components/complementary-certifications/item/framework/framework-details.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/framework-details.gjs
@@ -1,0 +1,79 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import sortBy from 'lodash/sortBy';
+
+import Area from '../../../common/tubes-details/area';
+
+export default class FrameworkDetails extends Component {
+  get areas() {
+    const areas = this.args.currentConsolidatedFramework.hasMany('areas').value();
+    return sortBy(areas, ['frameworkId', 'code']).map((area) => this.buildAreaViewModel(area));
+  }
+
+  buildAreaViewModel(area) {
+    return {
+      title: `${area.code} · ${area.title}`,
+      color: area.color,
+      competences: sortBy(area.hasMany('competences').value(), 'index').map((competence) =>
+        this.buildCompetenceViewModel(competence),
+      ),
+    };
+  }
+
+  buildCompetenceViewModel(competence) {
+    return {
+      id: competence.id,
+      title: `${competence.index} ${competence.name}`,
+      thematics: sortBy(competence.hasMany('thematics').value(), 'index').map((thematic) =>
+        this.buildThematicViewModel(thematic),
+      ),
+    };
+  }
+
+  buildThematicViewModel(thematic) {
+    return {
+      name: thematic.name,
+      nbTubes: thematic.hasMany('tubes').value().length,
+      tubes: sortBy(thematic.hasMany('tubes').value(), 'practicalTitle').map((tube) => this.buildTubeViewModel(tube)),
+    };
+  }
+
+  buildTubeViewModel(tube) {
+    return {
+      id: tube.id,
+      title: `${tube.name} : ${tube.practicalTitle}`,
+      level: undefined, // To prevent tube level display
+      mobile: tube.mobile,
+      tablet: tube.tablet,
+      skills: sortBy(tube.hasMany('skills').value(), 'difficulty').map((skill) => this.buildSkillViewModel(skill)),
+    };
+  }
+
+  buildSkillViewModel(skill) {
+    return {
+      id: skill.id,
+      difficulty: skill.difficulty,
+    };
+  }
+
+  <template>
+    <section class="framework-details">
+      <h2 class="framework-details__title">
+        {{t "components.complementary-certifications.item.framework.details.title"}}
+      </h2>
+
+      <PixBlock @variant="admin">
+        {{#each this.areas as |area|}}
+          <Area
+            @title={{area.title}}
+            @color={{area.color}}
+            @competences={{area.competences}}
+            @displayDeviceCompatibility={{true}}
+            @displaySkillDifficultyAvailability={{true}}
+          />
+        {{/each}}
+      </PixBlock>
+    </section>
+  </template>
+}

--- a/admin/app/models/certification-consolidated-framework.js
+++ b/admin/app/models/certification-consolidated-framework.js
@@ -2,5 +2,6 @@ import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class CertificationConsolidatedFramework extends Model {
   @belongsTo('complementary-certification', { async: false, inverse: null }) complementaryCertification;
+  @hasMany('area', { async: true, inverse: null }) areas;
   @hasMany('tubes', { async: false, inverse: null }) tubes;
 }

--- a/admin/app/styles/components/complementary-certifications/item/framework.scss
+++ b/admin/app/styles/components/complementary-certifications/item/framework.scss
@@ -4,6 +4,13 @@
   display: inline-flex;
 }
 
+.framework__no-current {
+  display: inline-flex;
+  margin-bottom: var(--pix-spacing-6x);
+}
+
+
+/* Creation form */
 .framework-creation-form__title {
   @extend %pix-title-s;
 
@@ -14,4 +21,21 @@
 .framework-creation-form__buttons {
   display: flex;
   gap: var(--pix-spacing-2x);
+}
+
+/* Framework details */
+.framework-details {
+  margin-top: var(--pix-spacing-6x);
+  padding-top: var(--pix-spacing-6x);
+  border-top: 1px solid var(--pix-neutral-100);
+}
+
+.framework-details__title {
+  @extend %pix-title-xs;
+
+  margin-bottom: var(--pix-spacing-4x);
+}
+
+.framework__table-empty {
+  margin-top: var(--pix-spacing-6x);
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -572,6 +572,10 @@ function routes() {
     return new Response(204);
   });
 
+  this.get('admin/complementary-certifications/:key/current-consolidated-framework', (schema, request) => {
+    return schema.certificationConsolidatedFrameworks.find(request.params.key);
+  });
+
   this.put('/admin/sessions/:id/comment', (schema, request) => {
     const sessionToUpdate = schema.sessions.find(request.params.id);
     const params = JSON.parse(request.requestBody);

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
@@ -20,6 +20,8 @@ module('Acceptance | Complementary certifications | Complementary certification 
       label: 'Pix+Droit',
     });
 
+    server.create('certification-consolidated-framework', { id: 'KEY' });
+
     // when
     const screen = await visit('/complementary-certifications/1/framework');
 

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
@@ -69,6 +69,9 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
           },
         ],
       });
+
+      server.create('certification-consolidated-framework', { id: 'AN' });
+
       const screen = await visit('/complementary-certifications/list');
 
       // when

--- a/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
@@ -1,21 +1,89 @@
 import { render } from '@1024pix/ember-testing-library';
 import Framework from 'pix-admin/components/complementary-certifications/item/framework';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | complementary-certifications/item/framework', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display a creation form button for framework', async function (assert) {
-    // given
+  let store;
+
+  hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:currentUser');
     currentUser.adminMember = { isSuperAdmin: true };
+
+    store = this.owner.lookup('service:store');
+
+    const serviceRouter = this.owner.lookup('service:router');
+    sinon.stub(serviceRouter, 'currentRoute').value({
+      parent: {
+        parent: {
+          params: {
+            complementary_certification_id: 'complementary-certification-id',
+          },
+        },
+      },
+    });
+
+    store.peekRecord = sinon.stub().resolves('complementary-certification-key');
+  });
+
+  test('it should display a creation form button for framework', async function (assert) {
+    // given
+    store.findRecord = sinon.stub().returns();
 
     // when
     const screen = await render(<template><Framework /></template>);
 
     // then
     assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
+  });
+
+  module('when a current consolidated framework exists', function () {
+    test('it should display the details component', async function (assert) {
+      // given
+      store.findRecord = sinon.stub().resolves({
+        hasMany: sinon.stub().returns({
+          value: sinon.stub().returns([]),
+        }),
+      });
+
+      // when
+      const screen = await render(<template><Framework /></template>);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .exists();
+    });
+  });
+
+  module('when there is no current consolidated framework', function () {
+    test('it should display the information and not the details component', async function (assert) {
+      // given
+      store.findRecord = sinon.stub().returns();
+
+      // when
+      const screen = await render(<template><Framework /></template>);
+
+      // then
+      assert
+        .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
+        .exists();
+
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .doesNotExist();
+    });
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/item/framework/framework-details-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/framework-details-test.gjs
@@ -1,0 +1,117 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import FrameworkDetails from 'pix-admin/components/complementary-certifications/item/framework/framework-details';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Complementary certifications/Item/Framework | Framework details', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when the current framework has at least one tube', function () {
+    test('it should display the current framework details', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const currentConsolidatedFramework = _initCurrentConsolidatedFramework(store);
+
+      // when
+      const screen = await render(
+        <template><FrameworkDetails @currentConsolidatedFramework={{currentConsolidatedFramework}} /></template>,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.item.framework.details.title'),
+          }),
+        )
+        .exists();
+
+      await clickByName('area1 code · area1 title');
+      await clickByName('competenceForArea1 index competenceForArea1 name');
+      assert.dom(screen.getByText('thematicForArea1 name')).exists();
+      assert.dom(screen.getByText('tubeForArea1 name : tubeForArea1 practicalTitle')).exists();
+      assert.strictEqual(this.element.querySelector('.skill-square__active').innerText, '3');
+      assert.dom(screen.getByText('tube2ForArea1 name : tube2ForArea1 practicalTitle')).exists();
+
+      await clickByName('area2 code · area2 title');
+      await clickByName('competenceForArea2 index competenceForArea2 name');
+      assert.dom(screen.getByText('thematicForArea2 name')).exists();
+      assert.dom(screen.getByText('tubeForArea2 name : tubeForArea2 practicalTitle')).exists();
+    });
+  });
+});
+
+function _initCurrentConsolidatedFramework(store) {
+  // Area 1, with 2 tubes
+  const skill = store.createRecord('skill', {
+    id: 'skill1',
+    difficulty: 3,
+  });
+  const tubeForArea1 = store.createRecord('tube', {
+    id: 'tubeForArea1',
+    name: 'tubeForArea1 name',
+    practicalTitle: 'tubeForArea1 practicalTitle',
+    skills: [skill],
+  });
+  const tube2ForArea1 = store.createRecord('tube', {
+    id: 'tube2ForArea1',
+    name: 'tube2ForArea1 name',
+    practicalTitle: 'tube2ForArea1 practicalTitle',
+  });
+  const thematicForArea1 = store.createRecord('thematic', {
+    id: 'thematicForArea1',
+    name: 'thematicForArea1 name',
+    index: 'thematicForArea1 index',
+    tubes: [tubeForArea1, tube2ForArea1],
+  });
+  const competenceForArea1 = store.createRecord('competence', {
+    id: 'competenceForArea1',
+    name: 'competenceForArea1 name',
+    index: 'competenceForArea1 index',
+    thematics: [thematicForArea1],
+  });
+  const area1 = store.createRecord('area', {
+    id: 'area1',
+    title: 'area1 title',
+    code: 'area1 code',
+    color: 'area1 color',
+    frameworkId: 'framework-id',
+    competences: [competenceForArea1],
+  });
+
+  // Area 2, with 1 tube
+  const tubeForArea2 = store.createRecord('tube', {
+    id: 'tubeForArea2',
+    name: 'tubeForArea2 name',
+    practicalTitle: 'tubeForArea2 practicalTitle',
+  });
+  const thematicForArea2 = store.createRecord('thematic', {
+    id: 'thematicForArea2',
+    name: 'thematicForArea2 name',
+    index: 'thematicForArea2 index',
+    tubes: [tubeForArea2],
+  });
+  const competenceForArea2 = store.createRecord('competence', {
+    id: 'competenceForArea2',
+    name: 'competenceForArea2 name',
+    index: 'competenceForArea2 index',
+    thematics: [thematicForArea2],
+  });
+  const area2 = store.createRecord('area', {
+    id: 'area2',
+    title: 'area2 title',
+    code: 'area2 code',
+    color: 'area2 color',
+    frameworkId: 'framework-id',
+    competences: [competenceForArea2],
+  });
+
+  return {
+    hasMany: sinon.stub().returns({
+      value: sinon.stub().returns([area1, area2]),
+    }),
+  };
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -401,6 +401,10 @@
             "success-notification": "The new framework has been successfully created.",
             "title": "Creating a new consolidated framework for {complementaryCertificationLabel}"
           },
+          "details": {
+            "title": "Current consolidated framework details"
+          },
+          "no-current-framework": "No consolidated framework is currently used.",
           "tab": "Consolidated framework"
         },
         "navigation": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -401,6 +401,11 @@
             "success-notification": "Le nouveau référentiel cadre a été créé avec succès",
             "title": "Créer un nouveau référentiel cadre pour {complementaryCertificationLabel}"
           },
+          "details": {
+            "empty-current-framework": "Le référentiel cadre actuel est vide.",
+            "title": "Détails du référentiel cadre actuel"
+          },
+          "no-current-framework": "Aucun référentiel cadre n'est utilisé actuellement.",
           "tab": "Référentiel cadre"
         },
         "navigation": {

--- a/api/src/certification/configuration/domain/usecases/get-current-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/get-current-consolidated-framework.js
@@ -1,18 +1,28 @@
 /**
  * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
  * @typedef {import ('./index.js').ConsolidatedFrameworkRepository} ConsolidatedFrameworkRepository
+ * @typedef {import ('./index.js').LearningContentRepository} LearningContentRepository
  */
 
 /**
  * @param {Object} params
  * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
  * @param {ConsolidatedFrameworkRepository} params.consolidatedFrameworkRepository
+ * @param {LearningContentRepository} params.learningContentRepository
  */
 export const getCurrentConsolidatedFramework = async ({
   complementaryCertificationKey,
   consolidatedFrameworkRepository,
+  learningContentRepository,
 }) => {
-  return consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey({
-    complementaryCertificationKey,
+  const currentConsolidatedFramework =
+    await consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey({
+      complementaryCertificationKey,
+    });
+
+  const frameworkAreas = await learningContentRepository.getFrameworkReferential({
+    challengeIds: currentConsolidatedFramework.challenges.map(({ challengeId }) => challengeId),
   });
+
+  return { ...currentConsolidatedFramework, areas: frameworkAreas };
 };

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -12,6 +12,7 @@ import * as attachableTargetProfileRepository from '../../infrastructure/reposit
 import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
 import * as consolidatedFrameworkRepository from '../../infrastructure/repositories/consolidated-framework-repository.js';
+import * as learningContentRepository from '../../infrastructure/repositories/learning-content-repository.js';
 
 /**
  *
@@ -24,6 +25,7 @@ import * as consolidatedFrameworkRepository from '../../infrastructure/repositor
  * @typedef {challengeRepository} ChallengeRepository
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {consolidatedFrameworkRepository} ConsolidatedFrameworkRepository
+ * @typedef {learningContentRepository} LearningContentRepository
  * @typedef {skillRepository} SkillRepository
  * @typedef {tubeRepository} TubeRepository
  **/
@@ -35,6 +37,7 @@ const dependencies = {
   challengeRepository,
   complementaryCertificationRepository,
   consolidatedFrameworkRepository,
+  learningContentRepository,
   skillRepository,
   tubeRepository,
 };

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -29,6 +29,10 @@ export async function getCurrentFrameworkByComplementaryCertificationKey({ compl
     })
     .select('*');
 
+  if (currentFrameworkChallengesDTO.length === 0) {
+    throw new NotFoundError(`There is no framework for complementary ${complementaryCertificationKey}`);
+  }
+
   return _toDomain({ certificationFrameworksChallengesDTO: currentFrameworkChallengesDTO });
 }
 

--- a/api/src/certification/configuration/infrastructure/repositories/index.js
+++ b/api/src/certification/configuration/infrastructure/repositories/index.js
@@ -1,0 +1,18 @@
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import * as consolidatedFrameworkRepository from './consolidated-framework-repository.js';
+import * as learningContentRepository from './learning-content-repository.js';
+
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {consolidatedFrameworkRepository} ConsolidatedFrameworkRepository
+ * @typedef {learningContentRepository} LearningContentRepository
+ */
+const repositoriesWithoutInjectedDependencies = {
+  consolidatedFrameworkRepository,
+  learningContentRepository,
+};
+
+const configurationRepositories = injectDependencies(repositoriesWithoutInjectedDependencies);
+
+export { configurationRepositories };

--- a/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
@@ -1,0 +1,58 @@
+import _ from 'lodash';
+
+import { LOCALE } from '../../../../shared/domain/constants.js';
+import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
+import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
+import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
+import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
+import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
+
+export async function getFrameworkReferential({ challengeIds }) {
+  const challenges = await challengeRepository.getMany(challengeIds, LOCALE.FRENCH_SPOKEN);
+
+  const skillIds = challenges.map((challenge) => challenge.skill.id);
+  const skills = await skillRepository.findByRecordIds(skillIds);
+
+  const tubeIds = skills.map((skill) => skill.tubeId);
+  const tubes = await tubeRepository.findByRecordIds(tubeIds, LOCALE.FRENCH_SPOKEN);
+  tubes.forEach((tube) => {
+    tube.skills = skills.filter((skill) => {
+      return skill.tubeId === tube.id;
+    });
+  });
+
+  const thematicIds = tubes.map((tube) => tube.thematicId);
+  const thematics = await thematicRepository.findByRecordIds(thematicIds, LOCALE.FRENCH_SPOKEN);
+  thematics.forEach((thematic) => {
+    thematic.tubes = tubes.filter((tube) => tube.thematicId === thematic.id);
+  });
+
+  const competenceIds = tubes.map((tube) => tube.competenceId);
+  const competences = await competenceRepository.findByRecordIds({
+    competenceIds,
+    locale: LOCALE.FRENCH_SPOKEN,
+  });
+  competences.forEach((competence) => {
+    competence.tubes = tubes.filter((tube) => {
+      return tube.competenceId === competence.id;
+    });
+    competence.thematics = thematics.filter((thematic) => {
+      return thematic.competenceId === competence.id;
+    });
+  });
+
+  const allAreaIds = competences.map((competence) => competence.areaId);
+  const uniqAreaIds = _.uniqBy(allAreaIds, 'id');
+  const areas = await areaRepository.findByRecordIds({
+    areaIds: uniqAreaIds,
+    locale: LOCALE.FRENCH_SPOKEN,
+  });
+  areas.forEach((area) => {
+    area.competences = competences.filter((competence) => {
+      return competence.areaId === area.id;
+    });
+  });
+
+  return areas;
+}

--- a/api/src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js
@@ -2,10 +2,36 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (consolidatedFramework) {
+const serialize = function (currentConsolidatedFramework) {
   return new Serializer('certification-consolidated-framework', {
-    attributes: ['complementaryCertificationKey', 'version', 'challenges'],
-  }).serialize(consolidatedFramework);
+    id: 'complementaryCertificationKey',
+    attributes: ['complementaryCertificationKey', 'version', 'areas'],
+    areas: {
+      ref: 'id',
+      included: true,
+      attributes: ['title', 'code', 'color', 'frameworkId', 'competences'],
+      competences: {
+        ref: 'id',
+        included: true,
+        attributes: ['name', 'index', 'thematics'],
+        thematics: {
+          ref: 'id',
+          included: true,
+          attributes: ['name', 'index', 'tubes'],
+          tubes: {
+            ref: 'id',
+            included: true,
+            attributes: ['name', 'practicalTitle', 'level', 'mobile', 'tablet', 'skills'],
+            skills: {
+              ref: 'id',
+              included: true,
+              attributes: ['difficulty'],
+            },
+          },
+        },
+      },
+    },
+  }).serialize(currentConsolidatedFramework);
 };
 
 export { serialize };

--- a/api/tests/certification/configuration/unit/domain/usecases/get-current-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-current-consolidated-framework_test.js
@@ -9,24 +9,36 @@ describe('Certification | Configuration | Unit | UseCase | get-current-consolida
     const consolidatedFrameworkRepository = {
       getCurrentFrameworkByComplementaryCertificationKey: sinon.stub(),
     };
-
-    const currentConsolidatedFramework = domainBuilder.certification.configuration.buildConsolidatedFramework();
+    const currentConsolidatedFramework = domainBuilder.certification.configuration.buildConsolidatedFramework({
+      challenges: [{ challengeId: 'rec1' }],
+    });
     consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey.resolves(
       currentConsolidatedFramework,
     );
+
+    const learningContentRepository = {
+      getFrameworkReferential: sinon.stub(),
+    };
+    const area = domainBuilder.buildArea();
+    learningContentRepository.getFrameworkReferential.resolves([area]);
 
     // when
     const results = await getCurrentConsolidatedFramework({
       complementaryCertificationKey,
       consolidatedFrameworkRepository,
+      learningContentRepository,
     });
 
     // then
     expect(
       consolidatedFrameworkRepository.getCurrentFrameworkByComplementaryCertificationKey,
-    ).to.have.been.calledOnceWith({
+    ).to.have.been.calledOnceWithExactly({
       complementaryCertificationKey,
     });
-    expect(results).to.deep.equal(currentConsolidatedFramework);
+
+    expect(learningContentRepository.getFrameworkReferential).to.have.been.calledOnceWithExactly({
+      challengeIds: currentConsolidatedFramework.challenges.map(({ challengeId }) => challengeId),
+    });
+    expect(results).to.deep.equal({ ...currentConsolidatedFramework, areas: [area] });
   });
 });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/consolidated-framework-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/consolidated-framework-serializer_test.js
@@ -1,4 +1,5 @@
 import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/consolidated-framework-serializer.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -7,20 +8,61 @@ describe('Certification | Configuration | Unit | Serializer | consolidated-frame
     it('should serialize attachable a consolidated framework to JSONAPI', function () {
       // given
       const consolidatedFramework = domainBuilder.certification.configuration.buildConsolidatedFramework();
+      const area = domainBuilder.buildArea({
+        competences: [domainBuilder.buildCompetence({ tubes: [domainBuilder.buildTube()] })],
+      });
 
       // when
-      const serializedConsolidatedFramework = serializer.serialize([consolidatedFramework]);
+      const serializedConsolidatedFramework = serializer.serialize({ ...consolidatedFramework, areas: [area] });
 
       // then
       expect(serializedConsolidatedFramework).to.deep.equal({
-        data: [
-          {
-            type: 'certification-consolidated-frameworks',
-            attributes: {
-              'complementary-certification-key': consolidatedFramework.complementaryCertificationKey,
-              version: consolidatedFramework.version,
-              challenges: consolidatedFramework.challenges,
+        data: {
+          attributes: {
+            'complementary-certification-key': ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            version: consolidatedFramework.version,
+          },
+          id: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          relationships: {
+            areas: {
+              data: [
+                {
+                  id: 'recArea123',
+                  type: 'areas',
+                },
+              ],
             },
+          },
+          type: 'certification-consolidated-frameworks',
+        },
+        included: [
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'recCOMP1',
+            type: 'competences',
+          },
+          {
+            attributes: {
+              code: '5',
+              color: 'red',
+              'framework-id': 'recFmk123',
+              title: 'Super domaine',
+            },
+            id: 'recArea123',
+            relationships: {
+              competences: {
+                data: [
+                  {
+                    id: 'recCOMP1',
+                    type: 'competences',
+                  },
+                ],
+              },
+            },
+            type: 'areas',
           },
         ],
       });


### PR DESCRIPTION
## 🔆 Problème

Actuellement nous permettons uniquement la création d'un nouveau référentiel cadre pour une complémentaire.
Nous n'avons pas encore le moyen de le visualiser par la suite.

## ⛱️ Proposition

Permettre la visualisation du nouveau référentiel cadre sur PixAdmin.

## 🏄 Pour tester

- Créer un nouveau référentiel cadre pour la complémentaire Cléa
- ✅ Constater de l'affichage du détail de ce nouveau référentiel cadre
- Voir aussi le référentiel cadre de Pix+Droit qui utilise son référentiel spécifique
