### PR TITLE
[FEATURE] Scorer une certification via une calibration du datamart (PIX-18809).

### DIFF
--- a/api/scripts/certification/sync-datamart-with-lcms-challenges.js
+++ b/api/scripts/certification/sync-datamart-with-lcms-challenges.js
@@ -1,0 +1,69 @@
+import 'dotenv/config';
+
+import dayjs from 'dayjs';
+
+import { knex as datamartKnex } from '../../datamart/knex-database-connection.js';
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { config } from '../../src/shared/config.js';
+
+export class SyncDatamartWithLCMSChallenges extends Script {
+  constructor() {
+    super({
+      description: '[NOT FOR PROD] Sync datamart with with another calibration than LCMS calibrated challenges',
+      permanent: false,
+      options: {},
+    });
+
+    this.totalNumberOfUpdatedRows = 0;
+  }
+
+  async handle({ _options, logger }) {
+    this.logger = logger;
+
+    if (!config.v3Certification.certificationCoreCalibration2024Id) {
+      throw new Error('missing CERTIFICATION_CORE_CALIBRATION_2024_ID');
+    }
+
+    const calibrationConf = {
+      certificationCoreCalibration2024Id: config.v3Certification.certificationCoreCalibration2024Id,
+    };
+
+    this.logger.info({ ...calibrationConf });
+
+    const challengesFromLCMS = await knex('learningcontent.challenges').whereNotNull('alpha').whereNotNull('delta');
+
+    const deleted = await datamartKnex('data_active_calibrated_challenges').del();
+    this.logger.info(`Deleted ${deleted} challenges from old calibrations`);
+
+    await datamartKnex('data_calibrations').del();
+    this.logger.info(`Deleted ${deleted} old calibration`);
+
+    await datamartKnex('data_calibrations').insert({
+      id: calibrationConf.certificationCoreCalibration2024Id,
+      calibration_date: dayjs().toDate(),
+      status: 'VALIDATED',
+      scope: 'COEUR',
+    });
+
+    const newPixCoeur = challengesFromLCMS.map((challenge) => {
+      return {
+        challenge_id: challenge.id,
+        alpha: Math.floor(challenge.alpha),
+        delta: Math.floor(challenge.delta),
+        calibration_id: calibrationConf.certificationCoreCalibration2024Id,
+      };
+    });
+
+    const { length } = await datamartKnex
+      .batchInsert('data_active_calibrated_challenges', newPixCoeur)
+      .returning('challenge_id');
+
+    this.logger.info(`Datamart is now synchronized for ${length} challenges`);
+
+    return 0;
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, SyncDatamartWithLCMSChallenges);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -635,6 +635,8 @@ const configuration = (function () {
     config.apiManager.url = 'http://external-partners-access/';
 
     config.infra.engineeringUserId = 800;
+
+    config.v3Certification.latestCalibrationDate = '2020-01-01';
   }
 
   return config;

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -4,6 +4,7 @@ import { AnswerStatus, Assessment } from '../../../../../src/shared/domain/model
 import {
   createServer,
   databaseBuilder,
+  datamartBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
   knex,
@@ -11,141 +12,293 @@ import {
 
 describe('Certification | Evaluation | Acceptance | Application |  certification rescoring', function () {
   describe('GET /api/admin/certifications/{certificationCourseId}/rescore', function () {
-    let server;
-    let originalConfigValue;
+    let server, originalConfigValue, originalCalibrationDateValue, originalCoreCalibrationIdValue, calibrationId;
 
     beforeEach(async function () {
+      calibrationId = 1;
       originalConfigValue = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
+      originalCalibrationDateValue = config.v3Certification.latestCalibrationDate;
+      originalCoreCalibrationIdValue = config.v3Certification.certificationCoreCalibration2024Id;
       config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = 1;
+      config.v3Certification.latestCalibrationDate = new Date('2024-07-23');
+      config.v3Certification.certificationCoreCalibration2024Id = calibrationId;
 
       server = await createServer();
     });
 
     afterEach(function () {
       config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification = originalConfigValue;
+      config.v3Certification.latestCalibrationDate = originalCalibrationDateValue;
+      config.v3Certification.certificationCoreCalibration2024Id = originalCoreCalibrationIdValue;
     });
 
-    it('should return 201 HTTP status code', async function () {
-      // given
-      const user = databaseBuilder.factory.buildUser.withRole({
-        role: 'SUPER_ADMIN',
-      });
+    describe('when scoring from the current framework', function () {
+      it('should return 201 HTTP status code', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole({
+          role: 'SUPER_ADMIN',
+        });
 
-      databaseBuilder.factory.learningContent.buildArea({
-        id: 'recArea0',
-        code: '66',
-        competenceIds: ['recCompetence0'],
-      });
-      databaseBuilder.factory.learningContent.buildCompetence({
-        id: 'recCompetence0',
-        name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
-        index: '1.1',
-        areaId: 'recArea0',
-        skillIds: ['recSkill0_0'],
-        origin: 'Pix',
-      });
-      databaseBuilder.factory.learningContent.buildTube({
-        id: 'recTube0_0',
-      });
-      databaseBuilder.factory.learningContent.buildSkill({
-        id: 'recSkill0_0',
-        name: '@recSkill0_0',
-        tubeId: 'recTube0_0',
-        status: 'actif',
-        level: 1,
-      });
-      databaseBuilder.factory.learningContent.buildChallenge({
-        id: 'recChallenge0_0_0',
-        competenceId: 'recCompetence0',
-        skillId: 'recSkill0_0',
-      });
+        databaseBuilder.factory.learningContent.buildArea({
+          id: 'recArea0',
+          code: '66',
+          competenceIds: ['recCompetence0'],
+        });
+        databaseBuilder.factory.learningContent.buildCompetence({
+          id: 'recCompetence0',
+          name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
+          index: '1.1',
+          areaId: 'recArea0',
+          skillIds: ['recSkill0_0'],
+          origin: 'Pix',
+        });
+        databaseBuilder.factory.learningContent.buildTube({
+          id: 'recTube0_0',
+        });
+        databaseBuilder.factory.learningContent.buildSkill({
+          id: 'recSkill0_0',
+          name: '@recSkill0_0',
+          tubeId: 'recTube0_0',
+          status: 'actif',
+          level: 1,
+        });
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'recChallenge0_0_0',
+          competenceId: 'recCompetence0',
+          skillId: 'recSkill0_0',
+        });
 
-      databaseBuilder.factory.buildFlashAlgorithmConfiguration({
-        maximumAssessmentLength: 1,
-        createdAt: new Date('2010-02-01'),
-      });
-      databaseBuilder.factory.buildScoringConfiguration({
-        createdByUserId: user.id,
-        createdAt: new Date('2010-02-01'),
-      });
-      databaseBuilder.factory.buildCompetenceScoringConfiguration({
-        createdByUserId: user.id,
-        configuration: [
-          {
-            competence: '1.1',
-            values: [
-              {
-                bounds: {
-                  max: 0,
-                  min: -5,
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+          maximumAssessmentLength: 1,
+          createdAt: new Date('2010-02-01'),
+        });
+        databaseBuilder.factory.buildScoringConfiguration({
+          createdByUserId: user.id,
+          createdAt: new Date('2010-02-01'),
+        });
+        databaseBuilder.factory.buildCompetenceScoringConfiguration({
+          createdByUserId: user.id,
+          configuration: [
+            {
+              competence: '1.1',
+              values: [
+                {
+                  bounds: {
+                    max: 0,
+                    min: -5,
+                  },
+                  competenceLevel: 0,
                 },
-                competenceLevel: 0,
-              },
-            ],
-          },
-        ],
-      });
+              ],
+            },
+          ],
+        });
 
-      const candidate = databaseBuilder.factory.buildUser();
-      const sessionId = databaseBuilder.factory.buildSession({
-        date: '2020/01/01',
-        time: '12:00',
-        finalizedAt: new Date('2020-01-01'),
-        version: AlgorithmEngineVersion.V3,
-      }).id;
+        const candidate = databaseBuilder.factory.buildUser();
+        const sessionId = databaseBuilder.factory.buildSession({
+          date: '2020/01/01',
+          time: '12:00',
+          finalizedAt: new Date('2020-01-01'),
+          version: AlgorithmEngineVersion.V3,
+        }).id;
 
-      databaseBuilder.factory.buildCertificationCandidate({
-        sessionId,
-        userId: candidate.id,
-      });
-      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-        sessionId,
-        userId: candidate.id,
-        version: AlgorithmEngineVersion.V3,
-      });
+        databaseBuilder.factory.buildCertificationCandidate({
+          sessionId,
+          userId: candidate.id,
+        });
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId: candidate.id,
+          version: AlgorithmEngineVersion.V3,
+          createdAt: new Date('2025-01-01'),
+        });
 
-      const assessment = databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourse.id,
-        userId: candidate.id,
-        type: Assessment.types.CERTIFICATION,
-        state: Assessment.states.COMPLETED,
-      });
-      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
-        courseId: certificationCourse.id,
-        isNeutralized: false,
-        challengeId: 'recChallenge0_0_0',
-        competenceId: 'recCompetence0',
-        associatedSkillName: '@recSkill0_0',
-        associatedSkillId: 'recSkill0_0',
-      });
-      databaseBuilder.factory.buildAnswer({
-        assessmentId: assessment.id,
-        challengeId: certificationChallenge.challengeId,
-        result: AnswerStatus.KO.status,
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessment.id,
-        pixScore: 200,
-      });
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: candidate.id,
+          type: Assessment.types.CERTIFICATION,
+          state: Assessment.states.COMPLETED,
+        });
+        const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          courseId: certificationCourse.id,
+          isNeutralized: false,
+          challengeId: 'recChallenge0_0_0',
+          competenceId: 'recCompetence0',
+          associatedSkillName: '@recSkill0_0',
+          associatedSkillId: 'recSkill0_0',
+        });
+        databaseBuilder.factory.buildAnswer({
+          assessmentId: assessment.id,
+          challengeId: certificationChallenge.challengeId,
+          result: AnswerStatus.KO.status,
+        });
+        databaseBuilder.factory.buildAssessmentResult({
+          assessmentId: assessment.id,
+          pixScore: 200,
+        });
 
-      await databaseBuilder.commit();
+        await databaseBuilder.commit();
 
-      const request = {
-        method: 'POST',
-        url: `/api/admin/certifications/${certificationCourse.id}/rescore`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
-      };
+        const request = {
+          method: 'POST',
+          url: `/api/admin/certifications/${certificationCourse.id}/rescore`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
 
-      // when
-      const response = await server.inject(request);
+        // when
+        const response = await server.inject(request);
 
-      // then
-      expect(response.statusCode).to.equal(201);
-      const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
-      expect(descOrderedAssessmentResults).to.have.length(2);
-      const [lastAssessmentResult] = descOrderedAssessmentResults;
-      expect(lastAssessmentResult.pixScore).to.be.equal(55);
-      expect(lastAssessmentResult.juryId).to.be.equal(user.id);
+        // then
+        expect(response.statusCode).to.equal(201);
+        const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
+        expect(descOrderedAssessmentResults).to.have.length(2);
+        const [lastAssessmentResult] = descOrderedAssessmentResults;
+        expect(lastAssessmentResult.pixScore).to.be.equal(55);
+        expect(lastAssessmentResult.juryId).to.be.equal(user.id);
+      });
+    });
+
+    describe('when scoring from an archived framework', function () {
+      it('should return 201 HTTP status code', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole({
+          role: 'SUPER_ADMIN',
+        });
+
+        databaseBuilder.factory.learningContent.buildArea({
+          id: 'recArea0',
+          code: '66',
+          competenceIds: ['recCompetence0'],
+        });
+        databaseBuilder.factory.learningContent.buildCompetence({
+          id: 'recCompetence0',
+          name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
+          index: '1.1',
+          areaId: 'recArea0',
+          skillIds: ['recSkill0_0'],
+          origin: 'Pix',
+        });
+        databaseBuilder.factory.learningContent.buildTube({
+          id: 'recTube0_0',
+        });
+        databaseBuilder.factory.learningContent.buildSkill({
+          id: 'recSkill0_0',
+          name: '@recSkill0_0',
+          tubeId: 'recTube0_0',
+          status: 'actif',
+          level: 1,
+        });
+        databaseBuilder.factory.learningContent.buildChallenge({
+          id: 'recChallenge0_0_0',
+          competenceId: 'recCompetence0',
+          skillId: 'recSkill0_0',
+          alpha: null,
+          delta: null,
+        });
+
+        datamartBuilder.factory.buildCalibration({
+          id: calibrationId,
+          scope: 'COEUR',
+          status: 'VALIDATED',
+        });
+        datamartBuilder.factory.buildActiveCalibratedChallenge({
+          calibrationId: calibrationId,
+          challengeId: 'recChallenge0_0_0',
+          alpha: 3.3,
+          delta: 4.4,
+        });
+
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+          maximumAssessmentLength: 1,
+          createdAt: new Date('2010-02-01'),
+        });
+        databaseBuilder.factory.buildScoringConfiguration({
+          createdByUserId: user.id,
+          createdAt: new Date('2010-02-01'),
+        });
+        databaseBuilder.factory.buildCompetenceScoringConfiguration({
+          createdByUserId: user.id,
+          configuration: [
+            {
+              competence: '1.1',
+              values: [
+                {
+                  bounds: {
+                    max: 0,
+                    min: -5,
+                  },
+                  competenceLevel: 0,
+                },
+              ],
+            },
+          ],
+        });
+
+        const candidate = databaseBuilder.factory.buildUser();
+        const sessionId = databaseBuilder.factory.buildSession({
+          date: '2020/01/01',
+          time: '12:00',
+          finalizedAt: new Date('2020-01-01'),
+          version: AlgorithmEngineVersion.V3,
+        }).id;
+
+        databaseBuilder.factory.buildCertificationCandidate({
+          sessionId,
+          userId: candidate.id,
+        });
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId: candidate.id,
+          version: AlgorithmEngineVersion.V3,
+          createdAt: new Date('2024-01-01'),
+        });
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: candidate.id,
+          type: Assessment.types.CERTIFICATION,
+          state: Assessment.states.COMPLETED,
+        });
+        const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          courseId: certificationCourse.id,
+          isNeutralized: false,
+          challengeId: 'recChallenge0_0_0',
+          competenceId: 'recCompetence0',
+          associatedSkillName: '@recSkill0_0',
+          associatedSkillId: 'recSkill0_0',
+          discriminant: 3.3,
+          difficulty: 4.4,
+        });
+        databaseBuilder.factory.buildAnswer({
+          assessmentId: assessment.id,
+          challengeId: certificationChallenge.challengeId,
+          result: AnswerStatus.KO.status,
+        });
+        databaseBuilder.factory.buildAssessmentResult({
+          assessmentId: assessment.id,
+          pixScore: 200,
+        });
+
+        await databaseBuilder.commit();
+        await datamartBuilder.commit();
+
+        const request = {
+          method: 'POST',
+          url: `/api/admin/certifications/${certificationCourse.id}/rescore`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+        const descOrderedAssessmentResults = await knex('assessment-results').orderBy('createdAt', 'DESC');
+        expect(descOrderedAssessmentResults).to.have.length(2);
+        const [lastAssessmentResult] = descOrderedAssessmentResults;
+        expect(lastAssessmentResult.pixScore).to.be.equal(55);
+        expect(lastAssessmentResult.juryId).to.be.equal(user.id);
+      });
     });
   });
 });

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/calibrated-challenge-service_test.js
@@ -190,25 +190,17 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
         // given
         const certificationCourseId = 1234;
         const assessmentId = 5678;
-        const challengesAfterCalibration = challengeList.slice(1);
-
-        const challengeExcludedFromCalibration = domainBuilder.buildChallenge({
-          ...challengeList[0],
-          discriminant: null,
-          difficulty: null,
-        });
+        const expectedAskedChallenges = challengeList;
 
         const expectedChallengeCalibrations = _buildDataFromAnsweredChallenges(
           challengeList,
           sharedChallengeRepository,
         );
 
-        const expectedAskedChallenges = [challengeExcludedFromCalibration, ...challengesAfterCalibration];
-
         certificationCourseRepository.get
           .withArgs({ id: certificationCourseId })
           .resolves(
-            domainBuilder.buildCertificationCourse({ id: certificationCourseId, createdAt: new Date('2025-06-23') }),
+            domainBuilder.buildCertificationCourse({ id: certificationCourseId, createdAt: new Date('2019-01-01') }),
           );
         certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
           .withArgs({ assessmentId })
@@ -220,14 +212,13 @@ describe('Certification | Evaluation | Unit | Domain | Services | calibrated cha
           .withArgs({ certificationCourseId })
           .resolves(expectedChallengeCalibrations);
 
-        challengeRepository.findFlashCompatibleWithoutLocale.resolves(challengesAfterCalibration);
+        challengeRepository.findFlashCompatibleWithoutLocale.resolves(expectedAskedChallenges);
 
         certificationCourseRepository.get
           .withArgs({ id: certificationCourseId })
           .resolves(
             domainBuilder.buildCertificationCourse({ id: certificationCourseId, createdAt: new Date('2025-06-20') }),
           );
-        config.v3Certification.latestCalibrationDate = new Date('2025-06-23');
 
         // when
         await calibratedChallengeService.findByCertificationCourseIdAndAssessmentId({


### PR DESCRIPTION
## 🔆 Problème

Suite à la PR #12897, nous ne renvoyions pas les challenges récupérés du datamart en cas de sélection de la calibration archivée

## ⛱️ Proposition

Renvoi des valeurs des challenges de la calibration archivée dans le datamart.

## 🌊 Remarques

⚠️  J'ai ajouté un script pour de la même manière que ce qui a été fait via le script de réplication des certif-challenges côté datamart, nous permettre de copier le référentiel courant dans le datamart en changeant les valeurs d'`alpha` et `delta` afin de simuler l'existence d'une ancienne calibration complète. (utile pour tester la dégradation)

## 🏄 Pour tester

- Si ce n'est pas déjà fait sur l'environnement de test, exécuter le script de synchronisation des challenges du datamart de façon à avoir un "ancien réferentiel" créé dans le datamart contenant l'ensemble des challenges disponibles dans LCMS avec des valeurs d'`alpha` et `delta` différentes.

```bash
scalingo -a "pix-api-review-pr12938" run "LOG_LEVEL=info node scripts/certification/sync-datamart-with-lcms-challenges.js"
```

- Sur Pix-Certif, créer une session (`certif-prescriptor@example.net`) et ajouter un candidat
- Sur Pix-App (`certif-success@example.net`), passer la certification en terminant le test
- Finaliser la session

- Exécuter les requêtes suivantes:

```sql
 /*Suppression des valeurs essentielles du référentiel pour vérifier que l'on sélectionne bien les challenges du datamart */
update learningcontent.challenges set alpha = null;
update learningcontent.challenges set delta = null;

/* Emulation d'une calibration différente de celle du référentiel courant */
update "certification-challenges" set discriminant = round(discriminant);
update "certification-challenges" set difficulty = round(difficulty);
```

- Rescorer/Rejeter votre certification

🎯 Votre certification a bien été rescorée en ayant obtenu un score différent de celui que vous aviez précédemment obtenu