### PR TITLE
[TECH] Nettoyage variables d’env matomo

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -11,12 +11,7 @@ function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue
   );
 }
 
-function _isFeatureEnabled(environmentVariable) {
-  return environmentVariable === 'true';
-}
-
 module.exports = function (environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'pix-admin',
     environment,
@@ -93,8 +88,6 @@ module.exports = function (environment) {
       includeFontAwesome: true,
     },
 
-    matomo: {},
-
     fontawesome: {
       warnIfNoIconsIncluded: true,
     },
@@ -126,10 +119,6 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.APP.TARGET_PROFILE_DASHBOARD_URL = 'https://exemple.net';
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-      ENV.matomo.debug = true;
-    }
   }
 
   if (environment === 'test') {
@@ -158,13 +147,6 @@ module.exports = function (environment) {
       enabled: true,
       usingProxy: false,
     };
-  }
-
-  if (environment === 'production') {
-    // here you can enable a production-specific feature
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-    }
   }
 
   return ENV;

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -12,14 +12,9 @@ function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue
   );
 }
 
-function _isFeatureEnabled(environmentVariable) {
-  return environmentVariable === 'true';
-}
-
 const ACTIVE_FEATURE_TOGGLES = [];
 
 module.exports = function (environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'pix-certif',
     environment,
@@ -105,19 +100,10 @@ module.exports = function (environment) {
       enabled: false,
     },
 
-    matomo: {},
-
     'ember-inputmask5': {
       defaults: { showMaskOnHover: false },
     },
   };
-
-  if (environment === 'development') {
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-      ENV.matomo.debug = true;
-    }
-  }
 
   if (environment === 'test') {
     // Testem prefers this...
@@ -138,12 +124,6 @@ module.exports = function (environment) {
       enabled: true,
       usingProxy: false,
     };
-  }
-
-  if (environment === 'production') {
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-    }
   }
 
   // Warn for unknown feature toggles

--- a/junior/app/routes/application.js
+++ b/junior/app/routes/application.js
@@ -3,7 +3,6 @@ import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service intl;
-  @service metrics;
 
   async beforeModel() {
     /*
@@ -17,6 +16,5 @@ export default class ApplicationRoute extends Route {
     Pour régler ce problème, il faut définir une locale ayant un fichier dans le dossier de traduction.
      */
     this.intl.setLocale('fr');
-    this.metrics.initialize();
   }
 }

--- a/junior/config/environment.js
+++ b/junior/config/environment.js
@@ -2,21 +2,12 @@
 
 require('dotenv').config({ quiet: true });
 
-function _isFeatureEnabled(environmentVariable) {
-  return environmentVariable === 'true';
-}
-
 module.exports = function (environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'junior',
     environment,
     locationType: 'history',
     rootURL: '/',
-    metrics: {
-      enabled: analyticsEnabled,
-      matomoUrl: process.env.WEB_ANALYTICS_URL,
-    },
     EmberENV: {
       EXTEND_PROTOTYPES: false,
       FEATURES: {
@@ -61,7 +52,6 @@ module.exports = function (environment) {
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
     ENV.APP.CHALLENGE_DISPLAY_DELAY = 0;
-    ENV.metrics.enabled = false;
 
     ENV['ember-cli-mirage'] = {
       enabled: true,

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/epreuves-components": "^0.7.0",
         "@1024pix/eslint-plugin": "^2.1.7",
@@ -79,15 +78,6 @@
       },
       "engines": {
         "node": "^22.17.0"
-      }
-    },
-    "node_modules/@1024pix/ember-matomo-tag-manager": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/ember-matomo-tag-manager/-/ember-matomo-tag-manager-2.4.3.tgz",
-      "integrity": "sha512-gsoFCZxMXO5purZh92WwgWyydRS/PftFr7+HRF9bRAHbPrqkd6NCmLEHvFZ9ETXKPB3SkF79Qh28SaljXTkb5g==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -45,7 +45,6 @@
     }
   },
   "devDependencies": {
-    "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/epreuves-components": "^0.7.0",
     "@1024pix/eslint-plugin": "^2.1.7",

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -133,11 +133,6 @@ module.exports = function (environment) {
       strikethrough: true,
     },
 
-    metrics: {
-      enabled: analyticsEnabled,
-      matomoUrl: process.env.WEB_ANALYTICS_URL,
-    },
-
     companion: {
       disabled: false,
     },
@@ -209,7 +204,6 @@ module.exports = function (environment) {
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
-    ENV.metrics.enabled = false;
 
     ENV.companion.disabled = true;
 

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -121,10 +121,6 @@ module.exports = function (environment) {
       enabled: false,
     },
 
-    metrics: {
-      enabled: analyticsEnabled,
-      matomoUrl: process.env.WEB_ANALYTICS_URL,
-    },
     metricsAdapters: [
       {
         name: 'PlausibleAdapter',
@@ -171,7 +167,6 @@ module.exports = function (environment) {
       autoClear: null,
       clearDuration: null,
     };
-    ENV.metrics.enabled = false;
     ENV.pagination.debounce = 0;
 
     ENV['ember-cli-mirage'] = {


### PR DESCRIPTION
## 🔆 Problème

Dans les fichiers environment.js des fronts, il reste des variables qui étaient utilisées par l’ancien système de metrics (matomo).

## ⛱️ Proposition

Supprimer les variables obsolètes.

## 🌊 Remarques

Le nouveau système de metrics (plausible), utilisent de nouvelles variables préfixées `ANALYTICS_`, mais il est aussi dépendant de l’ancienne variable `WEB_ANALYTICS_ENABLED`, il faudrait que celle-ci soit renommée en `ANALYTICS_ENABLED` pour plus de cohérence.

## 🏄 Pour tester

:shrug: 