### PR TITLE
[TECH] Isoler la logique des URL de PixApp  (PIX-18811)

### DIFF
--- a/mon-pix/app/components/sitemap/content.gjs
+++ b/mon-pix/app/components/sitemap/content.gjs
@@ -111,13 +111,6 @@ export default class Content extends Component {
                 </a>
               </li>
               <li class="sitemap-content-items-link-resources__resource">
-                <a href={{this.accessibilityHelpUrl}} target="_blank" rel="noopener noreferrer">
-                  {{t "pages.sitemap.accessibility.help"}}
-                  <PixIcon @name="openNew" @ariaHidden={{true}} />
-                  <span class="sr-only">{{t "navigation.external-link-title"}}</span>
-                </a>
-              </li>
-              <li class="sitemap-content-items-link-resources__resource">
                 <a href={{this.cguUrl}} target="_blank" rel="noopener noreferrer">
                   {{t "navigation.footer.eula"}}
                   <PixIcon @name="openNew" @ariaHidden={{true}} />

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -1,0 +1,131 @@
+// This file is the ORIGINAL file. Copies of it are used in all the fronts.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import Service, { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
+
+const { DEFAULT_LOCALE } = ENV.APP;
+
+// Don't use directly this service, use a url service which extends it
+export default class UrlBaseService extends Service {
+  @service currentDomain;
+  @service locale;
+
+  get homeUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `${ENV.rootURL}?lang=${currentLocale}`;
+  }
+
+  get serverStatusUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `https://status.pix.org/?locale=${currentLocale}`;
+  }
+
+  get pixAppUrl() {
+    if (!ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION) return ENV.rootURL;
+    const tld = this.currentDomain.getExtension();
+    return `${ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION}${tld}`;
+  }
+
+  get pixAppCampaignRootUrl() {
+    return `${this.pixAppUrl}/campagne`;
+  }
+
+  get pixAppForgottenPasswordUrl() {
+    const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
+    const currentLocale = this.locale.currentLocale;
+    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+  }
+
+  getPixWebsiteUrl(pathname = '') {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const rootUrl = PIX_WEBSITE_ROOT_URLS[locale] || PIX_WEBSITE_ROOT_URLS[DEFAULT_LOCALE];
+    return pathname ? `${rootUrl}/${pathname}` : rootUrl;
+  }
+
+  getPixWebsiteUrlFor(pathKey) {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const pathsByLocale = PIX_WEBSITE_PATHS[pathKey] || {};
+    const pathname = pathsByLocale[locale] || pathsByLocale[DEFAULT_LOCALE];
+    return this.getPixWebsiteUrl(pathname);
+  }
+}
+
+// Pix website URLs for each supported locales
+export const PIX_WEBSITE_ROOT_URLS = {
+  'fr-FR': 'https://pix.fr',
+  'fr-BE': 'https://pix.org/fr-be',
+  'nl-BE': 'https://pix.org/nl-be',
+  nl: 'https://pix.org/nl-be',
+  en: 'https://pix.org/en',
+  es: 'https://pix.org/en',
+  fr: 'https://pix.org/fr',
+};
+
+// Pix website paths for each supported locales
+export const PIX_WEBSITE_PATHS = {
+  CGU: {
+    'fr-FR': 'conditions-generales-d-utilisation',
+    'fr-BE': 'conditions-generales-d-utilisation',
+    'nl-BE': 'algemene-gebruiksvoorwaarden',
+    nl: 'algemene-gebruiksvoorwaarden',
+    en: 'terms-and-conditions',
+    es: 'terms-and-conditions',
+    fr: 'conditions-generales-d-utilisation',
+  },
+  LEGAL_NOTICE: {
+    'fr-FR': 'mentions-legales',
+    'fr-BE': 'mentions-legales',
+    'nl-BE': 'wettelijke-vermeldingen',
+    nl: 'wettelijke-vermeldingen',
+    en: 'legal-notice',
+    es: 'legal-notice',
+    fr: 'mentions-legales',
+  },
+  DATA_PROTECTION_POLICY: {
+    'fr-FR': 'politique-protection-donnees-personnelles-app',
+    'fr-BE': 'politique-protection-donnees-personnelles-app',
+    'nl-BE': 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    en: 'personal-data-protection-policy',
+    es: 'personal-data-protection-policy',
+    fr: 'politique-protection-donnees-personnelles-app',
+  },
+  ACCESSIBILITY: {
+    'fr-FR': 'accessibilite',
+    'fr-BE': 'accessibilite',
+    'nl-BE': 'toegankelijkheid',
+    nl: 'toegankelijkheid',
+    en: 'accessibility',
+    es: 'accessibility',
+    fr: 'accessibilite',
+  },
+  ACCESSIBILITY_ORGA: {
+    'fr-FR': 'accessibilite-pix-orga',
+    'fr-BE': 'accessibilite-pix-orga',
+    'nl-BE': 'toegankelijkheid-pix-orga',
+    nl: 'toegankelijkheid-pix-orga',
+    en: 'accessibility-pix-orga',
+    es: 'accessibility-pix-orga',
+    fr: 'accessibilite-pix-orga',
+  },
+  SUPPORT: {
+    'fr-FR': 'support',
+    'fr-BE': 'support',
+    'nl-BE': 'support',
+    nl: 'support',
+    en: 'support',
+    es: 'support',
+    fr: 'support',
+  },
+  CERTIFICATION_RESULTS_EXPLANATION: {
+    'fr-FR': 'certification-comprendre-score-niveau',
+    'fr-BE': 'certification-comprendre-score-niveau',
+    'nl-BE': 'mijn-certificeringsresultaten-begrijpen',
+    nl: 'mijn-certificeringsresultaten-begrijpen',
+    en: 'understand-certification-results',
+    es: 'understand-certification-results',
+    fr: 'certification-comprendre-score-niveau',
+  },
+};

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -1,158 +1,36 @@
-import Service, { service } from '@ember/service';
-import ENV from 'mon-pix/config/environment';
+import { service } from '@ember/service';
 
-const ENGLISH_INTERNATIONAL_LOCALE = 'en';
-const DUTCH_INTERNATIONAL_LOCALE = 'nl';
-const SPANISH_INTERNATIONAL_LOCALE = 'es';
+import UrlBaseService from './url-base.js';
 
-export default class Url extends Service {
-  @service currentDomain;
+export default class Url extends UrlBaseService {
   @service intl;
-  @service locale;
-
-  definedHomeUrl = ENV.rootURL;
 
   get showcase() {
-    return { url: this._showcaseWebsiteUrl, linkText: this._showcaseWebsiteLinkText };
-  }
-
-  get homeUrl() {
-    const currentLanguage = this.locale.currentLocale;
-    return `${this.definedHomeUrl}?lang=${currentLanguage}`;
+    const linkText = this.intl.t('navigation.showcase-homepage', { tld: this.currentDomain.getExtension() });
+    return { url: this.getPixWebsiteUrl(), linkText };
   }
 
   get cguUrl() {
-    const currentLanguage = this.locale.currentLocale;
-
-    if (this.currentDomain.isFranceDomain) {
-      return `https://pix.fr/conditions-generales-d-utilisation`;
-    }
-
-    switch (currentLanguage) {
-      case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/terms-and-conditions';
-      case DUTCH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden';
-      case SPANISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/terms-and-conditions ';
-      default:
-        return 'https://pix.org/fr/conditions-generales-d-utilisation';
-    }
+    return this.getPixWebsiteUrlFor('CGU');
   }
 
   get legalNoticeUrl() {
-    const currentLanguage = this.locale.currentLocale;
-
-    if (this.currentDomain.isFranceDomain) {
-      return `https://pix.fr/mentions-legales`;
-    }
-
-    switch (currentLanguage) {
-      case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/legal-notice';
-      case DUTCH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/nl-be/wettelijke-vermeldingen';
-      case SPANISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/legal-notice';
-      default:
-        return 'https://pix.org/fr/mentions-legales';
-    }
+    return this.getPixWebsiteUrlFor('LEGAL_NOTICE');
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.locale.currentLocale;
-
-    if (this.currentDomain.isFranceDomain) {
-      return `https://pix.fr/politique-protection-donnees-personnelles-app`;
-    }
-
-    switch (currentLanguage) {
-      case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/personal-data-protection-policy';
-      case DUTCH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
-      case SPANISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/personal-data-protection-policy';
-      default:
-        return 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
-    }
+    return this.getPixWebsiteUrlFor('DATA_PROTECTION_POLICY');
   }
 
   get accessibilityUrl() {
-    const currentLanguage = this.locale.currentLocale;
-
-    if (this.currentDomain.isFranceDomain) {
-      return `https://pix.fr/accessibilite`;
-    }
-
-    switch (currentLanguage) {
-      case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en/accessibility';
-      case DUTCH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/nl-be/toegankelijkheid';
-      case SPANISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/accessibility';
-      default:
-        return 'https://pix.org/fr/accessibilite';
-    }
-  }
-
-  get accessibilityHelpUrl() {
-    const currentLanguage = this.locale.currentLocale;
-    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en/help-accessibility`;
-    }
-    if (currentLanguage === SPANISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb/help-accessibility`;
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/aide-accessibilite`;
+    return this.getPixWebsiteUrlFor('ACCESSIBILITY');
   }
 
   get supportHomeUrl() {
-    const currentLocale = this.locale.currentLocale;
-
-    if (this.currentDomain.isFranceDomain) {
-      return 'https://pix.fr/support';
-    }
-
-    let locale;
-    if (currentLocale == 'nl') {
-      locale = 'nl-BE';
-    } else if (this.locale.isSupportedLocale(currentLocale)) {
-      locale = currentLocale;
-    } else {
-      locale = ENGLISH_INTERNATIONAL_LOCALE;
-    }
-
-    return `https://pix.org/${locale}/support`;
-  }
-
-  get serverStatusUrl() {
-    const currentLanguage = this.locale.currentLocale;
-    return `https://status.pix.org/?locale=${currentLanguage}`;
+    return this.getPixWebsiteUrlFor('SUPPORT');
   }
 
   get certificationResultsExplanationUrl() {
-    if (this.currentDomain.isFranceDomain) {
-      return 'https://pix.fr/certification-comprendre-score-niveau';
-    }
-
-    return 'https://pix.org/fr/certification-comprendre-score-niveau';
-  }
-
-  get _showcaseWebsiteUrl() {
-    const currentLanguage = this.locale.currentLocale;
-
-    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en`;
-    }
-    if (currentLanguage === DUTCH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/nl-be`;
-    }
-    return `https://pix.${this.currentDomain.getExtension()}`;
-  }
-
-  get _showcaseWebsiteLinkText() {
-    return this.intl.t('navigation.showcase-homepage', { tld: this.currentDomain.getExtension() });
+    return this.getPixWebsiteUrlFor('CERTIFICATION_RESULTS_EXPLANATION');
   }
 }

--- a/mon-pix/tests/integration/components/Sitemap/content-test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content-test.js
@@ -71,24 +71,6 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
       .hasAttribute('href', 'https://pix.fr/politique-protection-donnees-personnelles-app');
   });
 
-  test('should contain an external link to help accessibility page', async function (assert) {
-    // given
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
-
-    // when
-    const screen = await render(hbs`<Sitemap::Content />`);
-
-    // then
-    assert
-      .dom(
-        screen.getByRole('link', {
-          name: `${t('pages.sitemap.accessibility.help')} ${t('navigation.external-link-title')}`,
-        }),
-      )
-      .hasAttribute('href', 'https://pix.fr/aide-accessibilite');
-  });
-
   test('should contain an external link to pix support home page', async function (assert) {
     // given & when
     const screen = await render(hbs`<Sitemap::Content />`);

--- a/mon-pix/tests/unit/services/url-base-test.js
+++ b/mon-pix/tests/unit/services/url-base-test.js
@@ -1,0 +1,249 @@
+// This file is the ORIGINAL file. Copies of it are used in all the fronts.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import { setLocale } from 'ember-intl/test-support';
+import { setupTest } from 'ember-qunit';
+import ENV from 'mon-pix/config/environment';
+import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'mon-pix/services/url-base';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+const { SUPPORTED_LOCALES } = ENV.APP;
+
+module('Unit | Service | url-base', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('homeUrl', function () {
+    test('returns the application home url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.homeUrl;
+
+      // then
+      assert.strictEqual(homeUrl, '/?lang=en');
+    });
+  });
+
+  module('serverStatusUrl', function () {
+    test('returns the Pix server status url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+    });
+  });
+
+  module('pixAppUrl', function () {
+    test('returns the Pix app url for tld org', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.org');
+    });
+
+    test('returns the Pix app url for tld fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr');
+    });
+  });
+
+  module('pixAppCampaignRootUrl', function () {
+    test('returns the Pix app campaign root url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppCampaignRootUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/campagne');
+    });
+  });
+
+  module('pixAppForgottenPasswordUrl', function () {
+    test('returns the Pix app forgotten password url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
+    });
+
+    test('returns the Pix app forgotten password url for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      setLocale('en');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+    });
+  });
+
+  module('getPixWebsiteUrl', function () {
+    test('returns the Pix website url for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl();
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en');
+    });
+
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/this-is-my-document');
+    });
+  });
+
+  module('getPixWebsiteUrlFor', function () {
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/terms-and-conditions');
+    });
+
+    module('when the tld is fr', function () {
+      test('returns the Pix website url for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr');
+      });
+
+      test('returns the Pix website url and path for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr/conditions-generales-d-utilisation');
+      });
+    });
+
+    module('when locale is unknown', function () {
+      test('returns the Pix website url with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        setLocale('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr');
+      });
+
+      test('returns the Pix website url and path with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        setLocale('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
+      });
+    });
+  });
+
+  module('Checks Pix website URLs and Paths', function () {
+    SUPPORTED_LOCALES.forEach(function (locale) {
+      test(`checks PIX_WEBSITE_ROOT_URLS manage all supported locales for ${locale}`, function (assert) {
+        // given / when
+        const url = PIX_WEBSITE_ROOT_URLS[locale];
+
+        // then
+        assert.ok(url);
+      });
+    });
+
+    Object.keys(PIX_WEBSITE_PATHS).forEach(function (pathKey) {
+      SUPPORTED_LOCALES.forEach(function (locale) {
+        test(`checks PIX_WEBSITE_PATHS.${pathKey} manage all supported locales for ${locale}`, function (assert) {
+          // given / when
+          const path = PIX_WEBSITE_PATHS[pathKey][locale];
+
+          // then
+          assert.ok(path);
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -1,81 +1,39 @@
 import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-
-const FRANCE_TLD = 'fr';
-const INTERNATIONAL_TLD = 'org';
-
-const ENGLISH_INTERNATIONAL_LOCALE = 'en';
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
-const DUTCH_INTERNATIONAL_LOCALE = 'nl';
-
-import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
 module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  module('#homeUrl', function () {
-    test('should get home url', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      service.definedHomeUrl = 'pix.test.fr';
-
-      const currentLocale = 'en';
-      setLocale([currentLocale, 'fr']);
-
-      // when
-      const homeUrl = service.homeUrl;
-
-      // then
-      const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${currentLocale}`;
-      assert.strictEqual(homeUrl, expectedDefinedHomeUrl);
-    });
-  });
-
-  module('#showcaseUrl', function (hooks) {
-    let defaultLocale;
-
-    hooks.beforeEach(function () {
-      defaultLocale = 'fr';
-    });
-
-    hooks.afterEach(function () {
-      setLocale(defaultLocale);
-    });
-
+  module('showcase', function () {
     [
       {
-        language: FRENCH_INTERNATIONAL_LOCALE,
-        currentDomainExtension: FRANCE_TLD,
+        language: 'fr',
+        currentDomainExtension: 'fr',
         expectedShowcaseUrl: 'https://pix.fr',
         expectedShowcaseLinkText: "Page d'accueil de Pix.fr",
       },
       {
-        language: FRENCH_INTERNATIONAL_LOCALE,
-        currentDomainExtension: INTERNATIONAL_TLD,
-        expectedShowcaseUrl: 'https://pix.org',
+        language: 'fr',
+        currentDomainExtension: 'org',
+        expectedShowcaseUrl: 'https://pix.org/fr',
         expectedShowcaseLinkText: "Page d'accueil de Pix.org",
       },
       {
-        language: ENGLISH_INTERNATIONAL_LOCALE,
-        currentDomainExtension: FRANCE_TLD,
-        expectedShowcaseUrl: 'https://pix.fr/en',
-        expectedShowcaseLinkText: "Pix.fr's Homepage",
-      },
-      {
-        language: ENGLISH_INTERNATIONAL_LOCALE,
-        currentDomainExtension: INTERNATIONAL_TLD,
+        language: 'en',
+        currentDomainExtension: 'org',
         expectedShowcaseUrl: 'https://pix.org/en',
         expectedShowcaseLinkText: "Pix.org's Homepage",
       },
     ].forEach(function (testCase) {
-      test(`should get "${testCase.expectedShowcaseUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function (assert) {
+      test(`gets "${testCase.expectedShowcaseUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function (assert) {
         // given
         const service = this.owner.lookup('service:url');
         service.definedHomeUrl = '/';
-        service.currentDomain = { getExtension: sinon.stub().returns(testCase.currentDomainExtension) };
+        sinon.stub(service.currentDomain, 'getExtension').returns(testCase.currentDomainExtension);
         setLocale([testCase.language]);
 
         // when
@@ -88,455 +46,156 @@ module('Unit | Service | url', function (hooks) {
     });
   });
 
-  module('#cguUrl', function () {
-    module('when website is pix.fr', function () {
-      test('returns the French page URL', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+  module('cguUrl', function () {
+    test('returns the Pix website CGU URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const cguUrl = service.cguUrl;
+      // when
+      const cguUrl = service.cguUrl;
 
-        // then
-        assert.strictEqual(cguUrl, expectedCguUrl);
-      });
-
-      module('when current language is not "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-
-          // when
-          const cguUrl = service.cguUrl;
-
-          // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
-        });
-      });
+      // then
+      assert.strictEqual(cguUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
     });
 
-    module('when website is pix.org', function () {
-      module('when current language is "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
+    test('returns the Pix website CGU URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const cguUrl = service.cguUrl;
+      // when
+      const cguUrl = service.cguUrl;
 
-          // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
-        });
-      });
-
-      module('when current language is "en"', function () {
-        test('returns the English page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          const expectedCguUrl = 'https://pix.org/en/terms-and-conditions';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-
-          // when
-          const cguUrl = service.cguUrl;
-
-          // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the Nederland page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          const expectedCguUrl = 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
-          service.locale = { currentLocale: DUTCH_INTERNATIONAL_LOCALE };
-
-          // when
-          const cguUrl = service.cguUrl;
-
-          // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
-        });
-      });
+      // then
+      assert.strictEqual(cguUrl, 'https://pix.org/en/terms-and-conditions');
     });
   });
 
-  module('#dataProtectionPolicyUrl', function () {
-    module('when website is pix.fr', function () {
-      test('returns the French page URL', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+  module('dataProtectionPolicyUrl', function () {
+    test('returns the Pix website data protection policy URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
-        // then
-        assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-      });
-
-      module('when current language is not "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-
-          // when
-          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
-
-          // then
-          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-        });
-      });
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
     });
 
-    module('when website is pix.org', function () {
-      module('when current language is "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
+    test('returns the Pix website data protection policy URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
-          // then
-          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-        });
-      });
-
-      module('when current language is "en"', function () {
-        test('returns the English page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl = 'https://pix.org/en/personal-data-protection-policy';
-
-          // when
-          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
-
-          // then
-          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the Nederland page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl =
-            'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
-
-          // when
-          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
-
-          // then
-          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-        });
-      });
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/en/personal-data-protection-policy');
     });
   });
 
-  module('#legalNoticeUrl', function () {
-    module('when website is pix.fr', function () {
-      test('returns the French page URL', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
+  module('legalNoticeUrl', function () {
+    test('returns the Pix website legal notice URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const legalNoticeUrl = service.legalNoticeUrl;
+      // when
+      const legalNoticeUrl = service.legalNoticeUrl;
 
-        // then
-        assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-      });
-
-      module('when current language is not "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
-
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-        });
-      });
+      // then
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
     });
 
-    module('when website is pix.org', function () {
-      module('when current language is "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedLegalNoticeUrl = 'https://pix.org/fr/mentions-legales';
+    test('returns the Pix website legal notice URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
+      // when
+      const legalNoticeUrl = service.legalNoticeUrl;
 
-          // then
-          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-        });
-      });
-
-      module('when current language is "en"', function () {
-        test('returns the English page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedLegalNoticeUrl = 'https://pix.org/en/legal-notice';
-
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the Nederland page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedLegalNoticeUrl = 'https://pix.org/nl-be/wettelijke-vermeldingen';
-
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-        });
-      });
+      // then
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/en/legal-notice');
     });
   });
 
-  module('#accessibilityUrl', function () {
-    module('when website is pix.fr', function () {
-      test('returns the French page URL', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-        const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
+  module('accessibilityUrl', function () {
+    test('returns the Pix website accessibility URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const accessibilityUrl = service.accessibilityUrl;
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
 
-        // then
-        assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-      });
-
-      module('when current language is not "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-        });
-      });
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite');
     });
 
-    module('when website is pix.org', function () {
-      module('when current language is "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
+    test('returns the Pix website accessibility URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
 
-          // then
-          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-        });
-      });
-
-      module('when current language is "en"', function () {
-        test('returns the English page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.org/en/accessibility';
-
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the Nederland page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.org/nl-be/toegankelijkheid';
-
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-        });
-      });
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/en/accessibility');
     });
   });
 
-  module('#supportHomeUrl', function () {
-    module('when website is pix.fr', function () {
-      test('returns the French page URL', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE };
-        const expectedSupportHomeUrl = 'https://pix.fr/support';
+  module('supportHomeUrl', function () {
+    test('returns the Pix website support URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const supportHomeUrl = service.supportHomeUrl;
+      // when
+      const supportHomeUrl = service.supportHomeUrl;
 
-        // then
-        assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-      });
-
-      module('when current language is not "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://pix.fr/support';
-
-          // when
-          const supportHomeUrl = service.supportHomeUrl;
-
-          // then
-          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-        });
-      });
+      // then
+      assert.strictEqual(supportHomeUrl, 'https://pix.org/fr/support');
     });
 
-    module('when website is pix.org', function () {
-      module('when current language is "fr"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: FRENCH_INTERNATIONAL_LOCALE, isSupportedLocale: () => true };
-          const expectedSupportHomeUrl = 'https://pix.org/fr/support';
+    test('returns the Pix website support URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const supportHomeUrl = service.supportHomeUrl;
+      // when
+      const supportHomeUrl = service.supportHomeUrl;
 
-          // then
-          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-        });
-      });
-
-      module('when current language is "en"', function () {
-        test('returns the English page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: ENGLISH_INTERNATIONAL_LOCALE, isSupportedLocale: () => true };
-          const expectedSupportHomeUrl = 'https://pix.org/en/support';
-
-          // when
-          const supportHomeUrl = service.supportHomeUrl;
-
-          // then
-          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the Nederland page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          service.locale = { currentLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://pix.org/nl-BE/support';
-
-          // when
-          const supportHomeUrl = service.supportHomeUrl;
-
-          // then
-          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-        });
-      });
+      // then
+      assert.strictEqual(supportHomeUrl, 'https://pix.org/en/support');
     });
   });
 
-  module('#certificationResultsExplanationUrl', function () {
-    module('when domain extension is .fr', function () {
-      test('returns the pix.fr website certification details page', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: true };
-        const expectedCertificationResultsExplanationUrl = 'https://pix.fr/certification-comprendre-score-niveau';
+  module('certificationResultsExplanationUrl', function () {
+    test('returns the Pix website certification results explanation URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
+      // when
+      const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
 
-        // then
-        assert.strictEqual(certificationResultsExplanationUrl, expectedCertificationResultsExplanationUrl);
-      });
+      // then
+      assert.strictEqual(
+        certificationResultsExplanationUrl,
+        'https://pix.org/fr/certification-comprendre-score-niveau',
+      );
     });
 
-    module('when domain extension is .org', function () {
-      test('returns the pix.org website certification details page', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain = { isFranceDomain: false };
-        const expectedCertificationResultsExplanationUrl = 'https://pix.org/fr/certification-comprendre-score-niveau';
+    test('returns the Pix website certification results explanation URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-        // when
-        const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
+      // when
+      const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;
 
-        // then
-        assert.strictEqual(certificationResultsExplanationUrl, expectedCertificationResultsExplanationUrl);
-      });
+      // then
+      assert.strictEqual(certificationResultsExplanationUrl, 'https://pix.org/en/understand-certification-results');
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Dans les fronts, la logique de gestion des URL est différentes entre toutes les applications notamment sur les URL de Pix site qui ont toujours la même logique.

## ⛱️ Proposition

Créer un service `url-base`, qui sera hérité dans chaque application par le service `url`.
Ce service exposera les URL communes à toutes les applications en fonction de la locale courante:
- URL de Pix Site
- Home URL : url de l'application courante
- Pix Status URL
- URL de Pix App : mot de passe oublié et campagne

La mise en place du service dans les autres applications sera réalisé dans d'autres PR quand le nouveau locale service sera disponible. 

## 🌊 Remarques

- Dans mon-pix, l'URL `https://pix.fr/aide-accessibilite` a été supprimée (et son code associé) car elle n'existe plus (vérifié dans Prismic)

## 🏄 Pour tester

- Aller sur pix.fr, vérifier les URL du footer.
- Aller sur pix.org, en français, vérifier les URL du footer.
- Aller sur pix.org, changer la langue, vérifier les URL du footer.
