### PR TITLE
[TECH] :truck: Déplace le modèle en lecture seule `CampaignReport` vers le contexte `/src/prescription/campaign/`

### DIFF
--- a/api/src/prescription/campaign/domain/read-models/CampaignReport.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignReport.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
-import { TubeCoverage } from '../../../prescription/campaign/domain/read-models/CampaignParticipation.js';
-import { CampaignTypes } from '../../../prescription/shared/domain/constants.js';
+import { CampaignTypes } from '../../../shared/domain/constants.js';
+import { TubeCoverage } from './CampaignParticipation.js';
 
 class CampaignReport {
   constructor({

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -4,11 +4,11 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CampaignParticipationStatuses } from '../../../../shared/domain/models/index.js';
-import { CampaignReport } from '../../../../shared/domain/read-models/CampaignReport.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { TargetProfileForSpecifier } from '../../../target-profile/domain/read-models/TargetProfileForSpecifier.js';
+import { CampaignReport } from '../../domain/read-models/CampaignReport.js';
 import { getLatestParticipationSharedForOneLearner } from './helpers/get-latest-participation-shared-for-one-learner.js';
 
 const { SHARED } = CampaignParticipationStatuses;

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -1,8 +1,8 @@
+import { CampaignReport } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
-import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | find-paginated-filtered-organization-campaigns', function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { CampaignReport } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import * as campaignReportRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
 import { findMasteryRates } from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
 import {
@@ -9,7 +10,6 @@ import {
 } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
 import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -1,8 +1,8 @@
 import * as campaignApi from '../../../../../../src/prescription/campaign/application/api/campaigns-api.js';
 import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
+import { CampaignReport } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { CampaignReport } from '../../../../../../src/shared/domain/read-models/CampaignReport.js';
 import { catchErr, expect, preventStubsToBeCalledUnexpectedly, sinon } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 

--- a/api/tests/tooling/domain-builder/factory/build-campaign-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-report.js
@@ -1,5 +1,5 @@
+import { CampaignReport } from '../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import { CampaignExternalIdTypes, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { CampaignReport } from '../../../../src/shared/domain/read-models/CampaignReport.js';
 
 const buildCampaignReport = function ({
   id = 1,


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seule `CampaignReport` est  dans le contexte partagé `/src/shared/`

## ⛱️ Proposition

Déplacer le modèle en lecture seule `CampaignReport` vers le contexte `/src/prescription/campaign/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Aller sur PixOrga : et consulter le détail d'une campagne : 

https://orga-pr12969.review.pix.fr/campagnes/105231 : vérifier que tout s'affiche correctement. 
