### PR TITLE
[FEATURE] Afficher quelle Attestation est activé dans PixAdmin (PIX-18856).

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -4,7 +4,7 @@ import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-al
 import { concat, get } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { t } from 'ember-intl';
+import { formatList, t } from 'ember-intl';
 import { and, eq } from 'ember-truth-helpers';
 import { DescriptionList } from 'pix-admin/components/ui/description-list';
 import Organization from 'pix-admin/models/organization';
@@ -145,36 +145,46 @@ function keys(obj) {
   return Object.keys(obj);
 }
 
-const FeaturesSection = <template>
-  <ul class="organization-information-section__features">
-    {{#each (keys Organization.featureList) as |feature|}}
-      {{#let
-        (get @features feature) (concat "components.organizations.information-section-view.features." feature)
-        as |organizationFeature featureLabel|
-      }}
-        {{#if (eq feature "SHOW_NPS")}}
-          <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
-            <a
-              rel="noopener noreferrer"
-              href={{organizationFeature.params.formNPSUrl}}
-              target="_blank"
-            >{{organizationFeature.params.formNPSUrl}}</a>
-          </Feature>
-        {{else if (eq feature "LEARNER_IMPORT")}}
-          <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
-            {{organizationFeature.params.name}}
-          </Feature>
-        {{else if (eq feature "ATTESTATIONS_MANAGEMENT")}}
-          <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
-            6ème
-          </Feature>
-        {{else}}
-          <Feature @label={{t featureLabel}} @value={{organizationFeature.active}} />
-        {{/if}}
-      {{/let}}
-    {{/each}}
-  </ul>
-</template>;
+class FeaturesSection extends Component {
+  @service intl;
+
+  attestationLabels = (attestations) => {
+    return attestations.map((name) =>
+      this.intl.t(`components.organizations.information-section-view.features.attestation-list.${name}`),
+    );
+  };
+
+  <template>
+    <ul class="organization-information-section__features">
+      {{#each (keys Organization.featureList) as |feature|}}
+        {{#let
+          (get @features feature) (concat "components.organizations.information-section-view.features." feature)
+          as |organizationFeature featureLabel|
+        }}
+          {{#if (eq feature "SHOW_NPS")}}
+            <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
+              <a
+                rel="noopener noreferrer"
+                href={{organizationFeature.params.formNPSUrl}}
+                target="_blank"
+              >{{organizationFeature.params.formNPSUrl}}</a>
+            </Feature>
+          {{else if (eq feature "LEARNER_IMPORT")}}
+            <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
+              {{organizationFeature.params.name}}
+            </Feature>
+          {{else if (eq feature "ATTESTATIONS_MANAGEMENT")}}
+            <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
+              {{formatList (this.attestationLabels organizationFeature.params)}}
+            </Feature>
+          {{else}}
+            <Feature @label={{t featureLabel}} @value={{organizationFeature.active}} />
+          {{/if}}
+        {{/let}}
+      {{/each}}
+    </ul>
+  </template>
+}
 
 const Feature = <template>
   <li

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -312,7 +312,7 @@ module('Integration | Component | organizations/information-section-view', funct
             // given
             const organization = EmberObject.create({
               features: {
-                ATTESTATIONS_MANAGEMENT: { active: true },
+                ATTESTATIONS_MANAGEMENT: { active: true, params: ['PARENTHOOD'] },
               },
             });
 
@@ -323,6 +323,14 @@ module('Integration | Component | organizations/information-section-view', funct
               screen.getByLabelText(
                 `${t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT')} : ${t(
                   'common.words.yes',
+                )}`,
+              ),
+            );
+
+            assert.ok(
+              screen.getByText(
+                `${t('components.organizations.information-section-view.features.ATTESTATIONS_MANAGEMENT')} : ${t(
+                  'components.organizations.information-section-view.features.attestation-list.PARENTHOOD',
                 )}`,
               ),
             );

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -524,6 +524,10 @@
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",
+          "attestation-list": {
+            "PARENTHOOD": "Parenthood",
+            "SIXTH_GRADE": "Sixth grade"
+          },
           "title": "Features"
         },
         "parent-organization": "Parent organization"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -525,6 +525,10 @@
           "PLACES_MANAGEMENT": "Affichage de la page Places sur PixOrga",
           "SHOW_NPS": "Affichage du Net Promoter Score",
           "SHOW_SKILLS": "Affichage des acquis dans l'export de résultats",
+          "attestation-list": {
+            "PARENTHOOD": "Parentalité",
+            "SIXTH_GRADE": "6ème"
+          },
           "title": "Fonctionnalités"
         },
         "parent-organization": "Organisation mère"

--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -107,6 +107,7 @@ async function _createProOrganization(databaseBuilder) {
     memberIds: [USER_ID_MEMBER_ORGANIZATION],
     features: [
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
+      { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID, params: JSON.stringify([ATTESTATIONS.PARENTHOOD]) },
       { id: FEATURE_PLACES_MANAGEMENT_ID },
       { id: FEATURE_COVER_RATE_ID },
       { id: FEATURE_CAMPAIGN_WITHOUT_USER_PROFILE_ID },

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -80,7 +80,7 @@ const archiveInBatch = async function (request, h) {
 };
 
 const getOrganizationDetails = async function (request, h, dependencies = { organizationForAdminSerializer }) {
-  const organizationId = request.params.id;
+  const organizationId = request.params.organizationId;
 
   const organizationDetails = await usecases.getOrganizationDetails({ organizationId });
   return dependencies.organizationForAdminSerializer.serialize(organizationDetails);

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -144,7 +144,7 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/admin/organizations/{id}',
+      path: '/api/admin/organizations/{organizationId}',
       config: {
         pre: [
           {
@@ -160,7 +160,7 @@ const register = async function (server) {
         ],
         validate: {
           params: Joi.object({
-            id: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId,
           }),
         },
         handler: (request, h) => organizationAdminController.getOrganizationDetails(request, h),

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -395,7 +395,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
-  describe('GET /api/admin/organizations/{id}', function () {
+  describe('GET /api/admin/organizations/{organizationId}', function () {
     context('Expected output', function () {
       it('should return the matching organization as JSON API', async function () {
         // given

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.controller.test.js
@@ -75,7 +75,7 @@ describe('Unit | Organizational Entities | Application | Controller | Admin | or
     it('should call the usecase and serialize the response', async function () {
       // given
       const organizationId = 1234;
-      const request = { params: { id: organizationId } };
+      const request = { params: { organizationId } };
 
       const organizationDetails = Symbol('organizationDetails');
       const organizationDetailsSerialized = Symbol('organizationDetailsSerialized');


### PR DESCRIPTION
## 🔆 Problème

Lorsque la feature des attestations est activé sur PixAdmin. on affiche en dur (6ème), ce qui n'est pas forcément le cas

## ⛱️ Proposition

Récupérer du back l'information des attestations active sur l'organisation

## 🌊 Remarques

Déplacement de certaines computation faites dans le repository alors que sa place n'y est pas. 

## 🏄 Pour tester

Aller sur PixAdmin, vérifier que sur l'orga "Attestations" nous voyons correctement l'attestation 6ème. ajouter une nouvelle attestation parentalité et vérifier qu'elle s'affiche correctement aussi.