### PR TITLE
[FEATURE] Relayer l'information de réalisation des conditions de victoires, lors d'une épreuve de prompt LLM, au front (PIX-18886)

### DIFF
--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -22,8 +22,9 @@ export class Chat {
   /**
    * @param {string=} message
    * @param {boolean=} shouldBeForwardedToLLM
+   * @param {boolean=} haveVictoryConditionsBeenFulfilled
    */
-  addUserMessage(message, shouldBeForwardedToLLM) {
+  addUserMessage(message, shouldBeForwardedToLLM, haveVictoryConditionsBeenFulfilled) {
     if (!message) return;
     this.messages.push(
       new Message({
@@ -32,6 +33,7 @@ export class Chat {
         shouldBeCountedAsAPrompt: shouldBeForwardedToLLM,
         shouldBeForwardedToLLM,
         shouldBeRenderedInPreview: true,
+        haveVictoryConditionsBeenFulfilled,
       }),
     );
   }
@@ -145,6 +147,7 @@ export class Message {
    * @param {boolean} params.shouldBeRenderedInPreview
    * @param {boolean} params.shouldBeCountedAsAPrompt
    * @param {boolean=} params.hasAttachmentBeenSubmittedAlongWithAPrompt
+   * @param {boolean=} params.haveVictoryConditionsBeenFulfilled
    */
   constructor({
     content,
@@ -155,6 +158,7 @@ export class Message {
     shouldBeRenderedInPreview,
     shouldBeCountedAsAPrompt,
     hasAttachmentBeenSubmittedAlongWithAPrompt,
+    haveVictoryConditionsBeenFulfilled,
   }) {
     this.content = content;
     this.isFromUser = isFromUser;
@@ -164,6 +168,7 @@ export class Message {
     this.shouldBeRenderedInPreview = !!shouldBeRenderedInPreview;
     this.shouldBeCountedAsAPrompt = !!shouldBeCountedAsAPrompt;
     this.hasAttachmentBeenSubmittedAlongWithAPrompt = hasAttachmentBeenSubmittedAlongWithAPrompt;
+    this.haveVictoryConditionsBeenFulfilled = haveVictoryConditionsBeenFulfilled;
   }
 
   get isAttachment() {
@@ -195,6 +200,7 @@ export class Message {
       shouldBeRenderedInPreview: this.shouldBeRenderedInPreview,
       shouldBeCountedAsAPrompt: this.shouldBeCountedAsAPrompt,
       hasAttachmentBeenSubmittedAlongWithAPrompt: this.hasAttachmentBeenSubmittedAlongWithAPrompt,
+      haveVictoryConditionsBeenFulfilled: this.haveVictoryConditionsBeenFulfilled,
     };
   }
 

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -7,12 +7,6 @@ import {
   TooLargeMessageInputError,
 } from '../errors.js';
 
-/**
- * @typedef {Object} StreamCapture
- * @property {string[]} LLMMessageParts - Accumulated message chunks.
- * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
- */
-
 export async function promptChat({
   chatId,
   userId,

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -7,6 +7,12 @@ import {
   TooLargeMessageInputError,
 } from '../errors.js';
 
+/**
+ * @typedef {Object} StreamCapture
+ * @property {string[]} LLMMessageParts - Accumulated message chunks.
+ * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
+ */
+
 export async function promptChat({
   chatId,
   userId,
@@ -68,10 +74,20 @@ export async function promptChat({
   });
 }
 
+/**
+ * @function
+ * @name addMessagesToChat
+ *
+ * @param {Chat} chat
+ * @param {string} prompt
+ * @param {boolean} shouldBeForwardedToLLM
+ * @param {Object} chatRepository
+ * @returns {(streamCapture: StreamCapture) => Promise<void>}
+ */
 function addMessagesToChat(chat, prompt, shouldBeForwardedToLLM, chatRepository) {
-  return async (llmMessage) => {
-    chat.addUserMessage(prompt, shouldBeForwardedToLLM);
-    chat.addLLMMessage(llmMessage);
+  return async (streamCapture) => {
+    chat.addUserMessage(prompt, shouldBeForwardedToLLM, streamCapture.haveVictoryConditionsBeenFulfilled);
+    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''));
     await chatRepository.save(chat);
   };
 }

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -17,6 +17,7 @@ export function serialize(chat) {
         content: next.content,
         attachmentName: current.attachmentName,
         isFromUser: true,
+        haveVictoryConditionsBeenFulfilled: next.haveVictoryConditionsBeenFulfilled,
       });
 
       messagesForPreview = messagesForPreview.toSpliced(i, 2, mergedMessage);
@@ -30,10 +31,11 @@ export function serialize(chat) {
     inputMaxChars: chat.configuration.inputMaxChars,
     inputMaxPrompts: chat.configuration.inputMaxPrompts,
     attachmentName: chat.configuration.attachmentName,
-    messages: messagesForPreview.map(({ content, attachmentName, isFromUser }) => ({
+    messages: messagesForPreview.map(({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled }) => ({
       content,
       attachmentName,
       isFromUser,
+      haveVictoryConditionsBeenFulfilled,
       isAttachmentValid: Boolean(attachmentName && chat.isAttachmentValid(attachmentName)),
     })),
   };

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -29,7 +29,7 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  *
  * @param {Object} params
  * @param {ReadableStream|null} params.llmResponse
- * @param {OnStreamDoneCallback} params.onStreamDone Callback called when stream is done streaming. Will be called asynchronously with one parameter: the complete LLM message
+ * @param {OnStreamDoneCallback} params.onStreamDone
  * @param {string} params.attachmentMessageType
  * @returns {Promise<module:stream.internal.PassThrough>}
  */

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -11,13 +11,25 @@ export const ATTACHMENT_MESSAGE_TYPES = {
   IS_VALID: 'IS_VALID',
   IS_INVALID: 'IS_INVALID',
 };
+
+/**
+ * @typedef {Object} StreamCapture
+ * @property {string[]} LLMMessageParts - Accumulated message chunks.
+ * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
+ */
+
+/**
+ * @callback OnStreamDoneCallback
+ * @param {StreamCapture} streamCapture
+ */
+
 /**
  * @function
  * @name fromLLMResponse
  *
  * @param {Object} params
  * @param {ReadableStream|null} params.llmResponse
- * @param {Function} params.onStreamDone Callback called when stream is done streaming. Will be called asynchronously with one parameter: the complete LLM message
+ * @param {OnStreamDoneCallback} params.onStreamDone Callback called when stream is done streaming. Will be called asynchronously with one parameter: the complete LLM message
  * @param {string} params.attachmentMessageType
  * @returns {Promise<module:stream.internal.PassThrough>}
  */
@@ -30,11 +42,15 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
     writableStream.write(getAttachmentEventMessage(attachmentMessageType === ATTACHMENT_MESSAGE_TYPES.IS_VALID));
   }
   const readableStream = llmResponse ?? emptyReadable();
-  const completeLLMMessage = [];
+  /** @type {StreamCapture} */
+  const streamCapture = {
+    LLMMessageParts: [],
+    haveVictoryConditionsBeenFulfilled: undefined,
+  };
   pipeline(
     readableStream,
     lengthPrefixedJsonDecoderTransform.getTransform(),
-    messageObjectToEventStreamTransform.getTransform(completeLLMMessage),
+    messageObjectToEventStreamTransform.getTransform(streamCapture),
     writableStream,
     async (err) => {
       if (err) {
@@ -43,7 +59,7 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
           writableStream.end('Error while streaming response from LLM');
         }
       } else {
-        await onStreamDone(completeLLMMessage.join(''));
+        await onStreamDone(streamCapture);
       }
     },
   );

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -1,12 +1,6 @@
 import { Transform } from 'node:stream';
 
 /**
- * @typedef {Object} StreamCapture
- * @property {string[]} LLMMessageParts - Accumulated message chunks.
- * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
- */
-
-/**
  * @param {StreamCapture} streamCapture Structure that will hold state, such as the accumulated LLM response
  * @returns {module:stream.internal.Transform}
  */

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -18,13 +18,13 @@ export function getTransform(streamCapture) {
       let data = '';
 
       if (isValid) {
-        data += 'event: victory-conditions-success\ndata: \n\n';
+        data += getVictoryConditionsSuccessEvent();
         streamCapture.haveVictoryConditionsBeenFulfilled = true;
       }
 
       if (message) {
         streamCapture.LLMMessageParts.push(...message.split(''));
-        data += toEventStreamData(message);
+        data += getFormattedMessage(message);
       }
 
       if (data) callback(null, data);
@@ -33,7 +33,11 @@ export function getTransform(streamCapture) {
   });
 }
 
-function toEventStreamData(message) {
+function getFormattedMessage(message) {
   const formattedMessage = message.replaceAll('\n', '\ndata: ');
   return `data: ${formattedMessage}\n\n`;
+}
+
+function getVictoryConditionsSuccessEvent() {
+  return 'event: victory-conditions-success\ndata: \n\n';
 }

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -8,14 +8,20 @@ export function getTransform(llmMessageAccumulator) {
   return new Transform({
     objectMode: true,
     transform(chunk, _encoding, callback) {
-      const { message } = chunk;
-      if (!message) {
-        callback();
-        return;
+      const { message, isValid } = chunk;
+      let data = '';
+
+      if (isValid) {
+        data += 'event: victory-conditions-success\ndata: \n\n';
       }
-      llmMessageAccumulator.push(...message.split(''));
-      const data = toEventStreamData(message);
-      callback(null, data);
+
+      if (message) {
+        llmMessageAccumulator.push(...message.split(''));
+        data += toEventStreamData(message);
+      }
+
+      if (data) callback(null, data);
+      else callback();
     },
   });
 }

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -272,7 +272,12 @@ describe('Acceptance | Route | llm-preview', function () {
               isFromUser: false,
               shouldBeRenderedInPreview: false,
             },
-            { content: 'un message', isFromUser: true, shouldBeRenderedInPreview: true },
+            {
+              content: 'un message',
+              isFromUser: true,
+              shouldBeRenderedInPreview: true,
+              haveVictoryConditionsBeenFulfilled: true,
+            },
             {
               content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
               isFromUser: false,
@@ -296,14 +301,33 @@ describe('Acceptance | Route | llm-preview', function () {
         inputMaxPrompts: 3,
         attachmentName: 'expected_file.txt',
         messages: [
-          { content: 'coucou user1', attachmentName: undefined, isFromUser: true, isAttachmentValid: false },
-          { content: 'coucou LLM1', attachmentName: undefined, isFromUser: false, isAttachmentValid: false },
-          { content: 'un message', attachmentName: 'expected_file.txt', isFromUser: true, isAttachmentValid: true },
+          {
+            content: 'coucou user1',
+            attachmentName: undefined,
+            isFromUser: true,
+            isAttachmentValid: false,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: 'coucou LLM1',
+            attachmentName: undefined,
+            isFromUser: false,
+            isAttachmentValid: false,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: 'un message',
+            attachmentName: 'expected_file.txt',
+            isFromUser: true,
+            isAttachmentValid: true,
+            haveVictoryConditionsBeenFulfilled: true,
+          },
           {
             content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
             attachmentName: undefined,
             isFromUser: false,
             isAttachmentValid: false,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
         ],
       });

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -28,6 +28,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: false,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
         {
           content: 'un message pas vide',
@@ -38,6 +39,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: true,
           shouldBeCountedAsAPrompt: true,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
       ]);
     });
@@ -67,6 +69,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: false,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
       ]);
     });
@@ -94,6 +97,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: true,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
       ]);
     });
@@ -121,6 +125,35 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: true,
           shouldBeCountedAsAPrompt: true,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
+        },
+      ]);
+    });
+
+    it('should set haveVictoryConditionsBeenFulfilled at true if given as true', function () {
+      // given
+      const chat = new Chat({
+        id: 'some-chat-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
+        hasAttachmentContextBeenAdded: false,
+        messages: [],
+      });
+
+      // when
+      chat.addUserMessage('some content', true, true);
+
+      // then
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some content',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: true,
+          shouldBeForwardedToLLM: true,
+          shouldBeRenderedInPreview: true,
+          shouldBeCountedAsAPrompt: true,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: true,
         },
       ]);
     });
@@ -150,6 +183,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: false,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
         {
           content: 'un message pas vide',
@@ -160,6 +194,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: true,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
       ]);
     });
@@ -189,6 +224,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeRenderedInPreview: false,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
         },
       ]);
     });
@@ -232,6 +268,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -242,6 +279,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -252,6 +290,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: true,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -262,6 +301,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 shouldBeCountedAsAPrompt: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -301,6 +341,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -311,6 +352,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -321,6 +363,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: true,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -331,6 +374,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 shouldBeCountedAsAPrompt: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -373,6 +417,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -383,6 +428,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -393,6 +439,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -432,6 +479,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -442,6 +490,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -452,6 +501,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -496,6 +546,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -506,6 +557,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -516,6 +568,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -555,6 +608,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -565,6 +619,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -575,6 +630,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -617,6 +673,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -627,6 +684,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -637,6 +695,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -676,6 +735,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: 'some answer',
@@ -686,6 +746,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
               {
                 content: undefined,
@@ -696,6 +757,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeForwardedToLLM: false,
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+                haveVictoryConditionsBeenFulfilled: undefined,
               },
             ]);
           });
@@ -818,6 +880,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
           }),
           new Message({
             attachmentName: 'file.txt',
@@ -850,6 +913,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
           {
             content: 'message llm 1',
@@ -860,6 +924,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             shouldBeForwardedToLLM: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
           {
             content: undefined,
@@ -870,6 +935,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
           },
           {
             content: undefined,
@@ -880,6 +946,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: false,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
         ],
       });
@@ -905,6 +972,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
           {
             content: 'message llm 1',
@@ -915,6 +983,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             shouldBeForwardedToLLM: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
           {
             content: undefined,
@@ -925,6 +994,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
           },
           {
             content: undefined,
@@ -972,6 +1042,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeForwardedToLLM: true,
               shouldBeRenderedInPreview: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
             new Message({
               attachmentName: 'file.txt',

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -20,7 +20,11 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
         }),
         hasAttachmentContextBeenAdded: false,
         messages: [
-          new Message({ content: 'Salut', isFromUser: true, shouldBeRenderedInPreview: true }),
+          new Message({
+            content: 'Salut',
+            isFromUser: true,
+            shouldBeRenderedInPreview: true,
+          }),
           new Message({
             content: 'Bonjour comment puis-je vous aider ?',
             isFromUser: false,
@@ -39,12 +43,19 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
         inputMaxChars: 500,
         inputMaxPrompts: 4,
         messages: [
-          { content: 'Salut', attachmentName: undefined, isFromUser: true, isAttachmentValid: false },
+          {
+            content: 'Salut',
+            attachmentName: undefined,
+            isFromUser: true,
+            isAttachmentValid: false,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
           {
             content: 'Bonjour comment puis-je vous aider ?',
             attachmentName: undefined,
             isFromUser: false,
             isAttachmentValid: false,
+            haveVictoryConditionsBeenFulfilled: undefined,
           },
         ],
       });
@@ -66,11 +77,17 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           }),
           hasAttachmentContextBeenAdded: false,
           messages: [
-            new Message({ content: 'Salut', isFromUser: true, shouldBeRenderedInPreview: false }),
+            new Message({
+              content: 'Salut',
+              isFromUser: true,
+              shouldBeRenderedInPreview: false,
+              haveVictoryConditionsBeenFulfilled: true,
+            }),
             new Message({
               content: 'Bonjour comment puis-je vous aider ?',
               isFromUser: false,
               shouldBeRenderedInPreview: true,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
           ],
         });
@@ -90,6 +107,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               attachmentName: undefined,
               isFromUser: false,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: true,
             },
           ],
         });
@@ -123,6 +141,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               shouldBeRenderedInPreview: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: true,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
             new Message({
               content: 'i should not be serialized',
@@ -144,6 +163,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
               isFromUser: true,
               shouldBeRenderedInPreview: true,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
           ],
         });
@@ -158,30 +178,40 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           inputMaxChars: 500,
           inputMaxPrompts: 4,
           messages: [
-            { content: 'Salut', attachmentName: undefined, isFromUser: true, isAttachmentValid: false },
+            {
+              content: 'Salut',
+              attachmentName: undefined,
+              isFromUser: true,
+              isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
             {
               content: 'Bonjour comment puis-je vous aider ?',
               attachmentName: undefined,
               isFromUser: false,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: 'Que contient ce fichier ?',
               attachmentName: 'chien.webp',
               isFromUser: true,
               isAttachmentValid: true,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
               attachmentName: undefined,
               isFromUser: false,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
               attachmentName: 'chat.webp',
               isFromUser: true,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: true,
             },
           ],
         });
@@ -215,6 +245,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               shouldBeRenderedInPreview: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
             new Message({
               content: 'i should not be serialized',
@@ -236,6 +267,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
               isFromUser: true,
               shouldBeRenderedInPreview: true,
+              haveVictoryConditionsBeenFulfilled: true,
             }),
           ],
         });
@@ -250,42 +282,54 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           inputMaxChars: 500,
           inputMaxPrompts: 4,
           messages: [
-            { content: 'Salut', attachmentName: undefined, isFromUser: true, isAttachmentValid: false },
+            {
+              content: 'Salut',
+              attachmentName: undefined,
+              isFromUser: true,
+              isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
             {
               content: 'Bonjour comment puis-je vous aider ?',
               attachmentName: undefined,
               isFromUser: false,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: undefined,
               attachmentName: 'chien.webp',
               isFromUser: true,
               isAttachmentValid: true,
+              haveVictoryConditionsBeenFulfilled: true,
             },
             {
               content: 'Que contient ce fichier ?',
               attachmentName: undefined,
               isFromUser: true,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
               attachmentName: undefined,
               isFromUser: false,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: undefined,
               attachmentName: 'chat.webp',
               isFromUser: true,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
               attachmentName: undefined,
               isFromUser: true,
               isAttachmentValid: false,
+              haveVictoryConditionsBeenFulfilled: true,
             },
           ],
         });


### PR DESCRIPTION
## 🔆 Problème

Dans une configuration LLM, il est possible de définir des conditions de victoire, vérifiées par poc-llm.
L'idée est d'indiquer à l'utilisateur que l'épreuve est réussie si les conditions de victoire sont remplies.

## ⛱️ Proposition

Côté poc-llm, dans le stream, on peut retrouver un "isValid': true dans le cas où les conditions de victoire ont été remplies.
Il faut :
- Relayer cette information dans le stream résultat, formatté SSE
- Persister cette information pour le cas du rechargement de conversation (dispo en preview uniquement)

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
