### PR TITLE
[FEATURE] Corriger couleur légende et pointillés autour des POI (PIX-18818)

### DIFF
--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -8,7 +8,7 @@ message-conversation::part(conversation) {
 .element-custom {
   fieldset {
     padding: var(--pix-spacing-2x);
-    border: 2px dashed rgb(var(--pix-tertiary-900-inline), 0.6);
+    border: 2px dashed var(--pix-primary-700);
     border-radius: var(--pix-spacing-2x);
   }
 
@@ -19,6 +19,6 @@ message-conversation::part(conversation) {
     gap: var(--pix-spacing-2x);
     align-items: center;
     padding: 0 var(--pix-spacing-2x);
-    color: var(--pix-tertiary-900);
+    color: var(--pix-primary-700);
   }
 }

--- a/mon-pix/app/components/module/element/_text.scss
+++ b/mon-pix/app/components/module/element/_text.scss
@@ -38,7 +38,7 @@
 
   fieldset {
     padding: var(--pix-spacing-2x);
-    border: 2px dashed rgb(var(--pix-tertiary-900-inline), 0.6);
+    border: 2px dashed var(--pix-primary-700);
     border-radius: var(--pix-spacing-2x);
   }
 
@@ -49,6 +49,6 @@
     gap: var(--pix-spacing-2x);
     align-items: center;
     padding: 0 var(--pix-spacing-2x);
-    color: var(--pix-tertiary-900);
+    color: var(--pix-primary-700);
   }
 }


### PR DESCRIPTION
## 🔆 Problème

Les POI sont encadrés par une bordure en tertiary-900, mais ce n'est pas la couleur attendue. 
Cette couleur avait été choisie pour des soucis d'a11y.

## ⛱️ Proposition

Appliquer le primary-700 sans variation d'opacité (vu avec Pierre) : https://1024pix.slack.com/archives/C049Q0KQLLD/p1753185538943089

## 🌊 Remarques

Le primary-700 permet d'être OK niveau a11y.

## 🏄 Pour tester

- Ouvrir le bac-a-sable
- Vérifier que pour un POI, l'encadré est bien présent avec les bonnes couleurs
