### PR TITLE
[FEATURE] Enlever le cache de la version des modules   (PIX-18716)

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -4,8 +4,6 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { LearningContentResourceNotFound } from '../../../shared/domain/errors.js';
 import { ModuleFactory } from '../factories/module-factory.js';
 
-const memoizedModuleVersions = new Map();
-
 async function getAllByIds({ ids, moduleDatasource }) {
   try {
     const modules = await moduleDatasource.getAllByIds(ids);
@@ -32,20 +30,12 @@ async function list({ moduleDatasource }) {
   return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
 }
 
-function resetMemoizedModuleVersions() {
-  memoizedModuleVersions.clear();
-}
-
-export { getAllByIds, getById, getBySlug, list, resetMemoizedModuleVersions };
+export { getAllByIds, getById, getBySlug, list };
 
 function _computeModuleVersion(moduleData) {
-  if (!memoizedModuleVersions.has(moduleData.slug)) {
-    const hash = crypto.createHash('sha256');
-    hash.update(JSON.stringify(moduleData));
-    const version = hash.copy().digest('hex');
-    memoizedModuleVersions.set(moduleData.slug, version);
-  }
-  return memoizedModuleVersions.get(moduleData.slug);
+  const hash = crypto.createHash('sha256');
+  hash.update(JSON.stringify(moduleData));
+  return hash.copy().digest('hex');
 }
 
 async function _getModule({ ref, moduleDatasource, query }) {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -9,10 +9,6 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
-  beforeEach(function () {
-    moduleRepository.resetMemoizedModuleVersions();
-  });
-
   describe('#getAllByIds', function () {
     it('should return all modules with their version', async function () {
       // given


### PR DESCRIPTION
## 🔆 Problème
La mémoïsation qu'on a mis en place pour mettre en cache pour les versions des modules pose problème sur les tests d'intégration en plus de rajouter de la complexité sur le sujet.

## ⛱️ Proposition

L'enlever car on n'arrive pour le moment pas à estimer les gains de performances dessus.

## 🌊 Remarques
RAS

## 🏄 Pour tester (non régression)

- Ouvrir la console navigateur
- Aller sur un module [bac-a-sable](https://app-pr12921.review.pix.fr/modules/bac-a-sable/details). 
- Vérifier que l'appel pour récupérer le module GET https://app-pr12921.review.pix.fr/api/modules/bac-a-sable renvoie bien, dans la réponse, la version dans `data.attributes.version` 
