### PR TITLE
[FEATURE] Ajout des feature flags useLocale et useOnlyHapiI18n (PIX-18779)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') useLocale;
+}

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -71,4 +71,16 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'team-prescription', 'pix-app'],
   },
+  useLocale: {
+    type: 'boolean',
+    description: 'Enable new locale management in apps.',
+    defaultValue: false,
+    tags: ['frontend', 'team-acces'],
+  },
+  useOnlyHapiI18n: {
+    type: 'boolean',
+    description: 'Enable exclusive usage of hapi i18n plugin for locale management in the API.',
+    defaultValue: false,
+    tags: ['team-acces'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'should-display-new-analysis-page': false,
             'is-v3-certification-page-enabled': false,
             'upgrade-to-real-user-enabled': false,
+            'use-locale': false,
           },
         },
       };

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') useLocale;
+}

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -6,4 +6,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isV3CertificationPageEnabled;
   @attr('boolean') upgradeToRealUserEnabled;
   @attr('boolean') isAutoShareEnabled;
+  @attr('boolean') useLocale;
 }

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') shouldDisplayNewAnalysisPage;
+  @attr('boolean') useLocale;
 }


### PR DESCRIPTION
## 🔆 Problème

Pour la remise à plat des locales, 2 nouveaux feature flags sont nécessaires : 
- `useLocale`
- `useOnlyHapiI18n`

## ⛱️ Proposition

Création des 2 FT :
- `useLocale` : booléen, disponible dans les frontends
- `useOnlyHapiI18n` : booléen, disponible dans l'api uniquement


## 🏄 Pour tester

1. Se connecter à l'API de la RA
```
scalingo --region osc-fr1 --app pix-api-review-pr12891 run bash
```
2. Exécuter les commandes 
```
npm run toggles -- -k useLocale
```
```
npm run toggles -- -k useOnlyHapiI18n
```

Vérifier les logs suivantes:
- Feature toggle "useLocale" is set to "false"
- Feature toggle "useOnlyHapiI18n" is set to "false"
