### PR TITLE
[FEATURE] Ajouter l'événénement QCUDiscoveryAnswered (PIX-18880)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -4,6 +4,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
@@ -52,6 +53,8 @@ class PassageEventFactory {
         return new QCUAnsweredEvent(eventData);
       case 'QCU_DECLARATIVE_ANSWERED':
         return new QCUDeclarativeAnsweredEvent(eventData);
+      case 'QCU_DISCOVERY_ANSWERED':
+        return new QCUDiscoveryAnsweredEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
+++ b/api/src/devcomp/domain/models/passage-events/answerable-element-events.js
@@ -67,6 +67,22 @@ class QCUDeclarativeAnsweredEvent extends PassageEventWithElement {
   }
 }
 
+class QCUDiscoveryAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
+    super({
+      type: 'QCU_DISCOVERY_ANSWERED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      answer,
+      status,
+    });
+  }
+}
+
 class QROCMAnsweredEvent extends PassageEventWithElementAnswered {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, answer, status }) {
     super({
@@ -83,4 +99,11 @@ class QROCMAnsweredEvent extends PassageEventWithElementAnswered {
   }
 }
 
-export { EmbedAnsweredEvent, QCMAnsweredEvent, QCUAnsweredEvent, QCUDeclarativeAnsweredEvent, QROCMAnsweredEvent };
+export {
+  EmbedAnsweredEvent,
+  QCMAnsweredEvent,
+  QCUAnsweredEvent,
+  QCUDeclarativeAnsweredEvent,
+  QCUDiscoveryAnsweredEvent,
+  QROCMAnsweredEvent,
+};

--- a/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/flashcard-events/answerable-element-events_test.js
@@ -3,6 +3,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
@@ -175,6 +176,41 @@ describe('Integration | Devcomp | Domain | Models | passage-events | answerable-
         expect(error).to.be.instanceOf(DomainError);
         expect(error.message).to.equal('The answer is required for a QCUDeclarativeAnsweredEvent');
       });
+    });
+  });
+
+  describe('#QCUDiscoveryAnsweredEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const elementId = '5ad40bc9-8b5c-47ee-b893-f8ab1a1b8095';
+      const answer = 'Poire';
+      const status = 'ok';
+
+      // when
+      const qcuAnsweredEvent = new QCUDiscoveryAnsweredEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+        answer,
+        status,
+      });
+
+      // then
+      expect(qcuAnsweredEvent.id).to.equal(id);
+      expect(qcuAnsweredEvent.type).to.equal('QCU_DISCOVERY_ANSWERED');
+      expect(qcuAnsweredEvent.occurredAt).to.equal(occurredAt);
+      expect(qcuAnsweredEvent.createdAt).to.equal(createdAt);
+      expect(qcuAnsweredEvent.passageId).to.equal(passageId);
+      expect(qcuAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(qcuAnsweredEvent.data).to.deep.equal({ elementId, answer, status });
     });
   });
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -6,6 +6,7 @@ import {
   QCMAnsweredEvent,
   QCUAnsweredEvent,
   QCUDeclarativeAnsweredEvent,
+  QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
@@ -356,6 +357,26 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCUDeclarativeAnsweredEvent);
+      });
+    });
+
+    describe('when given a QCU_DISCOVERY_ANSWERED event', function () {
+      it('should return a QCUDiscoveryAnsweredEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          type: 'QCU_DISCOVERY_ANSWERED',
+          answer: 'Poire',
+          status: 'ok',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(QCUDiscoveryAnsweredEvent);
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème

On veut pouvoir tracer le fait que l'utilisateur répond à un élément de type QCU découverte

## ⛱️ Proposition

Ajouter l'événement QCUDiscoveryAnswered correspondant à cela. 

## 🌊 Remarques

RAS

## 🏄 Pour tester

- CI au vert ✅ 
