### PR TITLE
[BUGFIX] faire remonter les paramètres de la feature d'attestation au front (PIX-18921)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -9,7 +9,10 @@ const PAD_TARGET_LENGTH = 3;
 const PAD_STRING = '0';
 
 const schema = Joi.object({
-  features: Joi.object().pattern(Joi.string(), Joi.object({ active: Joi.boolean(), params: Joi.object().empty(null) })),
+  features: Joi.object().pattern(
+    Joi.string(),
+    Joi.object({ active: Joi.boolean(), params: Joi.alternatives().try(Joi.object(), Joi.array()).empty(null) }),
+  ),
 }).unknown();
 
 class OrganizationForAdmin {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -171,6 +171,16 @@ const get = async function ({ organizationId }) {
       };
     }
 
+    if (key === ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key) {
+      return {
+        ...features,
+        [key]: {
+          active: enabled,
+          params,
+        },
+      };
+    }
+
     return { ...features, [key]: { active: enabled, params: null } };
   }, {});
 

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -149,39 +149,30 @@ const get = async function ({ organizationId }) {
   const importFormats = await knex('organization-learner-import-formats');
 
   organization.features = availableFeatures.reduce((features, { key, enabled, params }) => {
-    if (key === ORGANIZATION_FEATURE.LEARNER_IMPORT.key) {
-      return {
-        ...features,
-        [key]: {
-          active: enabled,
-          params: enabled
-            ? { name: importFormats.find(({ id }) => params.organizationLearnerImportFormatId === id).name }
-            : null,
-        },
-      };
-    }
+    switch (key) {
+      case ORGANIZATION_FEATURE.LEARNER_IMPORT.key:
+        return {
+          ...features,
+          [key]: {
+            active: enabled,
+            params: enabled
+              ? { name: importFormats.find(({ id }) => params.organizationLearnerImportFormatId === id).name }
+              : null,
+          },
+        };
+      case ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key:
+      case ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key:
+        return {
+          ...features,
+          [key]: {
+            active: enabled,
+            params,
+          },
+        };
 
-    if (key === ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key) {
-      return {
-        ...features,
-        [key]: {
-          active: enabled,
-          params,
-        },
-      };
+      default:
+        return { ...features, [key]: { active: enabled, params: null } };
     }
-
-    if (key === ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key) {
-      return {
-        ...features,
-        [key]: {
-          active: enabled,
-          params,
-        },
-      };
-    }
-
-    return { ...features, [key]: { active: enabled, params: null } };
   }, {});
 
   organization.tags = tags.map((tag) => {


### PR DESCRIPTION
## 🔆 Problème

[Un commit](https://github.com/1024pix/pix/pull/12966#issuecomment-3126412119) a été un peu rapidement dropped oupsi

## ⛱️ Proposition

Faire remonter les paramètres de la feature d'attestation au front

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- se connecter à Pix Admin
- se rendre sur la page d'une orga ayant la feature d'attestations 
- observer qu'on a bien les tabs
- tada
- (faire un tour global tant qu'on y est, tour de manège gratos)