### PR TITLE
[FEATURE] Tester le comportement du commentaire de pix-bot-github sur une PR JP puis réouverte en HERA

### DIFF
--- a/hera
+++ b/hera
@@ -1,0 +1,11 @@
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy
+test deploy


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- j'ouvre une PR JP => commentaire pix-bot-github version JP
- je close la PR
- je réouvre la PR, toujours en version JP => vérifier s'il y'a un nouveau commentaire pix-bot-github (✅ on a bien un nouveau commentaire, pourquoi on fait ça d'ailleurs ??)
((=> voir avec l'équipe, est-ce qu'on tri par date de création pour être sûr d'éditer le premier ?))
- je close la PR
- je réouvre, avec le label HERA => vérifier qu'un des commentaire à été édité (✅  le premier com a été édité, l'autre est resté tel quel, normal)
