### PR TITLE
[FEATURE] Automatiquement fermer les PRs en draft sans activité depuis +30 jours

### DIFF
--- a/.github/workflows/check-old-pull-requests.yml
+++ b/.github/workflows/check-old-pull-requests.yml
@@ -25,19 +25,13 @@ jobs:
         run: |
           ONE_MONTH_AGO=$(date -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ)
           echo "Searching opened pull requests from $ONE_MONTH_AGO"
-          OPENED_PRS=$(gh pr list --json number,updatedAt,isDraft --limit 100)
+          OPENED_PRS=$(gh pr list --json number,updatedAt --limit 100)
           PR_COUNT=$(echo "$OPENED_PRS" | jq '. | length')
           echo "Found $PR_COUNT PRs opened"
 
           echo "$OPENED_PRS" | jq -c '.[]' | while read -r PR; do
             PR_NUMBER=$(echo "$PR" | jq -r '.number')
             UPDATED_AT=$(echo "$PR" | jq -r '.updatedAt')
-            IS_DRAFT=$(echo "$PR" | jq -r '.isDraft')
-
-            if [[ "$IS_DRAFT" == "true" ]]; then
-              echo "[#$PR_NUMBER] skip draft"
-              continue
-            fi
 
             if [[ "$UPDATED_AT" < "$ONE_MONTH_AGO" ]]; then
               echo "[#$PR_NUMBER] inactive PR since $UPDATED_AT"


### PR DESCRIPTION
## 🔆 Problème
Depuis #12508, on ferme les PRs sans activité depuis +30 jours. Pour ne pas aller trop vite, on avait exclu les PRs en draft de ce mécanisme. À date sur 32 PRs ouvertes, 12 sont des PRs en draft dont une petite moitié sans activité depuis 2 mois ou plus. Cela entraine une consommation inutile de ressource.

## ⛱️ Proposition
Inclure les PRs en draft dans ce nettoyage.

## 🌊 Remarques
Restons alerte en cas de retours du contenu métier qui n'ont pas encore trop l'habitude de cette manière de travailler.

## 🏄 Pour tester
Je ne sais pas.