### PR TITLE
[TECH] Renommer la table quest_participations et ajouter les contraintes nécessaires (PIX-18841)

### DIFF
--- a/api/db/database-builder/factory/combined-course-participation.js
+++ b/api/db/database-builder/factory/combined-course-participation.js
@@ -24,7 +24,7 @@ const buildCombinedCourseParticipation = function ({
   };
 
   databaseBuffer.pushInsertable({
-    tableName: 'quest_participations',
+    tableName: 'combined_course_participations',
     values,
   });
 

--- a/api/db/migrations/20250723084849_rename-quest-participations-to-combined-course-participations.js
+++ b/api/db/migrations/20250723084849_rename-quest-participations-to-combined-course-participations.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.renameTable('quest_participations', 'combined_course_participations');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.renameTable('combined_course_participations', 'quest_participations');
+};
+
+export { down, up };

--- a/api/db/migrations/20250723085543_modify-combined_course_participation_status_constraint.js
+++ b/api/db/migrations/20250723085543_modify-combined_course_participation_status_constraint.js
@@ -1,0 +1,45 @@
+const TABLE_NAME = 'combined_course_participations';
+const FORMER_TABLE_NAME = 'quest_participations';
+const COLUMN_NAME = 'status';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+const formatAlterTableEnumSql = (tableName, columnName, enums, caseFunction) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${constraintName};`,
+    `UPDATE ${tableName} SET ${COLUMN_NAME}=${caseFunction}(${COLUMN_NAME});`,
+    `ALTER TABLE ${tableName} ADD CONSTRAINT ${constraintName} CHECK (${columnName} = ANY (ARRAY['${enums.join(
+      "'::text, '",
+    )}'::text]));`,
+  ].join('\n');
+};
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.dropChecks([`${FORMER_TABLE_NAME}_${COLUMN_NAME}_check`]);
+    table.text(COLUMN_NAME).defaultTo('STARTED').alter();
+    table.integer('organizationLearnerId').notNullable().alter();
+    table.integer('questId').notNullable().alter();
+  });
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(formatAlterTableEnumSql(TABLE_NAME, COLUMN_NAME, ['STARTED', 'COMPLETED'], 'UPPER'));
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(formatAlterTableEnumSql(TABLE_NAME, COLUMN_NAME, ['started', 'completed'], 'LOWER'));
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).defaultTo('started').alter();
+    table.integer('organizationLearnerId').nullable().alter();
+    table.integer('questId').nullable().alter();
+  });
+};
+
+export { down, up };

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -26,15 +26,13 @@ const OrganizationLearnerLoggerContext = {
 };
 
 const CombinedCourseParticipationStatuses = {
-  NOT_STARTED: 'not-started',
-  STARTED: 'started',
-  COMPLETED: 'completed',
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED',
 };
 
 const CombinedCourseStatuses = {
+  ...CombinedCourseParticipationStatuses,
   NOT_STARTED: 'NOT_STARTED',
-  STARTED: 'STARTED',
-  COMPLETED: 'COMPLETED',
 };
 
 export {

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -4,7 +4,7 @@ import { CombinedCourseParticipation } from '../../domain/models/CombinedCourseP
 
 export const save = async function ({ organizationLearnerId, questId }) {
   const knexConnection = DomainTransaction.getConnection();
-  await knexConnection('quest_participations')
+  await knexConnection('combined_course_participations')
     .insert({
       questId,
       organizationLearnerId,
@@ -16,13 +16,18 @@ export const save = async function ({ organizationLearnerId, questId }) {
 export const getByUserId = async function ({ userId, questId }) {
   const knexConnection = DomainTransaction.getConnection();
 
-  const questParticipations = await knexConnection('quest_participations')
-    .select('quest_participations.id', 'questId', 'organizationLearnerId', 'quest_participations.status')
+  const questParticipations = await knexConnection('combined_course_participations')
+    .select(
+      'combined_course_participations.id',
+      'questId',
+      'organizationLearnerId',
+      'combined_course_participations.status',
+    )
     .join(
       'view-active-organization-learners',
       'view-active-organization-learners.id',
       '=',
-      'quest_participations.organizationLearnerId',
+      'combined_course_participations.organizationLearnerId',
     )
     .where({
       'view-active-organization-learners.userId': userId,

--- a/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
@@ -18,7 +18,7 @@ describe('Integration | Combined course | Domain | UseCases | start-combined-cou
       });
 
       //then
-      const [participation] = await knex('quest_participations').where({
+      const [participation] = await knex('combined_course_participations').where({
         questId,
         organizationLearnerId: organizationLearner.id,
       });
@@ -52,7 +52,7 @@ describe('Integration | Combined course | Domain | UseCases | start-combined-cou
           .first();
         expect(createdOrganizationLearner).not.to.be.undefined;
 
-        const [participation] = await knex('quest_participations').where({
+        const [participation] = await knex('combined_course_participations').where({
           questId,
           organizationLearnerId: createdOrganizationLearner.id,
         });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -18,7 +18,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       });
 
       //then
-      const [participation] = await knex('quest_participations').where({
+      const [participation] = await knex('combined_course_participations').where({
         organizationLearnerId,
         questId,
       });
@@ -43,7 +43,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       await combinedCourseParticipationRepository.save({ organizationLearnerId, questId });
 
       // then
-      const [participation] = await knex('quest_participations').where({
+      const [participation] = await knex('combined_course_participations').where({
         organizationLearnerId,
         questId,
       });


### PR DESCRIPTION
## 🔆 Problème

La table `quest_participations` contient des "CombinedCourseParticipations".
De plus, il existe une contrainte sur le nom des status en minuscules, ce qui n'est pas cohérent avec les autres tables.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On ajoute 2 migrations.
Une première pour renommer la table `quest_participations` en `combined_course_participations`.
Une deuxième pour convertir la contrainte de status en minuscule vers des status en majuscules.
On en profite pour spécifier que les colonnes `questId` et `organizationLearnerId` ne peuvent pas être nulles.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Rollback la dernière migration avec `npm run db:rollback:latest`.
Participer à un parcours combiné (avec `attestation-blank@example.net` par exemple).
Exécuter la migration avec `npm run db:migrate`

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
