### PR TITLE
[BUGFIX] Afficher correctement les cartes récapitulatives des campagnes sur PixApp (PIX-17246).

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.gjs
@@ -13,13 +13,10 @@ export default class Disabled extends Component {
         <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
           {{t "pages.campaign-participation-overview.card.tag.disabled"}}
         </PixTag>
-        <h2
-          class="campaign-participation-overview-card-header__title"
-          aria-label={{@model.organizationName}}
-        >{{@model.organizationName}}</h2>
+        <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
         <strong
           class="campaign-participation-overview-card-header__subtitle"
-          aria-label={{@model.campaignTitle}}
+          title={{@model.campaignTitle}}
         >{{@model.campaignTitle}}</strong>
         <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
           {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.gjs
@@ -13,8 +13,14 @@ export default class Disabled extends Component {
         <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
           {{t "pages.campaign-participation-overview.card.tag.disabled"}}
         </PixTag>
-        <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
-        <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
+        <h2
+          class="campaign-participation-overview-card-header__title"
+          aria-label={{@model.organizationName}}
+        >{{@model.organizationName}}</h2>
+        <strong
+          class="campaign-participation-overview-card-header__subtitle"
+          aria-label={{@model.campaignTitle}}
+        >{{@model.campaignTitle}}</strong>
         <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
           {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}
         </time>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -15,13 +15,10 @@ export default class Ended extends Component {
         <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
           {{t "pages.campaign-participation-overview.card.tag.finished"}}
         </PixTag>
-        <h2
-          class="campaign-participation-overview-card-header__title"
-          aria-label={{@model.organizationName}}
-        >{{@model.organizationName}}</h2>
+        <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
         <strong
           class="campaign-participation-overview-card-header__subtitle"
-          aria-label={{@model.campaignTitle}}
+          title={{@model.campaignTitle}}
         >{{@model.campaignTitle}}</strong>
         <time class="campaign-participation-overview-card-header__date" datetime="{{@model.sharedAt}}">
           {{t "pages.campaign-participation-overview.card.finished-at" date=(dayjsFormat @model.sharedAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -15,8 +15,14 @@ export default class Ended extends Component {
         <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
           {{t "pages.campaign-participation-overview.card.tag.finished"}}
         </PixTag>
-        <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
-        <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
+        <h2
+          class="campaign-participation-overview-card-header__title"
+          aria-label={{@model.organizationName}}
+        >{{@model.organizationName}}</h2>
+        <strong
+          class="campaign-participation-overview-card-header__subtitle"
+          aria-label={{@model.campaignTitle}}
+        >{{@model.campaignTitle}}</strong>
         <time class="campaign-participation-overview-card-header__date" datetime="{{@model.sharedAt}}">
           {{t "pages.campaign-participation-overview.card.finished-at" date=(dayjsFormat @model.sharedAt "DD/MM/YYYY")}}
         </time>

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
@@ -9,13 +9,10 @@ import t from 'ember-intl/helpers/t';
       <PixTag class="campaign-participation-overview-card-header__tag" @color="green-light">
         {{t "pages.campaign-participation-overview.card.tag.started"}}
       </PixTag>
-      <h2
-        class="campaign-participation-overview-card-header__title"
-        aria-label={{@model.organizationName}}
-      >{{@model.organizationName}}</h2>
+      <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
       <strong
         class="campaign-participation-overview-card-header__subtitle"
-        aria-label={{@model.campaignTitle}}
+        title={{@model.campaignTitle}}
       >{{@model.campaignTitle}}</strong>
       <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
         {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
@@ -9,8 +9,14 @@ import t from 'ember-intl/helpers/t';
       <PixTag class="campaign-participation-overview-card-header__tag" @color="green-light">
         {{t "pages.campaign-participation-overview.card.tag.started"}}
       </PixTag>
-      <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
-      <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
+      <h2
+        class="campaign-participation-overview-card-header__title"
+        aria-label={{@model.organizationName}}
+      >{{@model.organizationName}}</h2>
+      <strong
+        class="campaign-participation-overview-card-header__subtitle"
+        aria-label={{@model.campaignTitle}}
+      >{{@model.campaignTitle}}</strong>
       <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
         {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}
       </time>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.gjs
@@ -9,8 +9,14 @@ import t from 'ember-intl/helpers/t';
       <PixTag class="campaign-participation-overview-card-header__tag" @color="yellow-light">
         {{t "pages.campaign-participation-overview.card.tag.completed"}}
       </PixTag>
-      <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
-      <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
+      <h2
+        class="campaign-participation-overview-card-header__title"
+        aria-label={{@model.organizationName}}
+      >{{@model.organizationName}}</h2>
+      <strong
+        class="campaign-participation-overview-card-header__subtitle"
+        aria-label={{@model.campaignTitle}}
+      >{{@model.campaignTitle}}</strong>
       <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
         {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}
       </time>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.gjs
@@ -9,13 +9,10 @@ import t from 'ember-intl/helpers/t';
       <PixTag class="campaign-participation-overview-card-header__tag" @color="yellow-light">
         {{t "pages.campaign-participation-overview.card.tag.completed"}}
       </PixTag>
-      <h2
-        class="campaign-participation-overview-card-header__title"
-        aria-label={{@model.organizationName}}
-      >{{@model.organizationName}}</h2>
+      <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
       <strong
         class="campaign-participation-overview-card-header__subtitle"
-        aria-label={{@model.campaignTitle}}
+        title={{@model.campaignTitle}}
       >{{@model.campaignTitle}}</strong>
       <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
         {{t "pages.campaign-participation-overview.card.started-at" date=(dayjsFormat @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -82,8 +82,11 @@
 
     display: block;
     margin-top: var(--pix-spacing-2x);
+    overflow: hidden;
     color: var(--pix-neutral-500);
     font-weight: var(--pix-font-bold);
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   &__date {


### PR DESCRIPTION
## 🔆 Problème

Les noms de campagnes a rallonge font dépasser les boutons du container principales. Comme la hauteur est fixé en dur ( c'est moche ) . 

## ⛱️ Proposition

Ajouter un ellipsis sur le nom de la campagne. lui rajouter un aria-label pour qu'il continue à être correctement vocalisé (NB: l'ellipsis n'est pas accessible pour une personne voyante elle n'aura pas la connaissance du nom de la campagne en entier )

## 🌊 Remarques

Revoir ce systeme de carte plus tard afin de s'affranchir au maximum des hauteur définit par défaut. merci. 

## 🏄 Pour tester

Aller sur PixOrga 
Modifier le title de la campagne PROASSMUL 

Aller sur PixApp 
Participer à la campagne PROASSMUL
Vérifier que sa carte ne déborde pas lorsque son nom de campagne est trop long