### PR TITLE
[FEATURE] Persister et transmettre les informations de consommation de tokens vers la preview pour les épreuves avec prompt LLM (PIX-18928)

### DIFF
--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -128,6 +128,15 @@ export class Chat {
       .map((message) => message.toLLMHistory());
   }
 
+  updateTokenConsumption(inputTokens, outputTokens) {
+    // FIXME this can be removed after some time, this guard was for the chats in cache at the time the feature was introduced
+    // The decision taken was to not update token consumption at all on an already cached chat
+    this.totalInputTokens = Number.isInteger(this.totalInputTokens) ? this.totalInputTokens + inputTokens : undefined;
+    this.totalOutputTokens = Number.isInteger(this.totalOutputTokens)
+      ? this.totalOutputTokens + outputTokens
+      : undefined;
+  }
+
   toDTO() {
     return {
       id: this.id,

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -8,15 +8,28 @@ export class Chat {
    * @param {string} params.configurationId
    * @param {Configuration} params.configuration
    * @param {boolean} params.hasAttachmentContextBeenAdded
+   * @param {number|undefined} params.totalInputTokens
+   * @param {number|undefined} params.totalOutputTokens
    * @param {Message[]} params.messages
    */
-  constructor({ id, userId, configurationId, configuration, hasAttachmentContextBeenAdded, messages = [] }) {
+  constructor({
+    id,
+    userId,
+    configurationId,
+    configuration,
+    hasAttachmentContextBeenAdded,
+    messages = [],
+    totalInputTokens,
+    totalOutputTokens,
+  }) {
     this.id = id;
     this.userId = userId;
     this.configurationId = configurationId;
     this.configuration = configuration;
     this.hasAttachmentContextBeenAdded = hasAttachmentContextBeenAdded;
     this.messages = messages;
+    this.totalInputTokens = totalInputTokens;
+    this.totalOutputTokens = totalOutputTokens;
   }
 
   /**
@@ -123,6 +136,8 @@ export class Chat {
       configuration: this.configuration.toDTO(),
       hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,
       messages: this.messages.map((message) => message.toDTO()),
+      totalInputTokens: this.totalInputTokens,
+      totalOutputTokens: this.totalOutputTokens,
     };
   }
 

--- a/api/src/llm/domain/usecases/start-chat.js
+++ b/api/src/llm/domain/usecases/start-chat.js
@@ -19,6 +19,8 @@ export async function startChat({
     configuration,
     hasAttachmentContextBeenAdded: false,
     messages: [],
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
   });
   await chatRepository.save(newChat);
   return newChat;

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -32,6 +32,8 @@ export function serialize(chat) {
     inputMaxPrompts: chat.configuration.inputMaxPrompts,
     attachmentName: chat.configuration.attachmentName,
     context: chat.configuration.context,
+    totalInputTokens: chat.totalInputTokens,
+    totalOutputTokens: chat.totalOutputTokens,
     messages: messagesForPreview.map(({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled }) => ({
       content,
       attachmentName,

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -16,6 +16,8 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  * @typedef {Object} StreamCapture
  * @property {string[]} LLMMessageParts - Accumulated message chunks.
  * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
+ * @property {number=} inputTokens
+ * @property {number=} outputTokens
  */
 
 /**
@@ -46,6 +48,8 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
   const streamCapture = {
     LLMMessageParts: [],
     haveVictoryConditionsBeenFulfilled: undefined,
+    inputTokens: 0,
+    outputTokens: 0,
   };
   pipeline(
     readableStream,

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -8,7 +8,7 @@ export function getTransform(streamCapture) {
   return new Transform({
     objectMode: true,
     transform(chunk, _encoding, callback) {
-      const { message, isValid } = chunk;
+      const { message, isValid, usage } = chunk;
       let data = '';
 
       if (isValid) {
@@ -19,6 +19,11 @@ export function getTransform(streamCapture) {
       if (message) {
         streamCapture.LLMMessageParts.push(...message.split(''));
         data += getFormattedMessage(message);
+      }
+
+      if (usage) {
+        streamCapture.inputTokens = usage?.inputTokens ?? streamCapture.inputTokens;
+        streamCapture.outputTokens = usage?.outputTokens ?? streamCapture.outputTokens;
       }
 
       if (data) callback(null, data);

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -258,6 +258,8 @@ describe('Acceptance | Route | llm-preview', function () {
             },
           },
           hasAttachmentContextBeenAdded: true,
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             { content: 'coucou user1', isFromUser: true, shouldBeRenderedInPreview: true },
             { content: 'coucou LLM1', isFromUser: false, shouldBeRenderedInPreview: true },
@@ -302,6 +304,8 @@ describe('Acceptance | Route | llm-preview', function () {
         inputMaxPrompts: 3,
         attachmentName: 'expected_file.txt',
         context: 'modulix',
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
         messages: [
           {
             content: 'coucou user1',

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -1776,6 +1776,119 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
         });
         expect(llmPostPromptScope.isDone()).to.be.true;
       });
+      it('should update the token consumption if such information was provided in the stream response', async function () {
+        // given
+        const chat = new Chat({
+          id: 'chatId',
+          userId: 123,
+          configurationId,
+          configuration,
+          hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 1_000,
+          totalOutputTokens: 2_000,
+          messages: [buildBasicUserMessage('coucou user1'), buildBasicAssistantMessage('coucou LLM1')],
+        });
+        await chatTemporaryStorage.save({
+          key: chat.id,
+          value: chat.toDTO(),
+          expirationDelaySeconds: ms('24h'),
+        });
+        const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
+          .post('/chat', {
+            configuration: {
+              llm: {
+                historySize: 123,
+              },
+              challenge: {
+                inputMaxPrompts: 100,
+                inputMaxChars: 255,
+              },
+            },
+            history: [
+              { content: 'coucou user1', role: 'user' },
+              { content: 'coucou LLM1', role: 'assistant' },
+            ],
+            prompt: 'un message',
+          })
+          .reply(
+            201,
+            Readable.from([
+              '60:{"ceci":"nest pas important","message":"coucou c\'est super"}',
+              '40:{"message":"\\nle couscous c plutot bon"}47:{"message":" mais la paella c pas mal aussi\\n"}',
+              '16:{"isValid":true}',
+              '78:{"jecrois":{"que":"jaifini"},"usage":{"inputTokens":3000,"outputTokens":5000}}',
+            ]),
+          );
+
+        // when
+        const stream = await promptChat({
+          chatId: 'chatId',
+          userId: 123,
+          message: 'un message',
+          attachmentName: null,
+          ...dependencies,
+        });
+
+        // then
+        const parts = [];
+        const decoder = new TextDecoder();
+        for await (const chunk of stream) {
+          parts.push(decoder.decode(chunk));
+        }
+        const llmResponse = parts.join('');
+        expect(llmResponse).to.deep.equal(
+          "data: coucou c'est super\n\ndata: \ndata: le couscous c plutot bon\n\ndata:  mais la paella c pas mal aussi\ndata: \n\nevent: victory-conditions-success\ndata: \n\n",
+        );
+        expect(await chatTemporaryStorage.get('chatId')).to.deep.equal({
+          id: 'chatId',
+          userId: 123,
+          configurationId: 'uneConfigQuiExist',
+          configuration: {
+            llm: {
+              historySize: 123,
+            },
+            challenge: {
+              inputMaxPrompts: 100,
+              inputMaxChars: 255,
+            },
+          },
+          hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 4_000,
+          totalOutputTokens: 7_000,
+          messages: [
+            {
+              content: 'coucou user1',
+              isFromUser: true,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: true,
+            },
+            {
+              content: 'coucou LLM1',
+              isFromUser: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: false,
+            },
+            {
+              content: 'un message',
+              isFromUser: true,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: true,
+              haveVictoryConditionsBeenFulfilled: true,
+            },
+            {
+              content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
+              isFromUser: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: false,
+            },
+          ],
+        });
+        expect(llmPostPromptScope.isDone()).to.be.true;
+      });
     });
   });
 });

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -48,6 +48,8 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
             id: '123e4567-e89b-12d3-a456-426614174000',
             configuration: new Configuration({}), // Configuration’s properties are not enumerable
             hasAttachmentContextBeenAdded: false,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
           }),
         );
         expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
@@ -67,6 +69,8 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
           },
           hasAttachmentContextBeenAdded: false,
           messages: [],
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
         });
       });
     });
@@ -105,6 +109,8 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
             configurationId: 'uneConfigQuiExist',
             configuration: new Configuration({}), // Configuration’s properties are not enumerable
             hasAttachmentContextBeenAdded: false,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
           }),
         );
         expect(llmApiScope.isDone()).to.be.true;
@@ -126,6 +132,8 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
             },
           },
           hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
           messages: [],
         });
       });

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -858,6 +858,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         configurationId: 'abc123',
         configuration: new Configuration(configurationDTO),
         hasAttachmentContextBeenAdded: true,
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
         messages: [
           new Message({
             content: 'message user 1',
@@ -903,6 +905,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         configurationId: 'abc123',
         configuration: configurationDTO,
         hasAttachmentContextBeenAdded: true,
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
         messages: [
           {
             content: 'message user 1',

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -848,220 +848,6 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
     });
   });
 
-  describe('#toDTO', function () {
-    it('should return the DTO version of the Chat model', function () {
-      // given
-      const configurationDTO = Symbol('configurationDTO');
-      const chat = new Chat({
-        id: 'some-chat-id',
-        userId: 123,
-        configurationId: 'abc123',
-        configuration: new Configuration(configurationDTO),
-        hasAttachmentContextBeenAdded: true,
-        totalInputTokens: 2_000,
-        totalOutputTokens: 5_000,
-        messages: [
-          new Message({
-            content: 'message user 1',
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-          }),
-          new Message({
-            content: 'message llm 1',
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeRenderedInPreview: true,
-            shouldBeForwardedToLLM: true,
-          }),
-          new Message({
-            attachmentName: 'file.txt',
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
-            haveVictoryConditionsBeenFulfilled: true,
-          }),
-          new Message({
-            attachmentName: 'file.txt',
-            attachmentContext: 'je suis un poulet',
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: false,
-          }),
-        ],
-      });
-
-      // when
-      const dto = chat.toDTO();
-
-      // then
-      expect(dto).to.deep.equal({
-        id: 'some-chat-id',
-        userId: 123,
-        configurationId: 'abc123',
-        configuration: configurationDTO,
-        hasAttachmentContextBeenAdded: true,
-        totalInputTokens: 2_000,
-        totalOutputTokens: 5_000,
-        messages: [
-          {
-            content: 'message user 1',
-            attachmentName: undefined,
-            attachmentContext: undefined,
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-            haveVictoryConditionsBeenFulfilled: undefined,
-          },
-          {
-            content: 'message llm 1',
-            attachmentName: undefined,
-            attachmentContext: undefined,
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeRenderedInPreview: true,
-            shouldBeForwardedToLLM: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-            haveVictoryConditionsBeenFulfilled: undefined,
-          },
-          {
-            content: undefined,
-            attachmentName: 'file.txt',
-            attachmentContext: undefined,
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
-            haveVictoryConditionsBeenFulfilled: true,
-          },
-          {
-            content: undefined,
-            attachmentName: 'file.txt',
-            attachmentContext: 'je suis un poulet',
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: false,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-            haveVictoryConditionsBeenFulfilled: undefined,
-          },
-        ],
-      });
-    });
-  });
-
-  describe('#fromDTO', function () {
-    it('should return a Chat model', function () {
-      // given
-      const dto = {
-        id: 'some-chat-id',
-        userId: 123,
-        configurationId: 'abc123',
-        configuration: {},
-        hasAttachmentContextBeenAdded: true,
-        messages: [
-          {
-            content: 'message user 1',
-            attachmentName: undefined,
-            attachmentContext: undefined,
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-            haveVictoryConditionsBeenFulfilled: undefined,
-          },
-          {
-            content: 'message llm 1',
-            attachmentName: undefined,
-            attachmentContext: undefined,
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeRenderedInPreview: true,
-            shouldBeForwardedToLLM: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-            haveVictoryConditionsBeenFulfilled: undefined,
-          },
-          {
-            content: undefined,
-            attachmentName: 'file.txt',
-            attachmentContext: undefined,
-            isFromUser: true,
-            shouldBeCountedAsAPrompt: true,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: true,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
-            haveVictoryConditionsBeenFulfilled: true,
-          },
-          {
-            content: undefined,
-            attachmentName: 'file.txt',
-            attachmentContext: 'je suis un poulet',
-            isFromUser: false,
-            shouldBeCountedAsAPrompt: false,
-            shouldBeForwardedToLLM: true,
-            shouldBeRenderedInPreview: false,
-            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-          },
-        ],
-      };
-
-      // when
-      const chat = Chat.fromDTO(dto);
-
-      // then
-      expect(chat).to.deepEqualInstance(
-        new Chat({
-          id: 'some-chat-id',
-          userId: 123,
-          configurationId: 'abc123',
-          configuration: new Configuration({}), // Configuration model has no enumerable properties
-          hasAttachmentContextBeenAdded: true,
-          messages: [
-            new Message({
-              content: 'message user 1',
-              isFromUser: true,
-              shouldBeCountedAsAPrompt: true,
-              shouldBeForwardedToLLM: true,
-              shouldBeRenderedInPreview: true,
-            }),
-            new Message({
-              content: 'message llm 1',
-              isFromUser: false,
-              shouldBeCountedAsAPrompt: false,
-              shouldBeRenderedInPreview: true,
-              shouldBeForwardedToLLM: true,
-            }),
-            new Message({
-              attachmentName: 'file.txt',
-              isFromUser: true,
-              shouldBeCountedAsAPrompt: true,
-              shouldBeForwardedToLLM: true,
-              shouldBeRenderedInPreview: true,
-              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
-              haveVictoryConditionsBeenFulfilled: true,
-            }),
-            new Message({
-              attachmentName: 'file.txt',
-              attachmentContext: 'je suis un poulet',
-              isFromUser: false,
-              shouldBeCountedAsAPrompt: false,
-              shouldBeForwardedToLLM: true,
-              shouldBeRenderedInPreview: false,
-            }),
-          ],
-        }),
-      );
-    });
-  });
-
   describe('#isAttachmentValid', function () {
     context('when configuration has no attachment', function () {
       it('returns false', function () {
@@ -1281,6 +1067,360 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           },
         ]);
       });
+    });
+  });
+
+  describe('#updateTokenConsumption', function () {
+    context('when chat has not initialized integer values for totalTokens attributes (old chats)', function () {
+      it('does nothing', function () {
+        // given
+        const configurationDTO = Symbol('configurationDTO');
+        const chat = new Chat({
+          id: 'some-chat-id',
+          userId: 123,
+          configurationId: 'abc123',
+          configuration: new Configuration(configurationDTO),
+          hasAttachmentContextBeenAdded: false,
+          messages: [
+            new Message({
+              content: 'message user 1',
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+            }),
+            new Message({
+              content: 'message llm 1',
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+            }),
+          ],
+        });
+
+        // when
+        chat.updateTokenConsumption(2_000, 5_000);
+
+        // then
+        expect(chat.toDTO()).to.deep.equal({
+          id: 'some-chat-id',
+          userId: 123,
+          configurationId: 'abc123',
+          configuration: configurationDTO,
+          hasAttachmentContextBeenAdded: false,
+          totalInputTokens: undefined,
+          totalOutputTokens: undefined,
+          messages: [
+            {
+              content: 'message user 1',
+              attachmentName: undefined,
+              attachmentContext: undefined,
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
+            {
+              content: 'message llm 1',
+              attachmentName: undefined,
+              attachmentContext: undefined,
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
+          ],
+        });
+      });
+    });
+
+    context('when chat has integer values for totalTokens attributes', function () {
+      it('adds to corresponding total the token counts in param', function () {
+        // given
+        const configurationDTO = Symbol('configurationDTO');
+        const chat = new Chat({
+          id: 'some-chat-id',
+          userId: 123,
+          configurationId: 'abc123',
+          configuration: new Configuration(configurationDTO),
+          hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 1_000,
+          totalOutputTokens: 10_000,
+          messages: [
+            new Message({
+              content: 'message user 1',
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+            }),
+            new Message({
+              content: 'message llm 1',
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+            }),
+          ],
+        });
+
+        // when
+        chat.updateTokenConsumption(2_000, 5_000);
+
+        // then
+        expect(chat.toDTO()).to.deep.equal({
+          id: 'some-chat-id',
+          userId: 123,
+          configurationId: 'abc123',
+          configuration: configurationDTO,
+          hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 3_000,
+          totalOutputTokens: 15_000,
+          messages: [
+            {
+              content: 'message user 1',
+              attachmentName: undefined,
+              attachmentContext: undefined,
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
+            {
+              content: 'message llm 1',
+              attachmentName: undefined,
+              attachmentContext: undefined,
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+              haveVictoryConditionsBeenFulfilled: undefined,
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe('#toDTO', function () {
+    it('should return the DTO version of the Chat model', function () {
+      // given
+      const configurationDTO = Symbol('configurationDTO');
+      const chat = new Chat({
+        id: 'some-chat-id',
+        userId: 123,
+        configurationId: 'abc123',
+        configuration: new Configuration(configurationDTO),
+        hasAttachmentContextBeenAdded: true,
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
+        messages: [
+          new Message({
+            content: 'message user 1',
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+          }),
+          new Message({
+            content: 'message llm 1',
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: true,
+          }),
+          new Message({
+            attachmentName: 'file.txt',
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
+          }),
+          new Message({
+            attachmentName: 'file.txt',
+            attachmentContext: 'je suis un poulet',
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: false,
+          }),
+        ],
+      });
+
+      // when
+      const dto = chat.toDTO();
+
+      // then
+      expect(dto).to.deep.equal({
+        id: 'some-chat-id',
+        userId: 123,
+        configurationId: 'abc123',
+        configuration: configurationDTO,
+        hasAttachmentContextBeenAdded: true,
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
+        messages: [
+          {
+            content: 'message user 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: 'message llm 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: undefined,
+            attachmentName: 'file.txt',
+            attachmentContext: undefined,
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
+          },
+          {
+            content: undefined,
+            attachmentName: 'file.txt',
+            attachmentContext: 'je suis un poulet',
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: false,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+        ],
+      });
+    });
+  });
+
+  describe('#fromDTO', function () {
+    it('should return a Chat model', function () {
+      // given
+      const dto = {
+        id: 'some-chat-id',
+        userId: 123,
+        configurationId: 'abc123',
+        configuration: {},
+        hasAttachmentContextBeenAdded: true,
+        messages: [
+          {
+            content: 'message user 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: 'message llm 1',
+            attachmentName: undefined,
+            attachmentContext: undefined,
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            haveVictoryConditionsBeenFulfilled: undefined,
+          },
+          {
+            content: undefined,
+            attachmentName: 'file.txt',
+            attachmentContext: undefined,
+            isFromUser: true,
+            shouldBeCountedAsAPrompt: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: true,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+            haveVictoryConditionsBeenFulfilled: true,
+          },
+          {
+            content: undefined,
+            attachmentName: 'file.txt',
+            attachmentContext: 'je suis un poulet',
+            isFromUser: false,
+            shouldBeCountedAsAPrompt: false,
+            shouldBeForwardedToLLM: true,
+            shouldBeRenderedInPreview: false,
+            hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          },
+        ],
+      };
+
+      // when
+      const chat = Chat.fromDTO(dto);
+
+      // then
+      expect(chat).to.deepEqualInstance(
+        new Chat({
+          id: 'some-chat-id',
+          userId: 123,
+          configurationId: 'abc123',
+          configuration: new Configuration({}), // Configuration model has no enumerable properties
+          hasAttachmentContextBeenAdded: true,
+          messages: [
+            new Message({
+              content: 'message user 1',
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+            }),
+            new Message({
+              content: 'message llm 1',
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+            }),
+            new Message({
+              attachmentName: 'file.txt',
+              isFromUser: true,
+              shouldBeCountedAsAPrompt: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: true,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: true,
+            }),
+            new Message({
+              attachmentName: 'file.txt',
+              attachmentContext: 'je suis un poulet',
+              isFromUser: false,
+              shouldBeCountedAsAPrompt: false,
+              shouldBeForwardedToLLM: true,
+              shouldBeRenderedInPreview: false,
+            }),
+          ],
+        }),
+      );
     });
   });
 });

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -20,6 +20,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           },
         }),
         hasAttachmentContextBeenAdded: false,
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
         messages: [
           new Message({
             content: 'Salut',
@@ -44,6 +46,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
         inputMaxChars: 500,
         inputMaxPrompts: 4,
         context: 'modulix',
+        totalInputTokens: 2_000,
+        totalOutputTokens: 5_000,
         messages: [
           {
             content: 'Salut',
@@ -78,6 +82,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             },
           }),
           hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             new Message({
               content: 'Salut',
@@ -104,6 +110,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           inputMaxChars: 500,
           inputMaxPrompts: 4,
           context: undefined,
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -133,6 +141,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             },
           }),
           hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             new Message({ content: 'Salut', isFromUser: true, shouldBeRenderedInPreview: true }),
             new Message({
@@ -182,6 +192,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           inputMaxChars: 500,
           inputMaxPrompts: 4,
           context: 'modulix',
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             {
               content: 'Salut',
@@ -239,6 +251,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             },
           }),
           hasAttachmentContextBeenAdded: false,
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             new Message({ content: 'Salut', isFromUser: true, shouldBeRenderedInPreview: true }),
             new Message({
@@ -288,6 +302,8 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
           inputMaxChars: 500,
           inputMaxPrompts: 4,
           context: 'modulix',
+          totalInputTokens: 2_000,
+          totalOutputTokens: 5_000,
           messages: [
             {
               content: 'Salut',


### PR DESCRIPTION
## 🔆 Problème

On souhaite ajouter des informations pertinentes pour le métier lorsqu'ils prévisualisent des configurations LLM pour les aider à mieux les concevoir.

## ⛱️ Proposition

Récupérer l'information de consommation de tokens lors de la réponse de poc-llm, la persister et la transmettre dans un contexte de preview.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Vérifier que la consommation en tokens est bien présente lorsqu'on fait un GET chat dans un contexte preview (démarrage ou rechargement)
