### PR TITLE
[FEATURE] Intégrer le QCU découverte (PIX-18829) (PIX-18879)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -34,6 +34,7 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms

--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -1,4 +1,8 @@
+@use 'pix-design-tokens/typography';
+
 .proposal-button {
+  @extend %pix-body-m;
+
   display: flex;
   align-items: center;
   width: 100%;
@@ -22,8 +26,12 @@
     cursor: not-allowed;
 
     &:hover {
-    background: var(--pix-neutral-0);
+      background: var(--pix-neutral-0);
     }
+  }
+
+  &.proposal-button--selected {
+    font-weight: var(--pix-font-bold);
   }
 
   &[disabled]:not(.proposal-button--selected) {
@@ -31,5 +39,26 @@
 
     background: var(--pix-primary-100);
     border-color: var(--state-border-color);
+  }
+}
+
+.proposal-button--variant-discovery {
+  &:hover,
+  &:active {
+    background: rgb(var(--pix-orga-50-inline), 0.5);
+  }
+
+  &.proposal-button--selected {
+    background: var(--pix-orga-50);
+    border-color: var(--pix-neutral-500);
+
+    &:hover {
+      background: var(--pix-orga-50);
+    }
+  }
+
+  &[disabled]:not(.proposal-button--selected) {
+    background: var(--pix-neutral-20);
+    border-color: transparent;
   }
 }

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -11,6 +11,7 @@ import QabElement from 'mon-pix/components/module/element/qab/qab';
 import QcmElement from 'mon-pix/components/module/element/qcm';
 import QcuElement from 'mon-pix/components/module/element/qcu';
 import QcuDeclarativeElement from 'mon-pix/components/module/element/qcu-declarative';
+import QcuDiscoveryElement from 'mon-pix/components/module/element/qcu-discovery';
 import QrocmElement from 'mon-pix/components/module/element/qrocm';
 import SeparatorElement from 'mon-pix/components/module/element/separator';
 import TextElement from 'mon-pix/components/module/element/text';
@@ -50,6 +51,8 @@ export default class ModulixElement extends Component {
       />
     {{else if (eq @element.type "qcu-declarative")}}
       <QcuDeclarativeElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
+    {{else if (eq @element.type "qcu-discovery")}}
+      <QcuDiscoveryElement @element={{@element}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "qcm")}}
       <QcmElement
         @element={{@element}}

--- a/mon-pix/app/components/module/component/proposal-button.gjs
+++ b/mon-pix/app/components/module/component/proposal-button.gjs
@@ -2,7 +2,9 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 <template>
   <button
-    class="proposal-button {{if @isSelected 'proposal-button--selected'}}"
+    class="proposal-button
+      {{if @isSelected 'proposal-button--selected'}}
+      {{if @isDiscoveryVariant 'proposal-button--variant-discovery'}}"
     type="submit"
     name={{@proposal.content}}
     value={{@proposal.id}}

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -1,0 +1,28 @@
+@use 'pix-design-tokens/typography';
+
+.element-qcu-discovery {
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__direction {
+    @extend %pix-body-s;
+
+    color: var(--pix-neutral-500);
+  }
+
+  &__proposals {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+    margin: var(--pix-spacing-4x) 0;
+  }
+
+  &__feedback {
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    color: var(--pix-neutral-800);
+    background: var(--pix-orga-50);
+    border-radius: 16px;
+  }
+}

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -1,0 +1,79 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import ProposalButton from 'mon-pix/components/module/component/proposal-button';
+
+import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import ModuleElement from './module-element';
+
+export default class ModuleQcuDiscovery extends ModuleElement {
+  @tracked selectedProposalId = null;
+  @tracked shouldDisplayFeedback = false;
+  @service passageEvents;
+
+  get selectedProposalFeedback() {
+    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
+  }
+
+  get selectedProposalAnswer() {
+    return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).content;
+  }
+
+  @action
+  isProposalSelected(proposalId) {
+    return this.selectedProposalId === proposalId;
+  }
+
+  @action
+  async onAnswer(event) {
+    event.preventDefault();
+    this.selectedProposalId = event.submitter.value;
+    this.shouldDisplayFeedback = true;
+    this.passageEvents.record({
+      type: 'QCU_DISCOVERY_ANSWERED',
+      data: {
+        elementId: this.element.id,
+        answer: this.selectedProposalId,
+        status: this.selectedProposalId === this.element.solution ? 'ok' : 'ko',
+      },
+    });
+
+    await this.args.onAnswer({ element: this.element });
+  }
+
+  get isAnswered() {
+    return this.selectedProposalId !== null;
+  }
+
+  <template>
+    <form class="element-qcu-discovery" onSubmit={{this.onAnswer}} aria-describedby="instruction-{{this.element.id}}">
+      <fieldset>
+        <legend class="screen-reader-only">
+          {{t "pages.modulix.qcuDiscovery.direction"}}
+        </legend>
+        <p class="element-qcu-discovery__instruction" id="instruction-{{this.element.id}}">
+          {{htmlUnsafe this.element.instruction}}
+        </p>
+        <p class="element-qcu-discovery__direction">
+          {{t "pages.modulix.qcuDiscovery.direction"}}
+        </p>
+        <div class="element-qcu-discovery__proposals">
+          {{#each this.element.proposals as |proposal|}}
+            <ProposalButton
+              @proposal={{proposal}}
+              @isDisabled={{this.isAnswered}}
+              @isSelected={{this.isProposalSelected proposal.id}}
+              @isDiscoveryVariant={{true}}
+            />
+          {{/each}}
+        </div>
+      </fieldset>
+    </form>
+    {{#if this.shouldDisplayFeedback}}
+      <div class="element-qcu-discovery__feedback" role="status" tabindex="-1">
+        {{htmlUnsafe this.selectedProposalFeedback}}
+      </div>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -28,6 +28,7 @@ export default class ModuleGrain extends Component {
     'qab',
     'qcu',
     'qcu-declarative',
+    'qcu-discovery',
     'qcm',
     'qrocm',
     'separator',
@@ -36,7 +37,7 @@ export default class ModuleGrain extends Component {
   ];
   static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition'];
 
-  static LOCALLY_ANSWERABLE_ELEMENTS = ['qab', 'qcu-declarative', 'flashcards'];
+  static LOCALLY_ANSWERABLE_ELEMENTS = ['qab', 'qcu-declarative', 'qcu-discovery', 'flashcards'];
 
   @tracked isStepperFinished = this.hasStepper === false;
 

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -99,6 +99,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/element/qab/qab-score-card' as *;
 @use '../components/module/element/qcu' as *;
 @use '../components/module/element/qcu-declarative' as *;
+@use '../components/module/element/qcu-discovery' as *;
 @use '../components/module/element/qcm' as *;
 @use '../components/module/element/qrocm' as *;
 @use '../components/module/element/separator' as *;

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -244,6 +244,27 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.ok(screen.getByRole('button', { name: element.proposals[0].content }));
   });
 
+  test('should display an element with a qcu discovery element', async function (assert) {
+    // given
+    const element = {
+      id: '0c397035-a940-441f-8936-050db7f997af',
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'prop1' },
+        { id: '2', content: 'prop2' },
+      ],
+      solution: '1',
+      type: 'qcu-discovery',
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.deepEqual(screen.getAllByText('Sélectionner la réponse qui vous semble la plus juste.').length, 2);
+    assert.ok(screen.getByRole('button', { name: element.proposals[0].content }));
+  });
+
   test('should display an element with a qcm element', async function (assert) {
     // given
     const element = {

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -1,0 +1,125 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ModuleQcuDiscovery from 'mon-pix/components/module/element/qcu-discovery';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | QCUDiscovery', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display an instruction, a direction and a list of proposals', async function (assert) {
+    // given
+    const qcuDiscoveryElement = _getQcuDiscoveryElement();
+    const { proposals } = qcuDiscoveryElement;
+
+    // when
+    const screen = await render(<template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} /></template>);
+
+    // then
+    assert.ok(screen.getByText('Quel est le dessert classique idéal lors d’un goûter ?'));
+    assert.deepEqual(screen.getAllByText(t('pages.modulix.qcuDiscovery.direction')).length, 2);
+    assert.ok(screen.getByRole('button', { name: proposals[0].content }));
+    assert.ok(screen.getByRole('button', { name: proposals[1].content }));
+    assert.ok(screen.getByRole('button', { name: proposals[2].content }));
+  });
+
+  module('when user clicks on one of the proposals', function () {
+    test('it should show feedback, disable proposal buttons and send an event', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcuDiscoveryElement = _getQcuDiscoveryElement();
+      const { proposals } = qcuDiscoveryElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const button1 = screen.getByRole('button', { name: proposals[0].content });
+      await click(button1);
+
+      // then
+      const button2 = screen.getByRole('button', { name: proposals[1].content });
+      const button3 = screen.getByRole('button', { name: proposals[2].content });
+      assert.dom(button1).isDisabled();
+      assert.dom(button2).isDisabled();
+      assert.dom(button3).isDisabled();
+      assert.ok(screen.getByText('Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !'));
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'QCU_DISCOVERY_ANSWERED',
+        data: {
+          elementId: qcuDiscoveryElement.id,
+          answer: proposals[0].id,
+          status: 'ok',
+        },
+      });
+    });
+
+    test('it should call "onAnswer" function pass as argument', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcuDiscoveryElement = _getQcuDiscoveryElement();
+      const { proposals } = qcuDiscoveryElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const button1 = screen.getByRole('button', { name: proposals[0].content });
+      await click(button1);
+
+      // then
+      sinon.assert.calledWithExactly(onAnswerStub, {
+        element: qcuDiscoveryElement,
+      });
+      assert.ok(true);
+    });
+  });
+});
+
+function _getQcuDiscoveryElement() {
+  const instruction = '<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>';
+  const solution = '1';
+
+  const proposals = [
+    {
+      id: '1',
+      content: 'Des cookies maison tout chauds',
+      feedback: {
+        diagnosis: '<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>',
+      },
+    },
+    {
+      id: '2',
+      content: 'Des mini-éclairs au chocolat',
+      feedback: {
+        diagnosis:
+          '<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>',
+      },
+    },
+    {
+      id: '3',
+      content: 'Un plateau de fruits frais et de fromage',
+      feedback: {
+        diagnosis: '<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>',
+      },
+    },
+    {
+      id: '4',
+      content: 'Une part de gâteau marbré au chocolat et à la vanille',
+      feedback: {
+        diagnosis: '<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>',
+      },
+    },
+  ];
+
+  return { id: '0c397035-a940-441f-8936-050db7f997af', instruction, proposals, solution };
+}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1764,6 +1764,9 @@
         "complementaryInstruction": "Select a single answer.",
         "direction": "There is no right or wrong answer."
       },
+      "qcuDiscovery": {
+        "direction": "Select the answer that you think is most accurate."
+      },
       "qrocm": {
         "direction": "Fill in the {count, plural, =1 {blank} other {blanks}}."
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1750,6 +1750,9 @@
         "complementaryInstruction": "Seleccione una sola respuesta.",
         "direction": "There is no right or wrong answer."
       },
+      "qcuDiscovery": {
+        "direction": "Seleccione la respuesta que le parezca más adecuada."
+      },
       "qrocm": {
         "direction": "Rellena {count, plural, =1 {le champ vide} other {les champs vides}}."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1730,7 +1730,7 @@
         },
         "title": {
           "lesson": "Leçon",
-          "summary":  "Récapitulatif"
+          "summary": "Récapitulatif"
         }
       },
       "interactiveElement": {
@@ -1763,6 +1763,9 @@
       "qcuDeclarative": {
         "complementaryInstruction": "Il n’y a pas de bonne ou de mauvaise réponse.",
         "direction": "Sélectionnez une seule réponse."
+      },
+      "qcuDiscovery": {
+        "direction": "Sélectionner la réponse qui vous semble la plus juste."
       },
       "qrocm": {
         "direction": "Remplissez {count, plural, =1 {le champ vide} other {les champs vides}}."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1753,6 +1753,9 @@
         "complementaryInstruction": "Kies één antwoord",
         "direction": "There is no right or wrong answer."
       },
+      "qcuDiscovery": {
+        "direction": "Selecteer het antwoord dat u het meest juist lijkt."
+      },
       "qrocm": {
         "direction": "Vul de lege velden in."
       },


### PR DESCRIPTION
## ⛱️ Proposition

En tant que contenu métier je souhaite avoir une modalité de type QCU pour la section découverte qui permettrait d’avoir un feedbacks sans être positif ou négatif 

## 🌊 Remarques

Ajout d'un niveau de gras sur la proposition sélectionnée du QCU declaratif suite à synchro design. => à voir si nécessaire de faire sur QCU/QCM (dans Pix UI).

## 🏄 Pour tester

Lorsque je contribue une modalité QCU découverte alors elle s’affiche correctement

Lorsque je clique sur une proposition alors j’ai bien un feedback qui s’affiche directement (sans bouton vérifier). Le bouton continuer s’affiche bien une fois que le feedback est affiché

Je n’ai pas la possibilité de réessayer

Une trace d'apprentissage `QCU_DISCOVERY_ANSWERED` est enregistrée

A tester sur le module [bac-a-sable](https://app-pr13027.review.pix.fr/modules/bac-a-sable/details)
