### PR TITLE
[FEATURE] Améliorer le contenu des bandeaux lorsque l'organisation n'a plus de places (PIX-18837)

### DIFF
--- a/orga/app/components/banner/maximum-places-exceeded.gjs
+++ b/orga/app/components/banner/maximum-places-exceeded.gjs
@@ -13,8 +13,12 @@ export default class MaximumPlacesExceeded extends Component {
 
   <template>
     {{#if this.displayMaximumPlacesExceededBanner}}
-      <PixBannerAlert @type="warning">
-        {{t "banners.maximum-places-exceeded.message"}}
+      <PixBannerAlert @type="error">
+        {{t
+          "banners.maximum-places-exceeded.message"
+          htmlSafe=true
+          linkClasses="link link--banner link--bold link--underlined"
+        }}
       </PixBannerAlert>
     {{/if}}
   </template>

--- a/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
+++ b/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
@@ -20,7 +20,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
       const screen = await render(<template><MaximumPlacesExceeded /></template>);
 
       // then
-      assert.notOk(screen.queryByText(this.intl.t('banners.maximum-places-exceeded.message')));
+      assert.notOk(screen.queryByText("Votre organisation n'a plus de places disponibles !"));
     });
   });
 
@@ -34,7 +34,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
         const screen = await render(<template><MaximumPlacesExceeded /></template>);
 
         // then
-        assert.notOk(screen.queryByText(this.intl.t('banners.maximum-places-exceeded.message')));
+        assert.notOk(screen.queryByText("Votre organisation n'a plus de places disponibles !"));
       });
     });
 
@@ -47,7 +47,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
         const screen = await render(<template><MaximumPlacesExceeded /></template>);
 
         // then
-        assert.ok(screen.getByText(this.intl.t('banners.maximum-places-exceeded.message')));
+        assert.ok(screen.getByText("Votre organisation n'a plus de places disponibles !"));
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -81,7 +81,7 @@
       "message": "Please note that your seats will expire in {days, number} days."
     },
     "maximum-places-exceeded": {
-      "message": "No more available places for the organization."
+      "message": "<b>Your organisation no longer has any seats available !</b><br />To take advantage of all the features, please free up some seats, get in touch with your Pix representative or '<'a href='https://pix.org/en/support-contact-form' title='contact us' class=\"{linkClasses}\" '>contact us using this form</a>'."
     },
     "over-capacity": {
       "message": "Please note that you are using more seats than your total capacity."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -81,7 +81,7 @@
       "message": "Attention, vos places arrivent à échéance dans {days, number} jours."
     },
     "maximum-places-exceeded": {
-      "message": "Plus de places disponibles pour l'organisation."
+      "message": "<b>Votre organisation n'a plus de places disponibles !</b><br />Pour bénéficier de toutes les fonctionnalités, merci de libérer des places, vous rapprocher de votre représentant Pix ou '<'a href='https://pix.fr/support/form/professionnel-le' title='contactez-nous(France)' class=\"{linkClasses}\" '>contactez-nous via ce formulaire</a>'. <br />Si vous êtes une organisation hors France '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contactez-nous (hors France)' class=\"{linkClasses}\" '>contactez-nous via ce formulaire</a>'."
     },
     "over-capacity": {
       "message": "Attention, vous consommez plus de places que votre capacité totale."

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -81,7 +81,7 @@
       "message": "{days, number} Houd er rekening mee dat je tickets over enkele dagen verlopen."
     },
     "maximum-places-exceeded": {
-      "message": "Er zijn geen plaatsen meer beschikbaar voor de organisatie."
+      "message": "<b>Uw organisatie heeft geen plaatsen meer beschikbaar !</b><br />Om gebruik te kunnen maken van alle mogelijkheden, kunt u een aantal plaatsen vrijmaken. Neem contact op met uw Pix-vertegenwoordiger of '<'a href='https://pix.org/en/support-contact-form' title='contact met ons' class=\"{linkClasses}\" '>contact met ons op via dit formulier</a>'."
     },
     "over-capacity": {
       "message": "Houd er rekening mee dat je meer plaats inneemt dan je totale capaciteit."


### PR DESCRIPTION
## 🔆 Problème

L'équipe de tech-days a fait un beau MVP pour permettre aux équipes métiers de bloquer certaines fonctionnalités de PixOrga aux prescripteurs lorsqu'ils n'ont plus de places disponibles. 
Ils ont prévu des bandeaux pour informer les prescripteurs mais le contenu est un peu succinct. 

## ⛱️ Proposition

Intégrer le contenu proposé par les équipes métiers dans les clés de trad. 

🇫🇷  Votre organisation n’a plus de places disponibles. Pour bénéficier de toutes les fonctionnalités, merci de libérer des places, vous rapprocher de votre représentant Pix ou contactez-nous via ce formulaire. https://pix.fr/support/form/professionnel-le 
Si vous êtes une organisation hors France, contactez-nous via ce formulaire. https://pix.org/fr/support/form/contactez-le-support-pix 

🇬🇧  Your organisation no longer has any seats available. To take advantage of all the features, please free up some seats, get in touch with your Pix representative or contact us via this form. https://pix.org/en/support-contact-form 

🇳🇱  Uw organisatie heeft geen plaatsen meer beschikbaar. Om gebruik te kunnen maken van alle mogelijkheden, kunt u een aantal plaatsen vrijmaken. Neem contact op met uw Pix-vertegenwoordiger of neem contact met ons op via dit formulier. https://pix.org/en/support-contact-form 

## 🌊 Remarques
Il y a un souci d'affichage du bandeau qui ne devrait pas se superposer à l'interface mais c'est à corriger dans PixUi. 

## 🏄 Pour tester

- Supprimer les lots de place de l'orga "PRO Classic" dans PixAdmin pour qu'elle soit en dépassement
- Activer l'option de blocage des fonctionnalités en cas de dépassement dans PixAdmin
- Voir le bandeau dans PixOrga 
- Tester les 3 langues