### PR TITLE
[BUGFIX] Réparer les attestations qui nécessitent que la participation soit terminée (PIX-18803).

### DIFF
--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -1,7 +1,7 @@
 import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
-import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
 import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
@@ -14,7 +14,7 @@ const completeAssessment = async function (request) {
     const assessment = await evaluationUsecases.completeAssessment({ assessmentId, locale });
     await evaluationUsecases.handleBadgeAcquisition({ assessment });
     await evaluationUsecases.handleStageAcquisition({ assessment });
-    if (assessment.userId && config.featureToggles.isQuestEnabled) {
+    if (assessment.userId && (await featureToggles.get('isQuestEnabled'))) {
       await questUsecases.rewardUser({ userId: assessment.userId });
     }
 

--- a/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
@@ -2,8 +2,8 @@ import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/u
 import { assessmentController } from '../../../../../src/evaluation/application/assessments/assessment-controller.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../../../src/quest/domain/usecases/index.js';
-import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | assessment-controller', function () {
@@ -59,7 +59,7 @@ describe('Unit | Controller | assessment-controller', function () {
 
     it('should not call the rewardUser usecase if the questEnabled flag is false', async function () {
       // given
-      config.featureToggles.isQuestEnabled = false;
+      sinon.stub(featureToggles, 'get').resolves(false);
       evaluationUsecases.completeAssessment.resolves({ userId: 12 });
 
       // when
@@ -71,7 +71,7 @@ describe('Unit | Controller | assessment-controller', function () {
 
     it('should call the rewardUser use case if there is a userId', async function () {
       // given
-      config.featureToggles.isQuestEnabled = true;
+      sinon.stub(featureToggles, 'get').resolves(true);
       evaluationUsecases.completeAssessment.resolves({ userId: 12 });
 
       // when


### PR DESCRIPTION
## 🔆 Problème

Les attestations  qui vérifient les conditions à la fin d'un assessment ne fonctionnent plus, car nous utilisons l'ancien mécanisme de feature toggles. 


## ⛱️ Proposition

Utiliser le nouveau système et améliorer le test.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- Sur Pix App, participer à la campagne PROASSMUL et constater à la fin que l'attestation est obtenue.