### PR TITLE
[TECH] utiliser le service pixMetrics (pix-18875)

### DIFF
--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -12,7 +12,7 @@ export default class AttestationContent extends Component {
   @service session;
   @service currentUser;
   @service fileSaver;
-  @service metrics;
+  @service pixMetrics;
   @service intl;
 
   get resultTitle() {
@@ -30,7 +30,7 @@ export default class AttestationContent extends Component {
   }
 
   sendMetrics() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Page Mes Attestations',
       'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',

--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -31,6 +31,7 @@ export default class AttestationContent extends Component {
 
   sendMetrics() {
     this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestation)', {
+      disabled: true,
       category: 'Page Mes Attestations',
       action: 'Cliquer sur le bouton Télécharger (attestation)',
     });

--- a/mon-pix/app/components/attestations/content.gjs
+++ b/mon-pix/app/components/attestations/content.gjs
@@ -30,11 +30,9 @@ export default class AttestationContent extends Component {
   }
 
   sendMetrics() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Page Mes Attestations',
-      'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',
-      'pix-event-name': 'Clic sur le bouton Télécharger (attestation)',
+    this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestation)', {
+      category: 'Page Mes Attestations',
+      action: 'Cliquer sur le bouton Télécharger (attestation)',
     });
   }
 

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -92,7 +92,7 @@ export default class SignupForm extends Component {
       const wasAnonymousBeforeSaving = user.isAnonymous;
       await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
       if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && wasAnonymousBeforeSaving) {
-        this.pixMetrics.trackEvent({ 'pix-event-name': 'SignUpFromAnonymousUserDone' });
+        this.pixMetrics.trackEvent('SignUpFromAnonymousUserDone');
         this.session.set('skipRedirectAfterSessionInvalidation', true);
         await this.session.invalidate();
       }

--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.gjs
@@ -23,7 +23,7 @@ export default class LandingPageStartBlock extends Component {
 
   @action
   async startCampaignParticipationAsAnonymous() {
-    this.pixMetrics.trackEvent({ 'pix-event-name': 'StartAutonomousCourseAsAnonymousClick' });
+    this.pixMetrics.trackEvent('StartAutonomousCourseAsAnonymousClick');
     this.args.startCampaignParticipation();
   }
 

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -67,11 +67,9 @@ export default class Ended extends Component {
 
   @action
   onClick() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Campaign participation',
-      'pix-event-action': `Voir le détail d'une participation partagée`,
-      'pix-event-name': `Voir le détail d'une participation partagée`,
+    this.pixMetrics.trackEvent(`Voir le détail d'une participation partagée`, {
+      category: 'Campaign participation',
+      action: `Voir le détail d'une participation partagée`,
     });
     this.router.transitionTo('campaigns.entry-point', this.args.model.campaignCode);
   }

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -68,6 +68,7 @@ export default class Ended extends Component {
   @action
   onClick() {
     this.pixMetrics.trackEvent(`Voir le détail d'une participation partagée`, {
+      disabled: true,
       category: 'Campaign participation',
       action: `Voir le détail d'une participation partagée`,
     });

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -51,7 +51,7 @@ export default class Ended extends Component {
     </PixBlock>
   </template>
   @service router;
-  @service metrics;
+  @service pixMetrics;
 
   get hasStages() {
     return this.args.model.totalStagesCount > 0;
@@ -67,7 +67,7 @@ export default class Ended extends Component {
 
   @action
   onClick() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Campaign participation',
       'pix-event-action': `Voir le détail d'une participation partagée`,

--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -112,7 +112,7 @@ export default class CampaignStartBlock extends Component {
   @action
   trackAccessForUser() {
     if (this.args.campaign.isSimplifiedAccess && !this.session.isAuthenticated) {
-      this.pixMetrics.trackEvent({ 'pix-event-name': 'StartSimplifiedAccessCampaignAsAnonymousClick' });
+      this.pixMetrics.trackEvent('StartSimplifiedAccessCampaignAsAnonymousClick');
     }
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -36,11 +36,9 @@ export default class AttestationResult extends Component {
   }
 
   sendMetrics() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',
-      'pix-event-name': 'Clic sur le bouton Télécharger (attestation)',
+    this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestation)', {
+      category: 'Fin de parcours',
+      action: 'Cliquer sur le bouton Télécharger (attestation)',
     });
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -37,6 +37,7 @@ export default class AttestationResult extends Component {
 
   sendMetrics() {
     this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestation)', {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Cliquer sur le bouton Télécharger (attestation)',
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -11,7 +11,7 @@ import kebabCase from 'lodash/kebabCase';
 export default class AttestationResult extends Component {
   @service session;
   @service fileSaver;
-  @service metrics;
+  @service pixMetrics;
   @service intl;
 
   get result() {
@@ -36,7 +36,7 @@ export default class AttestationResult extends Component {
   }
 
   sendMetrics() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -27,6 +27,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
   @action
   handleCustomButtonDisplay() {
     this.pixMetrics.trackEvent('Présence d’un bouton comportant un lien externe', {
+      disabled: true,
       category: 'Fin de parcours',
       action: "Affichage du bloc de l'organisation",
     });
@@ -35,6 +36,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
   @action
   handleCustomButtonClick() {
     this.pixMetrics.trackEvent('Clic sur le lien externe', {
+      disabled: true,
       category: 'Fin de parcours',
       action: "Affichage du bloc de l'organisation",
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -26,21 +26,17 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   @action
   handleCustomButtonDisplay() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': "Affichage du bloc de l'organisation",
-      'pix-event-name': 'Présence d’un bouton comportant un lien externe',
+    this.pixMetrics.trackEvent('Présence d’un bouton comportant un lien externe', {
+      category: 'Fin de parcours',
+      action: "Affichage du bloc de l'organisation",
     });
   }
 
   @action
   handleCustomButtonClick() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': "Affichage du bloc de l'organisation",
-      'pix-event-name': 'Clic sur le lien externe',
+    this.pixMetrics.trackEvent('Clic sur le lien externe', {
+      category: 'Fin de parcours',
+      action: "Affichage du bloc de l'organisation",
     });
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 import MarkdownToHtml from '../../../../markdown-to-html';
 
 export default class EvaluationResultsCustomOrganizationBlock extends Component {
-  @service metrics;
+  @service pixMetrics;
 
   get customButtonUrl() {
     if (this.args.campaign.customResultPageButtonUrl && this.args.campaign.customResultPageButtonText) {
@@ -26,7 +26,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   @action
   handleCustomButtonDisplay() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': "Affichage du bloc de l'organisation",
@@ -36,7 +36,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
 
   @action
   handleCustomButtonClick() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': "Affichage du bloc de l'organisation",

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -100,11 +100,9 @@ export default class EvaluationResultsHero extends Component {
       const adapter = this.store.adapterFor('campaign-participation-result');
       await adapter.beginImprovement(campaignParticipationResult.id);
 
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Amélioration des résultats',
-        'pix-event-name': "Clic sur le bouton 'Je retente'",
+      this.pixMetrics.trackEvent("Clic sur le bouton 'Je retente'", {
+        category: 'Fin de parcours',
+        action: 'Amélioration des résultats',
       });
 
       this.router.transitionTo('campaigns.entry-point', this.args.campaign.code);
@@ -131,11 +129,9 @@ export default class EvaluationResultsHero extends Component {
       });
       this.args.onResultsShared();
 
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Envoi des résultats',
-        'pix-event-name': "Envoi des résultats depuis l'en-tête",
+      this.pixMetrics.trackEvent("Envoi des résultats depuis l'en-tête", {
+        category: 'Fin de parcours',
+        action: 'Envoi des résultats',
       });
     } catch {
       this.hasGlobalError = true;
@@ -151,27 +147,23 @@ export default class EvaluationResultsHero extends Component {
 
   @action
   handleBackToHomepageDisplay() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Sortie de parcours',
-      'pix-event-name': "Affichage du bouton 'Revenir à la page d'accueil'",
+    this.pixMetrics.trackEvent("Affichage du bouton 'Revenir à la page d'accueil'", {
+      category: 'Fin de parcours',
+      action: 'Sortie de parcours',
     });
   }
 
   @action
   handleBackToHomepageClick() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Sortie de parcours',
-      'pix-event-name': "Clic sur le bouton 'Revenir à la page d'accueil'",
+    this.pixMetrics.trackEvent("Clic sur le bouton 'Revenir à la page d'accueil'", {
+      category: 'Fin de parcours',
+      action: 'Sortie de parcours',
     });
   }
 
   @action
   handleSignUpClick() {
-    this.pixMetrics.trackEvent({ 'pix-event-name': 'CampaignResultSignUpFromAnonymousUserClick' });
+    this.pixMetrics.trackEvent('CampaignResultSignUpFromAnonymousUserClick');
   }
 
   <template>

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -101,6 +101,7 @@ export default class EvaluationResultsHero extends Component {
       await adapter.beginImprovement(campaignParticipationResult.id);
 
       this.pixMetrics.trackEvent("Clic sur le bouton 'Je retente'", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Amélioration des résultats',
       });
@@ -130,6 +131,7 @@ export default class EvaluationResultsHero extends Component {
       this.args.onResultsShared();
 
       this.pixMetrics.trackEvent("Envoi des résultats depuis l'en-tête", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Envoi des résultats',
       });
@@ -148,6 +150,7 @@ export default class EvaluationResultsHero extends Component {
   @action
   handleBackToHomepageDisplay() {
     this.pixMetrics.trackEvent("Affichage du bouton 'Revenir à la page d'accueil'", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Sortie de parcours',
     });
@@ -156,6 +159,7 @@ export default class EvaluationResultsHero extends Component {
   @action
   handleBackToHomepageClick() {
     this.pixMetrics.trackEvent("Clic sur le bouton 'Revenir à la page d'accueil'", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Sortie de parcours',
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -23,42 +23,34 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   constructor() {
     super(...arguments);
     if (this.args.campaignParticipationResult.canRetry) {
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
-        'pix-event-name': "Présence du bouton 'Repasser un parcours'",
+      this.pixMetrics.trackEvent("Présence du bouton 'Repasser un parcours'", {
+        category: 'Fin de parcours',
+        action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
     }
 
     if (this.args.campaignParticipationResult.canReset) {
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
-        'pix-event-name': "Présence du bouton 'Remettre à zéro et tout retenter'",
+      this.pixMetrics.trackEvent("Présence du bouton 'Remettre à zéro et tout retenter'", {
+        category: 'Fin de parcours',
+        action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
     }
   }
 
   @action
   handleRetryClick() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
-      'pix-event-name': "Clic sur le bouton 'Repasser mon parcours'",
+    this.pixMetrics.trackEvent("Clic sur le bouton 'Repasser mon parcours'", {
+      category: 'Fin de parcours',
+      action: 'Affichage du bloc RAZ/Repasser un parcours',
     });
   }
 
   @action
   toggleResetModalVisibility() {
     if (!this.isResetModalVisible) {
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
-        'pix-event-name': "Ouverture de la modale 'Remettre à zéro et tout retenter'",
+      this.pixMetrics.trackEvent("Ouverture de la modale 'Remettre à zéro et tout retenter'", {
+        category: 'Fin de parcours',
+        action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
     }
 
@@ -67,11 +59,9 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   @action
   handleResetClick() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
-      'pix-event-name': "Confirmation de la modale 'Remettre à zéro et tout retenter'",
+    this.pixMetrics.trackEvent("Confirmation de la modale 'Remettre à zéro et tout retenter'", {
+      category: 'Fin de parcours',
+      action: 'Affichage du bloc RAZ/Repasser un parcours',
     });
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -24,6 +24,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
     super(...arguments);
     if (this.args.campaignParticipationResult.canRetry) {
       this.pixMetrics.trackEvent("Présence du bouton 'Repasser un parcours'", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
@@ -31,6 +32,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
     if (this.args.campaignParticipationResult.canReset) {
       this.pixMetrics.trackEvent("Présence du bouton 'Remettre à zéro et tout retenter'", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
@@ -40,6 +42,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   @action
   handleRetryClick() {
     this.pixMetrics.trackEvent("Clic sur le bouton 'Repasser mon parcours'", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Affichage du bloc RAZ/Repasser un parcours',
     });
@@ -49,6 +52,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   toggleResetModalVisibility() {
     if (!this.isResetModalVisible) {
       this.pixMetrics.trackEvent("Ouverture de la modale 'Remettre à zéro et tout retenter'", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Affichage du bloc RAZ/Repasser un parcours',
       });
@@ -60,6 +64,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   @action
   handleResetClick() {
     this.pixMetrics.trackEvent("Confirmation de la modale 'Remettre à zéro et tout retenter'", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Affichage du bloc RAZ/Repasser un parcours',
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -11,7 +11,7 @@ import dayjsDurationHumanize from 'ember-dayjs/helpers/dayjs-duration-humanize';
 import { t } from 'ember-intl';
 
 export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
-  @service metrics;
+  @service pixMetrics;
   @service intl;
   @service featureToggles;
   @service dayjs;
@@ -23,7 +23,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   constructor() {
     super(...arguments);
     if (this.args.campaignParticipationResult.canRetry) {
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -32,7 +32,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
     }
 
     if (this.args.campaignParticipationResult.canReset) {
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -43,7 +43,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   @action
   handleRetryClick() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -54,7 +54,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   @action
   toggleResetModalVisibility() {
     if (!this.isResetModalVisible) {
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',
@@ -67,7 +67,7 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
 
   @action
   handleResetClick() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage du bloc RAZ/Repasser un parcours',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -9,11 +9,9 @@ export default class EvaluationResultsDetailsTab extends Component {
 
   constructor() {
     super(...arguments);
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Affichage onglet',
-      'pix-event-name': "Affichage de l'onglet Détails",
+    this.pixMetrics.trackEvent("Affichage de l'onglet Détails", {
+      category: 'Fin de parcours',
+      action: 'Affichage onglet',
     });
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -5,11 +5,11 @@ import { t } from 'ember-intl';
 import CompetenceRow from './competence-row';
 
 export default class EvaluationResultsDetailsTab extends Component {
-  @service metrics;
+  @service pixMetrics;
 
   constructor() {
     super(...arguments);
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -10,6 +10,7 @@ export default class EvaluationResultsDetailsTab extends Component {
   constructor() {
     super(...arguments);
     this.pixMetrics.trackEvent("Affichage de l'onglet Détails", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Affichage onglet',
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -11,11 +11,9 @@ export default class Rewards extends Component {
   constructor() {
     super(...arguments);
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Affichage onglet',
-      'pix-event-name': "Affichage de l'onglet Récompenses",
+    this.pixMetrics.trackEvent("Affichage de l'onglet Récompenses", {
+      category: 'Fin de parcours',
+      action: 'Affichage onglet',
     });
   }
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -6,12 +6,12 @@ import { t } from 'ember-intl';
 import RewardsBadge from './badge';
 
 export default class Rewards extends Component {
-  @service metrics;
+  @service pixMetrics;
 
   constructor() {
     super(...arguments);
 
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/rewards/index.gjs
@@ -12,6 +12,7 @@ export default class Rewards extends Component {
     super(...arguments);
 
     this.pixMetrics.trackEvent("Affichage de l'onglet Récompenses", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Affichage onglet',
     });

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -20,11 +20,9 @@ export default class EvaluationResultsTabsTrainings extends Component {
   constructor() {
     super(...arguments);
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Fin de parcours',
-      'pix-event-action': 'Affichage onglet',
-      'pix-event-name': "Affichage de l'onglet Formations",
+    this.pixMetrics.trackEvent("Affichage de l'onglet Formations", {
+      category: 'Fin de parcours',
+      action: 'Affichage onglet',
     });
   }
 
@@ -49,11 +47,9 @@ export default class EvaluationResultsTabsTrainings extends Component {
       campaignParticipationResultToShare.isShared = true;
       campaignParticipationResultToShare.canImprove = false;
 
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Fin de parcours',
-        'pix-event-action': 'Envoi des résultats',
-        'pix-event-name': "Envoi des résultats depuis l'onglet Formations",
+      this.pixMetrics.trackEvent("Envoi des résultats depuis l'onglet Formations", {
+        category: 'Fin de parcours',
+        action: 'Envoi des résultats',
       });
     } catch {
       this.isShareResultsError = true;

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -10,7 +10,7 @@ import TrainingCard from '../../../../training/card';
 
 export default class EvaluationResultsTabsTrainings extends Component {
   @service currentUser;
-  @service metrics;
+  @service pixMetrics;
   @service campaignParticipationResult;
   @service store;
 
@@ -20,7 +20,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
   constructor() {
     super(...arguments);
 
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Fin de parcours',
       'pix-event-action': 'Affichage onglet',
@@ -49,7 +49,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
       campaignParticipationResultToShare.isShared = true;
       campaignParticipationResultToShare.canImprove = false;
 
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Fin de parcours',
         'pix-event-action': 'Envoi des résultats',

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -21,6 +21,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
     super(...arguments);
 
     this.pixMetrics.trackEvent("Affichage de l'onglet Formations", {
+      disabled: true,
       category: 'Fin de parcours',
       action: 'Affichage onglet',
     });
@@ -48,6 +49,7 @@ export default class EvaluationResultsTabsTrainings extends Component {
       campaignParticipationResultToShare.canImprove = false;
 
       this.pixMetrics.trackEvent("Envoi des résultats depuis l'onglet Formations", {
+        disabled: true,
         category: 'Fin de parcours',
         action: 'Envoi des résultats',
       });

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -261,11 +261,9 @@ export default class ChallengeStatement extends Component {
   }
 
   addMetrics() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Vocalisation',
-      'pix-event-action': "Lecture d'une épreuve",
-      'pix-event-name': `Clic sur le bouton de lecture d'épreuve : ${this.isSpeaking ? 'play' : 'stop'}`,
+    this.pixMetrics.trackEvent(`Clic sur le bouton de lecture d'épreuve : ${this.isSpeaking ? 'play' : 'stop'}`, {
+      category: 'Vocalisation',
+      action: "Lecture d'une épreuve",
     });
   }
 

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -167,7 +167,7 @@ export default class ChallengeStatement extends Component {
   @service currentUser;
   @service featureToggles;
   @service router;
-  @service metrics;
+  @service pixMetrics;
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
@@ -261,7 +261,7 @@ export default class ChallengeStatement extends Component {
   }
 
   addMetrics() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Vocalisation',
       'pix-event-action': "Lecture d'une épreuve",

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -262,6 +262,7 @@ export default class ChallengeStatement extends Component {
 
   addMetrics() {
     this.pixMetrics.trackEvent(`Clic sur le bouton de lecture d'épreuve : ${this.isSpeaking ? 'play' : 'stop'}`, {
+      disabled: true,
       category: 'Vocalisation',
       action: "Lecture d'une épreuve",
     });

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -24,44 +24,36 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStart() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton Commencer un passage`,
+    this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage`, {
+      category: 'Modulix',
+      action: `Détails du module : ${this.args.module.slug}`,
     });
     this.router.transitionTo('module.passage', this.args.module.slug);
   }
 
   @action
   onModuleStartUsingSmallScreen() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
+    this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage en petit écran`, {
+      category: 'Modulix',
+      action: `Détails du module : ${this.args.module.slug}`,
     });
     this.router.transitionTo('module.passage', this.args.module.slug);
   }
 
   @action
   onSmallScreenModalOpen() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
-      'pix-event-name': `Ouvre la modale d'alerte de largeur d'écran`,
+    this.pixMetrics.trackEvent(`Ouvre la modale d'alerte de largeur d'écran`, {
+      category: 'Modulix',
+      action: `Détails du module : ${this.args.module.slug}`,
     });
     this.isSmallScreenModalOpen = true;
   }
 
   @action
   onSmallScreenModalClose() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Détails du module : ${this.args.module.slug}`,
-      'pix-event-name': `Ferme la modale d'alerte de largeur d'écran`,
+    this.pixMetrics.trackEvent(`Ferme la modale d'alerte de largeur d'écran`, {
+      category: 'Modulix',
+      action: `Détails du module : ${this.args.module.slug}`,
     });
     this.isSmallScreenModalOpen = false;
   }

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -13,7 +13,7 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixDetails extends Component {
   @service router;
-  @service metrics;
+  @service pixMetrics;
   @service media;
 
   @tracked isSmallScreenModalOpen = false;
@@ -24,7 +24,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStart() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -35,7 +35,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStartUsingSmallScreen() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -46,7 +46,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onSmallScreenModalOpen() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,
@@ -57,7 +57,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onSmallScreenModalClose() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Détails du module : ${this.args.module.slug}`,

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -25,6 +25,7 @@ export default class ModulixDetails extends Component {
   @action
   onModuleStart() {
     this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage`, {
+      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -34,6 +35,7 @@ export default class ModulixDetails extends Component {
   @action
   onModuleStartUsingSmallScreen() {
     this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage en petit écran`, {
+      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -43,6 +45,7 @@ export default class ModulixDetails extends Component {
   @action
   onSmallScreenModalOpen() {
     this.pixMetrics.trackEvent(`Ouvre la modale d'alerte de largeur d'écran`, {
+      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -52,6 +55,7 @@ export default class ModulixDetails extends Component {
   @action
   onSmallScreenModalClose() {
     this.pixMetrics.trackEvent(`Ferme la modale d'alerte de largeur d'écran`, {
+      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -76,6 +76,7 @@ export default class ModulePassage extends Component {
     this.pixMetrics.trackEvent(
       `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
       {
+        disabled: true,
         category: 'Modulix',
         action: `Passage du module : ${this.args.module.slug}`,
       },
@@ -106,6 +107,7 @@ export default class ModulePassage extends Component {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
     this.pixMetrics.trackEvent(`Click sur le bouton Terminer du grain : ${grainId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -131,6 +133,7 @@ export default class ModulePassage extends Component {
   @action
   async onElementRetry(answerData) {
     this.pixMetrics.trackEvent(`Click sur le bouton réessayer de l'élément : ${answerData.element.id}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -139,6 +142,7 @@ export default class ModulePassage extends Component {
   @action
   async onImageAlternativeTextOpen(imageElementId) {
     this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle : ${imageElementId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -147,6 +151,7 @@ export default class ModulePassage extends Component {
   @action
   async onVideoTranscriptionOpen(videoElementId) {
     this.pixMetrics.trackEvent(`Click sur le bouton transcription : ${videoElementId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -155,6 +160,7 @@ export default class ModulePassage extends Component {
   @action
   async onVideoPlay({ elementId }) {
     this.pixMetrics.trackEvent(`Click sur le bouton Play : ${elementId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -163,6 +169,7 @@ export default class ModulePassage extends Component {
   @action
   async onFileDownload({ elementId, downloadedFormat }) {
     this.pixMetrics.trackEvent(`Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -174,6 +181,7 @@ export default class ModulePassage extends Component {
     this.modulixAutoScroll.focusAndScroll(element);
 
     this.pixMetrics.trackEvent(`Click sur le grain ${grainId} de la barre de navigation`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -183,6 +191,7 @@ export default class ModulePassage extends Component {
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
+      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -73,12 +73,13 @@ export default class ModulePassage extends Component {
   onStepperNextStep(currentStepPosition) {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
-    });
+    this.pixMetrics.trackEvent(
+      `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
+      {
+        category: 'Modulix',
+        action: `Passage du module : ${this.args.module.slug}`,
+      },
+    );
   }
 
   addNextGrainToDisplay() {
@@ -104,11 +105,9 @@ export default class ModulePassage extends Component {
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton Terminer du grain : ${grainId}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton Terminer du grain : ${grainId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
     this.passageEvents.record({
       type: 'PASSAGE_TERMINATED',
@@ -131,51 +130,41 @@ export default class ModulePassage extends Component {
 
   @action
   async onElementRetry(answerData) {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton réessayer de l'élément : ${answerData.element.id}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton réessayer de l'élément : ${answerData.element.id}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
   @action
   async onImageAlternativeTextOpen(imageElementId) {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElementId}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle : ${imageElementId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
   @action
   async onVideoTranscriptionOpen(videoElementId) {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton transcription : ${videoElementId}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton transcription : ${videoElementId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
   @action
   async onVideoPlay({ elementId }) {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton Play : ${elementId}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton Play : ${elementId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
   @action
   async onFileDownload({ elementId, downloadedFormat }) {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`,
+    this.pixMetrics.trackEvent(`Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
@@ -184,22 +173,18 @@ export default class ModulePassage extends Component {
     const element = document.getElementById(`grain_${grainId}`);
     this.modulixAutoScroll.focusAndScroll(element);
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `Click sur le grain ${grainId} de la barre de navigation`,
+    this.pixMetrics.trackEvent(`Click sur le grain ${grainId} de la barre de navigation`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.module.slug}`,
-      'pix-event-name': `${eventToggle} de l'élément Expand : ${elementId}`,
+    this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
     });
   }
 

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -12,7 +12,7 @@ import ModuleNavbar from './layout/navbar';
 
 export default class ModulePassage extends Component {
   @service router;
-  @service metrics;
+  @service pixMetrics;
   @service store;
   @service modulixAutoScroll;
   @service passageEvents;
@@ -73,7 +73,7 @@ export default class ModulePassage extends Component {
   onStepperNextStep(currentStepPosition) {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -104,7 +104,7 @@ export default class ModulePassage extends Component {
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -131,7 +131,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onElementRetry(answerData) {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -141,7 +141,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onImageAlternativeTextOpen(imageElementId) {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -151,7 +151,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoTranscriptionOpen(videoElementId) {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -161,7 +161,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoPlay({ elementId }) {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -171,7 +171,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onFileDownload({ elementId, downloadedFormat }) {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -184,7 +184,7 @@ export default class ModulePassage extends Component {
     const element = document.getElementById(`grain_${grainId}`);
     this.modulixAutoScroll.focusAndScroll(element);
 
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,
@@ -195,7 +195,7 @@ export default class ModulePassage extends Component {
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.slug}`,

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -35,7 +35,7 @@ export default class Card extends Component {
     </PixBlock>
   </template>
   @service intl;
-  @service metrics;
+  @service pixMetrics;
   @service router;
 
   get durationFormatted() {
@@ -104,7 +104,7 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Accès Contenu Formatif',
       'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -105,6 +105,7 @@ export default class Card extends Component {
   @action
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le cf : ${this.args.training.title}`, {
+      disabled: true,
       category: 'Accès Contenu Formatif',
       action: `Click depuis : ${this.router.currentRouteName}`,
     });

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -104,11 +104,9 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Accès Contenu Formatif',
-      'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,
-      'pix-event-name': `Ouvre le cf : ${this.args.training.title}`,
+    this.pixMetrics.trackEvent(`Ouvre le cf : ${this.args.training.title}`, {
+      category: 'Accès Contenu Formatif',
+      action: `Click depuis : ${this.router.currentRouteName}`,
     });
   }
 }

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -154,6 +154,7 @@ export default class Card extends Component {
   @action
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le tutoriel : ${this.args.tutorial.title}`, {
+      disabled: true,
       category: 'Accès tuto',
       action: `Click depuis : ${this.router.currentRouteName}`,
     });

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -153,11 +153,9 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Accès tuto',
-      'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,
-      'pix-event-name': `Ouvre le tutoriel : ${this.args.tutorial.title}`,
+    this.pixMetrics.trackEvent(`Ouvre le tutoriel : ${this.args.tutorial.title}`, {
+      category: 'Accès tuto',
+      action: `Click depuis : ${this.router.currentRouteName}`,
     });
   }
 }

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -58,7 +58,7 @@ export default class Card extends Component {
   @service intl;
   @service store;
   @service currentUser;
-  @service metrics;
+  @service pixMetrics;
   @service router;
 
   @tracked savingStatus;
@@ -153,7 +153,7 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Accès tuto',
       'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -252,6 +252,7 @@ export default class ChallengeController extends Controller {
     this.pixMetrics.trackEvent(
       `Clic sur le bouton d'activation de la vocalisation : ${this.isTextToSpeechActivated ? 'activé' : 'désactivé'}`,
       {
+        disabled: true,
         category: 'Vocalisation',
         action: 'Activation globale de la vocalisation',
       },

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -17,7 +17,7 @@ export default class ChallengeController extends Controller {
   @service store;
   @service currentUser;
   @service focusedCertificationChallengeWarningManager;
-  @service metrics;
+  @service pixMetrics;
 
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
@@ -249,7 +249,7 @@ export default class ChallengeController extends Controller {
   }
 
   addMetrics() {
-    this.metrics.trackEvent({
+    this.pixMetrics.trackEvent({
       event: 'custom-event',
       'pix-event-category': 'Vocalisation',
       'pix-event-action': 'Activation globale de la vocalisation',

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -249,11 +249,12 @@ export default class ChallengeController extends Controller {
   }
 
   addMetrics() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
-      'pix-event-category': 'Vocalisation',
-      'pix-event-action': 'Activation globale de la vocalisation',
-      'pix-event-name': `Clic sur le bouton d'activation de la vocalisation : ${this.isTextToSpeechActivated ? 'activé' : 'désactivé'}`,
-    });
+    this.pixMetrics.trackEvent(
+      `Clic sur le bouton d'activation de la vocalisation : ${this.isTextToSpeechActivated ? 'activé' : 'désactivé'}`,
+      {
+        category: 'Vocalisation',
+        action: 'Activation globale de la vocalisation',
+      },
+    );
   }
 }

--- a/mon-pix/app/metrics-adapters/plausible-adapter.js
+++ b/mon-pix/app/metrics-adapters/plausible-adapter.js
@@ -29,9 +29,10 @@ export default class PlausibleAdapter extends BaseAdapter {
   /**
    * Custom events allow you to measure button clicks, form completions...
    *
+   * @param {string} eventName - must not contain spaces, examples: verify-this or That+Completion
    * @param {Object} params
-   * @param {string} params.eventName - must not contain spaces, examples: verify-this or That+Completion
    * @param {Objects} params.props - event metadatas, must not contain any personally identifiable information
+   * @param {Objects} params.plausibleAttributes - pros that will override plausible event data
    */
   trackEvent({ eventName, plausibleAttributes = {}, ...props }) {
     window.plausible(eventName, { ...plausibleAttributes, props });

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -11,7 +11,7 @@ export default class EntryPoint extends Route {
   @service session;
   @service router;
   @service store;
-  @service metrics;
+  @service pixMetrics;
 
   buildRouteInfoMetadata() {
     return { doNotTrackPage: true };
@@ -42,7 +42,7 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'participantExternalId', participantExternalId);
     }
     if (queryParams.retry) {
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Campagnes',
         'pix-event-action': 'Retenter la campagne',
@@ -51,7 +51,7 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
     if (queryParams.reset) {
-      this.metrics.trackEvent({
+      this.pixMetrics.trackEvent({
         event: 'custom-event',
         'pix-event-category': 'Campagnes',
         'pix-event-action': 'Remise à zéro de la campagne',

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -42,20 +42,16 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'participantExternalId', participantExternalId);
     }
     if (queryParams.retry) {
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Campagnes',
-        'pix-event-action': 'Retenter la campagne',
-        'pix-event-name': 'Clic sur Retenter la campagne',
+      this.pixMetrics.trackEvent('Clic sur Retenter la campagne', {
+        category: 'Campagnes',
+        action: 'Retenter la campagne',
       });
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
     if (queryParams.reset) {
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Campagnes',
-        'pix-event-action': 'Remise à zéro de la campagne',
-        'pix-event-name': 'Clic sur Remise à zéro de la campagne',
+      this.pixMetrics.trackEvent('Clic sur Remise à zéro de la campagne', {
+        category: 'Campagnes',
+        action: 'Remise à zéro de la campagne',
       });
       this.campaignStorage.set(campaign.code, 'reset', transition.to.queryParams.reset);
     }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -43,6 +43,7 @@ export default class EntryPoint extends Route {
     }
     if (queryParams.retry) {
       this.pixMetrics.trackEvent('Clic sur Retenter la campagne', {
+        disabled: true,
         category: 'Campagnes',
         action: 'Retenter la campagne',
       });
@@ -50,6 +51,7 @@ export default class EntryPoint extends Route {
     }
     if (queryParams.reset) {
       this.pixMetrics.trackEvent('Clic sur Remise à zéro de la campagne', {
+        disabled: true,
         category: 'Campagnes',
         action: 'Remise à zéro de la campagne',
       });

--- a/mon-pix/app/services/pix-metrics.js
+++ b/mon-pix/app/services/pix-metrics.js
@@ -4,7 +4,7 @@ export default class PixMetricsService extends Service {
   @service metrics;
   @service router;
 
-  trackEvent({ event: _, 'pix-event-name': eventName, ...props }) {
+  trackEvent(eventName, props = {}) {
     const url = this.getRedactedPageUrl();
     this.metrics.trackEvent({ eventName, plausibleAttributes: { u: url }, ...props });
   }

--- a/mon-pix/app/services/pix-metrics.js
+++ b/mon-pix/app/services/pix-metrics.js
@@ -4,7 +4,8 @@ export default class PixMetricsService extends Service {
   @service metrics;
   @service router;
 
-  trackEvent(eventName, props = {}) {
+  trackEvent(eventName, { disabled, ...props } = {}) {
+    if (disabled) return;
     const url = this.getRedactedPageUrl();
     this.metrics.trackEvent({ eventName, plausibleAttributes: { u: url }, ...props });
   }

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -83,7 +83,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
           trackEvent = sinon.stub();
           context = {};
         }
-        this.owner.register('service:metrics', MetricsStubService);
+        this.owner.register('service:pix-metrics', MetricsStubService);
 
         const screen = await visit(`/assessments/${assessment.id}/challenges/${challenge.id}`);
         await click(screen.getByRole('button', { name: 'Désactiver la vocalisation' }));

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
@@ -169,6 +169,7 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
         sinon.assert.calledWithExactly(metrics.trackEvent, `Voir le détail d'une participation partagée`, {
           category: 'Campaign participation',
           action: `Voir le détail d'une participation partagée`,
+          disabled: true,
         });
         assert.ok(true);
       });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended-test.js
@@ -142,7 +142,7 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
         // given
         const router = this.owner.lookup('service:router');
         router.transitionTo = sinon.stub();
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
@@ -166,11 +166,9 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ended',
         await click(screen.getByRole('button', { name: 'Voir le détail' }));
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Campaign participation',
-          'pix-event-action': `Voir le détail d'une participation partagée`,
-          'pix-event-name': `Voir le détail d'une participation partagée`,
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Voir le détail d'une participation partagée`, {
+          category: 'Campaign participation',
+          action: `Voir le détail d'une participation partagée`,
         });
         assert.ok(true);
       });

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -92,6 +92,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       assert.ok(
         metricsAddStub.calledWithExactly('Clic sur le bouton Télécharger (attestation)', {
           category: 'Fin de parcours',
+          disabled: true,
           action: 'Cliquer sur le bouton Télécharger (attestation)',
         }),
       );

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -74,7 +74,7 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       }
       const metricsAddStub = sinon.stub().resolves();
 
-      this.owner.register('service:metrics', MetricsStub);
+      this.owner.register('service:pix-metrics', MetricsStub);
 
       // when
       const screen = await render(<template><AttestationResult @results={{result}} /></template>);
@@ -90,11 +90,9 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       );
 
       assert.ok(
-        metricsAddStub.calledWithExactly({
-          event: 'custom-event',
-          'pix-event-category': 'Fin de parcours',
-          'pix-event-action': 'Cliquer sur le bouton Télécharger (attestation)',
-          'pix-event-name': 'Clic sur le bouton Télécharger (attestation)',
+        metricsAddStub.calledWithExactly('Clic sur le bouton Télécharger (attestation)', {
+          category: 'Fin de parcours',
+          action: 'Cliquer sur le bouton Télécharger (attestation)',
         }),
       );
     });

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -279,7 +279,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 class MetricsStubService extends Service {
                   trackEvent = trackEvent;
                 }
-                this.owner.register('service:metrics', MetricsStubService);
+                this.owner.register('service:pix-metrics', MetricsStubService);
 
                 const screen = await render(
                   hbs`<ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @isTextToSpeechActivated={{true}} />`,
@@ -289,11 +289,9 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 await click(screen.getByRole('button', { name: t('pages.challenge.statement.text-to-speech.play') }));
 
                 // then
-                sinon.assert.calledWithExactly(trackEvent, {
-                  event: 'custom-event',
-                  'pix-event-category': 'Vocalisation',
-                  'pix-event-action': "Lecture d'une épreuve",
-                  'pix-event-name': "Clic sur le bouton de lecture d'épreuve : play",
+                sinon.assert.calledWithExactly(trackEvent, "Clic sur le bouton de lecture d'épreuve : play", {
+                  category: 'Vocalisation',
+                  action: "Lecture d'une épreuve",
                 });
                 assert.ok(true);
               });

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -291,6 +291,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 // then
                 sinon.assert.calledWithExactly(trackEvent, "Clic sur le bouton de lecture d'épreuve : play", {
                   category: 'Vocalisation',
+                  disabled: true,
                   action: "Lecture d'une épreuve",
                 });
                 assert.ok(true);

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -49,11 +49,9 @@ module('Integration | Component | Module | Details', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Détails du module : ${module.slug}`,
-          'pix-event-name': `Click sur le bouton Commencer un passage`,
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
+          category: 'Modulix',
+          action: `Détails du module : ${module.slug}`,
         });
         assert.ok(true);
       });
@@ -85,11 +83,9 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(metrics.trackEvent, {
-            event: 'custom-event',
-            'pix-event-category': 'Modulix',
-            'pix-event-action': `Détails du module : ${module.slug}`,
-            'pix-event-name': `Click sur le bouton Commencer un passage`,
+          sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
+            category: 'Modulix',
+            action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
         });
@@ -120,11 +116,9 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(metrics.trackEvent, {
-            event: 'custom-event',
-            'pix-event-category': 'Modulix',
-            'pix-event-action': `Détails du module : ${module.slug}`,
-            'pix-event-name': `Ouvre la modale d'alerte de largeur d'écran`,
+          sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre la modale d'alerte de largeur d'écran`, {
+            category: 'Modulix',
+            action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
         });
@@ -167,12 +161,14 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(metrics.trackEvent, {
-              event: 'custom-event',
-              'pix-event-category': 'Modulix',
-              'pix-event-action': `Détails du module : ${module.slug}`,
-              'pix-event-name': `Click sur le bouton Commencer un passage en petit écran`,
-            });
+            sinon.assert.calledWithExactly(
+              metrics.trackEvent,
+              `Click sur le bouton Commencer un passage en petit écran`,
+              {
+                category: 'Modulix',
+                action: `Détails du module : ${module.slug}`,
+              },
+            );
             assert.ok(true);
           });
 
@@ -214,11 +210,9 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(metrics.trackEvent, {
-              event: 'custom-event',
-              'pix-event-category': 'Modulix',
-              'pix-event-action': `Détails du module : ${module.slug}`,
-              'pix-event-name': `Ferme la modale d'alerte de largeur d'écran`,
+            sinon.assert.calledWithExactly(metrics.trackEvent, `Ferme la modale d'alerte de largeur d'écran`, {
+              category: 'Modulix',
+              action: `Détails du module : ${module.slug}`,
             });
             assert.ok(true);
           });
@@ -251,7 +245,7 @@ module('Integration | Component | Module | Details', function (hooks) {
 function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
   const router = this.owner.lookup('service:router');
   router.transitionTo = sinon.stub();
-  const metrics = this.owner.lookup('service:metrics');
+  const metrics = this.owner.lookup('service:pix-metrics');
   metrics.trackEvent = sinon.stub();
   const store = this.owner.lookup('service:store');
 

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -52,6 +52,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
           category: 'Modulix',
           action: `Détails du module : ${module.slug}`,
+          disabled: true,
         });
         assert.ok(true);
       });
@@ -85,6 +86,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
             category: 'Modulix',
+            disabled: true,
             action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
@@ -118,6 +120,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre la modale d'alerte de largeur d'écran`, {
             category: 'Modulix',
+            disabled: true,
             action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
@@ -166,6 +169,7 @@ module('Integration | Component | Module | Details', function (hooks) {
               `Click sur le bouton Commencer un passage en petit écran`,
               {
                 category: 'Modulix',
+                disabled: true,
                 action: `Détails du module : ${module.slug}`,
               },
             );
@@ -212,6 +216,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             // then
             sinon.assert.calledWithExactly(metrics.trackEvent, `Ferme la modale d'alerte de largeur d'écran`, {
               category: 'Modulix',
+              disabled: true,
               action: `Détails du module : ${module.slug}`,
             });
             assert.ok(true);

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -303,7 +303,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       // when
@@ -453,7 +453,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
   module('when user clicks on an answerable element verify button', function () {
     test('should save the element answer', async function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       const store = this.owner.lookup('service:store');
@@ -497,7 +497,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
   module('when user clicks on an answerable element retry button', function () {
     test('should push metrics event', async function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       // given
@@ -520,11 +520,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.activity.retry'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton réessayer de l'élément : ${element.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer de l'élément : ${element.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });
@@ -533,7 +531,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
   module('when user opens an image alternative text modal', function () {
     test('should push metrics event', async function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       // given
@@ -559,11 +557,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName("Afficher l'alternative textuelle");
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton alternative textuelle : ${element.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle : ${element.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });
@@ -571,7 +567,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     module('when image is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         // given
@@ -601,12 +597,14 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName("Afficher l'alternative textuelle");
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.slug}`,
-          'pix-event-name': `Click sur le bouton alternative textuelle : ${imageElement.id}`,
-        });
+        sinon.assert.calledWithExactly(
+          metrics.trackEvent,
+          `Click sur le bouton alternative textuelle : ${imageElement.id}`,
+          {
+            category: 'Modulix',
+            action: `Passage du module : ${module.slug}`,
+          },
+        );
         assert.ok(true);
       });
     });
@@ -615,7 +613,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
   module('when user opens a video transcription modal', function () {
     test('should push metrics event', async function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       // given
@@ -642,11 +640,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName('Afficher la transcription');
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton transcription : ${element.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${element.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });
@@ -654,7 +650,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     module('when video is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         // given
@@ -685,11 +681,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName('Afficher la transcription');
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.slug}`,
-          'pix-event-name': `Click sur le bouton transcription : ${videoElement.id}`,
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${videoElement.id}`, {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
       });
@@ -720,19 +714,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
 
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       // when
       await clickByName(onStepperNextStepButtonName);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
-      });
+      sinon.assert.calledWithExactly(
+        metrics.trackEvent,
+        `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
+        {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
+        },
+      );
       assert.ok(true);
     });
   });
@@ -862,7 +858,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push an event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       const videoElement = {
@@ -895,11 +891,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });
@@ -907,7 +901,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     module('when video is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         // given
@@ -940,11 +934,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.slug}`,
-          'pix-event-name': `Click sur le bouton Play : ${videoElement.id}`,
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
       });
@@ -955,7 +947,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should push an event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       const downloadedFormat = '.pdf';
@@ -989,19 +981,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
       downloadLink.click();
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
-      });
+      sinon.assert.calledWithExactly(
+        metrics.trackEvent,
+        `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
+        {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
+        },
+      );
       assert.ok(true);
     });
 
     module('when download is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         // given
@@ -1035,12 +1029,14 @@ module('Integration | Component | Module | Passage', function (hooks) {
         link.click();
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.slug}`,
-          'pix-event-name': `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
-        });
+        sinon.assert.calledWithExactly(
+          metrics.trackEvent,
+          `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
+          {
+            category: 'Modulix',
+            action: `Passage du module : ${module.slug}`,
+          },
+        );
         assert.ok(true);
       });
     });
@@ -1055,7 +1051,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       this.owner.register('adapter:passage', PassageAdapterStub);
       const router = this.owner.lookup('service:router');
       router.transitionTo = sinon.stub();
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
       const store = this.owner.lookup('service:store');
       const passageEventsService = this.owner.lookup('service:passage-events');
@@ -1086,11 +1082,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.grain.terminate'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Click sur le bouton Terminer du grain : ${grain.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer du grain : ${grain.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
         type: 'PASSAGE_TERMINATED',
@@ -1123,7 +1117,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         grains: [grain],
       });
       const passage = store.createRecord('passage');
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       //  when
@@ -1133,11 +1127,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Ouverture de l'élément Expand : ${expandElement.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });
@@ -1168,7 +1160,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
           grains: [grain],
         });
         const passage = store.createRecord('passage');
-        const metrics = this.owner.lookup('service:metrics');
+        const metrics = this.owner.lookup('service:pix-metrics');
         metrics.trackEvent = sinon.stub();
 
         //  when
@@ -1178,11 +1170,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await click(expandSummarySelector);
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.slug}`,
-          'pix-event-name': `Ouverture de l'élément Expand : ${expandElement.id}`,
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
       });
@@ -1213,7 +1203,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         grains: [grain],
       });
       const passage = store.createRecord('passage');
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
 
       //  when
@@ -1226,11 +1216,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.slug}`,
-        'pix-event-name': `Fermeture de l'élément Expand : ${expandElement.id}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand : ${expandElement.id}`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -522,6 +522,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer de l'élément : ${element.id}`, {
         category: 'Modulix',
+        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -559,6 +560,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle : ${element.id}`, {
         category: 'Modulix',
+        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -602,6 +604,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
           `Click sur le bouton alternative textuelle : ${imageElement.id}`,
           {
             category: 'Modulix',
+            disabled: true,
             action: `Passage du module : ${module.slug}`,
           },
         );
@@ -642,6 +645,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${element.id}`, {
         category: 'Modulix',
+        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -683,6 +687,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${videoElement.id}`, {
           category: 'Modulix',
+          disabled: true,
           action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
@@ -726,6 +731,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
         {
           category: 'Modulix',
+          disabled: true,
           action: `Passage du module : ${module.slug}`,
         },
       );
@@ -893,6 +899,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
         category: 'Modulix',
+        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -936,6 +943,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
           category: 'Modulix',
+          disabled: true,
+
           action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
@@ -986,6 +995,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
         {
           category: 'Modulix',
+          disabled: true,
+
           action: `Passage du module : ${module.slug}`,
         },
       );
@@ -1034,6 +1045,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
           `Click sur le bouton Télécharger au format ${downloadedFormat} de ${downloadElement.id}`,
           {
             category: 'Modulix',
+            disabled: true,
+
             action: `Passage du module : ${module.slug}`,
           },
         );
@@ -1084,6 +1097,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer du grain : ${grain.id}`, {
         category: 'Modulix',
+        disabled: true,
+
         action: `Passage du module : ${module.slug}`,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
@@ -1129,6 +1144,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
         category: 'Modulix',
+        disabled: true,
+
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -1172,6 +1189,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
           category: 'Modulix',
+          disabled: true,
+
           action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
@@ -1218,6 +1237,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand : ${expandElement.id}`, {
         category: 'Modulix',
+        disabled: true,
+
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/module/video_test.gjs
+++ b/mon-pix/tests/unit/components/module/video_test.gjs
@@ -75,7 +75,7 @@ module('Unit | Component | Module | Video', function (hooks) {
       // given
       const video = { id: 'video-id' };
 
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = () => {};
 
       const component = createGlimmerComponent('module/element/video', {

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -190,7 +190,7 @@ module('Unit | Component | Training | card', function (hooks) {
   module('#trackAccess', function () {
     test('should push event on click', function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
       const trainingTitle = 'Mon super CF';
       const component = createGlimmerComponent('training/card', {
@@ -203,11 +203,9 @@ module('Unit | Component | Training | card', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Accès Contenu Formatif',
-        'pix-event-action': `Click depuis : ${currentRouteName}`,
-        'pix-event-name': `Ouvre le cf : ${trainingTitle}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf : ${trainingTitle}`, {
+        category: 'Accès Contenu Formatif',
+        action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -205,6 +205,7 @@ module('Unit | Component | Training | card', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf : ${trainingTitle}`, {
         category: 'Accès Contenu Formatif',
+        disabled: true,
         action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -224,6 +224,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel : ${tutorialTitle}`, {
         category: 'Accès tuto',
+        disabled: true,
         action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -209,7 +209,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
   module('#trackAccess', function () {
     test('should push event on click', function (assert) {
       // given
-      const metrics = this.owner.lookup('service:metrics');
+      const metrics = this.owner.lookup('service:pix-metrics');
       metrics.trackEvent = sinon.stub();
       const tutorialTitle = 'Mon super tutoriel';
       component = createGlimmerComponent('tutorials/card', {
@@ -222,11 +222,9 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Accès tuto',
-        'pix-event-action': `Click depuis : ${currentRouteName}`,
-        'pix-event-name': `Ouvre le tutoriel : ${tutorialTitle}`,
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel : ${tutorialTitle}`, {
+        category: 'Accès tuto',
+        action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/mon-pix/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -31,17 +31,17 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
     });
 
     this.adapter.trackEvent({
-      'pix-event-category': 'button',
-      'pix-event-action': 'click',
       eventName: 'nav buttons',
-      'pix-event-value': 4,
+      category: 'button',
+      action: 'click',
+      value: 4,
     });
     assert.ok(
       stub.calledWith('nav buttons', {
         props: {
-          'pix-event-category': 'button',
-          'pix-event-action': 'click',
-          'pix-event-value': 4,
+          category: 'button',
+          action: 'click',
+          value: 4,
         },
       }),
       'it sends the correct arguments',
@@ -54,19 +54,19 @@ module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
     });
 
     this.adapter.trackEvent({
-      'pix-event-category': 'button',
-      'pix-event-action': 'click',
       eventName: 'nav buttons',
-      'pix-event-value': 4,
+      category: 'button',
+      action: 'click',
+      value: 4,
       plausibleAttributes: { u: 'hello' },
     });
     assert.ok(
       stub.calledWith('nav buttons', {
         u: 'hello',
         props: {
-          'pix-event-category': 'button',
-          'pix-event-action': 'click',
-          'pix-event-value': 4,
+          category: 'button',
+          action: 'click',
+          value: 4,
         },
       }),
       'it sends the correct arguments',

--- a/mon-pix/tests/unit/services/pix-metrics-test.js
+++ b/mon-pix/tests/unit/services/pix-metrics-test.js
@@ -85,6 +85,34 @@ module('Unit | Service | PixMetrics', function (hooks) {
     });
   });
   module('trackEvent', function () {
+    test('it should not called mertricsService if disabled props to true', function (assert) {
+      // given
+      const currentURL = '/campagnes/SCOASSMUL/presentation';
+      const currentRoute = {
+        name: 'campaigns.campaign-landing-page',
+        params: {},
+        parent: {
+          name: 'campaigns',
+          params: {
+            id: 'SCOASSMUL',
+          },
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackEvent('mon-event', { params: 1, disabled: true });
+
+      // then
+      assert.ok(metricsService.trackEvent.notCalled);
+    });
+
     test('it should redact id from url', function (assert) {
       // given
       const currentURL = '/campagnes/SCOASSMUL/presentation';

--- a/mon-pix/tests/unit/services/pix-metrics-test.js
+++ b/mon-pix/tests/unit/services/pix-metrics-test.js
@@ -107,7 +107,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       sinon.stub(routerService, 'currentURL').value(currentURL);
 
       // when
-      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
@@ -141,7 +141,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       sinon.stub(routerService, 'currentURL').value(currentURL);
 
       // when
-      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {


### PR DESCRIPTION
## 🔆 Problème

Les évènements ne remontent pas correctement dans plausible car on a oublié d'utiliser le service pixMetrix pour ces derniers, lors de la migration vers plausible

## ⛱️ Proposition

Utiliser le bon service pour faire remonter les évènements

## 🌊 Remarques

On profite de la PR pour prendre en compte des retours fait lors de la mej et modifier la signature de trackEvent
```diff
- trackEvent({eventName, props})
+ trackEvent(eventName, {props})
```


## 🏄 Pour tester

- positionner les variables d'env pour activer le tracking sur la RA et la redéployer
- Se ballader sur mon-pix (modulix, campagne)
- Voir les évènement sur plausible
