### PR TITLE
[FEATURE] Ajouter des titres aux grains Leçon et Récap (PIX-18813)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -89,9 +89,11 @@ $grain-card-border-radius: var(--pix-spacing-4x);
 }
 
 .grain-card-icon {
-  @extend %pix-title-m;
+ margin-right: var(--pix-spacing-1x);
+}
 
-  margin-bottom: var(--pix-spacing-4x);
+.grain-card-title {
+  @extend %pix-title-s;
 }
 
 .grain-card-content {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -193,12 +193,23 @@ export default class ModuleGrain extends Component {
     return this.args.grain.type === 'summary';
   }
 
+  get isGrainTypeWithTitle() {
+    return this.args.grain.type === 'lesson' || this.args.grain.type === 'summary';
+  }
+
   get isGrainTypeWithTag() {
     return this.args.grain.type === 'activity' || this.args.grain.type === 'discovery';
   }
 
-  get emojiGrain() {
-    return '📌';
+  get grainTitle() {
+    switch (this.args.grain.type) {
+      case 'lesson':
+        return this.intl.t('pages.modulix.grain.title.lesson');
+      case 'summary':
+        return this.intl.t('pages.modulix.grain.title.summary');
+      default:
+        return '';
+    }
   }
 
   get tagText() {
@@ -223,8 +234,9 @@ export default class ModuleGrain extends Component {
             {{this.tagText}}
           </PixTag>
         {{/if}}
-        {{#if this.isGrainTypeSummary}}
-          <p class="grain-card-icon">{{this.emojiGrain}}</p>
+        {{#if this.isGrainTypeWithTitle}}
+          <h2 class="grain-card-title">
+            {{this.grainTitle}}</h2>
         {{/if}}
         <div class="grain-card__content">
           <!-- eslint-disable-next-line no-unused-vars -->

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1646,4 +1646,48 @@ module('Integration | Component | Module | Grain', function (hooks) {
       assert.dom(screen.getByText('Activité')).exists();
     });
   });
+
+  module('when grain has type ‘lesson‘', function () {
+    test('should display a title', async function (assert) {
+      // given
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = {
+        id: '12345-abcdef',
+        type: 'lesson',
+        components: [{ type: 'element', element: textElement }],
+      };
+
+      // when
+      const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('Leçon')).exists();
+    });
+  });
+
+  module('when grain has type ‘Summary‘', function () {
+    test('should display a title', async function (assert) {
+      // given
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = {
+        id: '12345-abcdef',
+        type: 'summary',
+        components: [{ type: 'element', element: textElement }],
+      };
+
+      // when
+      const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('Récapitulatif')).exists();
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1726,6 +1726,10 @@
           "discovery": "Discovery",
           "lesson": "Lesson",
           "summary": "Summary"
+        },
+        "title": {
+          "lesson": "Lesson",
+          "summary": "Summary"
         }
       },
       "interactiveElement": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1712,6 +1712,10 @@
           "discovery": "Descubrimiento",
           "lesson": "Lección",
           "summary": "Recapitular"
+        },
+        "title": {
+          "lesson": "Lección",
+          "summary":  "Recapitular"
         }
       },
       "interactiveElement": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1726,6 +1726,10 @@
           "discovery": "Découverte",
           "lesson": "Leçon",
           "summary": "Récap'"
+        },
+        "title": {
+          "lesson": "Leçon",
+          "summary":  "Récapitulatif"
         }
       },
       "interactiveElement": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1715,6 +1715,10 @@
           "discovery": "Ontdekking",
           "lesson": "Les",
           "summary": "Recap"
+        },
+        "title": {
+          "lesson": "Les",
+          "summary":  "Recap"
         }
       },
       "interactiveElement": {


### PR DESCRIPTION
## 🔆 Problème

On veut ajouter des titres aux grains de type 'summary' et 'lesson'.

## ⛱️ Proposition

Le faire : 
- Mettre le titre “Leçon” au grain 'lesson'
- Mettre le titre “récapitulatif” au grain 'summary'

## 🌊 Remarques

- L'emoji a été supprimé pour ça.
- A faire tester avant de merger !

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr12911.review.pix.fr/modules/bac-a-sable/details)
- Vérifier que le titre `Récap` s'affiche bien !
- Aller sur le module [ChatGPT vraiment neutre](https://app-pr12911.review.pix.fr/modules/chatgpt-vraiment-neutre/passage)
- Vérifier que le titre 'Leçon' s'affiche bien !
