### PR TITLE
[BUGFIX] Redirige l'utilisateur connecté sur la page de réconciliation lorsqu'il accède à un parcours combiné (PIX-18835).

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -59,7 +59,7 @@ export default class FillInCampaignCodeController extends Controller {
         this.campaign = await verifiedCode.campaign;
         this.router.transitionTo('campaigns.entry-point', verifiedCode.id);
       } else {
-        this.router.transitionTo('combined-courses', verifiedCode.id);
+        this.router.transitionTo('organizations.access', verifiedCode.id);
       }
     } catch (error) {
       this.onStartCampaignError(error);

--- a/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
@@ -1,6 +1,7 @@
-import { getScreen, visit } from '@1024pix/ember-testing-library';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -78,8 +79,7 @@ module('Acceptance | Combined course | Start Combined course workflow', function
         //given
         const user = server.create('user', 'withEmail', { hasSeenAssessmentInstructions: false });
         // when
-        await unabortedVisit('/parcours/COMBINIX1');
-        const screen = getScreen();
+        const screen = await unabortedVisit('/parcours/COMBINIX1');
         await _loginUser(screen, user);
 
         assert.strictEqual(currentURL(), '/parcours/COMBINIX1');
@@ -88,7 +88,6 @@ module('Acceptance | Combined course | Start Combined course workflow', function
   });
   module('when user is logged in', function () {
     let combinedCourse;
-
     module('when organization is restricted', function (hooks) {
       hooks.beforeEach(async function () {
         const prescritUser = server.create('user', 'withEmail', {
@@ -109,6 +108,20 @@ module('Acceptance | Combined course | Start Combined course workflow', function
 
           //then
           assert.strictEqual(currentURL(), '/organisations/COMBINIX1/prescrit/eleve');
+        });
+
+        module('when using fill in code page', function () {
+          test('should redirect to sco reconciliation page', async function (assert) {
+            //given
+            const screen = await unabortedVisit('/campagnes');
+
+            //when
+            await fillByLabel(`${t('pages.fill-in-campaign-code.label')} *`, 'COMBINIX1');
+            await click(screen.getByRole('button', { name: t('pages.fill-in-campaign-code.start') }));
+
+            //then
+            assert.strictEqual(currentURL(), '/organisations/COMBINIX1/prescrit/eleve');
+          });
         });
       });
     });

--- a/mon-pix/tests/helpers/unaborted-visit.js
+++ b/mon-pix/tests/helpers/unaborted-visit.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { getScreen, visit } from '@1024pix/ember-testing-library';
 import { settled } from '@ember/test-helpers';
 
 // Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch en attendant l'évolution attendue dans Ember :
@@ -13,6 +13,7 @@ export async function unabortedVisit(url) {
 
     await settled();
   }
+  return getScreen();
 }
 
 function _isEmberTransitionAborted(error) {


### PR DESCRIPTION
## 🔆 Problème

Lorsque l'utilisateur est déjà connecté et tente d'accéder à un parcours combiné pour une organisation avec import via la page de saisi de code il est redirigé sur la page de parcours combiné sans être réconcilié.

## ⛱️ Proposition

Forcer le passage par la brique d'accès pour les parcours combiné quand on passe par la page de saisi de code.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter sur MonPix avec le compte attestation-blank
- Aller sur la page de saisi d'un code
- Saisir le code COMBINIX1
- Constater qu'un arrive sur la page de reconciliation qui demande le nom, prénom et date de naissance
