### PR TITLE
[TECH] :wastebasket: Supprime le fichier temporaire `EmailAttempt`

### DIFF
--- a/api/src/shared/domain/models/EmailingAttempt.js
+++ b/api/src/shared/domain/models/EmailingAttempt.js
@@ -1,2 +1,0 @@
-// FIXME this file should be deleted after migration
-export * from '../../mail/domain/models/EmailingAttempt.js';

--- a/api/src/shared/domain/models/index.js
+++ b/api/src/shared/domain/models/index.js
@@ -71,7 +71,6 @@ import { CompetenceTree } from './CompetenceTree.js';
 import { ComplementaryCertificationHabilitation } from './ComplementaryCertificationHabilitation.js';
 import { Correction } from './Correction.js';
 import { Course } from './Course.js';
-import { EmailingAttempt } from './EmailingAttempt.js';
 import { Examiner } from './Examiner.js';
 import { Framework } from './Framework.js';
 import { Hint } from './Hint.js';
@@ -146,7 +145,6 @@ export {
   Correction,
   Course,
   DataProtectionOfficer,
-  EmailingAttempt,
   Examiner,
   FlashAssessmentAlgorithm,
   Framework,

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -10,8 +10,8 @@ import {
   publishSession,
 } from '../../../../../../src/certification/session-management/domain/services/session-publication-service.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { EmailingAttempt } from '../../../../../../src/shared/domain/models/index.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
+import { EmailingAttempt } from '../../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Domain | Services | session-publication-service', function () {

--- a/api/tests/team/integration/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/integration/domain/services/organization-invitation.service.test.js
@@ -5,10 +5,10 @@ import {
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
 } from '../../../../../src/shared/domain/errors.js';
-import { EmailingAttempt } from '../../../../../src/shared/domain/models/EmailingAttempt.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
 import { mailService } from '../../../../../src/shared/domain/services/mail-service.js';
 import * as organizationRepository from '../../../../../src/shared/infrastructure/repositories/organization-repository.js';
+import { EmailingAttempt } from '../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import { organizationInvitationService } from '../../../../../src/team/domain/services/organization-invitation.service.js';
 import { organizationInvitationRepository } from '../../../../../src/team/infrastructure/repositories/organization-invitation.repository.js';

--- a/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/team/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -3,8 +3,8 @@ import {
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
 } from '../../../../../src/shared/domain/errors.js';
-import { EmailingAttempt } from '../../../../../src/shared/domain/models/EmailingAttempt.js';
 import { mailService } from '../../../../../src/shared/domain/services/mail-service.js';
+import { EmailingAttempt } from '../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -3,7 +3,7 @@ import {
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
 } from '../../../../../src/shared/domain/errors.js';
-import { EmailingAttempt } from '../../../../../src/shared/domain/models/index.js';
+import { EmailingAttempt } from '../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
   createOrUpdateCertificationCenterInvitation,

--- a/api/tests/team/unit/domain/services/organization-invitation.service.test.js
+++ b/api/tests/team/unit/domain/services/organization-invitation.service.test.js
@@ -2,8 +2,8 @@ import {
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
 } from '../../../../../src/shared/domain/errors.js';
-import { EmailingAttempt } from '../../../../../src/shared/domain/models/EmailingAttempt.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
+import { EmailingAttempt } from '../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import { organizationInvitationService } from '../../../../../src/team/domain/services/organization-invitation.service.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';


### PR DESCRIPTION
## 🔆 Problème

Dans `src/shared/domain/models/` il y a un fichier qui ne fait qu'un import d'un autre fichier...

## ⛱️ Proposition

Supprimer ce fichier intermédiaire inuntile.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
