### PR TITLE
[TECH] Rendre silencieux les avertissements de deprecation de Pix App.

### DIFF
--- a/mon-pix/app/deprecation-workflow.js
+++ b/mon-pix/app/deprecation-workflow.js
@@ -1,3 +1,42 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
-setupDeprecationWorkflow();
+setupDeprecationWorkflow({
+  workflow: [
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.deprecate-tracking-package',
+    },
+    {
+      handler: 'silence',
+      matchId: 'ember-data:deprecate-store-extends-ember-object',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroying-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroyed-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import-destroy-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--register-destructor-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'importing-inject-from-ember-service',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.ember-inflector',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import-testing-from-ember',
+    },
+  ],
+});


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Les déprécations Ember affichent des warnings dans la console du navigateur ce qui entraine beaucoup de bruits pour les dev.

## ⛱️ Proposition

Utiliser `ember-cli-deprecation-workflow` pour rendre ces avertissements silencieux. Voir [https://github.com/ember-cli/ember-cli-deprecation-workflow](https://github.com/ember-cli/ember-cli-deprecation-workflow) pour le guide d'utilisation de cet outil.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

Les avertissements ont été rendus silencieux **mais** il faudra les traiter par la suite pour ne pas bloquer les futures montées de version d'Ember.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

En local, lancer les tests de Pix App.

```js
cd mon-pix
npm run dev
```

Se rendre sur localhost:4200/tests
Vérifier que la console n'affiche pas d'avertissements de dépréciations.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
