### PR TITLE
[BUGFIX] Corriger les fichiers de config Scalingo pour les RAs front

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -7,7 +7,7 @@
     },
     "PIX_APP_URL_WITHOUT_EXTENSION": {
       "generator": "template",
-      "template": "https://app-pr%PR_NUMBER%.review.pix"
+      "template": "https://app-pr%PR_NUMBER%.review.pix."
     }
   },
   "formation": {

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -7,7 +7,7 @@
     },
     "PIX_APP_URL_WITHOUT_EXTENSION": {
       "generator": "template",
-      "template": "https://app-pr%PR_NUMBER%.review.pix"
+      "template": "https://app-pr%PR_NUMBER%.review.pix."
     }
   },
   "formation": {

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -7,7 +7,7 @@
     },
     "PIX_APP_URL_WITHOUT_EXTENSION": {
       "generator": "template",
-      "template": "https://app-pr%PR_NUMBER%.review.pix"
+      "template": "https://app-pr%PR_NUMBER%.review.pix."
     }
   },
   "formation": {


### PR DESCRIPTION
## 🔆 Problème

Dans cette PR https://github.com/1024pix/pix/pull/13009 ajoutant des fichiers de config Scalingo pour les RAs front, un point a été oublié dans l'url de la var d'env `PIX_APP_URL_WITHOUT_EXTENSION`.

```
"PIX_APP_URL_WITHOUT_EXTENSION": {
      "generator": "template",
      "template": "https://app-pr/%PR_NUMBER%.review.pix."
    }
```

## ⛱️ Proposition

Ajout d'un point

## 🌊 Remarques

<img width="146" height="201" alt="Capture d’écran 2025-07-29 à 14 15 07" src="https://github.com/user-attachments/assets/6dc9c99d-4eba-4a20-8e4a-2017665eac06" />
