### PR TITLE
[FEATURE] Enlever le runtime NodeJS des containers front

### DIFF
--- a/admin/.slugignore
+++ b/admin/.slugignore
@@ -1,3 +1,4 @@
+.scalingo/node
 app
 config
 ember-cli-build.js

--- a/certif/.slugignore
+++ b/certif/.slugignore
@@ -1,3 +1,4 @@
+.scalingo/node
 app
 config
 ember-cli-build.js

--- a/junior/.slugignore
+++ b/junior/.slugignore
@@ -1,3 +1,4 @@
+.scalingo/node
 app
 config
 ember-cli-build.js

--- a/mon-pix/.slugignore
+++ b/mon-pix/.slugignore
@@ -1,3 +1,4 @@
+.scalingo/node
 app
 config
 ember-cli-build.js

--- a/orga/.slugignore
+++ b/orga/.slugignore
@@ -1,3 +1,4 @@
+.scalingo/node
 app
 config
 ember-cli-build.js


### PR DESCRIPTION
## 🔆 Problème

Les containers front (app, certif, etc.) embarquent le runtime NodeJS pour rien.

## ⛱️ Proposition

Supprimer le runtime NodeJS des containers front.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Vérifier que les apps fonctionnent et que les images Docker Scalingo font moins de 100mo.