### PR TITLE
[FEATURE] Mettre à jour le label du bouton Vérifier sur les modules (PIX-18814)

### DIFF
--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -69,7 +69,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     let screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
     await click(screen.getByLabelText('I am the right answer!'));
 
-    const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
 
     assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -49,7 +49,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
     const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
     const qcmForm = screen.getByRole('group');
@@ -70,7 +70,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     assert.false(wrongAnswerCheckbox.checked);
     assert.false(rightAnswerCheckbox.checked);
 
-    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(wrongAnswerCheckbox);
     await click(rightAnswerCheckbox);
     await click(qcmVerifyButtonCameBack);
@@ -119,7 +119,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
     const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
     const qcmForm = screen.getByRole('group');
@@ -140,7 +140,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     assert.false(wrongAnswerCheckbox.checked);
     assert.false(rightAnswerCheckbox.checked);
 
-    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(qcmVerifyButtonCameBack);
     const validationAlert = screen.queryAllByRole('alert')[1];
 

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -68,7 +68,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
     const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
     const firstQcuForm = screen.getByRole('group');
@@ -88,7 +88,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);
 
-    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(wrongAnswerRadio);
     await click(firstQcuVerifyButtonCameBack);
     assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
@@ -157,7 +157,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
     const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
     const firstQcuForm = screen.getByRole('group');
@@ -177,7 +177,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);
 
-    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(firstQcuVerifyButtonCameBack);
     const validationAlert = screen.queryAllByRole('alert')[1];
 

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -69,7 +69,6 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     // when
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
     const qrocmForm = screen.getByRole('group');
 
     // answer select proposal initially
@@ -82,6 +81,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     );
 
     // submit
+    const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
 
     assert.dom(screen.getByRole('status')).exists();
@@ -104,7 +104,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       'false',
     );
 
-    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
 
     // re-answer select proposal
     await clickByName('Réponse 1');
@@ -190,7 +190,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     // when
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     const input = screen.getByLabelText('Réponse 1');
 
     // answer input proposal
@@ -214,7 +214,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     await click(retryButton);
 
     // then
-    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(qrocmVerifyButtonCameBack);
     const validationAlert = screen.queryAllByRole('alert')[1];
 

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -71,7 +71,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
 
     // when
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier ma réponse' });
     const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
 
     // when

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -67,7 +67,7 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
 
     // when
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier ma réponse' });
     const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
 
     // when

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -78,7 +78,7 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
     // when
     const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
 
     // answer input proposal
     await fillIn(screen.getByLabelText('Réponse 1'), '@');
@@ -95,6 +95,6 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
 
     // then
     assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-    assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
+    assert.notOk(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
   });
 });

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -221,7 +221,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     );
 
     // then
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
   });
 
   test('should display an element with a qcu declarative element', async function (assert) {
@@ -265,7 +265,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     );
 
     // then
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
   });
 
   test('should display an element with a qrocm element', async function (assert) {
@@ -316,7 +316,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     );
 
     // then
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
   });
 
   test('should display an element with a flashcards element', async function (assert) {

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -50,7 +50,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.ok(screen.getByLabelText('checkbox2'));
     assert.ok(screen.getByLabelText('checkbox3'));
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     assert.dom(verifyButton).exists();
   });
 
@@ -78,7 +78,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     await click(screen.getByLabelText(answeredProposal[0].content));
     await click(screen.getByLabelText(answeredProposal[1].content));
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
 
     // then
@@ -111,7 +111,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
     // when
     await click(screen.getByLabelText('checkbox1'));
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
@@ -134,9 +134,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
 
     // when
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
     await click(screen.getByLabelText('checkbox1'));
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
@@ -168,7 +168,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display a ko feedback when exists', async function (assert) {
@@ -196,7 +196,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
     assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display retry button when a ko feedback appears', async function (assert) {

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -50,7 +50,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.ok(screen.getByLabelText('radio1'));
     assert.ok(screen.getByLabelText('radio2'));
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     assert.dom(verifyButton).exists();
   });
 
@@ -70,7 +70,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await render(<template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerSpy}} /></template>);
     await click(screen.getByLabelText(answeredProposal.content));
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
 
     // then
@@ -101,7 +101,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await render(<template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerSpy}} /></template>);
 
     // when
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
@@ -123,9 +123,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await render(<template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerSpy}} /></template>);
 
     // when
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
     await click(screen.getByLabelText('radio1'));
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
@@ -156,7 +156,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.getByText('Good job!')).exists();
     assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
     assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display a ko feedback when exists', async function (assert) {
@@ -183,7 +183,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.getByText('Too Bad!')).exists();
     assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
     assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display retry button when a ko feedback appears', async function (assert) {

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -225,7 +225,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('button', { name: 'select-aria' })).hasText("le fournisseur d'adresse mail");
-    assert.ok(screen.getByRole('button', { name: 'Vérifier' }));
+    assert.ok(screen.getByRole('button', { name: 'Vérifier ma réponse' }));
   });
 
   test('should display an error message if QROCM is validated without response', async function (assert) {
@@ -258,7 +258,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     const screen = await render(<template><ModuleQrocm @element={{qrocm}} /></template>);
 
     // when
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
@@ -297,7 +297,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     );
 
     // when
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
     await clickByName('select-aria');
     await screen.findByRole('listbox');
     await click(
@@ -305,7 +305,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
         name: "le fournisseur d'adresse mail",
       }),
     );
-    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
     assert
@@ -342,7 +342,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       );
       await fillIn(screen.getByLabelText('Réponse 1'), userResponse);
 
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
       await click(verifyButton);
 
       // then
@@ -403,7 +403,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       const screen = await render(
         <template><ModuleQrocm @element={{qrocm}} @onAnswer={{onElementAnswerSpy}} /></template>,
       );
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
 
       // when
       await clickByName('select-aria');
@@ -451,7 +451,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     // then
     assert.dom(screen.getByText('Correct!')).exists();
     assert.dom(screen.getByText('Good job!')).exists();
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display a ko feedback when exists', async function (assert) {
@@ -475,7 +475,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     // then
     assert.dom(screen.getByText('Wrong!')).exists();
     assert.dom(screen.getByText('Too Bad!')).exists();
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
   });
 
   test('should display retry button when a ko feedback appears', async function (assert) {

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -53,7 +53,7 @@ module('Integration | Component | Module | Step', function (hooks) {
       );
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1639,7 +1639,7 @@
       "buttons": {
         "activity": {
           "retry": "Retry",
-          "verify": "Verify"
+          "verify": "Verify my answer"
         },
         "element": {
           "alternativeText": "Show alternative text",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1625,7 +1625,7 @@
       "buttons": {
         "activity": {
           "retry": "Volver a intentarlo",
-          "verify": "Comprobar"
+          "verify": "Compruebe mi respuesta"
         },
         "element": {
           "alternativeText": "Mostrar el texto alternativo",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1639,7 +1639,7 @@
       "buttons": {
         "activity": {
           "retry": "Réessayer",
-          "verify": "Vérifier"
+          "verify": "Vérifier ma réponse"
         },
         "element": {
           "alternativeText": "Afficher l'alternative textuelle",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1628,7 +1628,7 @@
       "buttons": {
         "activity": {
           "retry": "Probeer het opnieuw",
-          "verify": "Kijk op"
+          "verify": "Controleer mijn antwoord"
         },
         "element": {
           "alternativeText": "Het tekstalternatief tonen",


### PR DESCRIPTION
## 🔆 Contexte

On veut mettre à jour le texte du bouton "Vérifier" sur les QCU / QCM / QROCM en "Vérifier ma réponse".

## ⛱️ Proposition

Le faire.

## 🌊 Remarques

RAS

## 🏄 Pour tester
### QCU
- Aller sur le module [Chatgpt vraiment neutre](https://app-pr12918.review.pix.fr/modules/chatgpt-vraiment-neutre/passage)
- Vérifier que le bouton affiche bien "Vérifier ma réponse"

### QCM
- Continuer dans le module jusqu'à arriver au QCM `Quelles sont les trois origines majeures des biais d'un LLM ?`
- Vérifier que le bouton pour valider affiche bien "Vérifier ma réponse"

### QROCM
- Aller sur le module [Bien écrire son adresse mail](https://app-pr12918.review.pix.fr/modules/bien-ecrire-son-adresse-mail/details)
- Aller jusqu'au 6ème grain et vérifier que le bouton pour valider affiche bien "Vérifier ma réponse"
