### PR TITLE
[FEATURE] Suppression de l'éligibilité en dehors de CleA (PIX-18853).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
+++ b/api/src/certification/enrolment/domain/usecases/get-user-certification-eligibility.js
@@ -1,9 +1,7 @@
 /**
  * @typedef {import ('./index.js').ComplementaryCertificationBadgeWithOffsetVersionRepository} ComplementaryCertificationBadgeWithOffsetVersionRepository
  */
-import _ from 'lodash';
 
-import { AssessmentResult } from '../../../../shared/domain/models/index.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { CertificationEligibility, UserCertificationEligibility } from '../read-models/UserCertificationEligibility.js';
 
@@ -17,57 +15,43 @@ const getUserCertificationEligibility = async function ({
   placementProfileService,
   certificationBadgesService,
   complementaryCertificationCourseRepository,
-  pixCertificationRepository,
   complementaryCertificationBadgeWithOffsetVersionRepository,
 }) {
   const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate });
   const isCertifiable = placementProfile.isCertifiable();
 
+  if (!isCertifiable) {
+    return new UserCertificationEligibility({
+      id: userId,
+      isCertifiable,
+      certificationEligibilities: [],
+    });
+  }
+
   const userAcquiredBadges = await certificationBadgesService.findLatestBadgeAcquisitions({
     userId,
     limitDate,
   });
-  const complementaryCertificationCourseWithResultsAcquiredByUser =
-    await complementaryCertificationCourseRepository.findByUserId({
-      userId,
-    });
 
-  const validatedUserPixCertifications = await _getValidatedUserPixCertifications({
-    userId,
-    pixCertificationRepository,
-  });
+  const [doubleCertificationBadge] = userAcquiredBadges.filter(
+    (acquiredBadge) => acquiredBadge.complementaryCertificationKey === ComplementaryCertificationKeys.CLEA,
+  );
 
   const certificationEligibilities = [];
-  for (const acquiredBadge of userAcquiredBadges) {
+
+  if (doubleCertificationBadge) {
     const allComplementaryCertificationBadgesForSameTargetProfile =
       await complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile({
-        complementaryCertificationBadgeId: acquiredBadge.complementaryCertificationBadgeId,
+        complementaryCertificationBadgeId: doubleCertificationBadge.complementaryCertificationBadgeId,
       });
     const acquiredComplementaryCertificationBadge = allComplementaryCertificationBadgesForSameTargetProfile.find(
-      ({ id }) => id === acquiredBadge.complementaryCertificationBadgeId,
-    );
-    let areEligibilityConditionsFulfilledForCurrentLevel = false;
-    let areEligibilityConditionsFulfilledForLowerLevel = false;
-    const isClea = acquiredBadge.complementaryCertificationKey === ComplementaryCertificationKeys.CLEA;
-
-    const lowerLevelAcquiredBadgeWithOffsetVersion = _getLowerLevelBadge(
-      allComplementaryCertificationBadgesForSameTargetProfile,
-      acquiredBadge,
+      ({ id }) => id === doubleCertificationBadge.complementaryCertificationBadgeId,
     );
 
-    if (isClea) {
-      areEligibilityConditionsFulfilledForCurrentLevel = isCertifiable;
-    } else if (validatedUserPixCertifications.length !== 0) {
-      areEligibilityConditionsFulfilledForCurrentLevel = _checkComplementaryEligibilityConditions({
-        validatedUserPixCertifications,
-        complementaryCertificationBadge: acquiredComplementaryCertificationBadge,
+    const complementaryCertificationCourseWithResultsAcquiredByUser =
+      await complementaryCertificationCourseRepository.findByUserId({
+        userId,
       });
-
-      areEligibilityConditionsFulfilledForLowerLevel = _checkComplementaryEligibilityConditions({
-        validatedUserPixCertifications,
-        complementaryCertificationBadge: lowerLevelAcquiredBadgeWithOffsetVersion,
-      });
-    }
 
     const isAcquiredExpectedLevel = _hasAcquiredComplementaryCertificationForExpectedLevel(
       complementaryCertificationCourseWithResultsAcquiredByUser,
@@ -78,32 +62,16 @@ const getUserCertificationEligibility = async function ({
     const badgeIsNotOutdated = acquiredComplementaryCertificationBadge?.offsetVersion === 0;
 
     if (
-      _isEligibleForCurrentLevel({
+      _isEligible({
         badgeIsNotOutdated,
         badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt,
-        areEligibilityConditionsFulfilledForCurrentLevel,
       })
     ) {
       certificationEligibilities.push(
         new CertificationEligibility({
-          label: acquiredBadge.complementaryCertificationBadgeLabel,
-          imageUrl: acquiredBadge.complementaryCertificationBadgeImageUrl,
-          isOutdated: acquiredBadge.isOutdated,
-          isAcquiredExpectedLevel,
-        }),
-      );
-    } else if (
-      _isEligibleForLowerLevel({
-        badgeIsNotOutdated,
-        badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt,
-        areEligibilityConditionsFulfilledForLowerLevel,
-      })
-    ) {
-      certificationEligibilities.push(
-        new CertificationEligibility({
-          label: lowerLevelAcquiredBadgeWithOffsetVersion.label,
-          imageUrl: lowerLevelAcquiredBadgeWithOffsetVersion.imageUrl,
-          isOutdated: lowerLevelAcquiredBadgeWithOffsetVersion.isOutdated,
+          label: doubleCertificationBadge.complementaryCertificationBadgeLabel,
+          imageUrl: doubleCertificationBadge.complementaryCertificationBadgeImageUrl,
+          isOutdated: doubleCertificationBadge.isOutdated,
           isAcquiredExpectedLevel,
         }),
       );
@@ -117,37 +85,8 @@ const getUserCertificationEligibility = async function ({
   });
 };
 
-function _isEligibleForLowerLevel({
-  badgeIsNotOutdated,
-  badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt,
-  areEligibilityConditionsFulfilledForLowerLevel,
-}) {
-  return (
-    (badgeIsNotOutdated || badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt) &&
-    areEligibilityConditionsFulfilledForLowerLevel
-  );
-}
-
-function _isEligibleForCurrentLevel({
-  badgeIsNotOutdated,
-  badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt,
-  areEligibilityConditionsFulfilledForCurrentLevel,
-}) {
-  return (
-    (badgeIsNotOutdated || badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt) &&
-    areEligibilityConditionsFulfilledForCurrentLevel
-  );
-}
-
-function _checkComplementaryEligibilityConditions({ validatedUserPixCertifications, complementaryCertificationBadge }) {
-  if (!complementaryCertificationBadge) {
-    return false;
-  }
-
-  const requiredScore = complementaryCertificationBadge.requiredPixScore;
-
-  const highestObtainedScore = _.maxBy(validatedUserPixCertifications, 'pixScore').pixScore;
-  return highestObtainedScore >= requiredScore;
+function _isEligible({ badgeIsNotOutdated, badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt }) {
+  return badgeIsNotOutdated || badgeIsOutdatedByOneVersionAndUserHasNoComplementaryCertificationForIt;
 }
 
 function _hasAcquiredComplementaryCertificationForExpectedLevel(
@@ -158,26 +97,6 @@ function _hasAcquiredComplementaryCertificationForExpectedLevel(
     (certificationTakenByUser) =>
       certificationTakenByUser.isAcquiredExpectedLevelByPixSource() &&
       acquiredComplementaryCertificationBadge?.id === certificationTakenByUser.complementaryCertificationBadgeId,
-  );
-}
-
-function _getLowerLevelBadge(allComplementaryCertificationBadgesForSameTargetProfile, acquiredBadge) {
-  return _.chain(allComplementaryCertificationBadgesForSameTargetProfile)
-    .sortBy('level')
-    .filter((badge) => badge.id != acquiredBadge.complementaryCertificationBadgeId)
-    .maxBy('level')
-    .value();
-}
-
-async function _getValidatedUserPixCertifications({ userId, pixCertificationRepository }) {
-  const userPixCertifications = await pixCertificationRepository.findByUserId({ userId });
-
-  // isCancelled will be removed
-  return userPixCertifications.filter(
-    (pixCertification) =>
-      !pixCertification.isCancelled &&
-      !pixCertification.isRejectedForFraud &&
-      pixCertification.status === AssessmentResult.status.VALIDATED,
   );
 }
 

--- a/api/tests/certification/enrolment/acceptance/application/user-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/user-route_test.js
@@ -1,3 +1,4 @@
+import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { AssessmentResult } from '../../../../../src/shared/domain/models/index.js';
 import {
   createServer,
@@ -183,7 +184,7 @@ describe('Certification | Enrolment | Acceptance | Routes | User', function () {
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     const cleaBadgeId = databaseBuilder.factory.buildBadge({
-      key: 'PARTNER_KEY',
+      key: ComplementaryCertificationKeys.CLEA,
       isCertifiable: true,
       targetProfileId,
       imageUrl: 'http://my-badge-image-url.com',
@@ -216,6 +217,7 @@ describe('Certification | Enrolment | Acceptance | Routes | User', function () {
 
     const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
       name: 'PARTNER_CERTIFICATION',
+      key: ComplementaryCertificationKeys.CLEA,
     }).id;
 
     databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -88,1350 +88,95 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
   context('eligibility', function () {
     const complementaryCertificationBadgeId = 123;
 
-    context('when user has a badge acquisition', function () {
-      context('when user has the required pix score', function () {
-        it('returns that user is eligible for current level', async function () {
-          // given
-          placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-            domainBuilder.buildPlacementProfile.buildCertifiable({
-              profileDate: limitDate,
-              userId,
-            }),
-          );
+    context('when user has acquired a non double certification badge', function () {
+      it('should not be added in the eligibilities of the model', async function () {
+        const complementaryCertificationKey = 'NOT_DOUBLE_CERTIFICATION';
+        const isCertifiable = true;
 
-          const complementaryBadgeAcquired = domainBuilder.buildCertifiableBadgeAcquisition();
-          certificationBadgesService.findLatestBadgeAcquisitions
-            .withArgs({
-              userId,
-              limitDate,
-            })
-            .resolves([complementaryBadgeAcquired]);
+        placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
+          domainBuilder.buildPlacementProfile.buildCertifiable({
+            profileDate: limitDate,
+            userId,
+          }),
+        );
 
-          complementaryCertificationCourseRepository.findByUserId.resolves([]);
-
-          const pixCertificationRequiredScore = 300;
-          pixCertificationRepository.findByUserId
-            .withArgs({
-              userId,
-            })
-            .resolves([
-              domainBuilder.certification.enrolment.buildPixCertification({
-                pixScore: pixCertificationRequiredScore,
-                status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
-                isRejectedForFraud: false,
-              }),
-            ]);
-
-          const complementaryBadgeWithOffset =
-            domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-              id: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-              requiredPixScore: pixCertificationRequiredScore,
-              level: 1,
-              offsetVersion: 0,
-            });
-          complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile
-            .withArgs({
-              complementaryCertificationBadgeId: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-            })
-            .resolves([complementaryBadgeWithOffset]);
-
-          // when
-          const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-          // then
-          expect(userCertificationEligibility).to.deep.equal(
-            domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-              id: userId,
-              isCertifiable: true,
-              certificationEligibilities: [
-                domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                  label: complementaryBadgeAcquired.complementaryCertificationBadgeLabel,
-                  imageUrl: complementaryBadgeAcquired.complementaryCertificationBadgeImageUrl,
-                  isAcquiredExpectedLevel: false,
-                  isOutdated: complementaryBadgeAcquired.isOutdated,
-                }),
-              ],
-            }),
-          );
-        });
-      });
-
-      context('when user has not the required pix score', function () {
-        it('returns that user is not eligible for current level', async function () {
-          // given
-          placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-            domainBuilder.buildPlacementProfile.buildCertifiable({
-              profileDate: limitDate,
-              userId,
-            }),
-          );
-
-          const complementaryBadgeAcquired = domainBuilder.buildCertifiableBadgeAcquisition();
-          certificationBadgesService.findLatestBadgeAcquisitions
-            .withArgs({
-              userId,
-              limitDate,
-            })
-            .resolves([complementaryBadgeAcquired]);
-
-          complementaryCertificationCourseRepository.findByUserId.resolves([]);
-
-          const pixCertificationRequiredScore = 300;
-          pixCertificationRepository.findByUserId
-            .withArgs({
-              userId,
-            })
-            .resolves([
-              domainBuilder.certification.enrolment.buildPixCertification({
-                pixScore: pixCertificationRequiredScore - 1,
-                status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
-                isRejectedForFraud: false,
-              }),
-            ]);
-
-          const complementaryBadgeWithOffset =
-            domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-              id: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-              requiredPixScore: pixCertificationRequiredScore,
-              level: 1,
-              offsetVersion: 0,
-            });
-          complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile
-            .withArgs({
-              complementaryCertificationBadgeId: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-            })
-            .resolves([complementaryBadgeWithOffset]);
-
-          // when
-          const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-          // then
-          expect(userCertificationEligibility).to.deep.equal(
-            domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-              id: userId,
-              isCertifiable: true,
-              certificationEligibilities: [],
-            }),
-          );
-        });
-      });
-
-      context('when there is a lower level', function () {
-        context('when the user has not the required pix score for the lower level', function () {
-          it('returns that user is not eligible for lower level', async function () {
-            // given
-            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-              domainBuilder.buildPlacementProfile.buildCertifiable({
-                profileDate: limitDate,
-                userId,
-              }),
-            );
-
-            const complementaryBadgeAcquired = domainBuilder.buildCertifiableBadgeAcquisition();
-            certificationBadgesService.findLatestBadgeAcquisitions
-              .withArgs({
-                userId,
-                limitDate,
-              })
-              .resolves([complementaryBadgeAcquired]);
-
-            complementaryCertificationCourseRepository.findByUserId.resolves([]);
-
-            const pixCertificationRequiredScore = 300;
-            pixCertificationRepository.findByUserId
-              .withArgs({
-                userId,
-              })
-              .resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: pixCertificationRequiredScore / 2 - 1,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-
-            const complementaryBadgesWithOffset = [
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: 999,
-                requiredPixScore: pixCertificationRequiredScore / 2,
-                level: 1,
-                offsetVersion: 0,
-              }),
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-                requiredPixScore: pixCertificationRequiredScore,
-                level: 2,
-                offsetVersion: 0,
-              }),
-            ];
-            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile
-              .withArgs({
-                complementaryCertificationBadgeId: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-              })
-              .resolves(complementaryBadgesWithOffset);
-
-            // when
-            const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-            // then
-            expect(userCertificationEligibility).to.deep.equal(
-              domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                id: userId,
-                isCertifiable: true,
-                certificationEligibilities: [],
-              }),
-            );
-          });
-        });
-
-        context('when the user has the required pix score for the lower level', function () {
-          it('returns that user is eligible for lower level', async function () {
-            // given
-            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-              domainBuilder.buildPlacementProfile.buildCertifiable({
-                profileDate: limitDate,
-                userId,
-              }),
-            );
-
-            const complementaryBadgeAcquired = domainBuilder.buildCertifiableBadgeAcquisition();
-            const lowerLevelComplementaryBadgeAcquired = domainBuilder.buildCertifiableBadgeAcquisition({
-              badgeId: 999,
-              complementaryCertificationId: complementaryBadgeAcquired.complementaryCertificationId,
-              complementaryCertificationKey: complementaryBadgeAcquired.complementaryCertificationKey,
-              complementaryCertificationBadgeImageUrl: 'pix+.toto.initié.fr',
-              complementaryCertificationBadgeLabel: 'Pix+ Toto Initié',
+        certificationBadgesService.findLatestBadgeAcquisitions
+          .withArgs({
+            userId,
+            limitDate,
+          })
+          .resolves([
+            domainBuilder.buildCertifiableBadgeAcquisition({
+              complementaryCertificationBadgeId,
+              complementaryCertificationKey,
+              complementaryCertificationBadgeImageUrl: 'monImageUrl',
+              complementaryCertificationBadgeLabel: 'monLabel',
               isOutdated: false,
-            });
-            certificationBadgesService.findLatestBadgeAcquisitions
-              .withArgs({
-                userId,
-                limitDate,
-              })
-              .resolves([complementaryBadgeAcquired]);
+            }),
+          ]);
 
-            complementaryCertificationCourseRepository.findByUserId.resolves([]);
+        const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
 
-            const pixCertificationRequiredScore = 300;
-            pixCertificationRepository.findByUserId
-              .withArgs({
-                userId,
-              })
-              .resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: pixCertificationRequiredScore / 2 + 1,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-
-            const complementaryBadgesWithOffset = [
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: 999,
-                requiredPixScore: pixCertificationRequiredScore / 2,
-                level: 1,
-                offsetVersion: 0,
-                label: 'Pix+ Toto Initié',
-                imageUrl: 'pix+.toto.initié.fr',
-                isOutdated: false,
-              }),
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-                requiredPixScore: pixCertificationRequiredScore,
-                level: 2,
-                offsetVersion: 0,
-                label: 'Pix+ Toto Avancé',
-                imageUrl: 'pix+.toto.avancé.fr',
-                isOutdated: false,
-              }),
-            ];
-            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile
-              .withArgs({
-                complementaryCertificationBadgeId: complementaryBadgeAcquired.complementaryCertificationBadgeId,
-              })
-              .resolves(complementaryBadgesWithOffset);
-
-            // when
-            const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-            // then
-            expect(userCertificationEligibility).to.deep.equal(
-              domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                id: userId,
-                isCertifiable: true,
-                certificationEligibilities: [
-                  domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                    label: lowerLevelComplementaryBadgeAcquired.complementaryCertificationBadgeLabel,
-                    imageUrl: lowerLevelComplementaryBadgeAcquired.complementaryCertificationBadgeImageUrl,
-                    isAcquiredExpectedLevel: false,
-                    isOutdated: lowerLevelComplementaryBadgeAcquired.isOutdated,
-                  }),
-                ],
-              }),
-            );
-          });
-        });
+        expect(userCertificationEligibility).to.deep.equal(
+          domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+            id: userId,
+            isCertifiable,
+            certificationEligibilities: [],
+          }),
+        );
       });
     });
 
-    context('when user has acquired a badge', function () {
+    context('when user has acquired a double certification badge', function () {
       let complementaryCertificationKey;
       const requiredPixScore = 150;
 
-      context('CLEA', function () {
-        beforeEach(function () {
-          complementaryCertificationKey = ComplementaryCertificationKeys.CLEA;
-        });
-
-        context('when acquired badge is outdated', function () {
-          const isOutdated = true;
-
-          beforeEach(function () {
-            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: '1234',
-                requiredPixScore,
-                offsetVersion: 0,
-              }),
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: complementaryCertificationBadgeId,
-                requiredPixScore,
-                offsetVersion: 1,
-              }),
-            ]);
-
-            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-              domainBuilder.certification.enrolment.buildPixCertification({
-                pixScore: requiredPixScore,
-                status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
-                isRejectedForFraud: false,
-              }),
-            ]);
-          });
-
-          context('when user is certifiable', function () {
-            const isCertifiable = true;
-
-            beforeEach(function () {
-              placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-                domainBuilder.buildPlacementProfile.buildCertifiable({
-                  profileDate: limitDate,
-                  userId,
-                }),
-              );
-            });
-
-            context('when user has an acquired certification for this badge', function () {
-              it('should not be added in the eligibilities of the model', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              context('when badge is outdated by more than one version', function () {
-                beforeEach(function () {
-                  complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
-                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                      id: '1234',
-                      requiredPixScore,
-                      offsetVersion: 0,
-                    }),
-                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                      id: '5678',
-                      requiredPixScore,
-                      offsetVersion: 1,
-                    }),
-                    domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                      id: complementaryCertificationBadgeId,
-                      requiredPixScore,
-                      offsetVersion: 2,
-                    }),
-                  ]);
-                });
-
-                it('should not be added in the eligibilities of the model', async function () {
-                  // given
-                  certificationBadgesService.findLatestBadgeAcquisitions
-                    .withArgs({
-                      userId,
-                      limitDate,
-                    })
-                    .resolves([
-                      domainBuilder.buildCertifiableBadgeAcquisition({
-                        complementaryCertificationBadgeId,
-                        complementaryCertificationKey,
-                        complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                        complementaryCertificationBadgeLabel: 'monLabel',
-                        isOutdated,
-                      }),
-                    ]);
-
-                  // when
-                  const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                  // then
-                  expect(userCertificationEligibility).to.deep.equal(
-                    domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                      id: userId,
-                      isCertifiable,
-                      certificationEligibilities: [],
-                    }),
-                  );
-                });
-              });
-
-              context('when badge is outdated by exactly one version', function () {
-                const offsetVersion = 1;
-
-                it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
-                  // given
-                  certificationBadgesService.findLatestBadgeAcquisitions
-                    .withArgs({
-                      userId,
-                      limitDate,
-                    })
-                    .resolves([
-                      domainBuilder.buildCertifiableBadgeAcquisition({
-                        complementaryCertificationBadgeId,
-                        complementaryCertificationKey,
-                        complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                        complementaryCertificationBadgeLabel: 'monLabel',
-                        isOutdated,
-                        offsetVersion,
-                      }),
-                    ]);
-
-                  // when
-                  const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                  // then
-                  expect(userCertificationEligibility).to.deep.equal(
-                    domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                      id: userId,
-                      isCertifiable,
-                      certificationEligibilities: [
-                        domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                          label: 'monLabel',
-                          imageUrl: 'monImageUrl',
-                          isAcquiredExpectedLevel: false,
-                          isOutdated: true,
-                        }),
-                      ],
-                    }),
-                  );
-                });
-              });
-            });
-          });
-
-          context('when user is not certifiable', function () {
-            const isCertifiable = false;
-
-            beforeEach(function () {
-              placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-                domainBuilder.buildPlacementProfile({
-                  profileDate: limitDate,
-                  userId,
-                  userCompetences: [domainBuilder.buildUserCompetence({ estimatedLevel: 1, pixScore: 1 })],
-                }),
-              );
-            });
-
-            context('when user has an acquired certification for this badge', function () {
-              it('should not be added in the eligibilities of the model', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated: true,
-                      offsetVersion: 1,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              context('when badge is outdated by more than one version', function () {
-                const offsetVersion = 2;
-
-                it('should not be added in the eligibilities of the model', async function () {
-                  // given
-                  certificationBadgesService.findLatestBadgeAcquisitions
-                    .withArgs({
-                      userId,
-                      limitDate,
-                    })
-                    .resolves([
-                      domainBuilder.buildCertifiableBadgeAcquisition({
-                        complementaryCertificationBadgeId,
-                        complementaryCertificationKey,
-                        complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                        complementaryCertificationBadgeLabel: 'monLabel',
-                        isOutdated,
-                        offsetVersion,
-                      }),
-                    ]);
-
-                  // when
-                  const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                  // then
-                  expect(userCertificationEligibility).to.deep.equal(
-                    domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                      id: userId,
-                      isCertifiable,
-                      certificationEligibilities: [],
-                    }),
-                  );
-                });
-              });
-
-              context('when badge is outdated by exactly one version', function () {
-                const offsetVersion = 1;
-
-                it('should not be added in the eligibilities of the model', async function () {
-                  // given
-                  certificationBadgesService.findLatestBadgeAcquisitions
-                    .withArgs({
-                      userId,
-                      limitDate,
-                    })
-                    .resolves([
-                      domainBuilder.buildCertifiableBadgeAcquisition({
-                        complementaryCertificationBadgeId,
-                        complementaryCertificationKey,
-                        complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                        complementaryCertificationBadgeLabel: 'monLabel',
-                        isOutdated,
-                        offsetVersion,
-                      }),
-                    ]);
-
-                  // when
-                  const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                  // then
-                  expect(userCertificationEligibility).to.deep.equal(
-                    domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                      id: userId,
-                      isCertifiable,
-                      certificationEligibilities: [],
-                    }),
-                  );
-                });
-              });
-            });
-          });
-        });
-
-        context('when acquired badge is not outdated', function () {
-          const isOutdated = false;
-
-          beforeEach(function () {
-            complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
-              domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                id: complementaryCertificationBadgeId,
-                requiredPixScore,
-                offsetVersion: 0,
-              }),
-            ]);
-          });
-
-          context('when user is certifiable', function () {
-            const isCertifiable = true;
-
-            beforeEach(function () {
-              placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-                domainBuilder.buildPlacementProfile.buildCertifiable({
-                  profileDate: limitDate,
-                  userId,
-                }),
-              );
-
-              pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: requiredPixScore,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-            });
-
-            context('when user has an acquired certification for this badge', function () {
-              it('returns a UserCertificationEligibility model with the corresponding eligibility', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [
-                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                        label: 'monLabel',
-                        imageUrl: 'monImageUrl',
-                        isAcquiredExpectedLevel: true,
-                        isOutdated,
-                      }),
-                    ],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              it('returns a UserCertificationEligibility model with the corresponding eligibility', async function () {
-                // given
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [
-                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                        label: 'monLabel',
-                        imageUrl: 'monImageUrl',
-                        isAcquiredExpectedLevel: false,
-                        isOutdated,
-                      }),
-                    ],
-                  }),
-                );
-              });
-            });
-          });
-
-          context('when user is not certifiable', function () {
-            const isCertifiable = false;
-
-            beforeEach(function () {
-              placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-                domainBuilder.buildPlacementProfile({
-                  profileDate: limitDate,
-                  userId,
-                  userCompetences: [domainBuilder.buildUserCompetence({ estimatedLevel: 1, pixScore: 1 })],
-                }),
-              );
-
-              pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: requiredPixScore,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-            });
-
-            context('when user has an acquired certification for this badge', function () {
-              it('should not be added in the eligibilities of the model', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              it('should not be added in the eligibilities of the model', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [],
-                  }),
-                );
-              });
-            });
-          });
-        });
+      beforeEach(function () {
+        complementaryCertificationKey = ComplementaryCertificationKeys.CLEA;
       });
 
-      context('not CLEA', function () {
-        const isCertifiable = true;
+      context('when acquired badge is outdated', function () {
+        const isOutdated = true;
 
         beforeEach(function () {
-          placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
-            domainBuilder.buildPlacementProfile.buildCertifiable({
-              profileDate: limitDate,
-              userId,
-            }),
-          );
-          complementaryCertificationKey = 'NOT CLEA';
           complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
+            domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+              id: '1234',
+              requiredPixScore,
+              offsetVersion: 0,
+            }),
             domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
               id: complementaryCertificationBadgeId,
               requiredPixScore,
-              offsetVersion: 0,
+              offsetVersion: 1,
+            }),
+          ]);
+
+          pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
+            domainBuilder.certification.enrolment.buildPixCertification({
+              pixScore: requiredPixScore,
+              status: AssessmentResult.status.VALIDATED,
+              isCancelled: false,
+              isRejectedForFraud: false,
             }),
           ]);
         });
 
-        context('when user has no pix certification', function () {
-          const isOutdated = false;
+        context('when user is certifiable', function () {
+          const isCertifiable = true;
 
           beforeEach(function () {
-            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([]);
-          });
-
-          it('should not be added in the eligibilities of the model', async function () {
-            complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-            certificationBadgesService.findLatestBadgeAcquisitions
-              .withArgs({
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
+              domainBuilder.buildPlacementProfile.buildCertifiable({
+                profileDate: limitDate,
                 userId,
-                limitDate,
-              })
-              .resolves([
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationBadgeId,
-                  complementaryCertificationKey,
-                  complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                  complementaryCertificationBadgeLabel: 'monLabel',
-                  isOutdated,
-                }),
-              ]);
-
-            const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-            expect(userCertificationEligibility).to.deep.equal(
-              domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                id: userId,
-                isCertifiable,
-                certificationEligibilities: [],
               }),
             );
           });
-        });
 
-        context(
-          'when user has a validated certification that is not cancelled not rejected and without the required pixscore',
-          function () {
-            const isOutdated = false;
-
-            beforeEach(function () {
-              pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: requiredPixScore - 1,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-            });
-
-            it('should not be added in the eligibilities of the model', async function () {
-              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              certificationBadgesService.findLatestBadgeAcquisitions
-                .withArgs({
-                  userId,
-                  limitDate,
-                })
-                .resolves([
-                  domainBuilder.buildCertifiableBadgeAcquisition({
-                    complementaryCertificationBadgeId,
-                    complementaryCertificationKey,
-                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                    complementaryCertificationBadgeLabel: 'monLabel',
-                    isOutdated,
-                  }),
-                ]);
-
-              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-              expect(userCertificationEligibility).to.deep.equal(
-                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                  id: userId,
-                  isCertifiable,
-                  certificationEligibilities: [],
-                }),
-              );
-            });
-          },
-        );
-
-        context(
-          'when user has a validated and cancelled certification that is not rejected for fraud and with the required pixscore',
-          function () {
-            const isOutdated = false;
-
-            beforeEach(function () {
-              pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: requiredPixScore,
-                  status: AssessmentResult.status.CANCELLED,
-                  isCancelled: true,
-                  isRejectedForFraud: false,
-                }),
-              ]);
-            });
-
-            it('should not be added in the eligibilities of the model', async function () {
-              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              certificationBadgesService.findLatestBadgeAcquisitions
-                .withArgs({
-                  userId,
-                  limitDate,
-                })
-                .resolves([
-                  domainBuilder.buildCertifiableBadgeAcquisition({
-                    complementaryCertificationBadgeId,
-                    complementaryCertificationKey,
-                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                    complementaryCertificationBadgeLabel: 'monLabel',
-                    isOutdated,
-                  }),
-                ]);
-
-              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-              expect(userCertificationEligibility).to.deep.equal(
-                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                  id: userId,
-                  isCertifiable,
-                  certificationEligibilities: [],
-                }),
-              );
-            });
-          },
-        );
-
-        context(
-          'when user has not cancelled but rejected for fraud validated pix certification with the required pix score',
-          function () {
-            const isOutdated = false;
-
-            beforeEach(function () {
-              pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-                domainBuilder.certification.enrolment.buildPixCertification({
-                  pixScore: requiredPixScore,
-                  status: AssessmentResult.status.VALIDATED,
-                  isCancelled: false,
-                  isRejectedForFraud: true,
-                }),
-              ]);
-            });
-
-            it('should not be added in the eligibilities of the model', async function () {
-              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              certificationBadgesService.findLatestBadgeAcquisitions
-                .withArgs({
-                  userId,
-                  limitDate,
-                })
-                .resolves([
-                  domainBuilder.buildCertifiableBadgeAcquisition({
-                    complementaryCertificationBadgeId,
-                    complementaryCertificationKey,
-                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                    complementaryCertificationBadgeLabel: 'monLabel',
-                    isOutdated,
-                  }),
-                ]);
-
-              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-              expect(userCertificationEligibility).to.deep.equal(
-                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                  id: userId,
-                  isCertifiable,
-                  certificationEligibilities: [],
-                }),
-              );
-            });
-          },
-        );
-
-        context('when user has not cancelled not rejected for fraud but not validated pix certification', function () {
-          const isOutdated = false;
-
-          beforeEach(function () {
-            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-              domainBuilder.certification.enrolment.buildPixCertification({
-                pixScore: requiredPixScore,
-                status: AssessmentResult.status.REJECTED,
-                isCancelled: true,
-                isRejectedForFraud: false,
-              }),
-            ]);
-          });
-
-          it('should not be added in the eligibilities of the model', async function () {
-            complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-            certificationBadgesService.findLatestBadgeAcquisitions
-              .withArgs({
-                userId,
-                limitDate,
-              })
-              .resolves([
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationBadgeId,
-                  complementaryCertificationKey,
-                  complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                  complementaryCertificationBadgeLabel: 'monLabel',
-                  isOutdated,
-                }),
-              ]);
-
-            const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-            expect(userCertificationEligibility).to.deep.equal(
-              domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                id: userId,
-                isCertifiable,
-                certificationEligibilities: [],
-              }),
-            );
-          });
-        });
-
-        context('when user has a pix certification delivered validated with the required pix score', function () {
-          beforeEach(function () {
-            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
-              domainBuilder.certification.enrolment.buildPixCertification({
-                pixScore: requiredPixScore,
-                status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
-                isRejectedForFraud: false,
-              }),
-            ]);
-          });
-
-          context('when acquired badge is not outdated', function () {
-            const isOutdated = false;
-
-            context('when user has an acquired certification for this badge', function () {
-              it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
-                // given
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [
-                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                        label: 'monLabel',
-                        imageUrl: 'monImageUrl',
-                        isAcquiredExpectedLevel: true,
-                        isOutdated: false,
-                      }),
-                    ],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
-                // given
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [
-                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                        label: 'monLabel',
-                        imageUrl: 'monImageUrl',
-                        isAcquiredExpectedLevel: false,
-                        isOutdated: false,
-                      }),
-                    ],
-                  }),
-                );
-              });
-            });
-          });
-
-          context('when acquired badge is outdated by one version', function () {
-            const isOutdated = true;
-
-            context('when user has an acquired certification for this badge', function () {
-              it('should not be added in the eligibilities of the model', async function () {
-                // given
-                complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                    id: '1234',
-                    requiredPixScore,
-                    offsetVersion: 0,
-                  }),
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                    id: complementaryCertificationBadgeId,
-                    requiredPixScore,
-                    offsetVersion: 1,
-                  }),
-                ]);
-
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
-                  domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
-                    complementaryCertificationBadgeId,
-                    results: [
-                      {
-                        source: ComplementaryCertificationCourseResult.sources.PIX,
-                        acquired: true,
-                        complementaryCertificationBadgeId,
-                      },
-                    ],
-                  }),
-                ]);
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [],
-                  }),
-                );
-              });
-            });
-
-            context('when user has not an acquired certification for this badge', function () {
-              beforeEach(function () {
-                complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
-              });
-
-              it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
-                // given
-                certificationBadgesService.findLatestBadgeAcquisitions
-                  .withArgs({
-                    userId,
-                    limitDate,
-                  })
-                  .resolves([
-                    domainBuilder.buildCertifiableBadgeAcquisition({
-                      complementaryCertificationBadgeId,
-                      complementaryCertificationKey,
-                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
-                      complementaryCertificationBadgeLabel: 'monLabel',
-                      isOutdated,
-                    }),
-                  ]);
-
-                // when
-                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
-
-                // then
-                expect(userCertificationEligibility).to.deep.equal(
-                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
-                    id: userId,
-                    isCertifiable,
-                    certificationEligibilities: [
-                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
-                        label: 'monLabel',
-                        imageUrl: 'monImageUrl',
-                        isAcquiredExpectedLevel: false,
-                        isOutdated,
-                      }),
-                    ],
-                  }),
-                );
-              });
-            });
-          });
-
-          context('when acquired badge is outdated by more than one version', function () {
-            const isOutdated = true;
-
+          context('when user has an acquired certification for this badge', function () {
             it('should not be added in the eligibilities of the model', async function () {
               // given
-              complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
-                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                  id: '1234',
-                  requiredPixScore,
-                  offsetVersion: 0,
-                }),
-                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                  id: '5678',
-                  requiredPixScore,
-                  offsetVersion: 1,
-                }),
-                domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
-                  id: complementaryCertificationBadgeId,
-                  requiredPixScore,
-                  offsetVersion: 2,
-                }),
-              ]);
-
               complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
                 domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
                   complementaryCertificationBadgeId,
@@ -1444,6 +189,491 @@ describe('Certification | Enrolment | Unit | Usecases | get-user-certification-e
                   ],
                 }),
               ]);
+
+              certificationBadgesService.findLatestBadgeAcquisitions
+                .withArgs({
+                  userId,
+                  limitDate,
+                })
+                .resolves([
+                  domainBuilder.buildCertifiableBadgeAcquisition({
+                    complementaryCertificationBadgeId,
+                    complementaryCertificationKey,
+                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                    complementaryCertificationBadgeLabel: 'monLabel',
+                    isOutdated,
+                  }),
+                ]);
+
+              // when
+              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+              // then
+              expect(userCertificationEligibility).to.deep.equal(
+                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                  id: userId,
+                  isCertifiable,
+                  certificationEligibilities: [],
+                }),
+              );
+            });
+          });
+
+          context('when user has not an acquired certification for this badge', function () {
+            beforeEach(function () {
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
+            });
+
+            context('when badge is outdated by more than one version', function () {
+              beforeEach(function () {
+                complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
+                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                    id: '1234',
+                    requiredPixScore,
+                    offsetVersion: 0,
+                  }),
+                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                    id: '5678',
+                    requiredPixScore,
+                    offsetVersion: 1,
+                  }),
+                  domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+                    id: complementaryCertificationBadgeId,
+                    requiredPixScore,
+                    offsetVersion: 2,
+                  }),
+                ]);
+              });
+
+              it('should not be added in the eligibilities of the model', async function () {
+                // given
+                certificationBadgesService.findLatestBadgeAcquisitions
+                  .withArgs({
+                    userId,
+                    limitDate,
+                  })
+                  .resolves([
+                    domainBuilder.buildCertifiableBadgeAcquisition({
+                      complementaryCertificationBadgeId,
+                      complementaryCertificationKey,
+                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                      complementaryCertificationBadgeLabel: 'monLabel',
+                      isOutdated,
+                    }),
+                  ]);
+
+                // when
+                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+                // then
+                expect(userCertificationEligibility).to.deep.equal(
+                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                    id: userId,
+                    isCertifiable,
+                    certificationEligibilities: [],
+                  }),
+                );
+              });
+            });
+
+            context('when badge is outdated by exactly one version', function () {
+              const offsetVersion = 1;
+
+              it('returns a UserCertificationEligibility model with the outdated eligibility inside', async function () {
+                // given
+                certificationBadgesService.findLatestBadgeAcquisitions
+                  .withArgs({
+                    userId,
+                    limitDate,
+                  })
+                  .resolves([
+                    domainBuilder.buildCertifiableBadgeAcquisition({
+                      complementaryCertificationBadgeId,
+                      complementaryCertificationKey,
+                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                      complementaryCertificationBadgeLabel: 'monLabel',
+                      isOutdated,
+                      offsetVersion,
+                    }),
+                  ]);
+
+                // when
+                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+                // then
+                expect(userCertificationEligibility).to.deep.equal(
+                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                    id: userId,
+                    isCertifiable,
+                    certificationEligibilities: [
+                      domainBuilder.certification.enrolment.buildV3CertificationEligibility({
+                        label: 'monLabel',
+                        imageUrl: 'monImageUrl',
+                        isAcquiredExpectedLevel: false,
+                        isOutdated: true,
+                      }),
+                    ],
+                  }),
+                );
+              });
+            });
+          });
+        });
+
+        context('when user is not certifiable', function () {
+          const isCertifiable = false;
+
+          beforeEach(function () {
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
+              domainBuilder.buildPlacementProfile({
+                profileDate: limitDate,
+                userId,
+                userCompetences: [domainBuilder.buildUserCompetence({ estimatedLevel: 1, pixScore: 1 })],
+              }),
+            );
+          });
+
+          context('when user has an acquired certification for this badge', function () {
+            it('should not be added in the eligibilities of the model', async function () {
+              // given
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
+                  complementaryCertificationBadgeId,
+                  results: [
+                    {
+                      source: ComplementaryCertificationCourseResult.sources.PIX,
+                      acquired: true,
+                      complementaryCertificationBadgeId,
+                    },
+                  ],
+                }),
+              ]);
+
+              certificationBadgesService.findLatestBadgeAcquisitions
+                .withArgs({
+                  userId,
+                  limitDate,
+                })
+                .resolves([
+                  domainBuilder.buildCertifiableBadgeAcquisition({
+                    complementaryCertificationBadgeId,
+                    complementaryCertificationKey,
+                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                    complementaryCertificationBadgeLabel: 'monLabel',
+                    isOutdated: true,
+                    offsetVersion: 1,
+                  }),
+                ]);
+
+              // when
+              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+              // then
+              expect(userCertificationEligibility).to.deep.equal(
+                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                  id: userId,
+                  isCertifiable,
+                  certificationEligibilities: [],
+                }),
+              );
+            });
+          });
+
+          context('when user has not an acquired certification for this badge', function () {
+            beforeEach(function () {
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
+            });
+
+            context('when badge is outdated by more than one version', function () {
+              const offsetVersion = 2;
+
+              it('should not be added in the eligibilities of the model', async function () {
+                // given
+                certificationBadgesService.findLatestBadgeAcquisitions
+                  .withArgs({
+                    userId,
+                    limitDate,
+                  })
+                  .resolves([
+                    domainBuilder.buildCertifiableBadgeAcquisition({
+                      complementaryCertificationBadgeId,
+                      complementaryCertificationKey,
+                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                      complementaryCertificationBadgeLabel: 'monLabel',
+                      isOutdated,
+                      offsetVersion,
+                    }),
+                  ]);
+
+                // when
+                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+                // then
+                expect(userCertificationEligibility).to.deep.equal(
+                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                    id: userId,
+                    isCertifiable,
+                    certificationEligibilities: [],
+                  }),
+                );
+              });
+            });
+
+            context('when badge is outdated by exactly one version', function () {
+              const offsetVersion = 1;
+
+              it('should not be added in the eligibilities of the model', async function () {
+                // given
+                certificationBadgesService.findLatestBadgeAcquisitions
+                  .withArgs({
+                    userId,
+                    limitDate,
+                  })
+                  .resolves([
+                    domainBuilder.buildCertifiableBadgeAcquisition({
+                      complementaryCertificationBadgeId,
+                      complementaryCertificationKey,
+                      complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                      complementaryCertificationBadgeLabel: 'monLabel',
+                      isOutdated,
+                      offsetVersion,
+                    }),
+                  ]);
+
+                // when
+                const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+                // then
+                expect(userCertificationEligibility).to.deep.equal(
+                  domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                    id: userId,
+                    isCertifiable,
+                    certificationEligibilities: [],
+                  }),
+                );
+              });
+            });
+          });
+        });
+      });
+
+      context('when acquired badge is not outdated', function () {
+        const isOutdated = false;
+
+        beforeEach(function () {
+          complementaryCertificationBadgeWithOffsetVersionRepository.getAllWithSameTargetProfile.resolves([
+            domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({
+              id: complementaryCertificationBadgeId,
+              requiredPixScore,
+              offsetVersion: 0,
+            }),
+          ]);
+        });
+
+        context('when user is certifiable', function () {
+          const isCertifiable = true;
+
+          beforeEach(function () {
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
+              domainBuilder.buildPlacementProfile.buildCertifiable({
+                profileDate: limitDate,
+                userId,
+              }),
+            );
+
+            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
+              domainBuilder.certification.enrolment.buildPixCertification({
+                pixScore: requiredPixScore,
+                status: AssessmentResult.status.VALIDATED,
+                isCancelled: false,
+                isRejectedForFraud: false,
+              }),
+            ]);
+          });
+
+          context('when user has an acquired certification for this badge', function () {
+            it('returns a UserCertificationEligibility model with the corresponding eligibility', async function () {
+              // given
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
+                  complementaryCertificationBadgeId,
+                  results: [
+                    {
+                      source: ComplementaryCertificationCourseResult.sources.PIX,
+                      acquired: true,
+                      complementaryCertificationBadgeId,
+                    },
+                  ],
+                }),
+              ]);
+
+              certificationBadgesService.findLatestBadgeAcquisitions
+                .withArgs({
+                  userId,
+                  limitDate,
+                })
+                .resolves([
+                  domainBuilder.buildCertifiableBadgeAcquisition({
+                    complementaryCertificationBadgeId,
+                    complementaryCertificationKey,
+                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                    complementaryCertificationBadgeLabel: 'monLabel',
+                    isOutdated,
+                  }),
+                ]);
+
+              // when
+              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+              // then
+              expect(userCertificationEligibility).to.deep.equal(
+                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                  id: userId,
+                  isCertifiable,
+                  certificationEligibilities: [
+                    domainBuilder.certification.enrolment.buildV3CertificationEligibility({
+                      label: 'monLabel',
+                      imageUrl: 'monImageUrl',
+                      isAcquiredExpectedLevel: true,
+                      isOutdated,
+                    }),
+                  ],
+                }),
+              );
+            });
+          });
+
+          context('when user has not an acquired certification for this badge', function () {
+            beforeEach(function () {
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
+            });
+
+            it('returns a UserCertificationEligibility model with the corresponding eligibility', async function () {
+              // given
+              certificationBadgesService.findLatestBadgeAcquisitions
+                .withArgs({
+                  userId,
+                  limitDate,
+                })
+                .resolves([
+                  domainBuilder.buildCertifiableBadgeAcquisition({
+                    complementaryCertificationBadgeId,
+                    complementaryCertificationKey,
+                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                    complementaryCertificationBadgeLabel: 'monLabel',
+                    isOutdated,
+                  }),
+                ]);
+
+              // when
+              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+              // then
+              expect(userCertificationEligibility).to.deep.equal(
+                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                  id: userId,
+                  isCertifiable,
+                  certificationEligibilities: [
+                    domainBuilder.certification.enrolment.buildV3CertificationEligibility({
+                      label: 'monLabel',
+                      imageUrl: 'monImageUrl',
+                      isAcquiredExpectedLevel: false,
+                      isOutdated,
+                    }),
+                  ],
+                }),
+              );
+            });
+          });
+        });
+
+        context('when user is not certifiable', function () {
+          const isCertifiable = false;
+
+          beforeEach(function () {
+            placementProfileService.getPlacementProfile.withArgs({ userId, limitDate }).resolves(
+              domainBuilder.buildPlacementProfile({
+                profileDate: limitDate,
+                userId,
+                userCompetences: [domainBuilder.buildUserCompetence({ estimatedLevel: 1, pixScore: 1 })],
+              }),
+            );
+
+            pixCertificationRepository.findByUserId.withArgs({ userId }).resolves([
+              domainBuilder.certification.enrolment.buildPixCertification({
+                pixScore: requiredPixScore,
+                status: AssessmentResult.status.VALIDATED,
+                isCancelled: false,
+                isRejectedForFraud: false,
+              }),
+            ]);
+          });
+
+          context('when user has an acquired certification for this badge', function () {
+            it('should not be added in the eligibilities of the model', async function () {
+              // given
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
+                  complementaryCertificationBadgeId,
+                  results: [
+                    {
+                      source: ComplementaryCertificationCourseResult.sources.PIX,
+                      acquired: true,
+                      complementaryCertificationBadgeId,
+                    },
+                  ],
+                }),
+              ]);
+
+              certificationBadgesService.findLatestBadgeAcquisitions
+                .withArgs({
+                  userId,
+                  limitDate,
+                })
+                .resolves([
+                  domainBuilder.buildCertifiableBadgeAcquisition({
+                    complementaryCertificationBadgeId,
+                    complementaryCertificationKey,
+                    complementaryCertificationBadgeImageUrl: 'monImageUrl',
+                    complementaryCertificationBadgeLabel: 'monLabel',
+                    isOutdated,
+                  }),
+                ]);
+
+              // when
+              const userCertificationEligibility = await getUserCertificationEligibility(dependencies);
+
+              // then
+              expect(userCertificationEligibility).to.deep.equal(
+                domainBuilder.certification.enrolment.buildUserCertificationEligibility({
+                  id: userId,
+                  isCertifiable,
+                  certificationEligibilities: [],
+                }),
+              );
+            });
+          });
+
+          context('when user has not an acquired certification for this badge', function () {
+            beforeEach(function () {
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([]);
+            });
+
+            it('should not be added in the eligibilities of the model', async function () {
+              // given
+              complementaryCertificationCourseRepository.findByUserId.withArgs({ userId }).resolves([
+                domainBuilder.certification.enrolment.buildComplementaryCertificationCourseWithResults({
+                  complementaryCertificationBadgeId,
+                  results: [
+                    {
+                      source: ComplementaryCertificationCourseResult.sources.PIX,
+                      acquired: true,
+                      complementaryCertificationBadgeId,
+                    },
+                  ],
+                }),
+              ]);
+
               certificationBadgesService.findLatestBadgeAcquisitions
                 .withArgs({
                   userId,


### PR DESCRIPTION
## 🔆 Problème

A partir de la prochaine rentrée, l'éligibilité aux certifications complémentaires ne sera plus nécessaire que pour la double certification Cléa.

## ⛱️ Proposition

- Filtre sur les badges récupérés depuis la méthode de récupération `findHighestCertifiable` pour ne récupérer que le dernier badge Cléa.
- Suppression de l'ensemble du code non lié à Cléa (niveau N-1, niveau attendu, ....)

## 🌊 Remarques

- Cette PR ne s'occupe QUE du bandeau d'éligibilité visible lors de la réconciliation du candidat et s'inscrit dans une série de PRs dédiée à la modification du comportement de l'éligibilité aux différents endroits où celle-ci est vérifiée.

## 🏄 Pour tester

- Créer une campagne Pix+ Droit avec le prescripteur `certif-prescriptor@example.net`
- Passer avec succès la campagne avec `certif-success` (déjà détenteur du badge certifiant CLEA) 
- Aller sur la page de certification
- Vérifier que seul le badge CLEA est remonté comme certifiant
- Rendre obsolète le badge CLEA
- Retourner sur la page de certification
- Vérifier la présence du message stipulant de la nouvelle non validité de ce badge CLEA
