### PR TITLE
[FEATURE] Utilisation du `aria-disabled` plutôt que du `disabled` sur les proposal-buttons

### DIFF
--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -22,8 +22,9 @@
     background: var(--pix-primary-10);
   }
 
-  &[disabled] {
+  &[aria-disabled] {
     cursor: not-allowed;
+    pointer-events: none;
 
     &:hover {
       background: var(--pix-neutral-0);
@@ -34,7 +35,7 @@
     font-weight: var(--pix-font-bold);
   }
 
-  &[disabled]:not(.proposal-button--selected) {
+  &[aria-disabled]:not(.proposal-button--selected) {
     --state-border-color: var(--pix-neutral-100);
 
     background: var(--pix-primary-100);
@@ -57,7 +58,7 @@
     }
   }
 
-  &[disabled]:not(.proposal-button--selected) {
+  &[aria-disabled]:not(.proposal-button--selected) {
     background: var(--pix-neutral-20);
     border-color: transparent;
   }

--- a/mon-pix/app/components/module/component/proposal-button.gjs
+++ b/mon-pix/app/components/module/component/proposal-button.gjs
@@ -1,15 +1,28 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
-<template>
-  <button
-    class="proposal-button
-      {{if @isSelected 'proposal-button--selected'}}
-      {{if @isDiscoveryVariant 'proposal-button--variant-discovery'}}"
-    type="submit"
-    name={{@proposal.content}}
-    value={{@proposal.id}}
-    disabled={{@isDisabled}}
-  >
-    {{htmlUnsafe @proposal.content}}
-  </button>
-</template>
+export default class ProposalButton extends Component {
+  @action
+  onButtonClick(event) {
+    if (this.args.isDisabled) {
+      event.preventDefault();
+    }
+  }
+
+  <template>
+    <button
+      class="proposal-button
+        {{if @isSelected 'proposal-button--selected'}}
+        {{if @isDiscoveryVariant 'proposal-button--variant-discovery'}}"
+      type="submit"
+      name={{@proposal.content}}
+      value={{@proposal.id}}
+      aria-disabled={{@isDisabled}}
+      {{on "click" this.onButtonClick}}
+    >
+      {{htmlUnsafe @proposal.content}}
+    </button>
+  </template>
+}

--- a/mon-pix/app/components/module/element/qab/_proposal-button.scss
+++ b/mon-pix/app/components/module/element/qab/_proposal-button.scss
@@ -24,7 +24,7 @@
     background: linear-gradient(0deg, rgb(var(--pix-primary-100-inline), 0.50) 0%, rgb(var(--pix-primary-100-inline), 0.50) 100%);
   }
 
-  &[disabled] {
+  &[aria-disabled] {
     --qab-proposal-border-color: var(--pix-primary-100);
 
     background: var(--pix-neutral-20);

--- a/mon-pix/app/components/module/element/qab/proposal-button.gjs
+++ b/mon-pix/app/components/module/element/qab/proposal-button.gjs
@@ -1,3 +1,5 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 export default class QabProposalButton extends Component {
   get ariaLabel() {
@@ -9,6 +11,13 @@ export default class QabProposalButton extends Component {
     return `/images/icons/${icon}`;
   }
 
+  @action
+  onButtonClick(event) {
+    if (this.args.isDisabled) {
+      event.preventDefault();
+    }
+  }
+
   <template>
     <button
       class="qab-proposal-button
@@ -17,8 +26,9 @@ export default class QabProposalButton extends Component {
       type="submit"
       name={{@option}}
       value={{@option}}
-      disabled={{@isDisabled}}
+      aria-disabled={{@isDisabled}}
       aria-label={{this.ariaLabel}}
+      {{on "click" this.onButtonClick}}
     >
       <span class="qab-proposal-button__option">{{@option}}</span>
       <span class="qab-proposal-button__text">{{@text}}</span>

--- a/mon-pix/tests/integration/components/module/proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/proposal-button_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import ProposalButton from 'mon-pix/components/module/component/proposal-button';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -38,7 +39,30 @@ module('Integration | Component | Module | ProposalButton', function (hooks) {
       const screen = await render(<template><ProposalButton @proposal={{proposal}} @isDisabled={{true}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('button', { name: proposal.content })).isDisabled();
+      assert.dom(screen.getByRole('button', { name: proposal.content })).hasAttribute('aria-disabled');
+    });
+
+    test('it should not send a click event when clicking on the proposal button', async function (assert) {
+      const proposal = {
+        id: '1',
+        content: 'Avant de mettre le dentifrice',
+        feedback: {
+          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+        },
+      };
+
+      const onSubmit = sinon.stub();
+
+      // when
+      await render(
+        <template>
+          <form onSubmit={{onSubmit}}><ProposalButton @proposal={{proposal}} @isDisabled={{true}} /></form>
+        </template>,
+      );
+
+      // then
+      sinon.assert.notCalled(onSubmit);
+      assert.ok(true);
     });
   });
 

--- a/mon-pix/tests/integration/components/module/qab-proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-proposal-button_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -31,7 +32,29 @@ module('Integration | Component | Module | QabProposalButton', function (hooks) 
       );
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).isDisabled();
+      assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).hasAttribute('aria-disabled');
+    });
+
+    test('it should not send a click event when clicking on the proposal button', async function (assert) {
+      const text = 'Faux';
+      const option = 'B';
+
+      const onSubmit = sinon.stub();
+
+      // when
+      await render(
+        <template>
+          <form onSubmit={{onSubmit}}><QabProposalButton
+              @text={{text}}
+              @option={{option}}
+              @isDisabled={{true}}
+            /></form>
+        </template>,
+      );
+
+      // then
+      sinon.assert.notCalled(onSubmit);
+      assert.ok(true);
     });
   });
 

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -100,11 +100,11 @@ module('Integration | Component | Module | QAB', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).hasClass('qab-proposal-button--selected');
-        assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).isDisabled();
+        assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).hasAttribute('aria-disabled');
         assert
           .dom(screen.getByRole('button', { name: 'Option B: Faux' }))
           .doesNotHaveClass('qab-proposal-button--selected');
-        assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).isDisabled();
+        assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasAttribute('aria-disabled');
         assert.dom(screen.getByRole('status')).hasText('Bonne réponse !');
       });
     });
@@ -122,9 +122,9 @@ module('Integration | Component | Module | QAB', function (hooks) {
         assert
           .dom(screen.getByRole('button', { name: 'Option A: Vrai' }))
           .doesNotHaveClass('qab-proposal-button--selected');
-        assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).isDisabled();
+        assert.dom(screen.getByRole('button', { name: 'Option A: Vrai' })).hasAttribute('aria-disabled');
         assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasClass('qab-proposal-button--selected');
-        assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).isDisabled();
+        assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasAttribute('aria-disabled');
         assert.dom(screen.getByRole('status')).hasText('Mauvaise réponse.');
       });
     });

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -45,9 +45,9 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       // then
       const button2 = screen.getByRole('button', { name: proposals[1].content });
       const button3 = screen.getByRole('button', { name: proposals[2].content });
-      assert.dom(button1).isDisabled();
-      assert.dom(button2).isDisabled();
-      assert.dom(button3).isDisabled();
+      assert.dom(button1).hasAttribute('aria-disabled');
+      assert.dom(button2).hasAttribute('aria-disabled');
+      assert.dom(button3).hasAttribute('aria-disabled');
       assert.ok(screen.getByText("C'est l'approche de la plupart des gens."));
       sinon.assert.calledWithExactly(passageEventRecordStub, {
         type: 'QCU_DECLARATIVE_ANSWERED',

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -46,9 +46,9 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
       // then
       const button2 = screen.getByRole('button', { name: proposals[1].content });
       const button3 = screen.getByRole('button', { name: proposals[2].content });
-      assert.dom(button1).isDisabled();
-      assert.dom(button2).isDisabled();
-      assert.dom(button3).isDisabled();
+      assert.dom(button1).hasAttribute('aria-disabled');
+      assert.dom(button2).hasAttribute('aria-disabled');
+      assert.dom(button3).hasAttribute('aria-disabled');
       assert.ok(screen.getByText('Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !'));
       sinon.assert.calledWithExactly(passageEventRecordStub, {
         type: 'QCU_DISCOVERY_ANSWERED',


### PR DESCRIPTION
## 🔆 Problème

La même chose que #885, le `disabled` ne permet pas de naviguer sur les boutons, contrairement au `aria-disabled`.

## ⛱️ Proposition

Remplacer les `disabled` des buttons par des `aria-disabled` sur QAB, QCU découverte/déclaratif.

## 🌊 Remarques

RAS

## 🏄 Pour tester

https://app-pr13051.review.pix.fr/modules/bac-a-sable/passage

Vérifier qu'on peut tabuler sur les boutons des modalités QAB, QCU découverte, QCU déclaratif après envoi, mais qu'on ne peut pas changer de sélection 