### PR TITLE
[TECH] :sparkles: Réplication des données de calibrations du `datawharehouse` vers le `datamart` (PIX-18842)

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -109,10 +109,10 @@ export const replications = [
   {
     name: 'data-active-calibrated-challenges',
     before: async ({ datamartKnex }) => {
-      await datamartKnex('').truncate();
+      await datamartKnex('data_active_calibrated_challenges').truncate();
     },
     from: ({ datawarehouseKnex }) => {
-      return datawarehouseKnex('data-active-calibrated-challenges').select(
+      return datawarehouseKnex('data_active_calibrated_challenges').select(
         'challenge_id',
         'alpha',
         'delta',
@@ -120,7 +120,7 @@ export const replications = [
       );
     },
     to: ({ datamartKnex }, chunk) => {
-      return datamartKnex('data-active-calibrated-challenges').insert(chunk);
+      return datamartKnex('data_active_calibrated_challenges').insert(chunk);
     },
   },
 ];

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -94,6 +94,35 @@ export const replications = [
       return datamartKnex('target_profiles_course_duration').insert(chunk);
     },
   },
+  {
+    name: 'data-calibration',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('data_calibrations').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data_calibrations').select('id', 'calibration_date', 'status', 'scope');
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('data_calibrations').insert(chunk);
+    },
+  },
+  {
+    name: 'data-active-calibrated-challenges',
+    before: async ({ datamartKnex }) => {
+      await datamartKnex('').truncate();
+    },
+    from: ({ datawarehouseKnex }) => {
+      return datawarehouseKnex('data-active-calibrated-challenges').select(
+        'challenge_id',
+        'alpha',
+        'delta',
+        'calibration_id',
+      );
+    },
+    to: ({ datamartKnex }, chunk) => {
+      return datamartKnex('data-active-calibrated-challenges').insert(chunk);
+    },
+  },
 ];
 
 export function getByName(name, dependencies = { replications }) {

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -95,7 +95,7 @@ export const replications = [
     },
   },
   {
-    name: 'data-calibration',
+    name: 'data-calibrations',
     before: async ({ datamartKnex }) => {
       await datamartKnex('data_calibrations').truncate();
     },


### PR DESCRIPTION
## 🔆 Problème

Les données manipulées par l'équipe Data le sont dans le `datawharehouse`.
L'équipe certification ne peut récupérer des données directement là-bas. 

## ⛱️ Proposition

Répliquer les données de calibration (`calibrations` et `active_calibrated_challenges`) vers le `datamart`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

_Voir avec Data pour avoir des données dans les tables de calibration de leur `datawharehouse` d'intégration_

Créer un token avec le scope `replication` :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr12942.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer la réplication :

```
curl -X POST "https://pix-api-maddo-review-pr12942.osc-fr1.scalingo.io/api/replications/data-calibrations" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST "https://pix-api-maddo-review-pr12942.osc-fr1.scalingo.io/api/replications/data-active-calibrated-challenges" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```

Se connecter à la DB de Maddo (le datamart) pour s'assurer que les données a répliquées sont bien sur le datamart.

```
scalingo -a "pix-api-maddo-review-pr12942" psql-console
```