### PR TITLE
[FEATURE] Ajuster les paramètres par défaut du lecteur vidéo dans Modulix

### DIFF
--- a/mon-pix/app/components/module/element/video.gjs
+++ b/mon-pix/app/components/module/element/video.gjs
@@ -37,7 +37,7 @@ export default class ModulixVideoElement extends Component {
   @action
   launchPlyr() {
     new Plyr(document.getElementById(this.args.video.id), {
-      hideControls: false,
+      hideControls: true,
       disableContextMenu: false,
       i18n: player_fr,
       loadSprite: false,


### PR DESCRIPTION
## 🔆 Problème

Quelques retours sur le lecteur vidéo : 
- possible d’afficher les sous titres par défaut sur une vidéo ?
- actuellement barre de lecture qui s’affiche en continu (comportement inhabituel) + si on affiche en plus les sous titre = occupe une grande partie de l’écran


## ⛱️ Proposition

- ~afficher les sous-titres par défaut (si il y en a)~
- cacher les contrôles sur la vidéo après 2 secondes.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier dans un module avec vidéo, exemple : https://app-pr13028.review.pix.fr/modules/controle-parental/passage
