### PR TITLE
[BUGFIX] Afficher correctement le référentiel dans le sélecteur de sujets sur Pix Orga (PIX-17183).

### DIFF
--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -145,7 +145,7 @@ export default class TubeList extends Component {
                 <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
                 <thead>
                   <tr>
-                    <Header @size="medium" @align="center" scope="col">
+                    <Header @size="medium" scope="col">
                       {{t "pages.preselect-target-profile.table.column.theme-name"}}
                     </Header>
                     <Header @size="wide" scope="col">

--- a/orga/app/components/tube/list.gjs
+++ b/orga/app/components/tube/list.gjs
@@ -148,9 +148,6 @@ export default class TubeList extends Component {
                     <Header @size="medium" @align="center" scope="col">
                       {{t "pages.preselect-target-profile.table.column.theme-name"}}
                     </Header>
-                    <Header @size="small" @align="center" scope="col">
-                      {{t "pages.preselect-target-profile.table.column.action"}}
-                    </Header>
                     <Header @size="wide" scope="col">
                       {{t "pages.preselect-target-profile.table.column.name"}}
                     </Header>

--- a/orga/app/components/tube/tube.gjs
+++ b/orga/app/components/tube/tube.gjs
@@ -20,24 +20,14 @@ export default class Tube extends Component {
   }
 
   <template>
-    <td class="table__column--center">
-      <PixCheckbox
-        @screenReaderOnly={{true}}
-        @id="tube-{{@tube.id}}"
-        {{on "click" this.toggleTube}}
-        @checked={{this.checked}}
-      >
+    <td>
+      <PixCheckbox @id="tube-{{@tube.id}}" {{on "click" this.toggleTube}} @checked={{this.checked}}>
         <:label>
           {{@tube.practicalTitle}}
           :
           {{@tube.practicalDescription}}
         </:label>
       </PixCheckbox>
-    </td>
-    <td>
-      {{@tube.practicalTitle}}
-      :
-      {{@tube.practicalDescription}}
     </td>
     <td class="table__column--center">
       <div

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -86,6 +86,7 @@
       th,
       td {
         padding-left: 1rem;
+        text-align: left;
         vertical-align: middle;
       }
 

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -76,6 +76,7 @@
 
       table {
         color: var(--pix-neutral-800);
+        border-collapse: collapse;
       }
 
       th {
@@ -88,6 +89,10 @@
         padding-left: 1rem;
         text-align: left;
         vertical-align: middle;
+      }
+
+      tr:not(:first-child) {
+        border-top: 1px solid var(--pix-neutral-20);
       }
 
       td.table__column--center,

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -63,7 +63,7 @@
     }
 
     &__content {
-      padding: 0;
+      padding: 0 1rem;
       cursor: auto;
 
       h2 {
@@ -85,6 +85,7 @@
 
       th,
       td {
+        padding-left: 1rem;
         vertical-align: middle;
       }
 

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -21,6 +21,20 @@
   .not-responsive {
     fill: var(--pix-error-700);
   }
+
+  .table__column {
+    &--medium {
+      width: 30%;
+    }
+
+    &--wide {
+      width: 60%;
+    }
+
+    &--small {
+      width: 5%;
+    }
+  }
 }
 
 .preselect-target-profile {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1376,7 +1376,6 @@
       "table": {
         "caption": "Topic selection",
         "column": {
-          "action": "Select",
           "mobile": "Mobile compliant",
           "name": "Topic name",
           "tablet": "Tablet compliant",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1376,7 +1376,6 @@
       "table": {
         "caption": "Sélection des sujets",
         "column": {
-          "action": "Sélection",
           "mobile": "Compatible smartphone",
           "name": "Nom du sujet",
           "tablet": "Compatible tablette",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1376,7 +1376,6 @@
       "table": {
         "caption": "Selectie van onderwerpen",
         "column": {
-          "action": "Selectie",
           "mobile": "Geschikt voor smartphone",
           "name": "Naam onderwerp",
           "tablet": "Geschikt voor tablet",


### PR DESCRIPTION
## 🔆 Problème

Le sélecteur de sujets sur Pix Orga a quelques problèmes d'affichage : 

<img width="3456" height="4110" alt="Screenshot 2025-07-29 at 12 14 06" src="https://github.com/user-attachments/assets/54ec56b5-674d-48ae-8979-c862c8c9aa4b" />

## ⛱️ Proposition

Rendre les choses plus lisibles, un découpage laser des commits a été effectué : 

- On ajoute un peu d'espace dans le contenu de l'accordéon et un padding à gauche sur les colonnes
- On supprime la colonne avec la checkbox uniquement pour rendre le sujet cliquable
- On remet la colonne thématique en text-align: left
- On ajoute une bordure entre chaque ligne
- On définit une taille de colonne pour que toutes les colonnes de la page soient de la même taille

<img width="3456" height="7372" alt="Screenshot 2025-07-29 at 12 14 57" src="https://github.com/user-attachments/assets/9dd6e02e-c439-49f3-a7e3-33307d8d5a04" />


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Sur Pix Orga se rendre sur `/selection-sujets` et constater