### PR TITLE
[FEATURE] Afficher les modules sur la page d'un parcours combiné (PIX-18847)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -42,6 +42,26 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
           },
         },
       },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: '6282925d-4775-4bca-b513-4c3009ec5886',
+            comparison: 'equal',
+          },
+        },
+      },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: '875df1ff-27c1-4b41-a0a8-5ff46013f35e',
+            comparison: 'equal',
+          },
+        },
+      },
     ],
   });
 }

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -2,7 +2,8 @@ import {
   CombinedCourseParticipationStatuses,
   CombinedCourseStatuses,
 } from '../../../prescription/shared/domain/constants.js';
-import { CombinedCourseItem } from './CombinedCourseItem.js';
+import { CombinedCourseItem, ITEM_TYPE } from './CombinedCourseItem.js';
+import { TYPES } from './Requirement.js';
 
 export class CombinedCourse {
   constructor({ id, code, organizationId, name } = {}) {
@@ -31,13 +32,36 @@ export class CombinedCourseDetails extends CombinedCourse {
   }
 
   get campaignIds() {
-    return this.#quest.successRequirements.map(({ data }) => data.campaignId.data);
+    return this.#quest.successRequirements
+      .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)
+      .map(({ data }) => data.campaignId.data);
+  }
+
+  get moduleIds() {
+    return this.#quest.successRequirements
+      .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.PASSAGES)
+      .map(({ data }) => data.moduleId.data);
   }
 
   generateItems(data) {
     this.items = this.#quest.successRequirements.map((requirement) => {
-      const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
-      return new CombinedCourseItem({ id: campaign.id, reference: campaign.code, title: campaign.name });
+      if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+        const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
+        return new CombinedCourseItem({
+          id: campaign.id,
+          reference: campaign.code,
+          title: campaign.name,
+          type: ITEM_TYPE.CAMPAIGN,
+        });
+      } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
+        const module = data.find(({ id }) => id === requirement.data.moduleId.data);
+        return new CombinedCourseItem({
+          id: module.id,
+          reference: module.slug,
+          title: module.title,
+          type: ITEM_TYPE.MODULE,
+        });
+      }
     });
   }
 }

--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -1,7 +1,13 @@
+export const ITEM_TYPE = {
+  CAMPAIGN: 'CAMPAIGN',
+  MODULE: 'MODULE',
+};
+
 export class CombinedCourseItem {
-  constructor({ id, title, reference }) {
+  constructor({ id, title, reference, type }) {
     this.id = id;
     this.title = title;
     this.reference = reference;
+    this.type = type;
   }
 }

--- a/api/src/quest/domain/models/Module.js
+++ b/api/src/quest/domain/models/Module.js
@@ -1,0 +1,7 @@
+export class Module {
+  constructor({ id, title, slug }) {
+    this.id = id;
+    this.title = title;
+    this.slug = slug;
+  }
+}

--- a/api/src/quest/domain/models/Requirement.js
+++ b/api/src/quest/domain/models/Requirement.js
@@ -16,6 +16,7 @@ export const TYPES = {
     ORGANIZATION_LEARNER: 'organizationLearner',
     ORGANIZATION: 'organization',
     CAMPAIGN_PARTICIPATIONS: 'campaignParticipations',
+    PASSAGES: 'passages',
   },
 };
 

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -8,6 +8,7 @@ export async function getCombinedCourseByCode({
   combinedCourseRepository,
   campaignRepository,
   questRepository,
+  moduleRepository,
 }) {
   const quest = await questRepository.getByCode({ code });
   const combinedCourse = await combinedCourseRepository.getByCode({ code });
@@ -24,15 +25,17 @@ export async function getCombinedCourseByCode({
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest, participation);
 
   const campaignIds = combinedCourseDetails.campaignIds;
-
   const campaigns = [];
-
   for (const campaignId of campaignIds) {
     const campaign = await campaignRepository.get({ id: campaignId });
     campaigns.push(campaign);
   }
 
-  combinedCourseDetails.generateItems(campaigns);
+  const moduleIds = combinedCourseDetails.moduleIds;
+
+  const modules = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds });
+
+  combinedCourseDetails.generateItems([...campaigns, ...modules]);
 
   return combinedCourseDetails;
 }

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -20,6 +20,7 @@ const dependencies = {
   combinedCourseParticipationRepository: repositories.combinedCourseParticipationRepository,
   combinedCourseParticipantRepository: repositories.combinedCourseParticipantRepository,
   combinedCourseRepository: repositories.combinedCourseRepository,
+  moduleRepository: repositories.moduleRepository,
   campaignRepository: repositories.campaignRepository,
   userRepository: repositories.userRepository,
   logger,

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -1,5 +1,6 @@
 import { Campaign } from '../../domain/models/Campaign.js';
 
+//TODO: deux méthodes a tester
 export const getByCode = async function ({ code, campaignsApi }) {
   const campaign = await campaignsApi.getByCode(code);
   return new Campaign(campaign);

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -1,3 +1,4 @@
+import * as modulesApi from '../../../devcomp/application/api/modules-api.js';
 import * as knowledgeElementsApi from '../../../evaluation/application/api/knowledge-elements-api.js';
 import * as userApi from '../../../identity-access-management/application/api/users-api.js';
 import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
@@ -13,6 +14,7 @@ import * as combinedCourseParticipantRepository from './combined-course-particip
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
 import * as combinedCourseRepository from './combined-course-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
+import * as moduleRepository from './module-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
@@ -22,6 +24,7 @@ const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewar
 
 const repositoriesWithoutInjectedDependencies = {
   eligibilityRepository,
+  moduleRepository,
   successRepository,
   rewardRepository,
   questRepository,
@@ -38,6 +41,7 @@ const dependencies = {
   campaignsApi,
   skillsApi,
   profileRewardApi,
+  modulesApi,
   targetProfilesApi,
   profileRewardTemporaryStorage,
   rewardApi,

--- a/api/src/quest/infrastructure/repositories/module-repository.js
+++ b/api/src/quest/infrastructure/repositories/module-repository.js
@@ -1,0 +1,7 @@
+import { Module } from '../../domain/models/Module.js';
+
+export const getByUserIdAndModuleIds = async ({ userId, moduleIds, modulesApi }) => {
+  const modules = await modulesApi.getUserModuleStatuses({ userId, moduleIds });
+
+  return modules.map((module) => new Module(module));
+};

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (combinedCourse) {
     items: {
       ref: 'id',
       included: true,
-      attributes: ['title', 'reference'],
+      attributes: ['title', 'reference', 'type'],
     },
     typeForAttribute: (attribute) => {
       if (attribute === 'items') return 'combined-course-items';

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -1,6 +1,6 @@
 import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import { CombinedCourseItem } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
+import { CombinedCourseItem, ITEM_TYPE } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
@@ -9,6 +9,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
   it('should return CombinedCourse for provided code', async function () {
     const code = 'SOMETHING';
     const campaign = databaseBuilder.factory.buildCampaign();
+    const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
     const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
       code,
       successRequirements: [
@@ -22,6 +23,16 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
             },
           },
         },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: moduleId,
+              comparison: 'equal',
+            },
+          },
+        },
       ],
     });
     const userId = databaseBuilder.factory.buildUser().id;
@@ -31,7 +42,18 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
 
     expect(result).to.be.instanceOf(CombinedCourse);
     expect(result.items).to.be.deep.equal([
-      new CombinedCourseItem({ id: campaign.id, reference: campaign.code, title: campaign.name }),
+      new CombinedCourseItem({
+        id: campaign.id,
+        reference: campaign.code,
+        title: campaign.name,
+        type: ITEM_TYPE.CAMPAIGN,
+      }),
+      new CombinedCourseItem({
+        id: moduleId,
+        reference: 'bac-a-sable',
+        title: 'Bac à sable',
+        type: ITEM_TYPE.MODULE,
+      }),
     ]);
     expect(result.id).to.equal(questId);
     expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);

--- a/api/tests/quest/unit/domain/models/Requirement_test.js
+++ b/api/tests/quest/unit/domain/models/Requirement_test.js
@@ -83,6 +83,23 @@ describe('Quest | Unit | Domain | Models | Requirement ', function () {
       });
     });
 
+    context('when requirement_type is "passages"', function () {
+      it('should build an ObjectRequirement', function () {
+        // given
+        const buildData = {
+          requirement_type: TYPES.OBJECT.PASSAGES,
+          comparison: COMPARISONS.ALL,
+          data: {},
+        };
+
+        // when
+        const requirement = buildRequirement(buildData);
+
+        // then
+        expect(requirement instanceof ObjectRequirement).to.be.true;
+      });
+    });
+
     context('when requirement_type is "skillProfile"', function () {
       it('should build an SkillProfileRequirement', function () {
         // given

--- a/api/tests/quest/unit/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/module-repository_test.js
@@ -1,0 +1,26 @@
+import { Module } from '../../../../../src/quest/domain/models/Module.js';
+import * as moduleRepository from '../../../../../src/quest/infrastructure/repositories/module-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Repositories | Module Repository', function () {
+  describe('#getByUserIdAndModuleIds', function () {
+    it('should call getUserModuleStatuses from modulesApi', async function () {
+      // given
+      const userId = 1;
+      const moduleIds = [1, 2];
+      const modules = [{ id: 1, title: 'title', slug: 'slug' }];
+
+      const modulesApiStub = {
+        getUserModuleStatuses: sinon.stub(),
+      };
+      modulesApiStub.getUserModuleStatuses.withArgs({ userId, moduleIds }).resolves(modules);
+
+      // when
+      const result = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds, modulesApi: modulesApiStub });
+
+      // then
+      expect(modulesApiStub.getUserModuleStatuses).to.be.called;
+      expect(result[0]).to.be.an.instanceOf(Module);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -1,4 +1,5 @@
 import { CombinedCourseStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { ITEM_TYPE } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
 import * as combinedCourseSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-serializer.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
@@ -34,6 +35,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           attributes: {
             title: 'diagnostique',
             reference: 'ABCDIAG1',
+            type: ITEM_TYPE.CAMPAIGN,
           },
         },
       ],

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -3,9 +3,10 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class CombinedCourseItem extends Model {
   @attr('string') title;
   @attr('string') reference;
+  @attr('string') type;
 
   get route() {
-    return 'campaigns';
+    return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';
   }
 
   @belongsTo('combined-course', { async: false, inverse: 'items' }) combinedCourse;

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -13,6 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: var(--pix-spacing-10x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: var(--pix-neutral-0);
   border: 1px solid var(--pix-primary-100);

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -54,6 +54,7 @@ module('Integration | Component | combined course', function (hooks) {
         id: 1,
         title: 'ma campagne',
         reference: 'ABCDIAG1',
+        type: 'CAMPAIGN',
       });
 
       const combinedCourse = store.createRecord('combined-course', {


### PR DESCRIPTION
## 🔆 Problème
Maintenant que nous avons permis l'affichage du parcours de diagnostique, il manque l'affichage des modules présent dans le parcours combiné

## ⛱️ Proposition
Afficher les différents modules dans la page du parcours combiné, et que ceux-ci redirige vers la page du début de leurs modules respectifs

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
