### PR TITLE
[FEATURE] Corriger les styles du QAB

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--pix-spacing-6x);
+    width: 100%;
   }
 
   &__cards {

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -11,6 +11,10 @@
     width: 100%;
   }
 
+  &__instruction {
+    font-weight: var(--pix-font-medium);
+  }
+
   &__cards {
     display: grid;
     grid-template-areas: 'center';


### PR DESCRIPTION
## 🔆 Problème

Les styles du QAB manque de cohérence avec le reste des modalités.

## ⛱️ Proposition

- Mettre l'instruction en gras
- Prendre toute la largeur disponible

## 🌊 Remarques
RAS

## 🏄 Pour tester
Dans le [bac à sable](https://app-pr12941.review.pix.fr/modules/bac-a-sable/passage), s'assurer que les styles sont plus cohérents.
