### PR TITLE
[TECH] Isoler la logique des URL dans les fronts (PIX-18876)

### DIFF
--- a/admin/app/components/login-form.gjs
+++ b/admin/app/components/login-form.gjs
@@ -66,7 +66,7 @@ export default class LoginForm extends Component {
     switch (error?.code) {
       case 'USER_IS_TEMPORARY_BLOCKED':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
-          url: this.url.forgottenPasswordUrl,
+          url: this.url.pixAppForgottenPasswordUrl,
           htmlSafe: true,
         });
         break;

--- a/admin/app/services/url-base.js
+++ b/admin/app/services/url-base.js
@@ -1,0 +1,136 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import Service, { service } from '@ember/service';
+import ENV from 'pix-admin/config/environment';
+
+const { DEFAULT_LOCALE } = ENV.APP;
+
+// Don't use directly this service, use a url service which extends it
+export default class UrlBaseService extends Service {
+  @service currentDomain;
+  @service locale;
+
+  get homeUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `${ENV.rootURL}?lang=${currentLocale}`;
+  }
+
+  get serverStatusUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `https://status.pix.org/?locale=${currentLocale}`;
+  }
+
+  get pixAppUrl() {
+    if (!ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION) return ENV.rootURL;
+    const tld = this.currentDomain.getExtension();
+    return `${ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION}${tld}`;
+  }
+
+  get pixAppForgottenPasswordUrl() {
+    const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
+    const currentLocale = this.locale.currentLocale;
+    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+  }
+
+  getPixWebsiteUrl(pathname = '') {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const rootUrl = PIX_WEBSITE_ROOT_URLS[locale] || PIX_WEBSITE_ROOT_URLS[DEFAULT_LOCALE];
+    return pathname ? `${rootUrl}/${pathname}` : rootUrl;
+  }
+
+  getPixWebsiteUrlFor(pathKey) {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const pathsByLocale = PIX_WEBSITE_PATHS[pathKey] || {};
+    const pathname = pathsByLocale[locale] || pathsByLocale[DEFAULT_LOCALE];
+    return this.getPixWebsiteUrl(pathname);
+  }
+}
+
+// Pix website URLs for each supported locales
+export const PIX_WEBSITE_ROOT_URLS = {
+  'fr-FR': 'https://pix.fr',
+  'fr-BE': 'https://pix.org/fr-be',
+  'nl-BE': 'https://pix.org/nl-be',
+  nl: 'https://pix.org/nl-be',
+  en: 'https://pix.org/en',
+  es: 'https://pix.org/en',
+  fr: 'https://pix.org/fr',
+};
+
+// Pix website paths for each supported locales
+export const PIX_WEBSITE_PATHS = {
+  CGU: {
+    'fr-FR': 'conditions-generales-d-utilisation',
+    'fr-BE': 'conditions-generales-d-utilisation',
+    'nl-BE': 'algemene-gebruiksvoorwaarden',
+    nl: 'algemene-gebruiksvoorwaarden',
+    en: 'terms-and-conditions',
+    es: 'terms-and-conditions',
+    fr: 'conditions-generales-d-utilisation',
+  },
+  LEGAL_NOTICE: {
+    'fr-FR': 'mentions-legales',
+    'fr-BE': 'mentions-legales',
+    'nl-BE': 'wettelijke-vermeldingen',
+    nl: 'wettelijke-vermeldingen',
+    en: 'legal-notice',
+    es: 'legal-notice',
+    fr: 'mentions-legales',
+  },
+  DATA_PROTECTION_POLICY: {
+    'fr-FR': 'politique-protection-donnees-personnelles-app',
+    'fr-BE': 'politique-protection-donnees-personnelles-app',
+    'nl-BE': 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    en: 'personal-data-protection-policy',
+    es: 'personal-data-protection-policy',
+    fr: 'politique-protection-donnees-personnelles-app',
+  },
+  ACCESSIBILITY: {
+    'fr-FR': 'accessibilite',
+    'fr-BE': 'accessibilite',
+    'nl-BE': 'toegankelijkheid',
+    nl: 'toegankelijkheid',
+    en: 'accessibility',
+    es: 'accessibility',
+    fr: 'accessibilite',
+  },
+  ACCESSIBILITY_ORGA: {
+    'fr-FR': 'accessibilite-pix-orga',
+    'fr-BE': 'accessibilite-pix-orga',
+    'nl-BE': 'toegankelijkheid-pix-orga',
+    nl: 'toegankelijkheid-pix-orga',
+    en: 'accessibility-pix-orga',
+    es: 'accessibility-pix-orga',
+    fr: 'accessibilite-pix-orga',
+  },
+  ACCESSIBILITY_CERTIF: {
+    'fr-FR': 'accessibilite-pix-certif',
+    'fr-BE': 'accessibilite-pix-certif',
+    'nl-BE': 'toegankelijkheid-pix-certif',
+    nl: 'toegankelijkheid-pix-certif',
+    en: 'accessibility-pix-certif',
+    es: 'accessibility-pix-certif',
+    fr: 'accessibilite-pix-certif',
+  },
+  SUPPORT: {
+    'fr-FR': 'support',
+    'fr-BE': 'support',
+    'nl-BE': 'support',
+    nl: 'support',
+    en: 'support',
+    es: 'support',
+    fr: 'support',
+  },
+  CERTIFICATION_RESULTS_EXPLANATION: {
+    'fr-FR': 'certification-comprendre-score-niveau',
+    'fr-BE': 'certification-comprendre-score-niveau',
+    'nl-BE': 'mijn-certificeringsresultaten-begrijpen',
+    nl: 'mijn-certificeringsresultaten-begrijpen',
+    en: 'understand-certification-results',
+    es: 'understand-certification-results',
+    fr: 'certification-comprendre-score-niveau',
+  },
+};

--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -1,23 +1,3 @@
-import Service, { service } from '@ember/service';
-import ENV from 'pix-admin/config/environment';
+import UrlBaseService from './url-base.js';
 
-export default class Url extends Service {
-  @service currentDomain;
-  @service locale;
-
-  definedHomeUrl = ENV.rootURL;
-  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
-
-  get homeUrl() {
-    return this.definedHomeUrl;
-  }
-
-  get forgottenPasswordUrl() {
-    const currentLanguage = this.locale.currentLocale;
-    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (currentLanguage === 'en') {
-      url += '?lang=en';
-    }
-    return url;
-  }
-}
+export default class Url extends UrlBaseService {}

--- a/admin/tests/unit/services/url-base-test.js
+++ b/admin/tests/unit/services/url-base-test.js
@@ -1,0 +1,234 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import { setLocale } from 'ember-intl/test-support';
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-admin/config/environment';
+import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'pix-admin/services/url-base';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+const { SUPPORTED_LOCALES } = ENV.APP;
+
+module('Unit | Service | url-base', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('homeUrl', function () {
+    test('returns the application home url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.homeUrl;
+
+      // then
+      assert.strictEqual(homeUrl, '/?lang=en');
+    });
+  });
+
+  module('serverStatusUrl', function () {
+    test('returns the Pix server status url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+    });
+  });
+
+  module('pixAppUrl', function () {
+    test('returns the Pix app url for tld org', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.org');
+    });
+
+    test('returns the Pix app url for tld fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr');
+    });
+  });
+
+  module('pixAppForgottenPasswordUrl', function () {
+    test('returns the Pix app forgotten password url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
+    });
+
+    test('returns the Pix app forgotten password url for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      setLocale('en');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+    });
+  });
+
+  module('getPixWebsiteUrl', function () {
+    test('returns the Pix website url for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl();
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en');
+    });
+
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/this-is-my-document');
+    });
+  });
+
+  module('getPixWebsiteUrlFor', function () {
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/terms-and-conditions');
+    });
+
+    module('when the tld is fr', function () {
+      test('returns the Pix website url for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr');
+      });
+
+      test('returns the Pix website url and path for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr/conditions-generales-d-utilisation');
+      });
+    });
+
+    module('when locale is unknown', function () {
+      test('returns the Pix website url with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr');
+      });
+
+      test('returns the Pix website url and path with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
+      });
+    });
+  });
+
+  module('Checks Pix website URLs and Paths', function () {
+    SUPPORTED_LOCALES.forEach(function (locale) {
+      test(`checks PIX_WEBSITE_ROOT_URLS manage all supported locales for ${locale}`, function (assert) {
+        // given / when
+        const url = PIX_WEBSITE_ROOT_URLS[locale];
+
+        // then
+        assert.ok(url);
+      });
+    });
+
+    Object.keys(PIX_WEBSITE_PATHS).forEach(function (pathKey) {
+      SUPPORTED_LOCALES.forEach(function (locale) {
+        test(`checks PIX_WEBSITE_PATHS.${pathKey} manage all supported locales for ${locale}`, function (assert) {
+          // given / when
+          const path = PIX_WEBSITE_PATHS[pathKey][locale];
+
+          // then
+          assert.ok(path);
+        });
+      });
+    });
+  });
+});

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -149,7 +149,7 @@ export default class ToggableLoginForm extends Component {
   }
 
   get forgottenPasswordUrl() {
-    return this.url.forgottenPasswordUrl;
+    return this.url.pixAppForgottenPasswordUrl;
   }
 
   _handleResponseError(errorResponse) {

--- a/certif/app/components/login/index.gjs
+++ b/certif/app/components/login/index.gjs
@@ -18,10 +18,6 @@ export default class Login extends Component {
   @tracked isErrorMessagePresent = false;
   @tracked errorMessage = null;
 
-  get forgottenPasswordUrl() {
-    return this.url.forgottenPasswordUrl;
-  }
-
   @action
   setEmail(event) {
     this.email = event.target.value;
@@ -51,13 +47,13 @@ export default class Login extends Component {
     switch (error?.code) {
       case 'SHOULD_CHANGE_PASSWORD':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.SHOULD_CHANGE_PASSWORD.I18N_KEY, {
-          url: this.url.forgottenPasswordUrl,
+          url: this.url.pixAppForgottenPasswordUrl,
           htmlSafe: true,
         });
         break;
       case 'USER_IS_TEMPORARY_BLOCKED':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
-          url: this.url.forgottenPasswordUrl,
+          url: this.url.pixAppForgottenPasswordUrl,
           htmlSafe: true,
         });
         break;
@@ -105,7 +101,7 @@ export default class Login extends Component {
           @setPassword={{this.setPassword}}
           @isErrorMessagePresent={{this.isErrorMessagePresent}}
           @errorMessage={{this.errorMessage}}
-          @forgottenPasswordUrl={{this.forgottenPasswordUrl}}
+          @forgottenPasswordUrl={{this.url.pixAppForgottenPasswordUrl}}
         />
       </main>
     </div>

--- a/certif/app/services/url-base.js
+++ b/certif/app/services/url-base.js
@@ -1,0 +1,136 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import Service, { service } from '@ember/service';
+import ENV from 'pix-certif/config/environment';
+
+const { DEFAULT_LOCALE } = ENV.APP;
+
+// Don't use directly this service, use a url service which extends it
+export default class UrlBaseService extends Service {
+  @service currentDomain;
+  @service locale;
+
+  get homeUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `${ENV.rootURL}?lang=${currentLocale}`;
+  }
+
+  get serverStatusUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `https://status.pix.org/?locale=${currentLocale}`;
+  }
+
+  get pixAppUrl() {
+    if (!ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION) return ENV.rootURL;
+    const tld = this.currentDomain.getExtension();
+    return `${ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION}${tld}`;
+  }
+
+  get pixAppForgottenPasswordUrl() {
+    const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
+    const currentLocale = this.locale.currentLocale;
+    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+  }
+
+  getPixWebsiteUrl(pathname = '') {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const rootUrl = PIX_WEBSITE_ROOT_URLS[locale] || PIX_WEBSITE_ROOT_URLS[DEFAULT_LOCALE];
+    return pathname ? `${rootUrl}/${pathname}` : rootUrl;
+  }
+
+  getPixWebsiteUrlFor(pathKey) {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const pathsByLocale = PIX_WEBSITE_PATHS[pathKey] || {};
+    const pathname = pathsByLocale[locale] || pathsByLocale[DEFAULT_LOCALE];
+    return this.getPixWebsiteUrl(pathname);
+  }
+}
+
+// Pix website URLs for each supported locales
+export const PIX_WEBSITE_ROOT_URLS = {
+  'fr-FR': 'https://pix.fr',
+  'fr-BE': 'https://pix.org/fr-be',
+  'nl-BE': 'https://pix.org/nl-be',
+  nl: 'https://pix.org/nl-be',
+  en: 'https://pix.org/en',
+  es: 'https://pix.org/en',
+  fr: 'https://pix.org/fr',
+};
+
+// Pix website paths for each supported locales
+export const PIX_WEBSITE_PATHS = {
+  CGU: {
+    'fr-FR': 'conditions-generales-d-utilisation',
+    'fr-BE': 'conditions-generales-d-utilisation',
+    'nl-BE': 'algemene-gebruiksvoorwaarden',
+    nl: 'algemene-gebruiksvoorwaarden',
+    en: 'terms-and-conditions',
+    es: 'terms-and-conditions',
+    fr: 'conditions-generales-d-utilisation',
+  },
+  LEGAL_NOTICE: {
+    'fr-FR': 'mentions-legales',
+    'fr-BE': 'mentions-legales',
+    'nl-BE': 'wettelijke-vermeldingen',
+    nl: 'wettelijke-vermeldingen',
+    en: 'legal-notice',
+    es: 'legal-notice',
+    fr: 'mentions-legales',
+  },
+  DATA_PROTECTION_POLICY: {
+    'fr-FR': 'politique-protection-donnees-personnelles-app',
+    'fr-BE': 'politique-protection-donnees-personnelles-app',
+    'nl-BE': 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    en: 'personal-data-protection-policy',
+    es: 'personal-data-protection-policy',
+    fr: 'politique-protection-donnees-personnelles-app',
+  },
+  ACCESSIBILITY: {
+    'fr-FR': 'accessibilite',
+    'fr-BE': 'accessibilite',
+    'nl-BE': 'toegankelijkheid',
+    nl: 'toegankelijkheid',
+    en: 'accessibility',
+    es: 'accessibility',
+    fr: 'accessibilite',
+  },
+  ACCESSIBILITY_ORGA: {
+    'fr-FR': 'accessibilite-pix-orga',
+    'fr-BE': 'accessibilite-pix-orga',
+    'nl-BE': 'toegankelijkheid-pix-orga',
+    nl: 'toegankelijkheid-pix-orga',
+    en: 'accessibility-pix-orga',
+    es: 'accessibility-pix-orga',
+    fr: 'accessibilite-pix-orga',
+  },
+  ACCESSIBILITY_CERTIF: {
+    'fr-FR': 'accessibilite-pix-certif',
+    'fr-BE': 'accessibilite-pix-certif',
+    'nl-BE': 'toegankelijkheid-pix-certif',
+    nl: 'toegankelijkheid-pix-certif',
+    en: 'accessibility-pix-certif',
+    es: 'accessibility-pix-certif',
+    fr: 'accessibilite-pix-certif',
+  },
+  SUPPORT: {
+    'fr-FR': 'support',
+    'fr-BE': 'support',
+    'nl-BE': 'support',
+    nl: 'support',
+    en: 'support',
+    es: 'support',
+    fr: 'support',
+  },
+  CERTIFICATION_RESULTS_EXPLANATION: {
+    'fr-FR': 'certification-comprendre-score-niveau',
+    'fr-BE': 'certification-comprendre-score-niveau',
+    'nl-BE': 'mijn-certificeringsresultaten-begrijpen',
+    nl: 'mijn-certificeringsresultaten-begrijpen',
+    en: 'understand-certification-results',
+    es: 'understand-certification-results',
+    fr: 'certification-comprendre-score-niveau',
+  },
+};

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,58 +1,33 @@
-import Service, { service } from '@ember/service';
-import ENV from 'pix-certif/config/environment';
+import { service } from '@ember/service';
 
-export default class Url extends Service {
-  @service currentDomain;
+import UrlBaseService from './url-base.js';
+
+export default class Url extends UrlBaseService {
   @service intl;
   @service locale;
 
-  definedHomeUrl = ENV.rootURL;
-  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
-
-  get homeUrl() {
-    return this.definedHomeUrl;
-  }
-
   get cguUrl() {
-    if (this.#isEnglishSpoken()) return 'https://pix.org/en/terms-and-conditions';
-    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
-  }
-
-  get dataProtectionPolicyUrl() {
-    if (this.#isEnglishSpoken()) return 'https://pix.org/en/personal-data-protection-policy';
-    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
-  }
-
-  get forgottenPasswordUrl() {
-    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (this.#isEnglishSpoken()) {
-      url += '?lang=en';
-    }
-    return url;
+    return this.getPixWebsiteUrlFor('CGU');
   }
 
   get legalNoticeUrl() {
-    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/mentions-legales';
+    return this.getPixWebsiteUrlFor('LEGAL_NOTICE');
+  }
 
-    return this.#isFrenchSpoken() ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en/legal-notice';
+  get dataProtectionPolicyUrl() {
+    return this.getPixWebsiteUrlFor('DATA_PROTECTION_POLICY');
   }
 
   get accessibilityUrl() {
-    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/accessibilite-pix-certif';
-
-    return this.#isFrenchSpoken()
-      ? 'https://pix.org/fr/accessibilite-pix-certif'
-      : 'https://pix.org/en/accessibility-pix-certif';
+    return this.getPixWebsiteUrlFor('ACCESSIBILITY_CERTIF');
   }
 
   get supportUrl() {
-    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/support';
-
-    return this.#isFrenchSpoken() ? 'https://pix.org/fr/support' : 'https://pix.org/en/support';
+    return this.getPixWebsiteUrlFor('SUPPORT');
   }
 
   get joiningIssueSheetUrl() {
-    if (this.#isFrenchSpoken()) {
+    if (this.locale.currentLocale === 'fr') {
       return 'https://cloud.pix.fr/s/b8BFXX94Ys2WGxM/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
     }
 
@@ -60,7 +35,7 @@ export default class Url extends Service {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    if (this.#isFrenchSpoken()) {
+    if (this.locale.currentLocale === 'fr') {
       return 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download';
     }
 
@@ -81,13 +56,5 @@ export default class Url extends Service {
 
   get invigilatorDocumentationUrl() {
     return 'https://cloud.pix.fr/s/s4H9x4PD4eKokqX';
-  }
-
-  #isFrenchSpoken() {
-    return this.locale.currentLocale === 'fr';
-  }
-
-  #isEnglishSpoken() {
-    return this.locale.currentLocale === 'en';
   }
 }

--- a/certif/tests/integration/components/auth/register-form-test.js
+++ b/certif/tests/integration/components/auth/register-form-test.js
@@ -62,10 +62,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       .exists();
     assert
       .dom(screen.getByRole('link', { name: "conditions d'utilisation de Pix" }))
-      .hasAttribute('href', 'https://pix.fr/conditions-generales-d-utilisation');
+      .hasAttribute('href', 'https://pix.org/fr/conditions-generales-d-utilisation');
     assert
       .dom(screen.getByRole('link', { name: 'politique de confidentialité' }))
-      .hasAttribute('href', 'https://pix.fr/politique-protection-donnees-personnelles-app');
+      .hasAttribute('href', 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
   });
 
   module('errors management', function () {

--- a/certif/tests/unit/services/url-base-test.js
+++ b/certif/tests/unit/services/url-base-test.js
@@ -1,0 +1,234 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import { setLocale } from 'ember-intl/test-support';
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-certif/config/environment';
+import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'pix-certif/services/url-base';
+import setupIntl from 'pix-certif/tests/helpers/setup-intl';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+const { SUPPORTED_LOCALES } = ENV.APP;
+
+module('Unit | Service | url-base', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('homeUrl', function () {
+    test('returns the application home url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.homeUrl;
+
+      // then
+      assert.strictEqual(homeUrl, '/?lang=en');
+    });
+  });
+
+  module('serverStatusUrl', function () {
+    test('returns the Pix server status url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+    });
+  });
+
+  module('pixAppUrl', function () {
+    test('returns the Pix app url for tld org', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.org');
+    });
+
+    test('returns the Pix app url for tld fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr');
+    });
+  });
+
+  module('pixAppForgottenPasswordUrl', function () {
+    test('returns the Pix app forgotten password url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
+    });
+
+    test('returns the Pix app forgotten password url for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      setLocale('en');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+    });
+  });
+
+  module('getPixWebsiteUrl', function () {
+    test('returns the Pix website url for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl();
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en');
+    });
+
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/this-is-my-document');
+    });
+  });
+
+  module('getPixWebsiteUrlFor', function () {
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/terms-and-conditions');
+    });
+
+    module('when the tld is fr', function () {
+      test('returns the Pix website url for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr');
+      });
+
+      test('returns the Pix website url and path for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr/conditions-generales-d-utilisation');
+      });
+    });
+
+    module('when locale is unknown', function () {
+      test('returns the Pix website url with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr');
+      });
+
+      test('returns the Pix website url and path with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
+      });
+    });
+  });
+
+  module('Checks Pix website URLs and Paths', function () {
+    SUPPORTED_LOCALES.forEach(function (locale) {
+      test(`checks PIX_WEBSITE_ROOT_URLS manage all supported locales for ${locale}`, function (assert) {
+        // given / when
+        const url = PIX_WEBSITE_ROOT_URLS[locale];
+
+        // then
+        assert.ok(url);
+      });
+    });
+
+    Object.keys(PIX_WEBSITE_PATHS).forEach(function (pathKey) {
+      SUPPORTED_LOCALES.forEach(function (locale) {
+        test(`checks PIX_WEBSITE_PATHS.${pathKey} manage all supported locales for ${locale}`, function (assert) {
+          // given / when
+          const path = PIX_WEBSITE_PATHS[pathKey][locale];
+
+          // then
+          assert.ok(path);
+        });
+      });
+    });
+  });
+});

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -1,292 +1,135 @@
+import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntl from '../../helpers/setup-intl';
-
-const FRANCE_TLD = 'fr';
-const INTERNATIONAL_TLD = 'org';
 
 module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks, 'fr');
 
-  let localeService;
-
-  hooks.beforeEach(function () {
-    localeService = this.owner.lookup('service:locale');
-  });
-
-  module('#dataProtectionPolicyUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+  module('dataProtectionPolicyUrl', function () {
+    test('returns the Pix website data protection policy URL', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
       // then
-      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns the Pix website data protection policy URL for a locale', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedDataProtectionPolicyUrl = 'https://pix.org/en/personal-data-protection-policy';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setLocale('en');
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
       // then
-      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-    });
-
-    test('should get "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedDataProtectionPolicyUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('fr');
-
-      // when
-      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
-
-      // then
-      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/en/personal-data-protection-policy');
     });
   });
 
-  module('#cguUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+  module('cguUrl', function () {
+    test('returns the Pix website CGU URL', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
       const cguUrl = service.cguUrl;
 
       // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns the Pix website CGU URL for a locale', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en/terms-and-conditions';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setLocale('en');
 
       // when
       const cguUrl = service.cguUrl;
 
       // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
-
-    test('should get "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('fr');
-
-      // when
-      const cguUrl = service.cguUrl;
-
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, 'https://pix.org/en/terms-and-conditions');
     });
   });
 
-  module('#forgottenPasswordUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+  module('legalNoticeUrl', function () {
+    test('returns the Pix website legal notice URL', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedForgottenPasswordUrl = 'https://app.pix.fr/mot-de-passe-oublie';
-      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
-      const forgottenPasswordUrl = service.forgottenPasswordUrl;
+      const legalNoticeUrl = service.legalNoticeUrl;
 
       // then
-      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns the Pix website legal notice URL for a locale', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie?lang=en';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setLocale('en');
 
       // when
-      const forgottenPasswordUrl = service.forgottenPasswordUrl;
+      const legalNoticeUrl = service.legalNoticeUrl;
 
       // then
-      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
-    });
-
-    test('should get "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie';
-      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      sinon.stub(localeService, 'currentLocale').value('fr');
-
-      // when
-      const forgottenPasswordUrl = service.forgottenPasswordUrl;
-
-      // then
-      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/en/legal-notice');
     });
   });
 
-  module('#legalNoticeUrl', function () {
-    module('when current domain is fr', function () {
-      test('should return "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
+  module('accessibilityUrl', function () {
+    test('returns the Pix website accessibility URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const legalNoticeUrl = service.legalNoticeUrl;
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
 
-        // then
-        assert.strictEqual(legalNoticeUrl, 'https://pix.fr/mentions-legales');
-      });
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite-pix-certif');
     });
 
-    module('when current domain is org', function () {
-      module('when current language is en', function () {
-        test('should return "pix.org/en" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          sinon.stub(localeService, 'currentLocale').value('en');
+    test('returns the Pix website accessibility URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
 
-          // then
-          assert.strictEqual(legalNoticeUrl, 'https://pix.org/en/legal-notice');
-        });
-      });
-
-      module('when current language is fr', function () {
-        test('should return "pix.org/fr" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          sinon.stub(localeService, 'currentLocale').value('fr');
-
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
-        });
-      });
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/en/accessibility-pix-certif');
     });
   });
 
-  module('#accessibilityUrl', function () {
-    module('when current domain is fr', function () {
-      test('should return "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
+  module('supportUrl', function () {
+    test('returns the Pix website support URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        // when
-        const accessibilityUrl = service.accessibilityUrl;
+      // when
+      const supportUrl = service.supportUrl;
 
-        // then
-        assert.strictEqual(accessibilityUrl, 'https://pix.fr/accessibilite-pix-certif');
-      });
+      // then
+      assert.strictEqual(supportUrl, 'https://pix.org/fr/support');
     });
 
-    module('when current domain is org', function () {
-      module('when current language is en', function () {
-        test('should return "pix.org/en" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          sinon.stub(localeService, 'currentLocale').value('en');
+    test('returns the Pix website support URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
 
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
+      // when
+      const supportUrl = service.supportUrl;
 
-          // then
-          assert.strictEqual(accessibilityUrl, 'https://pix.org/en/accessibility-pix-certif');
-        });
-      });
-
-      module('when current language is fr', function () {
-        test('should return "pix.org/fr" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          sinon.stub(localeService, 'currentLocale').value('fr');
-
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite-pix-certif');
-        });
-      });
-    });
-  });
-
-  module('#supportUrl', function () {
-    module('when current domain is fr', function () {
-      test('should return "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
-
-        // when
-        const supportUrl = service.supportUrl;
-
-        // then
-        assert.strictEqual(supportUrl, 'https://pix.fr/support');
-      });
-    });
-
-    module('when current domain is org', function () {
-      module('when current language is en', function () {
-        test('should return "pix.org/en/support/home" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          sinon.stub(localeService, 'currentLocale').value('en');
-
-          // when
-          const supportUrl = service.supportUrl;
-
-          // then
-          assert.strictEqual(supportUrl, 'https://pix.org/en/support');
-        });
-      });
-
-      module('when current language is fr', function () {
-        test('should return "pix.org" url', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { primaryLocale: 'fr' };
-
-          // when
-          const supportUrl = service.supportUrl;
-
-          // then
-          assert.strictEqual(supportUrl, 'https://pix.org/fr/support');
-        });
-      });
+      // then
+      assert.strictEqual(supportUrl, 'https://pix.org/en/support');
     });
   });
 

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -28,10 +28,6 @@ export default class UrlBaseService extends Service {
     return `${ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION}${tld}`;
   }
 
-  get pixAppCampaignRootUrl() {
-    return `${this.pixAppUrl}/campagne`;
-  }
-
   get pixAppForgottenPasswordUrl() {
     const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
     const currentLocale = this.locale.currentLocale;
@@ -109,6 +105,15 @@ export const PIX_WEBSITE_PATHS = {
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
+  },
+  ACCESSIBILITY_CERTIF: {
+    'fr-FR': 'accessibilite-pix-certif',
+    'fr-BE': 'accessibilite-pix-certif',
+    'nl-BE': 'toegankelijkheid-pix-certif',
+    nl: 'toegankelijkheid-pix-certif',
+    en: 'accessibility-pix-certif',
+    es: 'accessibility-pix-certif',
+    fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
     'fr-FR': 'support',

--- a/mon-pix/tests/unit/services/url-base-test.js
+++ b/mon-pix/tests/unit/services/url-base-test.js
@@ -76,23 +76,6 @@ module('Unit | Service | url-base', function (hooks) {
     });
   });
 
-  module('pixAppCampaignRootUrl', function () {
-    test('returns the Pix app campaign root url', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url-base');
-      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
-
-      const domainService = this.owner.lookup('service:current-domain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
-
-      // when
-      const homeUrl = service.pixAppCampaignRootUrl;
-
-      // then
-      assert.strictEqual(homeUrl, 'https://app.pix.fr/campagne');
-    });
-  });
-
   module('pixAppForgottenPasswordUrl', function () {
     test('returns the Pix app forgotten password url', function (assert) {
       // given
@@ -200,7 +183,8 @@ module('Unit | Service | url-base', function (hooks) {
       test('returns the Pix website url with the default locale', function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
-        setLocale('xxx');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor();
@@ -212,7 +196,8 @@ module('Unit | Service | url-base', function (hooks) {
       test('returns the Pix website url and path with the default locale', function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
-        setLocale('xxx');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor('CGU');

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -36,10 +36,6 @@ export default class LoginForm extends Component {
     return !this.args.isWithInvitation;
   }
 
-  get forgottenPasswordUrl() {
-    return this.url.forgottenPasswordUrl;
-  }
-
   @action
   async authenticate(event) {
     event.preventDefault();
@@ -146,13 +142,13 @@ export default class LoginForm extends Component {
     switch (error?.code) {
       case 'SHOULD_CHANGE_PASSWORD':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.SHOULD_CHANGE_PASSWORD.I18N_KEY, {
-          url: this.url.forgottenPasswordUrl,
+          url: this.url.pixAppForgottenPasswordUrl,
           htmlSafe: true,
         });
         break;
       case 'USER_IS_TEMPORARY_BLOCKED':
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
-          url: this.url.forgottenPasswordUrl,
+          url: this.url.pixAppForgottenPasswordUrl,
           htmlSafe: true,
         });
         break;
@@ -245,7 +241,7 @@ export default class LoginForm extends Component {
         </PixButton>
 
         <div class="login-form__forgotten-password">
-          <a href="{{this.forgottenPasswordUrl}}" target="_blank" rel="noopener noreferrer">
+          <a href="{{this.url.pixAppForgottenPasswordUrl}}" target="_blank" rel="noopener noreferrer">
             {{t "pages.login-form.forgot-password"}}
           </a>
         </div>

--- a/orga/app/services/url-base.js
+++ b/orga/app/services/url-base.js
@@ -1,0 +1,136 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import Service, { service } from '@ember/service';
+import ENV from 'pix-orga/config/environment';
+
+const { DEFAULT_LOCALE } = ENV.APP;
+
+// Don't use directly this service, use a url service which extends it
+export default class UrlBaseService extends Service {
+  @service currentDomain;
+  @service locale;
+
+  get homeUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `${ENV.rootURL}?lang=${currentLocale}`;
+  }
+
+  get serverStatusUrl() {
+    const currentLocale = this.locale.currentLocale;
+    return `https://status.pix.org/?locale=${currentLocale}`;
+  }
+
+  get pixAppUrl() {
+    if (!ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION) return ENV.rootURL;
+    const tld = this.currentDomain.getExtension();
+    return `${ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION}${tld}`;
+  }
+
+  get pixAppForgottenPasswordUrl() {
+    const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
+    const currentLocale = this.locale.currentLocale;
+    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+  }
+
+  getPixWebsiteUrl(pathname = '') {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const rootUrl = PIX_WEBSITE_ROOT_URLS[locale] || PIX_WEBSITE_ROOT_URLS[DEFAULT_LOCALE];
+    return pathname ? `${rootUrl}/${pathname}` : rootUrl;
+  }
+
+  getPixWebsiteUrlFor(pathKey) {
+    const locale = this.currentDomain.isFranceDomain ? 'fr-FR' : this.locale.currentLocale;
+    const pathsByLocale = PIX_WEBSITE_PATHS[pathKey] || {};
+    const pathname = pathsByLocale[locale] || pathsByLocale[DEFAULT_LOCALE];
+    return this.getPixWebsiteUrl(pathname);
+  }
+}
+
+// Pix website URLs for each supported locales
+export const PIX_WEBSITE_ROOT_URLS = {
+  'fr-FR': 'https://pix.fr',
+  'fr-BE': 'https://pix.org/fr-be',
+  'nl-BE': 'https://pix.org/nl-be',
+  nl: 'https://pix.org/nl-be',
+  en: 'https://pix.org/en',
+  es: 'https://pix.org/en',
+  fr: 'https://pix.org/fr',
+};
+
+// Pix website paths for each supported locales
+export const PIX_WEBSITE_PATHS = {
+  CGU: {
+    'fr-FR': 'conditions-generales-d-utilisation',
+    'fr-BE': 'conditions-generales-d-utilisation',
+    'nl-BE': 'algemene-gebruiksvoorwaarden',
+    nl: 'algemene-gebruiksvoorwaarden',
+    en: 'terms-and-conditions',
+    es: 'terms-and-conditions',
+    fr: 'conditions-generales-d-utilisation',
+  },
+  LEGAL_NOTICE: {
+    'fr-FR': 'mentions-legales',
+    'fr-BE': 'mentions-legales',
+    'nl-BE': 'wettelijke-vermeldingen',
+    nl: 'wettelijke-vermeldingen',
+    en: 'legal-notice',
+    es: 'legal-notice',
+    fr: 'mentions-legales',
+  },
+  DATA_PROTECTION_POLICY: {
+    'fr-FR': 'politique-protection-donnees-personnelles-app',
+    'fr-BE': 'politique-protection-donnees-personnelles-app',
+    'nl-BE': 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
+    en: 'personal-data-protection-policy',
+    es: 'personal-data-protection-policy',
+    fr: 'politique-protection-donnees-personnelles-app',
+  },
+  ACCESSIBILITY: {
+    'fr-FR': 'accessibilite',
+    'fr-BE': 'accessibilite',
+    'nl-BE': 'toegankelijkheid',
+    nl: 'toegankelijkheid',
+    en: 'accessibility',
+    es: 'accessibility',
+    fr: 'accessibilite',
+  },
+  ACCESSIBILITY_ORGA: {
+    'fr-FR': 'accessibilite-pix-orga',
+    'fr-BE': 'accessibilite-pix-orga',
+    'nl-BE': 'toegankelijkheid-pix-orga',
+    nl: 'toegankelijkheid-pix-orga',
+    en: 'accessibility-pix-orga',
+    es: 'accessibility-pix-orga',
+    fr: 'accessibilite-pix-orga',
+  },
+  ACCESSIBILITY_CERTIF: {
+    'fr-FR': 'accessibilite-pix-certif',
+    'fr-BE': 'accessibilite-pix-certif',
+    'nl-BE': 'toegankelijkheid-pix-certif',
+    nl: 'toegankelijkheid-pix-certif',
+    en: 'accessibility-pix-certif',
+    es: 'accessibility-pix-certif',
+    fr: 'accessibilite-pix-certif',
+  },
+  SUPPORT: {
+    'fr-FR': 'support',
+    'fr-BE': 'support',
+    'nl-BE': 'support',
+    nl: 'support',
+    en: 'support',
+    es: 'support',
+    fr: 'support',
+  },
+  CERTIFICATION_RESULTS_EXPLANATION: {
+    'fr-FR': 'certification-comprendre-score-niveau',
+    'fr-BE': 'certification-comprendre-score-niveau',
+    'nl-BE': 'mijn-certificeringsresultaten-begrijpen',
+    nl: 'mijn-certificeringsresultaten-begrijpen',
+    en: 'understand-certification-results',
+    es: 'understand-certification-results',
+    fr: 'certification-comprendre-score-niveau',
+  },
+};

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -1,134 +1,41 @@
-import Service, { service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
-import { ENGLISH_INTERNATIONAL_LOCALE } from './locale.js';
+import UrlBaseService from './url-base.js';
 
-const FRENCH_LOCALE = 'fr';
-const PIX_FR_DOMAIN = 'https://pix.fr';
-const PIX_STATUS_DOMAIN = 'https://status.pix.org';
-
-export default class Url extends Service {
+export default class Url extends UrlBaseService {
   @service currentDomain;
   @service currentUser;
-  @service locale;
-
-  SHOWCASE_WEBSITE_LOCALE_PATH = {
-    ACCESSIBILITY: {
-      en: '/accessibility-pix-orga',
-      fr: '/accessibilite-pix-orga',
-      nl: '/toegankelijkheid-pix-orga',
-    },
-    CGU: {
-      en: '/terms-and-conditions',
-      fr: '/conditions-generales-d-utilisation',
-      nl: '/algemene-gebruiksvoorwaarden',
-    },
-    DATA_PROTECTION_POLICY: {
-      en: '/personal-data-protection-policy',
-      fr: '/politique-protection-donnees-personnelles-app',
-      nl: '/beleid-inzake-de-bescherming-van-persoonsgegevens',
-    },
-    LEGAL_NOTICE: {
-      en: '/legal-notice',
-      fr: '/mentions-legales',
-      nl: '/wettelijke-vermeldingen',
-    },
-  };
-
-  definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
-  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
-
-  definedHomeUrl = ENV.rootURL;
-
-  getLegalDocumentUrl(path) {
-    return `${this._getPixWebsiteUrl()}/${path}`;
-  }
-
-  get campaignsRootUrl() {
-    return this.definedCampaignsRootUrl
-      ? this.definedCampaignsRootUrl
-      : `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/campagnes/`;
-  }
-
-  get homeUrl() {
-    return `${this.definedHomeUrl}?lang=${this._getCurrentLanguage()}`;
-  }
 
   get legalNoticeUrl() {
-    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE;
-    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
+    return this.getPixWebsiteUrlFor('LEGAL_NOTICE');
   }
 
   get cguUrl() {
-    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU;
-    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
+    return this.getPixWebsiteUrlFor('CGU');
   }
 
   get dataProtectionPolicyUrl() {
-    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY;
-    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
+    return this.getPixWebsiteUrlFor('DATA_PROTECTION_POLICY');
   }
 
   get accessibilityUrl() {
-    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
-    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
+    return this.getPixWebsiteUrlFor('ACCESSIBILITY_ORGA');
   }
 
-  get serverStatusUrl() {
-    return `${PIX_STATUS_DOMAIN}?locale=${this._getCurrentLanguage()}`;
-  }
-
-  get forgottenPasswordUrl() {
-    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (this._getCurrentLanguage() !== FRENCH_LOCALE) {
-      url += `?lang=${this._getCurrentLanguage()}`;
-    }
-
-    return url;
-  }
-
-  _getCurrentLanguage() {
-    return this.locale.currentLocale;
+  get campaignsRootUrl() {
+    if (ENV.APP.CAMPAIGNS_ROOT_URL) return ENV.APP.CAMPAIGNS_ROOT_URL;
+    return `${this.pixAppUrl}/campagnes/`;
   }
 
   get pixJuniorSchoolUrl() {
     const schoolCode = this.currentUser.organization.schoolCode;
-    if (!schoolCode) {
-      return '';
-    }
+    if (!schoolCode) return '';
 
     return `${this.currentDomain.getJuniorBaseUrl()}/schools/${schoolCode}`;
   }
 
-  _getPixWebsiteUrl() {
-    if (this.currentDomain.isFranceDomain) {
-      return PIX_FR_DOMAIN;
-    }
-    const currentLocale = this.locale.currentLocale;
-    let locale;
-    if (currentLocale == 'nl') {
-      locale = 'nl-BE';
-    } else if (this.locale.isSupportedLocale(currentLocale)) {
-      locale = currentLocale;
-    } else {
-      locale = ENGLISH_INTERNATIONAL_LOCALE;
-    }
-
-    return `https://pix.org/${locale}`;
-  }
-
-  _computeShowcaseWebsiteUrl(translations) {
-    const websiteUrl = this._getPixWebsiteUrl();
-
-    if (this.currentDomain.isFranceDomain) {
-      return `${websiteUrl}${translations.fr}`;
-    }
-
-    const currentLanguage = this._getCurrentLanguage();
-    if (this.locale.pixLanguages.includes(currentLanguage)) {
-      return `${websiteUrl}${translations[currentLanguage]}`;
-    }
-
-    return 'https://pix.org/fr/mentions-legales';
+  getLegalDocumentUrl(path) {
+    return this.getPixWebsiteUrl(path);
   }
 }

--- a/orga/tests/unit/services/url-base-test.js
+++ b/orga/tests/unit/services/url-base-test.js
@@ -1,0 +1,234 @@
+// This file is a COPY of an original file from mon-pix.
+// If you need a change, modify the original file and
+// propagate the changes in the copies in all the fronts.
+
+import { setLocale } from 'ember-intl/test-support';
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-orga/config/environment';
+import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'pix-orga/services/url-base';
+import setupIntl from 'pix-orga/tests/helpers/setup-intl';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+const { SUPPORTED_LOCALES } = ENV.APP;
+
+module('Unit | Service | url-base', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('homeUrl', function () {
+    test('returns the application home url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.homeUrl;
+
+      // then
+      assert.strictEqual(homeUrl, '/?lang=en');
+    });
+  });
+
+  module('serverStatusUrl', function () {
+    test('returns the Pix server status url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+    });
+  });
+
+  module('pixAppUrl', function () {
+    test('returns the Pix app url for tld org', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.org');
+    });
+
+    test('returns the Pix app url for tld fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr');
+    });
+  });
+
+  module('pixAppForgottenPasswordUrl', function () {
+    test('returns the Pix app forgotten password url', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
+    });
+
+    test('returns the Pix app forgotten password url for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
+
+      const domainService = this.owner.lookup('service:current-domain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      setLocale('en');
+
+      // when
+      const homeUrl = service.pixAppForgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+    });
+  });
+
+  module('getPixWebsiteUrl', function () {
+    test('returns the Pix website url for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl();
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en');
+    });
+
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/this-is-my-document');
+    });
+  });
+
+  module('getPixWebsiteUrlFor', function () {
+    test('returns the Pix website url and path for the current locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url-base');
+      setLocale('en');
+
+      // when
+      const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+      // then
+      assert.strictEqual(homeUrl, 'https://pix.org/en/terms-and-conditions');
+    });
+
+    module('when the tld is fr', function () {
+      test('returns the Pix website url for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr');
+      });
+
+      test('returns the Pix website url and path for the tld fr', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const domainService = this.owner.lookup('service:current-domain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+        setLocale('en');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.fr/conditions-generales-d-utilisation');
+      });
+    });
+
+    module('when locale is unknown', function () {
+      test('returns the Pix website url with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor();
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr');
+      });
+
+      test('returns the Pix website url and path with the default locale', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url-base');
+        const localeService = this.owner.lookup('service:locale');
+        sinon.stub(localeService, 'currentLocale').value('xxx');
+
+        // when
+        const homeUrl = service.getPixWebsiteUrlFor('CGU');
+
+        // then
+        assert.strictEqual(homeUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
+      });
+    });
+  });
+
+  module('Checks Pix website URLs and Paths', function () {
+    SUPPORTED_LOCALES.forEach(function (locale) {
+      test(`checks PIX_WEBSITE_ROOT_URLS manage all supported locales for ${locale}`, function (assert) {
+        // given / when
+        const url = PIX_WEBSITE_ROOT_URLS[locale];
+
+        // then
+        assert.ok(url);
+      });
+    });
+
+    Object.keys(PIX_WEBSITE_PATHS).forEach(function (pathKey) {
+      SUPPORTED_LOCALES.forEach(function (locale) {
+        test(`checks PIX_WEBSITE_PATHS.${pathKey} manage all supported locales for ${locale}`, function (assert) {
+          // given / when
+          const path = PIX_WEBSITE_PATHS[pathKey][locale];
+
+          // then
+          assert.ok(path);
+        });
+      });
+    });
+  });
+});

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -1,6 +1,6 @@
-import Service from '@ember/service';
 import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
+import ENV from 'pix-orga/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -10,327 +10,134 @@ module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
+  module('legalNoticeUrl', function () {
+    test('returns the Pix website legal notice URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const legalNoticeUrl = service.legalNoticeUrl;
+
+      // then
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
+    });
+
+    test('returns the Pix website legal notice URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
+
+      // when
+      const legalNoticeUrl = service.legalNoticeUrl;
+
+      // then
+      assert.strictEqual(legalNoticeUrl, 'https://pix.org/en/legal-notice');
+    });
+  });
+
+  module('cguUrl', function () {
+    test('returns the Pix website CGU URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
+    });
+
+    test('returns the Pix website CGU URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, 'https://pix.org/en/terms-and-conditions');
+    });
+  });
+
+  module('dataProtectionPolicyUrl', function () {
+    test('returns the Pix website data protection policy URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
+    });
+
+    test('returns the Pix website data protection policy URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
+
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/en/personal-data-protection-policy');
+    });
+  });
+
+  module('accessibilityUrl', function () {
+    test('returns the Pix website accessibility URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
+
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite-pix-orga');
+    });
+
+    test('returns the Pix website accessibility URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
+
+      // when
+      const accessibilityUrl = service.accessibilityUrl;
+
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/en/accessibility-pix-orga');
+    });
+  });
+
   module('#campaignsRootUrl', function () {
     test('returns default campaigns root url when is defined', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      service.definedCampaignsRootUrl = 'pix.test.fr';
+      sinon.stub(ENV, 'APP').value({ CAMPAIGNS_ROOT_URL: 'https://app.test.pix.fr/campagnes/' });
 
       // when
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
-      assert.strictEqual(campaignsRootUrl, service.definedCampaignsRootUrl);
+      assert.strictEqual(campaignsRootUrl, 'https://app.test.pix.fr/campagnes/');
     });
 
-    test('returns "pix.test" url when current domain contains pix.test', function (assert) {
+    test('returns campaigns root url for current pix-app environement', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCampaignsRootUrl = 'https://app.pix.test/campagnes/';
-      service.definedCampaignsRootUrl = undefined;
-      service.currentDomain = { getExtension: sinon.stub().returns('test') };
+      sinon
+        .stub(ENV, 'APP')
+        .value({ CAMPAIGNS_ROOT_URL: null, PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.test.pix.' });
+
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('org');
 
       // when
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
-      assert.strictEqual(campaignsRootUrl, expectedCampaignsRootUrl);
-    });
-  });
-
-  module('#homeUrl', function () {
-    test('returns home url with current locale', function (assert) {
-      // given
-      const currentLocale = 'en';
-      setLocale([currentLocale, 'fr']);
-
-      const service = this.owner.lookup('service:url');
-      const expectedHomeUrl = `${service.definedHomeUrl}?lang=${currentLocale}`;
-
-      // when
-      const homeUrl = service.homeUrl;
-
-      // then
-      assert.strictEqual(homeUrl, expectedHomeUrl);
-    });
-  });
-
-  module('#legalNoticeUrl', function () {
-    module('when domain is pix.fr', function () {
-      test('returns "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedUrl = 'https://pix.fr/mentions-legales';
-        service.currentDomain = { isFranceDomain: true };
-        service.locale = { currentLocale: 'fr' };
-
-        // when
-        const url = service.legalNoticeUrl;
-
-        // then
-        assert.strictEqual(url, expectedUrl);
-      });
-    });
-
-    module('when domain is pix.org', function () {
-      [
-        {
-          currentLocale: 'en',
-          expectedUrl: 'https://pix.org/en/legal-notice',
-        },
-        {
-          currentLocale: 'fr',
-          expectedUrl: 'https://pix.org/fr/mentions-legales',
-        },
-        {
-          currentLocale: 'nl',
-          expectedUrl: 'https://pix.org/nl-BE/wettelijke-vermeldingen',
-        },
-      ].forEach(({ currentLocale, expectedUrl }) => {
-        test(`returns "pix.org" ${currentLocale} url when locale is ${currentLocale}`, function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          sinon.stub(service.locale, 'currentLocale').value(currentLocale);
-
-          service.currentDomain = { isFranceDomain: false };
-
-          // when
-          const url = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(url, expectedUrl);
-        });
-      });
-    });
-  });
-
-  module('#forgottenPasswordUrl', function () {
-    [
-      {
-        locale: 'en',
-        currentDomain: 'org',
-        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie?lang=en',
-      },
-      {
-        locale: 'fr',
-        currentDomain: 'fr',
-        expectedUrl: 'https://app.pix.fr/mot-de-passe-oublie',
-      },
-      {
-        locale: 'fr',
-        currentDomain: 'org',
-        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie',
-      },
-      {
-        locale: 'nl',
-        currentDomain: 'org',
-        expectedUrl: 'https://app.pix.org/mot-de-passe-oublie?lang=nl',
-      },
-    ].forEach(({ locale, expectedUrl, currentDomain }) => {
-      test(`returns forgotten password url when locale is ${locale} and domain is ${currentDomain}`, function (assert) {
-        // given
-        const urlService = this.owner.lookup('service:url');
-        class CurrentDomainServiceStub extends Service {
-          getExtension() {
-            return currentDomain;
-          }
-        }
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
-        sinon.stub(urlService.locale, 'currentLocale').value(locale);
-
-        // when
-        const url = urlService.forgottenPasswordUrl;
-
-        // then
-        assert.strictEqual(url, expectedUrl);
-      });
-    });
-  });
-
-  module('#dataProtectionPolicyUrl', function () {
-    module('when domain is pix.fr', function () {
-      test('returns "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-        service.currentDomain = { isFranceDomain: true };
-
-        sinon.stub(service.locale, 'currentLocale').value('fr');
-
-        // when
-        const cguUrl = service.dataProtectionPolicyUrl;
-
-        // then
-        assert.strictEqual(cguUrl, expectedUrl);
-      });
-    });
-
-    module('when domain is pix.org', function () {
-      [
-        {
-          currentLocale: 'en',
-          expectedUrl: 'https://pix.org/en/personal-data-protection-policy',
-        },
-        {
-          currentLocale: 'fr',
-          expectedUrl: 'https://pix.org/fr/politique-protection-donnees-personnelles-app',
-        },
-        {
-          currentLocale: 'nl',
-          expectedUrl: 'https://pix.org/nl-BE/beleid-inzake-de-bescherming-van-persoonsgegevens',
-        },
-      ].forEach(({ currentLocale, expectedUrl }) => {
-        test(`returns "pix.org" ${currentLocale} url when locale is ${currentLocale}`, function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          sinon.stub(service.locale, 'currentLocale').value(currentLocale);
-
-          // when
-          const url = service.dataProtectionPolicyUrl;
-
-          // then
-          assert.strictEqual(url, expectedUrl);
-        });
-      });
-    });
-  });
-
-  module('#cguUrl', function () {
-    module('when domain is pix.fr', function () {
-      test('returns "pix.fr" url', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-        service.currentDomain = { isFranceDomain: true };
-        sinon.stub(service.locale, 'currentLocale').value('fr');
-
-        // when
-        const url = service.cguUrl;
-
-        // then
-        assert.strictEqual(url, expectedUrl);
-      });
-    });
-
-    module('when domain is pix.org', function () {
-      [
-        {
-          currentLocale: 'en',
-          expectedUrl: 'https://pix.org/en/terms-and-conditions',
-        },
-        {
-          currentLocale: 'fr',
-          expectedUrl: 'https://pix.org/fr/conditions-generales-d-utilisation',
-        },
-        {
-          currentLocale: 'nl',
-          expectedUrl: 'https://pix.org/nl-BE/algemene-gebruiksvoorwaarden',
-        },
-      ].forEach(({ currentLocale, expectedUrl }) => {
-        test(`returns "pix.org" ${currentLocale} url when locale is ${currentLocale}`, function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          sinon.stub(service.locale, 'currentLocale').value(currentLocale);
-
-          // when
-          const url = service.cguUrl;
-
-          // then
-          assert.strictEqual(url, expectedUrl);
-        });
-      });
-    });
-  });
-
-  module('#accessibilityUrl', function () {
-    module('when domain is pix.fr', function () {
-      test('returns "pix.fr"', function (assert) {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
-        service.currentDomain = { isFranceDomain: true };
-        sinon.stub(service.locale, 'currentLocale').value('fr');
-
-        // when
-        const url = service.accessibilityUrl;
-
-        // then
-        assert.strictEqual(url, expectedUrl);
-      });
-    });
-
-    module('when domain is pix.org', function () {
-      [
-        {
-          currentLocale: 'en',
-          expectedUrl: 'https://pix.org/en/accessibility-pix-orga',
-        },
-        {
-          currentLocale: 'fr',
-          expectedUrl: 'https://pix.org/fr/accessibilite-pix-orga',
-        },
-        {
-          currentLocale: 'nl',
-          expectedUrl: 'https://pix.org/nl-BE/toegankelijkheid-pix-orga',
-        },
-      ].forEach(({ currentLocale, expectedUrl }) => {
-        test(`returns "pix.org" ${currentLocale} url when locale is ${currentLocale}`, function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: false };
-          sinon.stub(service.locale, 'currentLocale').value(currentLocale);
-
-          // when
-          const url = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(url, expectedUrl);
-        });
-      });
-    });
-  });
-
-  module('#serverStatusUrl', function () {
-    test('returns "status.pix.org" in english when current language is en', function (assert) {
-      // given
-      const expectedUrl = 'https://status.pix.org?locale=en';
-      const service = this.owner.lookup('service:url');
-      sinon.stub(service.locale, 'currentLocale').value('en');
-
-      // when
-      const serverStatusUrl = service.serverStatusUrl;
-
-      // then
-      assert.strictEqual(serverStatusUrl, expectedUrl);
-    });
-
-    test('returns "status.pix.org" in french when current language is fr', function (assert) {
-      // given
-      const expectedUrl = 'https://status.pix.org?locale=fr';
-      const service = this.owner.lookup('service:url');
-      sinon.stub(service.locale, 'currentLocale').value('fr');
-
-      // when
-      const serverStatusUrl = service.serverStatusUrl;
-
-      // then
-      assert.strictEqual(serverStatusUrl, expectedUrl);
-    });
-
-    test('returns "status.pix.org" in french when current language is nl', function (assert) {
-      // given
-      const expectedUrl = 'https://status.pix.org?locale=nl';
-      const service = this.owner.lookup('service:url');
-      sinon.stub(service.locale, 'currentLocale').value('nl');
-
-      // when
-      const serverStatusUrl = service.serverStatusUrl;
-
-      // then
-      assert.strictEqual(serverStatusUrl, expectedUrl);
+      assert.strictEqual(campaignsRootUrl, 'https://app.test.pix.org/campagnes/');
     });
   });
 
@@ -357,44 +164,27 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#getLegalDocumentUrl', function () {
-    [
-      {
-        locale: 'en',
-        currentDomain: 'org',
-        expectedUrl: 'https://pix.org/en/my-custom-path',
-      },
-      {
-        locale: 'fr',
-        currentDomain: 'fr',
-        expectedUrl: 'https://pix.fr/my-custom-path',
-      },
-      {
-        locale: 'fr',
-        currentDomain: 'org',
-        expectedUrl: 'https://pix.org/fr/my-custom-path',
-      },
-      {
-        locale: 'nl',
-        currentDomain: 'org',
-        expectedUrl: 'https://pix.org/nl-BE/my-custom-path',
-      },
-    ].forEach(({ locale, expectedUrl, currentDomain }) => {
-      test(`returns legal document URL when locale is ${locale} and domain is ${currentDomain}`, function (assert) {
-        // given
-        const urlService = this.owner.lookup('service:url');
-        sinon.stub(urlService.locale, 'currentLocale').value(locale);
+    test('returns the Pix legal document URL', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
 
-        class CurrentDomainServiceStub extends Service {
-          isFranceDomain = currentDomain === 'fr';
-        }
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      // when
+      const accessibilityUrl = service.getLegalDocumentUrl('my-legal-document-path');
 
-        // when
-        const url = urlService.getLegalDocumentUrl('my-custom-path');
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/my-legal-document-path');
+    });
 
-        // then
-        assert.strictEqual(url, expectedUrl);
-      });
+    test('returns the Pix legal document URL for a locale', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      setLocale('en');
+
+      // when
+      const accessibilityUrl = service.getLegalDocumentUrl('my-legal-document-path');
+
+      // then
+      assert.strictEqual(accessibilityUrl, 'https://pix.org/en/my-legal-document-path');
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Dans les fronts, la logique de gestion des URL est différentes entre toutes les applications notamment sur les URL de Pix site qui ont toujours la même logique.

## ⛱️ Proposition

Appliquer le service `url-base` (de mon-pix), qui sera hérité dans chaque application par le service `url`. (PixAdmin, PixCertif, PixOrga)

## 🌊 Remarques

N/A

## 🏄 Pour tester

**Pix Admin:**
- Pas d'utilisation d'url spécifique

**Pix Orga (fr, org + language switcher):**
- Vérifier les URL du footer.
- Tester l'URL de mot de passe oublié
- Tester l'URL des CGUs quand on doit les accepter
- Tester l'URL des campagnes dans la page d'une campagne

**Pix Certif (fr, org + language switcher):**
- Vérifier les URL du footer.
- Tester l'URL de mot de passe oublié