### PR TITLE
[TECH] :card_file_box: Ajoute une contrainte d'unicité dans la table `certif-frameworks-challenges` (pix-18680)

### DIFF
--- a/api/db/migrations/20250729070138_add-constraint-to-version-column-into-certification-frameworks-challenges-table.js
+++ b/api/db/migrations/20250729070138_add-constraint-to-version-column-into-certification-frameworks-challenges-table.js
@@ -1,0 +1,32 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string('version')
+      .notNullable()
+      .comment(
+        'Version of consolidated  framework. The version is by framework key, meaning that different frameworks can have the same version.',
+      )
+      .alter();
+
+    table.unique(['version', 'challengeId', 'complementaryCertificationKey']);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('version').nullable().alter();
+    table.dropUnique(['version', 'challengeId', 'complementaryCertificationKey']);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous ne devrions pas avoir deux challengeId pour une même version sur une même certification complémentaire.

## ⛱️ Proposition

Ajouter une contrainte unique pour la table `certification-frameworks-challenges` avec  les colonnes  `challengeId`, `version` et `complementaryCertificationKey`.

## 🌊 Remarques

~~:warning: en attente du passage d'un script pour « nourrir » la colonne `version` en production~~
C'est bon, c'est fait.

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
