### PR TITLE
[BUGFIX] Afficher seulement les apprenants ayant un vrai compte dans la liste des attestations sur PixOrga (PIX-18860).

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -153,13 +153,17 @@ async function getAttestationStatusForOrganizationLearnersAndKey({
   organizationId,
   attestationsApi,
 }) {
-  const userIds = organizationLearners.map((learner) => learner.userId);
+  const isRealLearner = (learner) =>
+    learner.firstName !== '' && learner.lastName !== '' && learner.firstName !== null && learner.lastName !== null;
+  const realOrganizationLearners = organizationLearners.filter(isRealLearner);
+  const userIds = realOrganizationLearners.map((learner) => learner.userId);
   const attestations = await attestationsApi.getAttestationsUserDetail({
     attestationKey,
     userIds,
     organizationId,
   });
-  return organizationLearners.map((organizationLearner) => {
+
+  return realOrganizationLearners.filter(isRealLearner).map((organizationLearner) => {
     const attestation = attestations.find(({ userId }) => userId === organizationLearner.userId);
     return new AttestationParticipantStatus({
       attestationKey,

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -831,6 +831,36 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       });
     });
 
+    context('when organization learner is linked to anonymous user', function () {
+      it('should return empry array', async function () {
+        // given
+        const attestation = databaseBuilder.factory.buildAttestation();
+        const firstUser = new User(
+          databaseBuilder.factory.buildUser({ firstName: '', lastName: '', isAnonymous: true }),
+        );
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          firstName: '',
+          lastName: '',
+          division: '',
+          userId: firstUser.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await organizationLearnerRepository.getAttestationStatusForOrganizationLearnersAndKey({
+          organizationId,
+          organizationLearners: [organizationLearner1],
+          attestationKey: attestation.key,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(0);
+      });
+    });
+
     context('when organization learner has obtained his attestation', function () {
       it('should return attestation participants status with obtainedAt filled', async function () {
         // given


### PR DESCRIPTION
## 🔆 Problème

La liste des attestations obtenu / non obtenu d'un apprenant remonte actuellement les utilisateurs anonyme. 

## ⛱️ Proposition

Ne plus remonter ces utilisateurs afin de ne pas remonter du bruit au prescripteur

## 🌊 Remarques

RAs

## 🏄 Pour tester

Aller sur Pro Classic et vérifier que l'apprenant avec un compte anonyme ne remonte plus dans la liste des attestations.