### PR TITLE
[TECH] Relayer les informations de contexte depuis la configuration poc-llm vers le front (PIX-18912)

### DIFF
--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -18,6 +18,7 @@ export async function startChat({ configId, userId }) {
     attachmentName: configuration.attachmentName,
     inputMaxChars: configuration.inputMaxChars,
     inputMaxPrompts: configuration.inputMaxPrompts,
+    context: configuration.context,
   });
 }
 

--- a/api/src/llm/application/api/models/LLMChatDTO.js
+++ b/api/src/llm/application/api/models/LLMChatDTO.js
@@ -1,8 +1,9 @@
 export class LLMChatDTO {
-  constructor({ id, attachmentName, inputMaxChars, inputMaxPrompts }) {
+  constructor({ id, attachmentName, inputMaxChars, inputMaxPrompts, context }) {
     this.id = id;
     this.inputMaxChars = inputMaxChars;
     this.inputMaxPrompts = inputMaxPrompts;
     this.attachmentName = attachmentName;
+    this.context = context;
   }
 }

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -94,17 +94,6 @@ export class Chat {
     return this.messages.filter((message) => message.isFromUser && message.shouldBeCountedAsAPrompt).length;
   }
 
-  toDTO() {
-    return {
-      id: this.id,
-      userId: this.userId,
-      configurationId: this.configurationId,
-      configuration: this.configuration.toDTO(),
-      hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,
-      messages: this.messages.map((message) => message.toDTO()),
-    };
-  }
-
   isAttachmentValid(attachmentName) {
     if (!this.configuration.hasAttachment) {
       return false;
@@ -124,6 +113,17 @@ export class Chat {
       .filter((message) => message.shouldBeForwardedToLLM)
       .slice(-this.configuration.historySize)
       .map((message) => message.toLLMHistory());
+  }
+
+  toDTO() {
+    return {
+      id: this.id,
+      userId: this.userId,
+      configurationId: this.configurationId,
+      configuration: this.configuration.toDTO(),
+      hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,
+      messages: this.messages.map((message) => message.toDTO()),
+    };
   }
 
   static fromDTO(chatDTO) {

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -33,6 +33,10 @@ export class Configuration {
     return this.#dto.attachment?.context;
   }
 
+  get context() {
+    return this.#dto.challenge?.context;
+  }
+
   toDTO() {
     return this.#dto;
   }
@@ -62,6 +66,7 @@ export class Configuration {
  * @property {number} challenge.inputMaxChars
  * @property {number} challenge.inputMaxPrompts
  * @property {object} challenge.victoryConditions FIXME add victoryConditions properties
+ * @property {string=} challenge.context
  * @property {Attachment=} attachment
  */
 

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -31,6 +31,7 @@ export function serialize(chat) {
     inputMaxChars: chat.configuration.inputMaxChars,
     inputMaxPrompts: chat.configuration.inputMaxPrompts,
     attachmentName: chat.configuration.attachmentName,
+    context: chat.configuration.context,
     messages: messagesForPreview.map(({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled }) => ({
       content,
       attachmentName,

--- a/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
+++ b/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
@@ -3,7 +3,6 @@ export function serialize(llmChatDTO) {
     inputMaxChars: llmChatDTO.inputMaxChars,
     inputMaxPrompts: llmChatDTO.inputMaxPrompts,
     attachmentName: llmChatDTO.attachmentName,
-    chatId: llmChatDTO.id, // FIXME remove as soon as PIX-18710 is in production
     id: llmChatDTO.id,
   };
 }

--- a/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
+++ b/api/src/shared/infrastructure/serializers/llm-chat-serializer.js
@@ -3,6 +3,7 @@ export function serialize(llmChatDTO) {
     inputMaxChars: llmChatDTO.inputMaxChars,
     inputMaxPrompts: llmChatDTO.inputMaxPrompts,
     attachmentName: llmChatDTO.attachmentName,
+    context: llmChatDTO.context,
     id: llmChatDTO.id,
   };
 }

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -289,7 +289,6 @@ describe('Acceptance | Controller | passage-controller', function () {
             attachmentName: 'file.txt',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
-          expect(response.result).to.have.property('chatId').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
         });
       });

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -263,6 +263,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
+              context: 'modulix',
             },
             attachment: {
               name: 'file.txt',
@@ -287,6 +288,7 @@ describe('Acceptance | Controller | passage-controller', function () {
             inputMaxChars: 456,
             inputMaxPrompts: 788,
             attachmentName: 'file.txt',
+            context: 'modulix',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -806,7 +806,6 @@ describe('Acceptance | Controller | assessment-controller', function () {
             attachmentName: 'file.txt',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
-          expect(response.result).to.have.property('chatId').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
         });
       });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -780,6 +780,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
+              context: 'evaluation',
             },
             attachment: {
               name: 'file.txt',
@@ -804,6 +805,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
             inputMaxChars: 456,
             inputMaxPrompts: 788,
             attachmentName: 'file.txt',
+            context: 'evaluation',
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -250,6 +250,7 @@ describe('Acceptance | Route | llm-preview', function () {
             challenge: {
               inputMaxChars: 500,
               inputMaxPrompts: 4,
+              context: 'modulix',
             },
             attachment: {
               name: 'expected_file.txt',
@@ -300,6 +301,7 @@ describe('Acceptance | Route | llm-preview', function () {
         inputMaxChars: 500,
         inputMaxPrompts: 3,
         attachmentName: 'expected_file.txt',
+        context: 'modulix',
         messages: [
           {
             content: 'coucou user1',

--- a/api/tests/llm/unit/application/api/llm-api_test.js
+++ b/api/tests/llm/unit/application/api/llm-api_test.js
@@ -30,6 +30,7 @@ describe('LLM | Unit | Application | API | llm', function () {
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
+              context: 'modulix',
             },
             attachment: {
               name: 'file.txt',
@@ -53,6 +54,7 @@ describe('LLM | Unit | Application | API | llm', function () {
             attachmentName: newChat.configuration.attachmentName,
             inputMaxChars: newChat.configuration.inputMaxChars,
             inputMaxPrompts: newChat.configuration.inputMaxPrompts,
+            context: newChat.configuration.context,
           }),
         );
         expect(startChat).to.have.been.calledOnceWithExactly({ configurationId: configId, userId });

--- a/api/tests/llm/unit/domain/models/Configuration_test.js
+++ b/api/tests/llm/unit/domain/models/Configuration_test.js
@@ -13,6 +13,7 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
           challenge: {
             inputMaxChars: 456,
             inputMaxPrompts: 789,
+            context: 'modulix',
           },
           attachment: {
             name: 'some-attachment-name',
@@ -28,6 +29,7 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
           hasAttachment: true,
           attachmentName: 'some-attachment-name',
           attachmentContext: 'some-attachment-context',
+          context: 'modulix',
         });
       });
     });
@@ -53,6 +55,7 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
           hasAttachment: false,
           attachmentName: undefined,
           attachmentContext: undefined,
+          context: undefined,
         });
       });
     });
@@ -82,6 +85,7 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
         challenge: {
           inputMaxChars: 456,
           inputMaxPrompts: 789,
+          context: 'evaluation',
         },
         attachment: {
           name: 'some-attachment-name',
@@ -101,6 +105,7 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
         hasAttachment: true,
         attachmentName: 'some-attachment-name',
         attachmentContext: 'some-attachment-context',
+        context: 'evaluation',
       });
     });
   });

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -13,6 +13,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           challenge: {
             inputMaxChars: 500,
             inputMaxPrompts: 5,
+            context: 'modulix',
           },
           attachment: {
             name: 'filename.txt',
@@ -42,6 +43,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
         attachmentName: 'filename.txt',
         inputMaxChars: 500,
         inputMaxPrompts: 4,
+        context: 'modulix',
         messages: [
           {
             content: 'Salut',
@@ -101,6 +103,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           attachmentName: 'filename.txt',
           inputMaxChars: 500,
           inputMaxPrompts: 4,
+          context: undefined,
           messages: [
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -123,6 +126,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             challenge: {
               inputMaxChars: 500,
               inputMaxPrompts: 5,
+              context: 'modulix',
             },
             attachment: {
               name: 'chien.webp',
@@ -177,6 +181,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           attachmentName: 'chien.webp',
           inputMaxChars: 500,
           inputMaxPrompts: 4,
+          context: 'modulix',
           messages: [
             {
               content: 'Salut',
@@ -227,6 +232,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             challenge: {
               inputMaxChars: 500,
               inputMaxPrompts: 5,
+              context: 'modulix',
             },
             attachment: {
               name: 'chien.webp',
@@ -281,6 +287,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           attachmentName: 'chien.webp',
           inputMaxChars: 500,
           inputMaxPrompts: 4,
+          context: 'modulix',
           messages: [
             {
               content: 'Salut',


### PR DESCRIPTION
## 🔆 Problème

On va ajouter un champ "challenge.context" dans la configuration LLM pour que le front soit au courant de si c'est joué en modulix ou en éval (ça fait changer des wordings etc)

## ⛱️ Proposition

Transmettre cette info dans les diverses sérialisations de "chat" (modulix/eval/preview)

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester


