### PR TITLE
[TECH] :truck: Déplace le modèle partagé `CertifiableProfileForLearningContent` vers le contexte  spécifique `src/certification/evaluation/`

### DIFF
--- a/api/src/certification/evaluation/domain/models/CertifiableProfileForLearningContent.js
+++ b/api/src/certification/evaluation/domain/models/CertifiableProfileForLearningContent.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { KnowledgeElement } from './KnowledgeElement.js';
+import { KnowledgeElement } from '../../../../shared/domain/models/KnowledgeElement.js';
 
 class CertifiableProfileForLearningContent {
   constructor({ learningContent, knowledgeElements, answerAndChallengeIdsByAnswerId }) {

--- a/api/src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { CertifiableProfileForLearningContent } from '../../../../shared/domain/models/CertifiableProfileForLearningContent.js';
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
+import { CertifiableProfileForLearningContent } from '../../domain/models/CertifiableProfileForLearningContent.js';
 
 const get = async function ({ id, profileDate, learningContent }) {
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: id, limitDate: profileDate });

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -59,7 +59,6 @@ import { BadgeForCalculation } from './BadgeForCalculation.js';
 import { CampaignLearningContent } from './CampaignLearningContent.js';
 import { CampaignParticipationResult } from './CampaignParticipationResult.js';
 import { CertifiableBadgeAcquisition } from './CertifiableBadgeAcquisition.js';
-import { CertifiableProfileForLearningContent } from './CertifiableProfileForLearningContent.js';
 import { CertificationCandidate } from './CertificationCandidate.js';
 import { CertificationCenter } from './CertificationCenter.js';
 import { CertificationCenterMembership } from './CertificationCenterMembership.js';
@@ -124,7 +123,6 @@ export {
   CampaignToStartParticipation,
   CampaignTypes,
   CertifiableBadgeAcquisition,
-  CertifiableProfileForLearningContent,
   CertificationAssessmentScore,
   CertificationAttestation,
   CertificationCandidate,

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/certifiable-profile-for-learning-content-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/certifiable-profile-for-learning-content-repository_test.js
@@ -1,5 +1,5 @@
+import { CertifiableProfileForLearningContent } from '../../../../../../src/certification/evaluation/domain/models/CertifiableProfileForLearningContent.js';
 import * as certifiableProfileForLearningContentRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/certifiable-profile-for-learning-content-repository.js';
-import { CertifiableProfileForLearningContent } from '../../../../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/tooling/domain-builder/factory/build-certifiable-profile-for-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifiable-profile-for-learning-content.js
@@ -1,4 +1,4 @@
-import { CertifiableProfileForLearningContent } from '../../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
+import { CertifiableProfileForLearningContent } from '../../../../src/certification/evaluation/domain/models/CertifiableProfileForLearningContent.js';
 
 const buildCertifiableProfileForLearningContent = function ({
   learningContent,

--- a/api/tests/unit/domain/models/CertifiableProfileForLearningContent_test.js
+++ b/api/tests/unit/domain/models/CertifiableProfileForLearningContent_test.js
@@ -1,4 +1,4 @@
-import { CertifiableProfileForLearningContent } from '../../../../src/shared/domain/models/CertifiableProfileForLearningContent.js';
+import { CertifiableProfileForLearningContent } from '../../../../src/certification/evaluation/domain/models/CertifiableProfileForLearningContent.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | CertifiableProfileForLearningContent', function () {


### PR DESCRIPTION
## 🔆 Problème

Le modèle partagé `CertifiableProfileForLearningContent` est dans le répertoire `src/shared/`  alors qu'il n'est utilisé que dans le contexte spécifique `src/certification/evaluation/`.

## ⛱️ Proposition

Déplacer le modèle partagé `CertifiableProfileForLearningContent` vers le contexte  spécifique `src/certification/evaluation/`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
