### PR TITLE
[FEATURE] Conserver le paramètre de vocalisation dans le localStorage

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -18,13 +18,14 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @service focusedCertificationChallengeWarningManager;
   @service pixMetrics;
+  @service storage;
 
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
   @tracked hasUserConfirmedTimedChallengeWarning = false;
-  @tracked isTextToSpeechActivated = true;
+  @tracked isTextToSpeechActivated = this.storage.getTextToSpeech();
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -242,6 +243,7 @@ export default class ChallengeController extends Controller {
 
   @action toggleTextToSpeech() {
     this.isTextToSpeechActivated = !this.isTextToSpeechActivated;
+    this.storage.setTextToSpeech(this.isTextToSpeechActivated);
     if (!this.isTextToSpeechActivated) {
       speechSynthesis.cancel();
     }

--- a/mon-pix/app/services/storage.js
+++ b/mon-pix/app/services/storage.js
@@ -1,6 +1,8 @@
 import Service from '@ember/service';
+import { toBool } from 'ember-source/@glimmer/global-context';
 
 const SESSIONSTORAGE_LOGIN = 'PIX_LOGIN';
+const LOCALSTORAGE_TEXT_TO_SPEECH = 'PIX_TEXT_TO_SPEECH';
 
 export default class Storage extends Service {
   setLogin(login) {
@@ -13,5 +15,17 @@ export default class Storage extends Service {
 
   clear() {
     return sessionStorage.clear();
+  }
+
+  getTextToSpeech() {
+    const value = localStorage.getItem(LOCALSTORAGE_TEXT_TO_SPEECH);
+    if (value !== null) {
+      return toBool(value);
+    }
+    return true;
+  }
+
+  setTextToSpeech(value) {
+    localStorage.setItem(LOCALSTORAGE_TEXT_TO_SPEECH, value);
   }
 }

--- a/mon-pix/tests/unit/services/storage-test.js
+++ b/mon-pix/tests/unit/services/storage-test.js
@@ -3,41 +3,77 @@ import { module, test } from 'qunit';
 
 module('Unit | Service | storage', function (hooks) {
   setupTest(hooks);
+  let service;
 
-  test('setLogin', function (assert) {
-    // given
-    const service = this.owner.lookup('service:storage');
-    const login = 'someone@example.net';
-
-    // when
-    service.setLogin(login);
-
-    // then
-    assert.strictEqual(sessionStorage.getItem('PIX_LOGIN'), login);
+  hooks.beforeEach(function () {
+    service = this.owner.lookup('service:storage');
   });
 
-  test('getLogin', function (assert) {
-    // given
-    const service = this.owner.lookup('service:storage');
-    const login = 'someone@example.net';
-    sessionStorage.setItem('PIX_LOGIN', login);
+  module('login', function () {
+    test('setLogin', function (assert) {
+      // given
+      const login = 'someone@example.net';
 
-    // when
-    const result = service.getLogin();
+      // when
+      service.setLogin(login);
 
-    // then
-    assert.strictEqual(result, login);
+      // then
+      assert.strictEqual(sessionStorage.getItem('PIX_LOGIN'), login);
+    });
+
+    test('getLogin', function (assert) {
+      // given
+      const login = 'someone@example.net';
+      sessionStorage.setItem('PIX_LOGIN', login);
+
+      // when
+      const result = service.getLogin();
+
+      // then
+      assert.strictEqual(result, login);
+    });
+
+    test('getLogin with no login', function (assert) {
+      // given
+      sessionStorage.clear();
+
+      // when
+      const result = service.getLogin();
+
+      // then
+      assert.strictEqual(result, null);
+    });
   });
 
-  test('getLogin with no login', function (assert) {
-    // given
-    const service = this.owner.lookup('service:storage');
-    sessionStorage.clear();
+  module('text to speech', function () {
+    test('should return the value of text to speech if is not null', function (assert) {
+      // given
+      localStorage.setItem('PIX_TEXT_TO_SPEECH', true);
 
-    // when
-    const result = service.getLogin();
+      // when
+      const result = service.getTextToSpeech();
 
-    // then
-    assert.strictEqual(result, null);
+      // then
+      assert.true(result);
+    });
+
+    test('should set the value correctly', function (assert) {
+      // when
+      service.setTextToSpeech(true);
+
+      // then
+      assert.strictEqual(localStorage.getItem('PIX_TEXT_TO_SPEECH'), 'true');
+    });
+
+    test('return true if value is not defined in localstorage', function (assert) {
+      // given
+      localStorage.removeItem('PIX_TEXT_TO_SPEECH');
+
+      // when
+      const result = service.getTextToSpeech();
+
+      // then
+      assert.true(result);
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'on joue des épreuves, on peut désactiver la vocalisation. Cette désactivation entraîne la disparition du bouton pour lire l'épreuve à voix haute, ce qui peut être utile surtout lorsqu'on utilise pas cette fonctionnalité. Or, à chaque rechargement ou changement d'épreuve, le paramètre de vocalisation se réactive, entraînant la réaparition du bouton pour lire l'épreuve à voix haute.

## ⛱️ Proposition

Conserver la valeur du bouton de vocalisation dans le localStorage et le réutiliser.

## 🌊 Remarques

- Sur les ordinateurs partagés, cela peut signifier que si l'un change le paramètre, cela sera changé pour le suivant également,
- Par défaut, on met la valeur à true comme précédemment,
- On utilise le localStorage mais on pourrait également utiliser le sessionStorage afin de perdre le paramètre à chaque changement de session.

## 🏄 Pour tester

- Se rendre sur Pix-app,
- Se connecter avec superadmin@example.net,
- Lancer une épreuve,
- Désactiver la vocalisation,
- Recharger la page,
- Constater que la vocalisation reste désactivée,
- Réactiver la vocalisation et recharger la page,
- Constater que la vocalisation est bien de retour.