### PR TITLE
[BUGFIX] Corriger l'activation de la feature d'import lorsque l'organisation n'a pas de prescrits (PIX-17766).

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -17,6 +17,10 @@ const deleteOrganizationLearners = withTransaction(async function ({
   userRecommendedTrainingRepository,
   organizationsProfileRewardRepository,
 }) {
+  if (organizationLearnerIds.length === 0) {
+    return;
+  }
+
   const organizationLearnersFromOrganization =
     await organizationLearnerRepository.findOrganizationLearnersByOrganizationId({
       organizationId,

--- a/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/delete-organization-learners_test.js
@@ -62,6 +62,16 @@ describe('Integration | UseCase | Organization Learners Management | Delete Orga
     clock.restore();
   });
 
+  context('when no organization learner is provided', function () {
+    it('should do nothing', async function () {
+      await expect(
+        usecases.deleteOrganizationLearners({
+          organizationLearnerIds: [],
+        }),
+      ).to.be.fulfilled;
+    });
+  });
+
   context('when feature toggle `isAnonymizationWithDeletionEnabled` is false', function () {
     beforeEach(async function () {
       await featureToggles.set('isAnonymizationWithDeletionEnabled', false);


### PR DESCRIPTION
## 🔆 Problème

Si on active la feature d’import avec l’option pour supprimer les learners alors que l’orga n’a pas de learners, on a des erreurs 

<details>
<summary>Details</summary>

2025-05-06 12:51:55.139870184 +0000 UTC [web-28] node:internal/process/promises:394
2025-05-06 12:51:55.140077962 +0000 UTC [web-28] triggerUncaughtException(err, true /* fromPromise */);
2025-05-06 12:51:55.140083066 +0000 UTC [web-28] ^
2025-05-06 12:51:55.140169367 +0000 UTC [web-28] Error: Transaction query already complete, run with DEBUG=knex:tx for more info
2025-05-06 12:51:55.140180257 +0000 UTC [web-28] at Object.queryBuilder (/app/node_modules/knex/lib/knex-builder/make-knex.js:112:26)
2025-05-06 12:51:55.140182482 +0000 UTC [web-28] at createQueryBuilder (/app/node_modules/knex/lib/knex-builder/make-knex.js:320:26)
2025-05-06 12:51:55.140182845 +0000 UTC [web-28] at knex (/app/node_modules/knex/lib/knex-builder/make-knex.js:101:12)
2025-05-06 12:51:55.140228188 +0000 UTC [web-28] at Module.removeByOrganizationLearnerIds (file:///app/src/prescription/learner-management/infrastructure/repositories/campaign-participation-repository.js:5:10)
2025-05-06 12:51:55.140228642 +0000 UTC [web-28] at deleteOrganizationLearners (file:///app/src/prescription/learner-management/domain/usecases/delete-organization-learners.js:21:41)
2025-05-06 12:51:55.140229190 +0000 UTC [web-28] at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-05-06 12:51:55.140229887 +0000 UTC [web-28] at async file:///app/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js:39:9 {
2025-05-06 12:51:55.140230259 +0000 UTC [web-28] originalStack: 'Error: Transaction query already complete, run with DEBUG=knex:tx for more info\n' +
2025-05-06 12:51:55.140230682 +0000 UTC [web-28] ' at completedError (/app/node_modules/knex/lib/execution/transaction.js:408:9)\n' +
2025-05-06 12:51:55.140268120 +0000 UTC [web-28] ' at /app/node_modules/knex/lib/execution/transaction.js:374:24\n' +
2025-05-06 12:51:55.140268951 +0000 UTC [web-28] ' at new Promise (<anonymous>)\n' +
2025-05-06 12:51:55.140269425 +0000 UTC [web-28] ' at trxClient.query (/app/node_modules/knex/lib/execution/transaction.js:370:12)\n' +
2025-05-06 12:51:55.140269898 +0000 UTC [web-28] ' at Runner.query (/app/node_modules/knex/lib/execution/runner.js:141:36)\n' +
2025-05-06 12:51:55.140270480 +0000 UTC [web-28] ' at ensureConnectionCallback (/app/node_modules/knex/lib/execution/internal/ensure-connection-callback.js:13:17)\n' +
2025-05-06 12:51:55.140271021 +0000 UTC [web-28] ' at Runner.ensureConnection (/app/node_modules/knex/lib/execution/runner.js:318:20)\n' +
2025-05-06 12:51:55.140303053 +0000 UTC [web-28] ' at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n' +
2025-05-06 12:51:55.140303600 +0000 UTC [web-28] ' at async Runner.run (/app/node_modules/knex/lib/execution/runner.js:30:19)\n' +
2025-05-06 12:51:55.140343454 +0000 UTC [web-28] ' at async deleteOrganizationLearners ([file:///app/src/prescription/learner-management/domain/usecases/delete-organization-learners.js:21:3)\n'](file:///app/src/prescription/learner-management/domain/usecases/delete-organization-learners.js:21:3)/n') +
2025-05-06 12:51:55.140344943 +0000 UTC [web-28] ' at async file:///app/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js:39:9'
2025-05-06 12:51:55.140345661 +0000 UTC [web-28] }
2025-05-06 12:51:55.140346116 +0000 UTC [web-28] Node.js v22.15.0

</details>

## ⛱️ Proposition

Faire un early return lorsqu'on appel l'use-case de suppression des learners sans learnerIds.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Sur Pix Admin, dans l'onglet administration > Commun : Ajouter un fichier csv avec la featureId: 1005 sur une orga qui n'a pas de learner 

```csv
"Feature ID";"Organization ID";"Params";"Delete Learner"
1005;1000001;;true
```