### PR TITLE
[FEATURE] Ajuster le CTA "Passer l'activité" (PIX-18797)

### DIFF
--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -216,6 +216,19 @@ export default class ModuleGrain extends Component {
     return this.intl.t(`pages.modulix.grain.tag.${this.args.grain.type}`);
   }
 
+  get skipButtonLabel() {
+    if (!this.hasStepper) {
+      return this.intl.t('pages.modulix.buttons.grain.skipActivity');
+    }
+
+    const stepper = this.args.grain.components.find((component) => component.type === 'stepper');
+    const stepperElements = stepper.steps.flatMap((step) => step.elements);
+    const stepperWithAnswerableElement = stepperElements.some((element) => element.isAnswerable);
+    return stepperWithAnswerableElement
+      ? this.intl.t('pages.modulix.buttons.grain.skipActivity')
+      : this.intl.t('pages.modulix.buttons.grain.skip');
+  }
+
   <template>
     <article
       id={{this.elementId}}
@@ -280,7 +293,7 @@ export default class ModuleGrain extends Component {
         {{#if this.shouldDisplaySkipButton}}
           <footer class="grain-card__footer grain-card__footer__with-skip-button">
             <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
-              {{t "pages.modulix.buttons.grain.skip"}}
+              {{this.skipButtonLabel}}
             </PixButton>
           </footer>
         {{/if}}

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -383,7 +383,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).doesNotExist();
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') }))
+          .doesNotExist();
       });
 
       module('when canMoveToNextGrain is true', function () {
@@ -532,7 +534,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
           // then
-          assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).exists();
+          assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') })).exists();
         });
       });
 
@@ -573,7 +575,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
           // then
-          assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).doesNotExist();
+          assert
+            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') }))
+            .doesNotExist();
         });
       });
     });
@@ -630,7 +634,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
                                 @onGrainContinue={{this.onGrainContinue}} @onGrainSkip={{this.onGrainSkip}}
                                 @passage={{this.passage}} />`,
       );
-      await clickByName(t('pages.modulix.buttons.grain.skip'));
+      await clickByName(t('pages.modulix.buttons.grain.skipActivity'));
 
       // then
       sinon.assert.calledOnce(onGrainSkipStub);
@@ -1020,7 +1024,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).doesNotExist();
+          assert
+            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') }))
+            .doesNotExist();
         });
       });
     });
@@ -1082,10 +1088,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
             // when
             const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}} @onStepperNextStep={{this.onStepperNextStep}} />`);
+              <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}}
+                                    @onElementRetry={{this.onElementRetry}}
+                                    @onStepperNextStep={{this.onStepperNextStep}} />`);
 
             // then
-            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).exists();
+            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') })).exists();
           });
 
           test('should not display continue button', async function (assert) {
@@ -1187,7 +1195,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
               await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
               // then
-              assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).exists();
+              assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') })).exists();
             });
 
             test('should not display continue button', async function (assert) {
@@ -1306,7 +1314,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           <Module::Grain::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @onElementRetry={{this.onElementRetry}}  />`);
 
             // then
-            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skip') })).exists();
+            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.grain.skipActivity') })).exists();
           });
           test('should not display continue button', async function (assert) {
             // given

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -275,7 +275,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.strictEqual(findAll('.element-text').length, 0);
 
       // when
-      await clickByName(t('pages.modulix.buttons.grain.skip'));
+      await clickByName(t('pages.modulix.buttons.grain.skipActivity'));
 
       // then
       assert.strictEqual(findAll('.element-text').length, 1);
@@ -307,7 +307,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       metrics.trackEvent = sinon.stub();
 
       // when
-      await clickByName(t('pages.modulix.buttons.grain.skip'));
+      await clickByName(t('pages.modulix.buttons.grain.skipActivity'));
 
       // then
       sinon.assert.calledWithExactly(passageEventRecordStub, {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1669,7 +1669,8 @@
         },
         "grain": {
           "continue": "Continue",
-          "skip": "Skip activity",
+          "skip": "Skip",
+          "skipActivity": "Skip activity",
           "terminate": "Terminate"
         },
         "stepper": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1655,7 +1655,8 @@
         },
         "grain": {
           "continue": "Continuar",
-          "skip": "Ir a la actividad",
+          "skip": "Ir a",
+          "skipActivity": "Ir a la actividad",
           "terminate": "Finalizar"
         },
         "stepper": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1669,7 +1669,8 @@
         },
         "grain": {
           "continue": "Continuer",
-          "skip": "Passer l‘activité",
+          "skip": "Passer",
+          "skipActivity": "Passer l‘activité",
           "terminate": "Terminer"
         },
         "stepper": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1658,7 +1658,8 @@
         },
         "grain": {
           "continue": "Ga verder met",
-          "skip": "Overslaan activiteit",
+          "skip": "Overslaan",
+          "skipActivity": "Overslaan activiteit",
           "terminate": "Afwerking"
         },
         "stepper": {


### PR DESCRIPTION
## 🔆 Problème

Le bouton "Passer l'activité" apparaît même dans les Stepper qui ne contiennent que des éléments non answerable

## ⛱️ Proposition

- ~Aligner à gauche au lieu de la droite~ https://github.com/1024pix/pix/pull/13163
- Dans un Stepper, si aucun élément n’est answerable, on affiche “Passer”
- Pour tout élément answerable, on affiche “Passer l’activité”

## 🌊 Remarques

Pour les POI, à voir plus tard avec équipe Contenu dev

## 🏄 Pour tester

- Aller sur le module [tmp-ia-deepfakes](https://app-pr12908.review.pix.fr/modules/tmp-ia-deepfakes)
- Vérifier que le label du bouton est maintenant `Passer l'activité` sauf dans le Stepper qui ne contient que des éléments non answerable (dans un grain Leçon)
