### PR TITLE
[FEATURE] Ajout des fichiers de config Scalingo pour les RAs front

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -1,0 +1,20 @@
+{
+  "name": "Pix Admin Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    },
+    "PIX_APP_URL_WITHOUT_EXTENSION": {
+      "generator": "template",
+      "template": "https://app-pr%PR_NUMBER%.review.pix"
+    }
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -1,0 +1,20 @@
+{
+  "name": "Pix Certif Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    },
+    "PIX_APP_URL_WITHOUT_EXTENSION": {
+      "generator": "template",
+      "template": "https://app-pr%PR_NUMBER%.review.pix"
+    }
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -1,0 +1,16 @@
+{
+  "name": "Pix Junior Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    }
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -1,0 +1,16 @@
+{
+  "name": "Pix App Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    }
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -1,0 +1,20 @@
+{
+  "name": "Pix Orga Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    },
+    "PIX_APP_URL_WITHOUT_EXTENSION": {
+      "generator": "template",
+      "template": "https://app-pr%PR_NUMBER%.review.pix"
+    }
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  },
+  "stack": "scalingo-22"
+}


### PR DESCRIPTION
## 🔆 Problème

Les applis fronts individuelles n’ont pas de fichier de configuration Scalingo.

## ⛱️ Proposition

Ajouter les fichiers manquants.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A