### PR TITLE
[FEATURE] Retirer le champ `state` du feedback du QCU déclaratif (PIX-18440)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -156,7 +156,6 @@
                 "id": "1",
                 "content": "Avant de mettre le dentifrice",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
                 }
               },
@@ -164,7 +163,6 @@
                 "id": "2",
                 "content": "Après avoir mis le dentifrice",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
                 }
               },
@@ -172,7 +170,6 @@
                 "id": "3",
                 "content": "Pendant que le dentifrice est mis",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Digne des plus grands acrobates !</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -619,7 +619,6 @@
                 "id": "1",
                 "content": "<p>Oui, j'ai déjà utilisé un outil de contrôle parental.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Super ! ✨ C’est un bon moyen de compléter le dialogue avec vos enfants. N’hésitez pas à réévaluer régulièrement les réglages selon leurs âges et leurs usages. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
                 }
               },
@@ -627,7 +626,6 @@
                 "id": "2",
                 "content": "<p>Pas encore, mais j'y pense.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Si vous avez envie de vous lancer, vous pouvez commencer simplement, par exemple en explorant les paramètres d’un seul appareil. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
                 }
               },
@@ -635,7 +633,6 @@
                 "id": "3",
                 "content": "<p>Non, je n'en ai pas besoin pour l'instant.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>L’important est de rester informé et prêt à agir si le besoin se présente. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
@@ -580,7 +580,6 @@
                 "id": "1",
                 "content": "<p>Partager la vidéo.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Attention à ne pas partager de deepfakes !</p>"
                 }
               },
@@ -588,7 +587,6 @@
                 "id": "2",
                 "content": "<p>Signaler la vidéo.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, quand on repère un deepfake sur un réseau social, on peut le signaler.</p>"
                 }
               },
@@ -596,7 +594,6 @@
                 "id": "3",
                 "content": "<p>Chercher la source.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Bon réflexe !&nbsp;</p>"
                 }
               },
@@ -604,7 +601,6 @@
                 "id": "4",
                 "content": "<p>En discuter avec vos amis.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, lorsqu'on a un doute sur un contenu en ligne, on peut demander l'avis de ses amis.</p>"
                 }
               },
@@ -612,7 +608,6 @@
                 "id": "5",
                 "content": "<p>Rien de spécial.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Passer son chemin face à un contenu en ligne qu'on soupçonne d'être un deepfake, c'est bien ! Le signaler, c'est mieux !</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -157,9 +157,7 @@
                 "ariaLabel": "nombre d'utilisation de l'IA",
                 "defaultValue": "",
                 "tolerances": [],
-                "solutions": [
-                  6
-                ]
+                "solutions": [6]
               }
             ],
             "feedbacks": {
@@ -481,7 +479,6 @@
                 "id": "1",
                 "content": "<p>oui</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Pas étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
                 }
               },
@@ -489,7 +486,6 @@
                 "id": "2",
                 "content": "<p>non</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
                 }
               },
@@ -497,7 +493,6 @@
                 "id": "3",
                 "content": "<p>J'hésite.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Vous n'êtes pas sûr, mais il y a de grandes chances que ce soit le cas. &nbsp;L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
@@ -887,7 +887,6 @@
                 "id": "1",
                 "content": "<p>Vous vérifiez cette information dans une encyclopédie. 📖</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !&nbsp;</p>"
                 }
               },
@@ -895,7 +894,6 @@
                 "id": "2",
                 "content": "<p>Vous supposez que la Statue de la liberté a été déplacée. 🧳</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Si un monument aussi connu était déplacé, il y aurait de nombreuses informations à ce sujet. Vérifier l'information serait une bonne idée !&nbsp;</p>"
                 }
               },
@@ -903,7 +901,6 @@
                 "id": "3",
                 "content": "<p>Vous cherchez sur internet une confirmation. 🔎</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !</p>"
                 }
               },
@@ -911,7 +908,6 @@
                 "id": "4",
                 "content": "<p>Vous réservez vos billets d’avion immédiatement. ✈️</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Attention ! Vous pourriez être déçu par votre voyage si vous partez pour voir la Statue de la Liberté à Tokyo.&nbsp;Vérifier l'information serait une bonne idée !</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
@@ -133,12 +133,7 @@
                 "diagnosis": "<p>Il faut donner plus de précisions&nbsp;: le contexte donne du sens au prompt. Plus l'IA a des informations sur la situation, meilleure sera sa réponse.<br></p>"
               }
             },
-            "solutions": [
-              "1",
-              "2",
-              "3",
-              "4"
-            ]
+            "solutions": ["1", "2", "3", "4"]
           }
         }
       ]
@@ -197,7 +192,6 @@
                 "id": "1",
                 "content": "<p>celui avec un ton festif</p>",
                 "feedback": {
-                  "state": "<p>Un choix sympa !</p>",
                   "diagnosis": "<p><strong>Un choix sympa !</strong>&nbsp; Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
                 }
               },
@@ -205,7 +199,6 @@
                 "id": "2",
                 "content": "<p>celui avec un ton sérieux</p>",
                 "feedback": {
-                  "state": "<p>Un choix formel !</p><p><br></p>",
                   "diagnosis": "<p><strong>Un choix formel ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
                 }
               },
@@ -213,7 +206,6 @@
                 "id": "3",
                 "content": "<p>celui avec un ton drôle</p>",
                 "feedback": {
-                  "state": "<p><br></p>",
                   "diagnosis": "<p><strong>Un choix original ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi. <br></p>"
                 }
               },
@@ -221,7 +213,6 @@
                 "id": "4",
                 "content": "<p>aucun ne me plait\t<br></p>",
                 "feedback": {
-                  "state": "<p>Pas de souci !&nbsp; </p>",
                   "diagnosis": "<p><strong>Pas de souci !</strong> Il existe beaucoup d’autres tons : enfantin, ironique, poétique… Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi ! </p>"
                 }
               }
@@ -286,14 +277,8 @@
                 "placeholder": "un seul mot",
                 "ariaLabel": "champs à remplir",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t2",
-                  "t3"
-                ],
-                "solutions": [
-                  "tableau"
-                ]
+                "tolerances": ["t1", "t2", "t3"],
+                "solutions": ["tableau"]
               }
             ],
             "feedbacks": {
@@ -431,11 +416,7 @@
                       "diagnosis": "<p>Ici, le format est le plan détaillé, le rôle est le coach de volley et le contexte correspond à l’heure d'entraînement pour des enfants de 6 à 8 ans débutant.<br></p>"
                     }
                   },
-                  "solutions": [
-                    "1",
-                    "2",
-                    "4"
-                  ]
+                  "solutions": ["1", "2", "4"]
                 }
               ]
             },
@@ -478,11 +459,7 @@
                       "diagnosis": "<p>Ici, le format est le formulaire d’inscription, le ton est formel et le contexte correspond à toutes les informations sur l’association, son public et la fréquence des cours.<br></p>"
                     }
                   },
-                  "solutions": [
-                    "1",
-                    "2",
-                    "3"
-                  ]
+                  "solutions": ["1", "2", "3"]
                 }
               ]
             },
@@ -525,10 +502,7 @@
                       "diagnosis": "<p>Ici, le rôle est Molière et le contexte, celui du match de volley à la plage.<br></p>"
                     }
                   },
-                  "solutions": [
-                    "1",
-                    "4"
-                  ]
+                  "solutions": ["1", "4"]
                 }
               ]
             },
@@ -571,12 +545,7 @@
                       "diagnosis": "<p>Ici, l’humoriste est le rôle, le format est un court discours, le ton est amusant. Le contexte est le pot de départ d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
                     }
                   },
-                  "solutions": [
-                    "1",
-                    "2",
-                    "3",
-                    "4"
-                  ]
+                  "solutions": ["1", "2", "3", "4"]
                 }
               ]
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
@@ -103,7 +103,7 @@
             "id": "de11d987-0276-4a1c-9266-cc28961283d5",
             "type": "custom",
             "tagName": "llm-compare-messages",
-            "props":{
+            "props": {
               "conversation1": {
                 "title": "Conversation 1",
                 "llmName": "Chatbot #1"
@@ -433,7 +433,6 @@
                 "id": "1",
                 "content": "<p>tous les articles de Wikipedia</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>C'est un bon début&nbsp;: les articles Wikipedia sont très nombreux, variés et souvent bien écrits.</p>"
                 }
               },
@@ -441,7 +440,6 @@
                 "id": "2",
                 "content": "<p>des discussions de forums</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>C'est intéressant pour avoir des mots du quotidien ! Mais la précision du vocabulaire ne sera sûrement pas garantie.<br></p>"
                 }
               },
@@ -449,7 +447,6 @@
                 "id": "3",
                 "content": "<p>des articles scientifiques</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>C'est utile pour avoir du vocabulaire scientifique, donc des mots très précis.</p>"
                 }
               },
@@ -457,7 +454,6 @@
                 "id": "4",
                 "content": "<p>toutes ces réponses</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>C'est l'idéal&nbsp;: plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
                 }
               },
@@ -465,7 +461,6 @@
                 "id": "5",
                 "content": "<p>Je ne sais pas.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
                 }
               }
@@ -677,7 +672,6 @@
                 "id": "1",
                 "content": "<p>J’utiliserai les réponses qu’elle me donne, sans les vérifier.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p><strong>C’est risqué ! </strong></p><p>Les logiciels d'IA générative répondent de manière souvent intéressante. </p><p>Mais ils ne connaissent pas la signification des mots et il peut y avoir des erreurs dans leurs réponses.</p>"
                 }
               },
@@ -685,7 +679,6 @@
                 "id": "2",
                 "content": "<p>Je poserai plusieurs questions pendant la discussion.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p><strong>C’est un bon réflexe !</strong> </p><p> En demandant des précisions par exemple, vous pourrez avoir une réponse plus précise. </p><p> Vous pouvez aussi demander : « Est-ce que cela est vraiment exact ? ».</p>"
                 }
               },
@@ -693,7 +686,6 @@
                 "id": "3",
                 "content": "<p>Je vérifierai les réponses avec d’autres outils (internet, livres…).</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p><strong>Oui, c'est important !</strong> </p><p>Un logiciel d'IA générative permet de trouver très rapidement des informations. </p><p>Mais il est nécessaire de vérifier ces informations ailleurs, avec d'autres sources.</p>"
                 }
               },
@@ -701,7 +693,6 @@
                 "id": "4",
                 "content": "<p>Je ne sais pas.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p><strong>Pas toujours facile de choisir !</strong> </p><p>Souvenez-vous qu’un logiciel d'IA générative peut faire des erreurs. Il faut donc toujours vérifier ses réponses.</p>"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -69,7 +69,6 @@
                 "id": "1",
                 "content": "<p>Il a l’air incollable.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, ce logiciel d'IA générative est capable de répondre de façon pertinente sur des sujets très divers ! On peut aussi remarquer qu'il est possible de lui poser des questions et d'obtenir des réponses comme si on discutait avec un humain. 💬 </p>"
                 }
               },
@@ -77,7 +76,6 @@
                 "id": "2",
                 "content": "<p>Il s’exprime comme un humain.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Effectivement, on pourrait penser qu'on discute avec un humain ! On peut aussi remarquer que ses réponses sont pertinentes sur des sujets très divers. 🏊‍♀️ </p>"
                 }
               },
@@ -85,7 +83,6 @@
                 "id": "3",
                 "content": "<p>Je ne sais pas.</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Ce logiciel d'IA générative permet de discuter comme on le ferait avec un humain. On remarque aussi que les réponses sont pertinentes sur des sujets très variés.</p>"
                 }
               }
@@ -141,7 +138,6 @@
                 "id": "1",
                 "content": "<p>kangourou</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Observez attentivement la taille du cercle nommé « koala » par rapport à celui qui représente « kangourou ».</p>"
                 }
               },
@@ -149,7 +145,6 @@
                 "id": "2",
                 "content": "<p>koala</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Pendant cette étape de l’entraînement, elle a bien remarqué que le mot « koala » apparaît souvent en même temps que « animaux », « Océanie », etc.</p>"
                 }
               },
@@ -157,7 +152,6 @@
                 "id": "3",
                 "content": "<p>wallaby</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>Observez attentivement la taille du cercle nommé « koala » par rapport à celui qui représente « wallaby ».</p>"
                 }
               }
@@ -494,7 +488,8 @@
                   "diagnosis": "<p>Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
                 }
               }
-            ],"solution": "3"
+            ],
+            "solution": "3"
           }
         }
       ]
@@ -785,7 +780,6 @@
                 "id": "1",
                 "content": "<p>oui</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>todo</p>"
                 }
               },
@@ -793,7 +787,6 @@
                 "id": "2",
                 "content": "<p>non</p>",
                 "feedback": {
-                  "state": "",
                   "diagnosis": "<p>todo</p>"
                 }
               }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu-declarative-schema.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
-import { feedbackSchema } from './feedback-schema.js';
+import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
 
 const qcuDeclarativeElementSchema = Joi.object({
   id: uuidSchema,
@@ -11,7 +11,7 @@ const qcuDeclarativeElementSchema = Joi.object({
     .items({
       id: proposalIdSchema.required(),
       content: htmlSchema.required(),
-      feedback: feedbackSchema.required(),
+      feedback: feedbackNeutralSchema.required(),
     })
     .required(),
 });

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -442,7 +442,12 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                   element: {
                     id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
                     type: 'download',
-                    files: [{ url: 'https://example.org/modulix/file.pdf', format: '.pdf' }],
+                    files: [
+                      {
+                        url: 'https://example.org/modulix/file.pdf',
+                        format: '.pdf',
+                      },
+                    ],
                   },
                 },
               ],
@@ -588,7 +593,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                         id: '1',
                         content: 'Avant de mettre le dentifrice',
                         feedback: {
-                          state: '',
                           diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
                         },
                       },
@@ -596,7 +600,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                         id: '2',
                         content: 'Après avoir mis le dentifrice',
                         feedback: {
-                          state: '',
                           diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
                         },
                       },
@@ -604,7 +607,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                         id: '3',
                         content: 'Pendant que le dentifrice est mis',
                         feedback: {
-                          state: '',
                           diagnosis: '<p>Digne des plus grands acrobates !</p>',
                         },
                       },
@@ -1237,7 +1239,12 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                         {
                           id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
                           type: 'download',
-                          files: [{ url: 'https://example.org/modulix/file.pdf', format: '.pdf' }],
+                          files: [
+                            {
+                              url: 'https://example.org/modulix/file.pdf',
+                              format: '.pdf',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1349,7 +1356,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                             {
                               id: '2',
                               content: 'Faux',
-                              feedback: { state: "Faux n'est pas la bonne réponse." },
+                              feedback: {
+                                state: "Faux n'est pas la bonne réponse.",
+                              },
                             },
                           ],
                           solution: '1',
@@ -1407,7 +1416,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                               id: '1',
                               content: 'Avant de mettre le dentifrice',
                               feedback: {
-                                state: '',
                                 diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
                               },
                             },
@@ -1415,7 +1423,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                               id: '2',
                               content: 'Après avoir mis le dentifrice',
                               feedback: {
-                                state: '',
                                 diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
                               },
                             },
@@ -1423,7 +1430,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                               id: '3',
                               content: 'Pendant que le dentifrice est mis',
                               feedback: {
-                                state: '',
                                 diagnosis: '<p>Digne des plus grands acrobates !</p>',
                               },
                             },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -41,7 +41,15 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta, version });
+      const moduleFromDomain = new Module({
+        id,
+        details,
+        slug,
+        title,
+        grains: [],
+        isBeta,
+        version,
+      });
       const expectedJson = {
         data: {
           type: 'modules',
@@ -212,7 +220,6 @@ function getComponents() {
             id: '1',
             content: 'plop',
             feedback: {
-              state: '',
               diagnosis: 'blabla',
             },
           },
@@ -220,7 +227,6 @@ function getComponents() {
             id: '2',
             content: 'bam',
             feedback: {
-              state: '',
               diagnosis: 'blabla',
             },
           },
@@ -399,7 +405,6 @@ function getAttributesComponents() {
             content: 'plop',
             id: '1',
             feedback: {
-              state: '',
               diagnosis: 'blabla',
             },
           },
@@ -407,7 +412,6 @@ function getAttributesComponents() {
             content: 'bam',
             id: '2',
             feedback: {
-              state: '',
               diagnosis: 'blabla',
             },
           },

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -405,7 +405,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 id: '1',
                 content: 'Avant de mettre le dentifrice',
                 feedback: {
-                  state: '',
                   diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
                 },
               },
@@ -413,7 +412,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 id: '2',
                 content: 'Après avoir mis le dentifrice',
                 feedback: {
-                  state: '',
                   diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
                 },
               },
@@ -421,7 +419,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 id: '3',
                 content: 'Pendant que le dentifrice est mis',
                 feedback: {
-                  state: '',
                   diagnosis: '<p>Digne des plus grands acrobates !</p>',
                 },
               },

--- a/mon-pix/tests/integration/components/module/proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/proposal-button_test.gjs
@@ -13,7 +13,6 @@ module('Integration | Component | Module | ProposalButton', function (hooks) {
       id: '1',
       content: 'Avant de mettre le dentifrice',
       feedback: {
-        state: '',
         diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
       },
     };
@@ -31,7 +30,6 @@ module('Integration | Component | Module | ProposalButton', function (hooks) {
         id: '1',
         content: 'Avant de mettre le dentifrice',
         feedback: {
-          state: '',
           diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
         },
       };
@@ -50,7 +48,6 @@ module('Integration | Component | Module | ProposalButton', function (hooks) {
         id: '1',
         content: 'Avant de mettre le dentifrice',
         feedback: {
-          state: '',
           diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
         },
       };

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -91,7 +91,6 @@ function _getQcuDeclarativeElement() {
       id: '1',
       content: 'Du ‘oui‘',
       feedback: {
-        state: '',
         diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
       },
     },
@@ -99,7 +98,6 @@ function _getQcuDeclarativeElement() {
       id: '2',
       content: 'Du ‘non‘',
       feedback: {
-        state: '',
         diagnosis: '<p>Possible, mais attention à ne pas faire une rafarinade !</p>',
       },
     },
@@ -107,7 +105,6 @@ function _getQcuDeclarativeElement() {
       id: '3',
       content: 'Du ‘peut-être‘',
       feedback: {
-        state: '',
         diagnosis: '<p>Digne des plus grands acrobates !</p>',
       },
     },


### PR DESCRIPTION
## 🔆 Problème

Le QCU déclaratif ne contient pas de bonne ou de mauvaise ~situation~ réponse. On ne souhaite pas afficher de constat lors du feedback.

## ⛱️ Proposition

Retirer le champ `state` du feedback du qcu-declarative.

## 🌊 Remarques

Penser à mettre à jour Modulix Editor.

## 🏄 Pour tester

CI 🍏 
