### PR TITLE
[FEATURE] Empêche le démarrage des activités d'un parcours combiné sur l'utilisateur n'a pas démarré (PIX-18905)

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -1,9 +1,21 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { LinkTo } from '@ember/routing';
 
+const Content = <template>
+  <div class="combined-course-item">
+    <div class="combined-course-item__title">{{@title}}</div>
+    {{#if @isLocked}}
+      <PixIcon @name="lock" @plainIcon={{true}} />
+    {{/if}}
+  </div>
+</template>;
+
 <template>
-  <LinkTo @route={{@item.route}} @model={{@item.reference}}>
-    <div class="combined-course-item">
-      <div class="combined-course-item__title">{{@item.title}}</div>
-    </div>
-  </LinkTo>
+  {{#if @isLocked}}
+    <Content @title={{@item.title}} @isLocked={{true}} />
+  {{else}}
+    <LinkTo @route={{@item.route}} @model={{@item.reference}} disabled>
+      <Content @title={{@item.title}} />
+    </LinkTo>
+  {{/if}}
 </template>

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -21,7 +21,7 @@ export default class CombinedCourses extends Component {
       {{/if}}
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}
-        <CombinedCourseItem @item={{item}} />
+        <CombinedCourseItem @item={{item}} @isLocked={{eq @combinedCourse.status "NOT_STARTED"}} />
       {{/each}}
     </div>
   </template>

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -24,6 +24,7 @@ module('Integration | Component | combined course', function (hooks) {
       // then
       assert.ok(screen.getByRole('button', { name: t('pages.combined-courses.content.start-button') }));
     });
+
     test('when clicking start button, should create quest participation', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -46,10 +47,9 @@ module('Integration | Component | combined course', function (hooks) {
       assert.notOk(screen.queryByRole('button', { name: t('pages.combined-courses.content.start-button') }));
     });
 
-    test('should display diagnostic campaign', async function (assert) {
+    test('should display diagnostic campaign with no link', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const router = this.owner.lookup('service:router');
       const combinedCourseItem = store.createRecord('combined-course-item', {
         id: 1,
         title: 'ma campagne',
@@ -73,9 +73,105 @@ module('Integration | Component | combined course', function (hooks) {
 
       // then
       assert.ok(screen.getByText('ma campagne'));
+      assert.notOk(screen.queryByRole('link', { name: 'ma campagne' }));
+    });
+
+    test('should display modules with no link', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'NOT_STARTED',
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByText('mon module'));
+      assert.notOk(screen.queryByRole('link', { name: 'mon module' }));
+    });
+  });
+
+  module('when participation is started', function () {
+    test('should display diagnostic campaign with related link', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:router');
+
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'ma campagne',
+        reference: 'ABCDIAG1',
+        type: 'CAMPAIGN',
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'STARTED',
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByText('ma campagne'));
       assert.strictEqual(
         screen.getByRole('link', { name: 'ma campagne' }).getAttribute('href'),
         router.urlFor('campaigns', { code: combinedCourseItem.reference }),
+      );
+    });
+
+    test('should display modules with with related link', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:router');
+
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'STARTED',
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByText('mon module'));
+      assert.strictEqual(
+        screen.getByRole('link', { name: 'mon module' }).getAttribute('href'),
+        router.urlFor('module', { slug: combinedCourseItem.reference }),
       );
     });
   });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'utilisateur peut cliquer sur les campagnes et les modules d'un parcours combiné même si il n'a pas cliquer sur "Commencer mon parcours"

## ⛱️ Proposition

Retirer les liens sur les éléments tant que l'utilisateur n'a pas démarré son parcours combiné.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter avec attestation-blank
- Rentrer le code COMBINIX1
- Constater qu'on ne peut pas cliquer sur les éléments
- Commencer votre parcours
- Constater qu'on peut cliquer sur les éléments
