### PR TITLE
[BUGFIX] Corriger la gestion d'erreur dans deux usecases combinix (PIX-18838)

### DIFF
--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -17,7 +17,7 @@ export async function getCombinedCourseByCode({
   try {
     participation = await combinedCourseParticipationRepository.getByUserId({ questId: quest.id, userId });
   } catch (err) {
-    if ((!err) instanceof NotFoundError) {
+    if (!(err instanceof NotFoundError)) {
       throw err;
     }
   }

--- a/api/src/quest/domain/usecases/get-verified-code.js
+++ b/api/src/quest/domain/usecases/get-verified-code.js
@@ -6,7 +6,7 @@ export const getVerifiedCode = async ({ code, campaignRepository, combinedCourse
     const campaign = await campaignRepository.getByCode({ code });
     return new VerifiedCode({ code: campaign.code, type: 'campaign' });
   } catch (error) {
-    if ((!error) instanceof NotFoundError) {
+    if (!(error instanceof NotFoundError)) {
       throw error;
     }
   }

--- a/api/tests/quest/unit/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-combined-course-by-code_test.js
@@ -1,0 +1,33 @@
+import { getCombinedCourseByCode } from '../../../../../src/quest/domain/usecases/get-combined-course-by-code.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Usecases | getCombinedCourseByCode', function () {
+  it('should throw error if not a NotFoundError', async function () {
+    // given
+    const userId = Symbol('userId');
+    const code = Symbol('code');
+    const questId = Symbol('questId');
+    const combinedCourse = Symbol('CombinedCourse');
+
+    const questRepositoryStub = { getByCode: sinon.stub() };
+    const combinedCourseRepositoryStub = { getByCode: sinon.stub() };
+    const combinedCourseParticipationRepositoryStub = { getByUserId: sinon.stub() };
+
+    questRepositoryStub.getByCode.resolves({ questId, userId });
+    combinedCourseRepositoryStub.getByCode.resolves(combinedCourse);
+    combinedCourseParticipationRepositoryStub.getByUserId.rejects(new Error('oops'));
+
+    // when
+    const error = await catchErr(getCombinedCourseByCode)({
+      userId,
+      code,
+      questRepository: questRepositoryStub,
+      combinedCourseRepository: combinedCourseRepositoryStub,
+      combinedCourseParticipationRepository: combinedCourseParticipationRepositoryStub,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('oops');
+  });
+});

--- a/api/tests/quest/unit/domain/usecases/get-verified-code_test.js
+++ b/api/tests/quest/unit/domain/usecases/get-verified-code_test.js
@@ -1,0 +1,25 @@
+import { getVerifiedCode } from '../../../../../src/quest/domain/usecases/get-verified-code.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Usecases | getVerifiedCode', function () {
+  it('should throw error if not a NotFoundError', async function () {
+    // given
+    const code = Symbol('code');
+
+    const campaignRepositoryStub = { getByCode: sinon.stub() };
+    const combinedCourseRepositoryStub = { getByCode: sinon.stub() };
+
+    campaignRepositoryStub.getByCode.rejects(new Error('oops'));
+
+    // when
+    const error = await catchErr(getVerifiedCode)({
+      code,
+      campaignRepository: campaignRepositoryStub,
+      combinedCourseRepository: combinedCourseRepositoryStub,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('oops');
+  });
+});


### PR DESCRIPTION
## 🔆 Problème
Dans les usecases `getCombinedCourseByCode` & `getVerifiedCode` une parenthèse s'est glisée au mauvais endroit dans le catch. Ce rends le comportement différent de celui attendu

## ⛱️ Proposition
On ajoute un test unitaire dans chacun des usecases, puis on corrige l'implem pour faire passer les tests

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
CI au vert 🐈‍⬛ 
