### PR TITLE
[TECH] Améliorer la répartition des shards pour le job playwright des tests end-to-end pour ne pas exécuter plusieurs fois certains tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1074,7 +1074,15 @@ jobs:
           command: npm run cache:refresh
       - run:
           name: Run E2E tests (with sharding)
-          command: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --grep-invert @runSerially --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+          command: |
+            if [ "$CIRCLE_NODE_TOTAL" -eq 1 ]; then
+              echo "Only one shard, running all tests without sharding..."
+              npx playwright test --grep-invert @runSerially
+            else
+              SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+              echo "Running sharded tests: shard $SHARD of $CIRCLE_NODE_TOTAL"
+              npx playwright test --grep-invert @runSerially --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+            fi
           environment:
             PIX_API_PORT: 3000
             PIX_APP_URL: http://localhost:4200
@@ -1084,7 +1092,13 @@ jobs:
             AUTH_SECRET: 'secret'
       - run:
           name: Run E2E tests (serially)
-          command: npx playwright test --grep @runSerially --workers=1
+          command: |
+            if [ "$CIRCLE_NODE_TOTAL" -eq 1 ] || [ "$CIRCLE_NODE_INDEX" -eq 0 ]; then
+              echo "Running serial tests..."
+              npx playwright test --grep @runSerially --workers=1
+            else
+              echo "Skipping serial tests on this shard."
+            fi
           environment:
             PIX_API_PORT: 3000
             PIX_APP_URL: http://localhost:4200

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1073,31 +1073,19 @@ jobs:
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
-          name: Run E2E tests (with sharding)
+          name: Run E2E tests
           command: |
             if [ "$CIRCLE_NODE_TOTAL" -eq 1 ]; then
-              echo "Only one shard, running all tests without sharding..."
+              echo "Only one shard: run both parallel and serial tests"
               npx playwright test --grep-invert @runSerially
-            else
-              SHARD="$((${CIRCLE_NODE_INDEX}+1))"
-              echo "Running sharded tests: shard $SHARD of $CIRCLE_NODE_TOTAL"
-              npx playwright test --grep-invert @runSerially --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
-            fi
-          environment:
-            PIX_API_PORT: 3000
-            PIX_APP_URL: http://localhost:4200
-            PIX_ORGA_URL: http://localhost:4201
-            PIX_CERTIF_URL: http://localhost:4203
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            AUTH_SECRET: 'secret'
-      - run:
-          name: Run E2E tests (serially)
-          command: |
-            if [ "$CIRCLE_NODE_TOTAL" -eq 1 ] || [ "$CIRCLE_NODE_INDEX" -eq 0 ]; then
-              echo "Running serial tests..."
+              npx playwright test --grep @runSerially --workers=1
+            elif [ "$CIRCLE_NODE_INDEX" -eq 0 ]; then
+              echo "Shard 0: run serial tests"
               npx playwright test --grep @runSerially --workers=1
             else
-              echo "Skipping serial tests on this shard."
+              SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+              echo "Shard $SHARD of $CIRCLE_NODE_TOTAL: run parallel tests"
+              npx playwright test --grep-invert @runSerially --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
             fi
           environment:
             PIX_API_PORT: 3000


### PR DESCRIPTION
## 🔆 Problème

Il existe deux "run" : 
- celui qui exécute en parallèle, avec les shards, les tests runnables en parallèle
- juste après, celui qui exécute les tests à lancer à part et en série.

Le problème c'est qu'avec la config actuelle, tous les shards exécutent le deuxième "run".

## ⛱️ Proposition

Merger les deux runs en un seul :
SI un seul shard
ALORS run tous les tests
OU SI plusieurs shards
 SI Shard 0
   run les tests en série
  SINON
   run tests parallèlisés avec shard


## 🌊 Remarques

# AVANT
<img width="1454" height="340" alt="e2e_avant00" src="https://github.com/user-attachments/assets/91ea725a-5c30-4518-b420-7be6c7de8f50" />
<img width="3216" height="224" alt="e2e_avant01" src="https://github.com/user-attachments/assets/912a3ef7-7d2f-47ad-b661-b058f351b8d9" />
<img width="3176" height="218" alt="e2e_avant02" src="https://github.com/user-attachments/assets/5a46a51d-83d9-4fdd-b223-d262bb911e67" />

# APRES
<img width="1142" height="349" alt="e2e_apres00" src="https://github.com/user-attachments/assets/645d1b47-82e9-4e88-ad45-19bf1d69c552" />
<img width="3225" height="289" alt="e2e_apres01" src="https://github.com/user-attachments/assets/038b5a6d-99a7-4f96-9500-d3ca5abebd41" />
<img width="3202" height="280" alt="e2e_apres02" src="https://github.com/user-attachments/assets/58e41527-acb2-4907-8915-d806ae94d458" />



## 🏄 Pour tester

Vérifier que dans circleci seul un shard se charge d'exécuter les tests en série
