### PR TITLE
[BUGFIX] Enlever le whereILike du getByCode de campaign

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-to-join-repository.js
@@ -21,7 +21,7 @@ const getByCode = async function ({ code, organizationFeatureAPI }) {
     })
     .join('organizations', 'organizations.id', 'campaigns.organizationId')
     .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
-    .whereILike('campaigns.code', code)
+    .where('campaigns.code', code.toUpperCase())
     .first();
 
   if (!result) {


### PR DESCRIPTION
## 🔆 Problème
Nous avions voulu rendre le code campagne insensible à la casse en faisant un whereILike sur le code dans le repository de campaign. Or, @1024pix/team-captains nous a alertés sur les problèmes de performance qui ont suivi cette modification.
 
## ⛱️ Proposition
On passe le code en upperCase quoiqu'il arrive dans la requête du repository.
