### PR TITLE
[TECH] :truck: Déplace le modèle `CertifiedScore` vers le contexte `src/certification/evaluation/`

### DIFF
--- a/api/src/certification/evaluation/domain/models/CertifiedScore.js
+++ b/api/src/certification/evaluation/domain/models/CertifiedScore.js
@@ -1,4 +1,4 @@
-import { PIX_COUNT_BY_LEVEL } from '../constants.js';
+import { PIX_COUNT_BY_LEVEL } from '../../../../shared/domain/constants.js';
 
 class CertifiedScore {
   constructor(value) {

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v2.js
@@ -17,12 +17,12 @@ import {
   AnswerCollectionForScoring,
   CertificationAssessmentScore,
   CertificationContract,
-  CertifiedScore,
   CompetenceMark,
   ReproducibilityRate,
 } from '../../../../../shared/domain/models/index.js';
 import { AssessmentResultFactory } from '../../../../scoring/domain/models/factories/AssessmentResultFactory.js';
 import { AlgorithmEngineVersion } from '../../../../shared/domain/models/AlgorithmEngineVersion.js';
+import { CertifiedScore } from '../../../domain/models/CertifiedScore.js';
 import { CertifiedLevel } from '../../models/CertifiedLevel.js';
 
 /**

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -67,7 +67,6 @@ import { CertificationChallenge } from './CertificationChallenge.js';
 import { CertificationChallengeWithType } from './CertificationChallengeWithType.js';
 import { CertificationContract } from './CertificationContract.js';
 import { CertificationResult } from './CertificationResult.js';
-import { CertifiedScore } from './CertifiedScore.js';
 import { Challenge } from './Challenge.js';
 import { Competence } from './Competence.js';
 import { CompetenceResult } from './CompetenceResult.js';
@@ -143,7 +142,6 @@ export {
   CertificationOfficer,
   CertificationReport,
   CertificationResult,
-  CertifiedScore,
   Challenge,
   Competence,
   CompetenceEvaluation,

--- a/api/tests/certification/evaluation/unit/domain/models/CertifiedScore_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/CertifiedScore_test.js
@@ -1,7 +1,7 @@
-import { CertifiedLevel } from '../../../../src/certification/evaluation/domain/models/CertifiedLevel.js';
-import { PIX_COUNT_BY_LEVEL } from '../../../../src/shared/domain/constants.js';
-import { CertifiedScore } from '../../../../src/shared/domain/models/CertifiedScore.js';
-import { expect } from '../../../test-helper.js';
+import { CertifiedLevel } from '../../../../../../src/certification/evaluation/domain/models/CertifiedLevel.js';
+import { CertifiedScore } from '../../../../../../src/certification/evaluation/domain/models/CertifiedScore.js';
+import { PIX_COUNT_BY_LEVEL } from '../../../../../../src/shared/domain/constants.js';
+import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertifiedScore', function () {
   it('is equal to the estimated score if the estimated level is certified', function () {


### PR DESCRIPTION
## 🔆 Problème

Le modèle `CertifiedScore` est dans le contexte partagé `/src/shared/` mais il n'est utilisé que dans le contexte `src/certification/evaluation/`.

## ⛱️ Proposition

 Déplacer le modèle `CertifiedScore` vers le contexte `src/certification/evaluation/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
