### PR TITLE
[FEATURE] Afficher la campagne de diagnostique sur la page d'un parcours combiné (PIX-18847)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -19,14 +19,30 @@ import { TARGET_PROFILE_BADGES_STAGES_ID, TARGET_PROFILE_NO_BADGES_NO_STAGES_ID 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
 function buildCombinedCourseQuest(databaseBuilder, organizationId) {
-  databaseBuilder.factory.buildQuest({
+  const campaign = databaseBuilder.factory.buildCampaign({
+    name: 'Je teste mes compétences',
+    organizationId,
+    code: 'CODE123',
+  });
+  databaseBuilder.factory.buildQuestForCombinedCourse({
     name: 'Combinix',
     rewardType: null,
     rewardId: null,
     code: 'COMBINIX1',
     organizationId,
     eligibilityRequirements: [],
-    successRequirements: [],
+    successRequirements: [
+      {
+        requirement_type: 'campaignParticipations',
+        comparison: 'all',
+        data: {
+          campaignId: {
+            data: campaign.id,
+            comparison: 'equal',
+          },
+        },
+      },
+    ],
   });
 }
 

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-to-join.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-to-join.js
@@ -2,7 +2,7 @@ export const getOrganizationToJoin = async function ({
   code,
   organizationToJoinRepository,
   campaignRepository,
-  questRepository,
+  combinedCourseRepository,
 }) {
   const campaign = await campaignRepository.getByCode(code);
 
@@ -10,9 +10,9 @@ export const getOrganizationToJoin = async function ({
     return organizationToJoinRepository.get({ id: campaign.organizationId });
   }
 
-  const quest = await questRepository.getByCode({ code });
+  const combinedCourse = await combinedCourseRepository.getByCode({ code });
 
   return organizationToJoinRepository.get({
-    id: quest.organizationId,
+    id: combinedCourse.organizationId,
   });
 };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -10,6 +10,7 @@ import * as userRepository from '../../../../identity-access-management/infrastr
 import { userToCreateRepository } from '../../../../identity-access-management/infrastructure/repositories/user-to-create.repository.js';
 import * as organizationFeaturesAPI from '../../../../organizational-entities/application/api/organization-features-api.js';
 import { tagRepository } from '../../../../organizational-entities/infrastructure/repositories/tag.repository.js';
+import * as combinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 import * as questRepository from '../../../../quest/infrastructure/repositories/quest-repository.js';
 import { cryptoService } from '../../../../shared/domain/services/crypto-service.js';
 import * as obfuscationService from '../../../../shared/domain/services/obfuscation-service.js';
@@ -21,6 +22,7 @@ import * as userService from '../../../../shared/domain/services/user-service.js
  * campaignRepository.getByCode
  * groupRepository.findByOrganizationId
  * questRepository.getByCode
+ * combinedCourseRepository.getByCode
  */
 import * as passwordValidator from '../../../../shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../../shared/domain/validators/user-validator.js';
@@ -72,6 +74,7 @@ const dependencies = {
   campaignParticipationOverviewRepository,
   registrationOrganizationLearnerRepository,
   questRepository,
+  combinedCourseRepository,
   tagRepository,
   userService,
   userReconciliationService,

--- a/api/src/quest/domain/models/Campaign.js
+++ b/api/src/quest/domain/models/Campaign.js
@@ -1,5 +1,7 @@
 export class Campaign {
-  constructor({ code }) {
+  constructor({ id, name, code }) {
+    this.id = id;
+    this.name = name;
     this.code = code;
   }
 }

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -2,13 +2,24 @@ import {
   CombinedCourseParticipationStatuses,
   CombinedCourseStatuses,
 } from '../../../prescription/shared/domain/constants.js';
+import { CombinedCourseItem } from './CombinedCourseItem.js';
 
 export class CombinedCourse {
-  constructor({ id, code, organizationId, name }, participation) {
+  constructor({ id, code, organizationId, name } = {}) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
+  }
+}
+
+export class CombinedCourseDetails extends CombinedCourse {
+  #quest;
+  items = null;
+
+  constructor({ id, code, organizationId, name }, quest, participation) {
+    super({ id, code, organizationId, name });
+    this.#quest = quest;
     if (!participation) {
       this.status = CombinedCourseStatuses.NOT_STARTED;
     } else {
@@ -17,5 +28,16 @@ export class CombinedCourse {
           ? CombinedCourseStatuses.STARTED
           : CombinedCourseStatuses.COMPLETED;
     }
+  }
+
+  get campaignIds() {
+    return this.#quest.successRequirements.map(({ data }) => data.campaignId.data);
+  }
+
+  generateItems(data) {
+    this.items = this.#quest.successRequirements.map((requirement) => {
+      const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
+      return new CombinedCourseItem({ id: campaign.id, reference: campaign.code, title: campaign.name });
+    });
   }
 }

--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -1,0 +1,7 @@
+export class CombinedCourseItem {
+  constructor({ id, title, reference }) {
+    this.id = id;
+    this.title = title;
+    this.reference = reference;
+  }
+}

--- a/api/src/quest/domain/models/Quest.js
+++ b/api/src/quest/domain/models/Quest.js
@@ -72,8 +72,7 @@ class Quest {
     if (campaignParticipationRequirements.length === 0) return [];
 
     const targetProfileIds = campaignParticipationRequirements
-      // TODO: requirement.criterion.data.targetProfileId.data would be more explicit
-      .map((requirement) => requirement.data.data?.targetProfileId?.data)
+      .map((requirement) => requirement.data?.targetProfileId?.data)
       .filter(Boolean)
       .flat();
 

--- a/api/src/quest/domain/models/Requirement.js
+++ b/api/src/quest/domain/models/Requirement.js
@@ -141,7 +141,7 @@ export class ObjectRequirement extends BaseRequirement {
   }
 
   get data() {
-    return Object.freeze(this.#criterion);
+    return Object.freeze(this.#criterion).data;
   }
 
   /**

--- a/api/src/quest/domain/usecases/get-verified-code.js
+++ b/api/src/quest/domain/usecases/get-verified-code.js
@@ -1,7 +1,7 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { VerifiedCode } from '../models/VerifiedCode.js';
 
-export const getVerifiedCode = async ({ code, campaignRepository, questRepository }) => {
+export const getVerifiedCode = async ({ code, campaignRepository, combinedCourseRepository }) => {
   try {
     const campaign = await campaignRepository.getByCode({ code });
     return new VerifiedCode({ code: campaign.code, type: 'campaign' });
@@ -10,6 +10,6 @@ export const getVerifiedCode = async ({ code, campaignRepository, questRepositor
       throw error;
     }
   }
-  const quest = await questRepository.getByCode({ code });
-  return new VerifiedCode({ code: quest.code, type: 'combined-course' });
+  const combinedCourse = await combinedCourseRepository.getByCode({ code });
+  return new VerifiedCode({ code: combinedCourse.code, type: 'combined-course' });
 };

--- a/api/src/quest/domain/usecases/start-combined-course.js
+++ b/api/src/quest/domain/usecases/start-combined-course.js
@@ -3,17 +3,17 @@ export async function startCombinedCourse({
   code,
   combinedCourseParticipantRepository,
   combinedCourseRepository,
-  questRepository,
+  combinedCourseParticipationRepository,
   userRepository,
 }) {
-  const quest = await questRepository.getByCode({ code });
+  const combinedCourse = await combinedCourseRepository.getByCode({ code });
   const user = await userRepository.findById({ userId });
 
   const organizationLearnerId = await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
     userId,
-    organizationId: quest.organizationId,
+    organizationId: combinedCourse.organizationId,
     organizationLearner: { firstName: user.firstName, lastName: user.lastName },
   });
 
-  await combinedCourseRepository.save({ organizationLearnerId, questId: quest.id });
+  await combinedCourseParticipationRepository.save({ organizationLearnerId, questId: combinedCourse.id });
 }

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -4,3 +4,8 @@ export const getByCode = async function ({ code, campaignsApi }) {
   const campaign = await campaignsApi.getByCode(code);
   return new Campaign(campaign);
 };
+
+export const get = async function ({ id, campaignsApi }) {
+  const campaign = await campaignsApi.get(id);
+  return new Campaign(campaign);
+};

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -1,0 +1,16 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { CombinedCourse } from '../../domain/models/CombinedCourse.js';
+
+const getByCode = async ({ code }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const quest = await knexConn('quests').select('id', 'organizationId', 'code', 'name').where('code', code).first();
+  if (!quest) {
+    throw new NotFoundError(`Le parcours combiné portant le code ${code} n'existe pas`);
+  }
+
+  return new CombinedCourse(quest);
+};
+
+export { getByCode };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -11,7 +11,7 @@ import { injectDependencies } from '../../../shared/infrastructure/utils/depende
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
-import * as combinedCourseRepository from './combined-course-participation-repository.js';
+import * as combinedCourseRepository from './combined-course-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';

--- a/api/src/quest/infrastructure/repositories/quest-repository.js
+++ b/api/src/quest/infrastructure/repositories/quest-repository.js
@@ -2,7 +2,6 @@ import chunk from 'lodash/chunk.js';
 
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { CombinedCourse } from '../../domain/models/CombinedCourse.js';
 import { Quest } from '../../domain/models/Quest.js';
 
 const toDomain = (quests) => quests.map((quest) => new Quest(quest));
@@ -33,7 +32,7 @@ const getByCode = async ({ code }) => {
     throw new NotFoundError(`La quête portant le code ${code} n'existe pas`);
   }
 
-  return new CombinedCourse(quest);
+  return new Quest(quest);
 };
 
 // envisager de mettre tableau vide en valeur par défaut des requirements si pas renseigné pour pas péter le code

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -4,7 +4,16 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourse) {
   return new Serializer('combined-courses', {
-    attributes: ['name', 'code', 'organizationId', 'status'],
+    attributes: ['name', 'code', 'organizationId', 'status', 'items'],
+    items: {
+      ref: 'id',
+      included: true,
+      attributes: ['title', 'reference'],
+    },
+    typeForAttribute: (attribute) => {
+      if (attribute === 'items') return 'combined-course-items';
+      else return attribute;
+    },
   }).serialize(combinedCourse);
 };
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-to-join_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-to-join_test.js
@@ -2,7 +2,7 @@ import * as campaignRepository from '../../../../../../src/prescription/campaign
 import { OrganizationToJoin } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationToJoin.js';
 import { getOrganizationToJoin } from '../../../../../../src/prescription/organization-learner/domain/usecases/get-organization-to-join.js';
 import { repositories } from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/index.js';
-import * as questRepository from '../../../../../../src/quest/infrastructure/repositories/quest-repository.js';
+import * as combinedCourseRepository from '../../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | get-organization-to-join', function () {
@@ -23,7 +23,7 @@ describe('Integration | UseCases | get-organization-to-join', function () {
       code: campaign.code,
       organizationToJoinRepository: repositories.organizationToJoinRepository,
       campaignRepository,
-      questRepository,
+      combinedCourseRepository,
     });
 
     //then
@@ -46,7 +46,7 @@ describe('Integration | UseCases | get-organization-to-join', function () {
       code: quest.code,
       organizationToJoinRepository: repositories.organizationToJoinRepository,
       campaignRepository,
-      questRepository,
+      combinedCourseRepository,
     });
 
     //then

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-to-join_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-to-join_test.js
@@ -5,25 +5,25 @@ import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | UseCases | get-organization-to-join', function () {
   let campaignRepository;
   let organizationToJoinRepository;
-  let questRepository;
+  let combinedCourseRepository;
 
   beforeEach(async function () {
     campaignRepository = { getByCode: sinon.stub() };
     organizationToJoinRepository = { get: sinon.stub() };
-    questRepository = { getByCode: sinon.stub() };
+    combinedCourseRepository = { getByCode: sinon.stub() };
   });
 
   it('should throw a not found error if both campaign and quest are not found', async function () {
     //given
     campaignRepository.getByCode.resolves(null);
-    questRepository.getByCode.rejects(new NotFoundError());
+    combinedCourseRepository.getByCode.rejects(new NotFoundError());
 
     //when
     const error = await catchErr(getOrganizationToJoin)({
       code: 'ABC',
       organizationToJoinRepository,
       campaignRepository,
-      questRepository,
+      combinedCourseRepository,
     });
 
     //then

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -1,5 +1,6 @@
 import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { CombinedCourseItem } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
@@ -7,20 +8,53 @@ import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code', function () {
   it('should return CombinedCourse for provided code', async function () {
     const code = 'SOMETHING';
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({ code });
+    const campaign = databaseBuilder.factory.buildCampaign();
+    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+      code,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaign.id,
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    });
     const userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
 
     const result = await usecases.getCombinedCourseByCode({ code, userId });
 
     expect(result).to.be.instanceOf(CombinedCourse);
+    expect(result.items).to.be.deep.equal([
+      new CombinedCourseItem({ id: campaign.id, reference: campaign.code, title: campaign.name }),
+    ]);
     expect(result.id).to.equal(questId);
     expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
   });
 
   it('should return started combined course for given userId', async function () {
     const code = 'SOMETHING';
-    const { id: questId, organizationId } = databaseBuilder.factory.buildQuestForCombinedCourse({ code });
+    const campaign = databaseBuilder.factory.buildCampaign();
+    const { id: questId, organizationId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+      code,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaign.id,
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    });
     const userId = databaseBuilder.factory.buildUser().id;
     const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
     databaseBuilder.factory.buildCombinedCourseParticipation({ questId, organizationLearnerId });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -1,0 +1,35 @@
+import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | combined-course', function () {
+  describe('#getByCode', function () {
+    it('should return a quest if code exists', async function () {
+      // given
+      const code = 'SOMETHING';
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const quest = databaseBuilder.factory.buildQuest({ code, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourseResult = await combinedCourseRepository.getByCode({ code });
+
+      // then
+      expect(combinedCourseResult).to.be.an.instanceof(CombinedCourse);
+      expect(combinedCourseResult).to.deep.equal(new CombinedCourse(quest));
+    });
+
+    it('should throw NotFoundError if quest does not exist', async function () {
+      // given
+      const code = 'NOTHINGTT';
+
+      // when
+      const error = await catchErr(combinedCourseRepository.getByCode)({ code });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`Le parcours combiné portant le code ${code} n'existe pas`);
+    });
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/quest-repository_test.js
@@ -1,5 +1,4 @@
 import { REWARD_TYPES } from '../../../../../src/quest/domain/constants.js';
-import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import * as questRepository from '../../../../../src/quest/infrastructure/repositories/quest-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -121,19 +120,19 @@ describe('Quest | Integration | Repository | quest', function () {
   });
 
   describe('#getByCode', function () {
-    it('should return a combined course if code exists', async function () {
+    it('should return a quest if code exists', async function () {
       // given
       const code = 'SOMETHING';
       const { id: organizationId } = databaseBuilder.factory.buildOrganization();
-      const questId = databaseBuilder.factory.buildQuest({ code, organizationId }).id;
+      const quest = databaseBuilder.factory.buildQuest({ code, organizationId });
       await databaseBuilder.commit();
 
       // when
-      const quest = await questRepository.getByCode({ code });
+      const questResult = await questRepository.getByCode({ code });
 
       // then
-      expect(quest).to.be.an.instanceof(CombinedCourse);
-      expect(quest).to.deep.equal(new CombinedCourse({ ...quest, id: questId }));
+      expect(questResult).to.be.an.instanceof(Quest);
+      expect(questResult).to.deep.equal(new Quest(quest));
     });
 
     it('should throw NotFoundError if quest does not exist', async function () {

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -1,0 +1,236 @@
+import {
+  CombinedCourseParticipationStatuses,
+  CombinedCourseStatuses,
+} from '../../../../../src/prescription/shared/domain/constants.js';
+import { Campaign } from '../../../../../src/quest/domain/models/Campaign.js';
+import { CombinedCourse, CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { CombinedCourseItem } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
+  describe('CombinedCourseDetails', function () {
+    describe('#campaignIds', function () {
+      it('should return ids of all campaigns included in the given combined course', function () {
+        // given
+        const campaignId = 2;
+        const quest = new Quest({
+          id: 1,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaignId,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+        // when
+        const campaignIds = combinedCourse.campaignIds;
+
+        // then
+        expect(campaignIds).to.deep.equal([campaignId]);
+      });
+    });
+
+    describe('#generateItems', function () {
+      it('returns a combined course item for provided campaign', function () {
+        // given
+        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+
+        const quest = new Quest({
+          id: 1,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaign.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+        // when
+        combinedCourse.generateItems([campaign]);
+
+        // then
+        expect(combinedCourse.items).to.deep.equal([
+          new CombinedCourseItem({ id: campaign.id, reference: campaign.code, title: campaign.name }),
+        ]);
+      });
+
+      it('should not take into account data that are not related to the quest', function () {
+        // given
+        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+        const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', name: 'diagnostique2' });
+
+        const quest = new Quest({
+          id: 1,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaign1.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+        // when
+        combinedCourse.generateItems([campaign1, campaign2]);
+
+        // then
+        expect(combinedCourse.items).to.deep.equal([
+          new CombinedCourseItem({ id: campaign1.id, reference: campaign1.code, title: campaign1.name }),
+        ]);
+      });
+
+      it('should keep success requirements order', function () {
+        // given
+        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+        const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', name: 'diagnostique2' });
+
+        const quest = new Quest({
+          id: 1,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaign2.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaign1.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+        // when
+        combinedCourse.generateItems([campaign1, campaign2]);
+
+        // then
+        expect(combinedCourse.items).to.deep.equal([
+          new CombinedCourseItem({ id: campaign2.id, reference: campaign2.code, title: campaign2.name }),
+          new CombinedCourseItem({ id: campaign1.id, reference: campaign1.code, title: campaign1.name }),
+        ]);
+      });
+    });
+
+    describe('#status', function () {
+      describe('when there is no participation', function () {
+        it('should set status to NOT_STARTED', function () {
+          // given
+          const quest = {
+            id: 1,
+            code: 'abcdiag',
+            organizationId: 1,
+            name: 'name',
+          };
+
+          // when
+          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+          // then
+          expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.NOT_STARTED);
+        });
+      });
+      describe('when there is a participation', function () {
+        it('should set status to STARTED if participation is STARTED', function () {
+          // given
+          const quest = {
+            id: 1,
+            code: 'abcdiag',
+            organizationId: 1,
+            name: 'name',
+          };
+          const participation = {
+            status: CombinedCourseParticipationStatuses.STARTED,
+          };
+
+          // when
+          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest, participation);
+
+          // then
+          expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.STARTED);
+        });
+
+        it('should set status to COMPLETED if participation is COMPLETED', function () {
+          // given
+          const quest = {
+            id: 1,
+            code: 'abcdiag',
+            organizationId: 1,
+            name: 'name',
+          };
+          const participation = {
+            status: CombinedCourseParticipationStatuses.COMPLETED,
+          };
+
+          // when
+          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest, participation);
+
+          // then
+          expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.COMPLETED);
+        });
+      });
+    });
+  });
+  describe('CombinedCourse', function () {
+    it('should return model with given parameters', function () {
+      // given
+      const id = 1;
+      const organizationId = 1;
+      const name = 'name';
+      const code = 'code';
+
+      // when
+      const combinedCourse = new CombinedCourse({ id, organizationId, name, code });
+
+      // then
+      expect(combinedCourse.code).to.deep.equal(code);
+      expect(combinedCourse.name).to.deep.equal(name);
+      expect(combinedCourse.organizationId).to.deep.equal(organizationId);
+      expect(combinedCourse.id).to.deep.equal(id);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -1,0 +1,30 @@
+import { Campaign } from '../../../../../src/quest/domain/models/Campaign.js';
+import * as campaignRepository from '../../../../../src/quest/infrastructure/repositories/campaign-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Repositories | campaign', function () {
+  let id;
+  let code;
+  let campaignsApiStub;
+
+  beforeEach(function () {
+    id = Symbol('id');
+    code = Symbol('code');
+    campaignsApiStub = {
+      get: sinon.stub(),
+      getByCode: sinon.stub(),
+    };
+    campaignsApiStub.get.withArgs(id).resolves(new Campaign({}));
+    campaignsApiStub.getByCode.withArgs(code).resolves(new Campaign({}));
+  });
+
+  describe('#get', function () {
+    it('should call get method from campaignsApi', async function () {
+      // when
+      const result = await campaignRepository.get({ id, campaignsApi: campaignsApiStub });
+
+      // then
+      expect(result).to.be.an.instanceof(Campaign);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -27,4 +27,14 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign', function () 
       expect(result).to.be.an.instanceof(Campaign);
     });
   });
+
+  describe('#getByCode', function () {
+    it('should call getByCode method from campaignsApi', async function () {
+      // when
+      const result = await campaignRepository.getByCode({ code, campaignsApi: campaignsApiStub });
+
+      // then
+      expect(result).to.be.an.instanceof(Campaign);
+    });
+  });
 });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -1,12 +1,11 @@
 import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
-import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import * as combinedCourseSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-serializer.js';
-import { expect } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | combined-course', function () {
   it('#serialize', function () {
     // given
-    const combinedCourse = new CombinedCourse({ id: 1, name: 'Mon parcours', code: 'COMBINIX1', organizationId: 1 });
+    const combinedCourse = domainBuilder.buildCombinedCourseDetails();
 
     // when
     const serializedCombinedCourse = combinedCourseSerializer.serialize(combinedCourse);
@@ -22,7 +21,22 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
         },
         type: 'combined-courses',
         id: '1',
+        relationships: {
+          items: {
+            data: [{ id: '1', type: 'combined-course-items' }],
+          },
+        },
       },
+      included: [
+        {
+          type: 'combined-course-items',
+          id: '1',
+          attributes: {
+            title: 'diagnostique',
+            reference: 'ABCDIAG1',
+          },
+        },
+      ],
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -1,0 +1,38 @@
+import { CombinedCourse, CombinedCourseDetails } from '../../../../src/quest/domain/models/CombinedCourse.js';
+import { Quest } from '../../../../src/quest/domain/models/Quest.js';
+import { domainBuilder } from '../domain-builder.js';
+
+function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
+  const campaign = domainBuilder.buildCampaign({ name: 'diagnostique', code: 'ABCDIAG1' });
+
+  quest =
+    quest ??
+    new Quest({
+      id: 1,
+      rewardId: null,
+      rewardType: null,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaign.id,
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    });
+
+  combinedCourse =
+    combinedCourse ?? new CombinedCourse({ id: 1, code: 'COMBINIX1', organizationId: 1, name: 'Mon parcours' });
+
+  const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest);
+  combinedCourseDetails.generateItems(items ?? [campaign]);
+
+  return combinedCourseDetails;
+}
+
+export { buildCombinedCourseDetails };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -68,6 +68,7 @@ import { buildChallenge, buildChallengeWithWebComponent } from './build-challeng
 import { buildChallengeLearningContentDataObject } from './build-challenge-learning-content-data-object.js';
 import { buildCleaCertifiedCandidate } from './build-clea-certified-candidate.js';
 import { buildClientApplication } from './build-client-application.js';
+import { buildCombinedCourseDetails } from './build-combined-course-details.js';
 import { buildCompetence } from './build-competence.js';
 import { buildCompetenceEvaluation } from './build-competence-evaluation.js';
 import { buildCompetenceMark } from './build-competence-mark.js';
@@ -404,6 +405,7 @@ export {
   buildChallengeWithWebComponent,
   buildCleaCertifiedCandidate,
   buildClientApplication,
+  buildCombinedCourseDetails,
   buildCompetence,
   buildCompetenceEvaluation,
   buildCompetenceForScoring,

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -1,0 +1,9 @@
+import { LinkTo } from '@ember/routing';
+
+<template>
+  <LinkTo @route={{@item.route}} @model={{@item.reference}}>
+    <div class="combined-course-item">
+      <div class="combined-course-item__title">{{@item.title}}</div>
+    </div>
+  </LinkTo>
+</template>

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -5,14 +5,25 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import eq from 'ember-truth-helpers/helpers/eq';
 
+import CombinedCourseItem from '../combined-course/combined-course-item';
+
 export default class CombinedCourses extends Component {
   <template>
-    {{#if (eq @combinedCourse.status "NOT_STARTED")}}
-      <PixButton @type="submit" @triggerAction={{this.startQuestParticipation}} @loading-color="white" @size="large">{{t
-          "pages.combined-courses.content.start-button"
-        }}
-      </PixButton>
-    {{/if}}
+    <div class="combined-course">
+      {{#if (eq @combinedCourse.status "NOT_STARTED")}}
+        <PixButton
+          @type="submit"
+          @triggerAction={{this.startQuestParticipation}}
+          @loading-color="white"
+          @size="large"
+        >{{t "pages.combined-courses.content.start-button"}}
+        </PixButton>
+      {{/if}}
+      <div class="combined-course__divider" />
+      {{#each @combinedCourse.items as |item|}}
+        <CombinedCourseItem @item={{item}} />
+      {{/each}}
+    </div>
   </template>
 
   @service currentUser;

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class CombinedCourseItem extends Model {
+  @attr('string') title;
+  @attr('string') reference;
+
+  get route() {
+    return 'campaigns';
+  }
+
+  @belongsTo('combined-course', { async: false, inverse: 'items' }) combinedCourse;
+}

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -1,8 +1,10 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class CombinedCourse extends Model {
   @attr('string') name;
   @attr('string') code;
   @attr() organizationId;
   @attr('string') status;
+
+  @hasMany('combined-course-item', { async: false, inverse: 'combinedCourse' }) items;
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -41,6 +41,7 @@
 @use 'components/certifications/shareable-certificate/v3-certificate' as *;
 @use 'components/certifications/shareable-certificate/v2-certificate' as *;
 @use 'components/certifications/certification-ender' as *;
+@use 'components/combined-courses' as *;
 @use 'components/communication-banner' as *;
 @use 'components/companion/blocker' as *;
 @use 'components/companion/check' as *;
@@ -199,16 +200,14 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use 'pages/certification-instructions' as *;
 @use 'pages/download-session-results' as *;
 
-
 .unauthenticated-page {
-
-  &>.pix-app-layout__main,
+  & > .pix-app-layout__main,
   .pix-app-layout__footer,
   .pix-app-layout__navigation {
     padding: 0;
   }
 
-  &>.pix-app-layout__main {
+  & > .pix-app-layout__main {
     max-width: 100%;
   }
 }

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -1,0 +1,24 @@
+@use 'pix-design-tokens/typography';
+
+.combined-course {
+  padding: var(--pix-spacing-12x) 80px;
+
+  &__divider {
+    margin: var(--pix-spacing-6x) 0;
+    border-top: 1px solid var(--pix-neutral-100);
+  }
+}
+
+.combined-course-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  background: var(--pix-neutral-0);
+  border: 1px solid var(--pix-primary-100);
+  border-radius: var(--pix-spacing-4x);
+
+  &__title {
+    @extend %pix-title-xxs;
+  }
+}

--- a/mon-pix/mirage/serializers/combined-course.js
+++ b/mon-pix/mirage/serializers/combined-course.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include: ['items'],
+});

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -45,5 +45,37 @@ module('Integration | Component | combined course', function (hooks) {
       // then
       assert.notOk(screen.queryByRole('button', { name: t('pages.combined-courses.content.start-button') }));
     });
+
+    test('should display diagnostic campaign', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:router');
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'ma campagne',
+        reference: 'ABCDIAG1',
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'NOT_STARTED',
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByText('ma campagne'));
+      assert.strictEqual(
+        screen.getByRole('link', { name: 'ma campagne' }).getAttribute('href'),
+        router.urlFor('campaigns', { code: combinedCourseItem.reference }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
La campagne de diagnostique n'est pas affiché dans la page d'un parcours combiné

## ⛱️ Proposition
Afficher la campagne de diagnostique dans la page du parcours combiné et rediriger vers la page de début de campagne lors du clic sur celle ci

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter avec `attestation-blank@example.net`
- Entrer le code 'COMBINIX1'
- Constater l'affichage du parcours de diagnostique
- Une fois avoir cliquer dessus, vérifier la bonne redirection sur la page de début de campagne