### PR TITLE
[FEATURE] [Back] Compléter et rendre plus pratique la validation des locales (PIX-18904)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -1,4 +1,5 @@
 import { BadRequestError, UnauthorizedError } from '../../../shared/application/http-errors.js';
+import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -53,9 +54,10 @@ async function authenticateOidcUser(request, h) {
  * @param h
  * @return {Promise<{access_token: string, logout_url_uuid: string}>}
  */
-async function createUser(request, h, dependencies = { requestResponseUtils }) {
+async function createUser(request, h, dependencies = { requestResponseUtils, localeService }) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
-  const localeFromCookie = request.state?.locale;
+  const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
+
   // todo(locale): really extract the language (use new Locale(locale).language)
   const language = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
   const origin = getForwardedOrigin(request.headers);

--- a/api/src/identity-access-management/application/user/user.admin.route.js
+++ b/api/src/identity-access-management/application/user/user.admin.route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { BadRequestError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { getSupportedLanguages, getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
+import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { QUERY_TYPES } from '../../domain/constants/user-query.js';
 import { userAdminController } from './user.admin.controller.js';
@@ -101,22 +101,46 @@ export const userAdminRoutes = [
         }),
         payload: Joi.object({
           data: {
-            attributes: {
-              'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-              'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-              email: Joi.string().email().allow(null).optional(),
-              username: Joi.string().allow(null).optional(),
-              lang: Joi.string().valid(...getSupportedLanguages()),
+            id: identifiersType.userId.required(),
+            type: Joi.string(),
+            attributes: Joi.object({
+              'first-name': Joi.string().required(),
+              'last-name': Joi.string().required(),
+              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
               locale: Joi.string()
-                .allow(null)
-                .optional()
-                .valid(...getSupportedLocales()),
-            },
+                .valid(...localeService.getSupportedLocales())
+                .allow(null),
+              email: Joi.string().allow(null),
+              username: Joi.string().allow(null),
+              password: Joi.string().allow(null),
+              cgu: Joi.boolean().allow(null),
+              'anonymous-user-token': Joi.string().allow(null),
+              'is-anonymous': Joi.boolean().allow(null),
+              'must-validate-terms-of-service': Joi.boolean().allow(null),
+              'code-for-last-profile-to-share': Joi.string().allow(null),
+              'email-confirmed': Joi.boolean().allow(null),
+              'has-assessment-participations': Joi.boolean().allow(null),
+              'has-recommended-trainings': Joi.boolean().allow(null),
+              'has-seen-assessment-instructions': Joi.boolean().allow(null),
+              'has-seen-focused-challenge-tooltip': Joi.boolean().allow(null),
+              'has-seen-new-dashboard-info': Joi.boolean().allow(null),
+              'has-seen-other-challenges-tooltip': Joi.boolean().allow(null),
+              'last-terms-of-service-validated-at': Joi.string().allow(null),
+              'pix-orga-terms-of-service-accepted': Joi.boolean().allow(null),
+              'last-pix-orga-terms-of-service-validated-at': Joi.string().allow(null),
+              'pix-certif-terms-of-service-accepted': Joi.boolean().allow(null),
+              'last-pix-certif-terms-of-service-validated-at': Joi.string().allow(null),
+              'is-pix-agent': Joi.boolean().allow(null),
+              'created-at': Joi.string().allow(null),
+              'last-logged-at': Joi.string().allow(null),
+              'email-confirmed-at': Joi.string().allow(null),
+              'has-been-anonymised': Joi.boolean().allow(null),
+              'anonymised-by-full-name': Joi.string().allow(null),
+              'has-been-anonymised-by': identifiersType.userId.allow(null).optional(),
+            }).required(),
+            relationships: Joi.object(),
           },
         }),
-        options: {
-          allowUnknown: true,
-        },
       },
       handler: (request, h) => userAdminController.updateUserDetailsByAdmin(request, h),
       notes: [

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -132,12 +132,10 @@ const getUserAuthenticationMethods = async function (request, h, dependencies = 
  * @return {Promise<*>}
  */
 const createUser = async function (request, h, dependencies = { userSerializer, requestResponseUtils, localeService }) {
-  const localeFromCookie = request.state?.locale;
-  const canonicalLocaleFromCookie = localeFromCookie
-    ? dependencies.localeService.getCanonicalLocale(localeFromCookie)
-    : undefined;
+  const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
+
   const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
-  const user = { ...dependencies.userSerializer.deserialize(request.payload), locale: canonicalLocaleFromCookie };
+  const user = { ...dependencies.userSerializer.deserialize(request.payload), locale: localeFromCookie };
   const localeFromHeader = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
   const password = request.payload.data.attributes.password;
@@ -268,8 +266,8 @@ const upgradeToRealUser = async function (
 ) {
   const anonymousUserId = request.auth.credentials.userId;
 
-  const localeFromCookie = request.state?.locale;
-  const locale = localeFromCookie ? dependencies.localeService.getCanonicalLocale(localeFromCookie) : undefined;
+  const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
+
   const language = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
   const userAttributes = {
@@ -277,7 +275,7 @@ const upgradeToRealUser = async function (
     lastName: request.payload.data.attributes['last-name'],
     email: request.payload.data.attributes.email,
     cgu: request.payload.data.attributes.cgu,
-    locale,
+    locale: localeFromCookie,
   };
 
   const password = request.payload.data.attributes.password;

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -150,7 +150,7 @@ export const userRoutes = [
   },
   {
     method: 'PATCH',
-    path: '/api/users/{id}',
+    path: '/api/users/{id}', // TODO: Rename this route to reflect it's only for upgradeToRealUser
     config: {
       pre: [
         {
@@ -164,6 +164,8 @@ export const userRoutes = [
         }),
         payload: Joi.object({
           data: Joi.object({
+            id: identifiersType.userId.required(),
+            type: Joi.string().required(),
             attributes: Joi.object({
               'first-name': Joi.string().required(),
               'last-name': Joi.string().required(),
@@ -171,6 +173,25 @@ export const userRoutes = [
               password: Joi.string().required(),
               cgu: Joi.boolean().required(),
               'anonymous-user-token': Joi.string().required(),
+              // TODO: attributes bellow should not be sent, they are not used.
+              username: Joi.string().allow(null),
+              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
+              locale: Joi.string()
+                .valid(...localeService.getSupportedLocales())
+                .allow(null),
+              'is-anonymous': Joi.boolean().allow(null),
+              'must-validate-terms-of-service': Joi.boolean().allow(null),
+              'code-for-last-profile-to-share': Joi.string().allow(null),
+              'email-confirmed': Joi.boolean().allow(null),
+              'has-assessment-participations': Joi.boolean().allow(null),
+              'has-recommended-trainings': Joi.boolean().allow(null),
+              'has-seen-assessment-instructions': Joi.boolean().allow(null),
+              'has-seen-focused-challenge-tooltip': Joi.boolean().allow(null),
+              'has-seen-new-dashboard-info': Joi.boolean().allow(null),
+              'has-seen-other-challenges-tooltip': Joi.boolean().allow(null),
+              'should-see-data-protection-policy-information-banner': Joi.boolean().allow(null),
+              'last-terms-of-service-validated-at': Joi.string().allow(null),
+              'last-data-protection-policy-seen-at': Joi.string().allow(null),
             }).required(),
           }).required(),
         }),

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -4,7 +4,7 @@ import XRegExp from 'xregexp';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { config } from '../../../shared/config.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
-import { getSupportedLanguages } from '../../../shared/domain/services/locale-service.js';
+import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { userController } from './user.controller.js';
 import { userVerification } from './user-existence-verification-pre-handler.js';
@@ -282,7 +282,7 @@ export const userRoutes = [
       validate: {
         params: Joi.object({
           id: identifiersType.userId,
-          lang: Joi.string().valid(...getSupportedLanguages()),
+          lang: Joi.string().valid(...localeService.getSupportedLanguages()),
         }),
       },
       pre: [

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -54,14 +54,35 @@ export const userRoutes = [
         payload: Joi.object({
           data: Joi.object({
             type: Joi.string(),
-            attributes: Joi.object().required(),
+            attributes: Joi.object({
+              'first-name': Joi.string().required(),
+              'last-name': Joi.string().required(),
+              lang: Joi.string().valid(...localeService.getSupportedLanguages()),
+              locale: Joi.string()
+                .valid(...localeService.getSupportedLocales())
+                .allow(null),
+              email: Joi.string().allow(null),
+              username: Joi.string().allow(null),
+              password: Joi.string().allow(null),
+              cgu: Joi.boolean().allow(null),
+              'anonymous-user-token': Joi.string().allow(null),
+              'is-anonymous': Joi.boolean().allow(null),
+              'must-validate-terms-of-service': Joi.boolean().allow(null),
+              'code-for-last-profile-to-share': Joi.string().allow(null),
+              'email-confirmed': Joi.boolean().allow(null),
+              'has-assessment-participations': Joi.boolean().allow(null),
+              'has-recommended-trainings': Joi.boolean().allow(null),
+              'has-seen-assessment-instructions': Joi.boolean().allow(null),
+              'has-seen-focused-challenge-tooltip': Joi.boolean().allow(null),
+              'has-seen-new-dashboard-info': Joi.boolean().allow(null),
+              'has-seen-other-challenges-tooltip': Joi.boolean().allow(null),
+              'should-see-data-protection-policy-information-banner': Joi.boolean().allow(null),
+              'pix-orga-terms-of-service-status': Joi.boolean().allow(null), // sent by Pix Orga when creating a user upon invitation
+            }).required(),
             relationships: Joi.object(),
           }).required(),
           meta: Joi.object(),
         }).required(),
-        options: {
-          allowUnknown: true,
-        },
       },
       handler: (request, h) => userController.createUser(request, h),
       notes: ['- **Cette route est publique**\n' + '- Crée un compte utilisateur'],

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -44,10 +44,6 @@ class User {
     } = {},
     dependencies = { localeService },
   ) {
-    if (locale) {
-      locale = dependencies.localeService.getCanonicalLocale(locale);
-    }
-
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -68,7 +64,7 @@ class User {
     this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;
     this.knowledgeElements = knowledgeElements;
     this.lang = dependencies.localeService.coerceLanguage(lang);
-    this.locale = locale;
+    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
     this.isAnonymous = isAnonymous;
     this.pixScore = pixScore;
     this.memberships = memberships;
@@ -110,8 +106,7 @@ class User {
   setLocaleIfNotAlreadySet(newLocale, dependencies = { localeService }) {
     this.hasBeenModified = false;
     if (newLocale && !this.locale) {
-      const canonicalLocale = dependencies.localeService.getCanonicalLocale(newLocale);
-      this.locale = canonicalLocale;
+      this.locale = dependencies.localeService.getNearestSupportedLocale(newLocale);
       this.hasBeenModified = true;
     }
   }

--- a/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
+++ b/api/src/identity-access-management/domain/models/UserDetailsForAdmin.js
@@ -32,10 +32,6 @@ class UserDetailsForAdmin {
     } = {},
     dependencies = { localeService },
   ) {
-    if (locale) {
-      locale = dependencies.localeService.getCanonicalLocale(locale);
-    }
-
     this.id = id;
     this.cgu = cgu;
     this.firstName = firstName;
@@ -48,7 +44,7 @@ class UserDetailsForAdmin {
     this.authenticationMethods = authenticationMethods;
     this.createdAt = createdAt;
     this.lang = lang;
-    this.locale = locale;
+    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
     this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
     this.lastPixOrgaTermsOfServiceValidatedAt = lastPixOrgaTermsOfServiceValidatedAt;
     this.lastPixCertifTermsOfServiceValidatedAt = lastPixCertifTermsOfServiceValidatedAt;

--- a/api/src/identity-access-management/domain/models/UserToCreate.js
+++ b/api/src/identity-access-management/domain/models/UserToCreate.js
@@ -22,10 +22,6 @@ class UserToCreate {
     updatedAt,
     dependencies = { localeService },
   } = {}) {
-    if (locale) {
-      locale = dependencies.localeService.getCanonicalLocale(locale);
-    }
-
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
@@ -35,7 +31,7 @@ class UserToCreate {
     this.mustValidateTermsOfService = mustValidateTermsOfService;
     this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
     this.lang = lang;
-    this.locale = locale;
+    this.locale = dependencies.localeService.getNearestSupportedLocale(locale);
     this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
     this.isAnonymous = isAnonymous;
     this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -150,9 +150,6 @@ function _mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.InvalidVerificationCodeError) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }
-  if (error instanceof SharedDomainErrors.LocaleFormatError) {
-    return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
-  }
   if (error instanceof SharedDomainErrors.LanguageNotSupportedError) {
     return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
   }

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -156,9 +156,6 @@ function _mapToHttpError(error) {
   if (error instanceof SharedDomainErrors.LanguageNotSupportedError) {
     return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
   }
-  if (error instanceof SharedDomainErrors.LocaleNotSupportedError) {
-    return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
-  }
   if (error instanceof AdminMemberError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -441,14 +441,6 @@ class LocaleFormatError extends DomainError {
   }
 }
 
-class LocaleNotSupportedError extends DomainError {
-  constructor(locale) {
-    super(`Given locale is not supported : "${locale}"`);
-    this.code = 'LOCALE_NOT_SUPPORTED';
-    this.meta = { locale };
-  }
-}
-
 class MissingAssessmentId extends DomainError {
   constructor(message = 'AssessmentId manquant ou incorrect') {
     super(message);
@@ -1075,7 +1067,6 @@ export {
   LanguageNotSupportedError,
   LearningContentResourceNotFound,
   LocaleFormatError,
-  LocaleNotSupportedError,
   ManyOrganizationsFoundError,
   MatchingReconciledStudentNotFoundError,
   MembershipCreationError,

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -433,14 +433,6 @@ class LearningContentResourceNotFound extends Error {
   }
 }
 
-class LocaleFormatError extends DomainError {
-  constructor(locale) {
-    super(`Given locale is in invalid format: "${locale}"`);
-    this.code = 'INVALID_LOCALE_FORMAT';
-    this.meta = { locale };
-  }
-}
-
 class MissingAssessmentId extends DomainError {
   constructor(message = 'AssessmentId manquant ou incorrect') {
     super(message);
@@ -1066,7 +1058,6 @@ export {
   InvalidVerificationCodeError,
   LanguageNotSupportedError,
   LearningContentResourceNotFound,
-  LocaleFormatError,
   ManyOrganizationsFoundError,
   MatchingReconciledStudentNotFoundError,
   MembershipCreationError,

--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -1,5 +1,3 @@
-import { LocaleFormatError, LocaleNotSupportedError } from '../errors.js';
-
 const ENGLISH_SPOKEN = 'en';
 const FRENCH_FRANCE = 'fr-fr';
 const FRENCH_SPOKEN = 'fr';
@@ -10,7 +8,7 @@ const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
 
 const DEFAULT_CHALLENGE_LOCALE = 'fr-fr';
 
-const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
+const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 const SUPPORTED_LANGUAGES = Array.from(new Set(SUPPORTED_LOCALES.map((locale) => new Intl.Locale(locale).language)));
 
@@ -54,21 +52,23 @@ function coerceLanguage(language) {
   return DEFAULT_LOCALE;
 }
 
-const getCanonicalLocale = function (locale) {
-  let canonicalLocale;
-
+function getNearestSupportedLocale(locale) {
+  if (!locale) return undefined;
   try {
-    canonicalLocale = Intl.getCanonicalLocales(locale)[0];
+    const intlLocale = new Intl.Locale(locale);
+
+    if (SUPPORTED_LOCALES.includes(intlLocale.toString())) {
+      return intlLocale.toString();
+    }
+
+    const localeMatch = SUPPORTED_LOCALES.find((l) => new Intl.Locale(l).language === intlLocale.language);
+    if (localeMatch) return localeMatch;
+
+    return DEFAULT_LOCALE;
   } catch {
-    throw new LocaleFormatError(locale);
+    return DEFAULT_LOCALE;
   }
-
-  if (!SUPPORTED_LOCALES.includes(canonicalLocale)) {
-    throw new LocaleNotSupportedError(canonicalLocale);
-  }
-
-  return canonicalLocale;
-};
+}
 
 export {
   coerceLanguage,
@@ -76,10 +76,10 @@ export {
   ENGLISH_SPOKEN,
   FRENCH_FRANCE,
   FRENCH_SPOKEN,
-  getCanonicalLocale,
   getChallengeLocales,
   getDefaultChallengeLocale,
   getDefaultLocale,
+  getNearestSupportedLocale,
   getSupportedLanguages,
   getSupportedLocales,
   SPANISH_SPOKEN,

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -105,7 +105,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
     server = await createServer();
   });
 
-  describe('POST /users/{id}/competences/{id}/reset', function () {
+  describe('POST /api/users/{id}/competences/{id}/reset', function () {
     describe('Resource access management', function () {
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
         // given

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -205,31 +205,6 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
       // then
       expect(response.statusCode).to.equal(401);
     });
-
-    it('fails with 401 if anonymousUserToken is invalid', async function () {
-      // given
-      const invalidPayload = {
-        ...requestPayload,
-        data: {
-          ...requestPayload.data,
-          attributes: {
-            ...requestPayload.data.attributes,
-            'anonymous-user-token': 'invalid-token',
-          },
-        },
-      };
-
-      // when
-      const response = await server.inject({
-        method: 'PATCH',
-        url: `/api/users/${userId}`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId }),
-        payload: invalidPayload,
-      });
-
-      // then
-      expect(response.statusCode).to.equal(401);
-    });
   });
 
   describe('GET /api/users/me', function () {

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -137,38 +137,6 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
         expect(response.statusCode).to.equal(201);
       });
     });
-
-    context('user is invalid', function () {
-      const validUserAttributes = {
-        'first-name': 'John',
-        'last-name': 'DoDoe',
-        email: 'john.doe@example.net',
-        password: 'Ab124B2C3#!',
-        cgu: true,
-      };
-
-      it('returns 400', async function () {
-        const invalidUserAttributes = { ...validUserAttributes, 'must-validate-terms-of-service': 'not_a_boolean' };
-
-        const options = {
-          method: 'POST',
-          url: '/api/users',
-          payload: {
-            data: {
-              type: 'users',
-              attributes: invalidUserAttributes,
-              relationships: {},
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(400);
-      });
-    });
   });
 
   describe('PATCH /api/users/{id}', function () {

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -37,6 +37,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
           attributes: {
             password: 'Password123',
             cgu: true,
+            'pix-orga-terms-of-service-status': true, // sent by Pix Orga when creating a user upon invitation
           },
           relationships: {},
         },
@@ -146,7 +147,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
         cgu: true,
       };
 
-      it('returns Unprocessable Entity (HTTP_422) with offending properties', async function () {
+      it('returns 400', async function () {
         const invalidUserAttributes = { ...validUserAttributes, 'must-validate-terms-of-service': 'not_a_boolean' };
 
         const options = {
@@ -165,8 +166,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(422);
-        expect(response.result.errors[0].title).to.equal('Invalid data attribute "mustValidateTermsOfService"');
+        expect(response.statusCode).to.equal(400);
       });
     });
   });

--- a/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
@@ -4,7 +4,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-
 import * as OidcIdentityProviders from '../../../../../src/identity-access-management/domain/constants/oidc-identity-providers.js';
 import { QUERY_TYPES } from '../../../../../src/identity-access-management/domain/constants/user-query.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 const CODE_IDENTITY_PROVIDER_GAR = NON_OIDC_IDENTITY_PROVIDERS.GAR.code;
 const CODE_IDENTITY_PROVIDER_POLE_EMPLOI = OidcIdentityProviders.POLE_EMPLOI.code;
@@ -88,53 +88,112 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       sinon.stub(userAdminController, 'updateUserDetailsByAdmin').returns('updated');
     });
 
-    it('should return bad request when firstName is missing', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
-      const url = '/api/admin/users/123';
+    context('invalid payload', function () {
+      context('when a required property is missing', function () {
+        it('returns an HTTP status code 400', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
 
-      const payload = {
-        data: {
-          id: '123',
-          attributes: {
-            'last-name': 'lastNameUpdated',
-            email: 'emailUpdated@example.net',
-          },
-        },
-      };
+          const userId = databaseBuilder.factory.buildUser.anonymous().id;
+          await databaseBuilder.commit();
 
-      // when
-      const response = await httpTestServer.request('PATCH', url, payload);
+          const payload = {
+            data: {
+              id: userId,
+              type: 'users',
+              attributes: {
+                'last-name': 'Baker',
+                email: 'josephine.baker@example.net',
+                password: 'someValidPassword-12345678',
+                cgu: true,
+              },
+            },
+          };
 
-      // then
-      expect(response.statusCode).to.equal(400);
-      const firstError = response.result.errors[0];
-      expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
-    });
+          const url = `/api/admin/users/${userId}`;
 
-    it('should return bad request when lastName is missing', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      const url = '/api/admin/users/123';
-      const payload = {
-        data: {
-          id: '123',
-          attributes: {
-            'first-name': 'firstNameUpdated',
-            email: 'emailUpdated',
-          },
-        },
-      };
+          // when
+          const response = await httpTestServer.request('PATCH', url, payload);
 
-      // when
-      const response = await httpTestServer.request('PATCH', url, payload);
+          // then
+          expect(response.statusCode).to.equal(400);
+          expect(response.result.errors[0].detail).to.equal('"data.attributes.first-name" is required');
+        });
+      });
 
-      // then
-      expect(response.statusCode).to.equal(400);
-      const firstError = response.result.errors[0];
-      expect(firstError.detail).to.equal('"data.attributes.last-name" is required');
+      context('when the locale is not supported', function () {
+        it('returns an HTTP status code 400', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+
+          const userId = databaseBuilder.factory.buildUser.anonymous().id;
+          await databaseBuilder.commit();
+
+          const locale1 = 'fr-fr';
+          const locale2 = 'tlh'; // tlh: Klingon locale
+          const payload = {
+            data: {
+              id: userId,
+              type: 'users',
+              attributes: {
+                'first-name': 'Joséphine',
+                'last-name': 'Baker',
+                email: 'josephine.baker@example.net',
+                password: 'someValidPassword-12345678',
+                cgu: true,
+              },
+            },
+          };
+
+          const url = `/api/admin/users/${userId}`;
+
+          // when
+          payload.locale = locale1;
+          const response1 = await httpTestServer.request('PATCH', url, payload);
+
+          payload.locale = locale2;
+          const response2 = await httpTestServer.request('PATCH', url, payload);
+
+          // then
+          expect(response1.statusCode).to.equal(400);
+          expect(response1.result.errors[0].detail).to.equal('"locale" is not allowed');
+          expect(response2.statusCode).to.equal(400);
+          expect(response2.result.errors[0].detail).to.equal('"locale" is not allowed');
+        });
+      });
+
+      context('when a property has not the valid format', function () {
+        it('returns an HTTP status code 400', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+
+          const userId = databaseBuilder.factory.buildUser.anonymous().id;
+          await databaseBuilder.commit();
+
+          const payload = {
+            data: {
+              id: userId,
+              type: 'users',
+              attributes: {
+                'first-name': 'Joséphine',
+                'last-name': 'Baker',
+                email: 'josephine.baker@example.net',
+                password: 'someValidPassword-12345678',
+                cgu: 'not_a_boolean',
+              },
+            },
+          };
+
+          const url = `/api/admin/users/${userId}`;
+
+          // when
+          const response = await httpTestServer.request('PATCH', url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          expect(response.result.errors[0].detail).to.equal('"data.attributes.cgu" must be a boolean');
+        });
+      });
     });
 
     it('should return a 400 when id in param is not a number"', async function () {

--- a/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user/user.admin.route.test.js
@@ -195,17 +195,6 @@ describe('Integration | Identity Access Management | Application | Route | Admin
         });
       });
     });
-
-    it('should return a 400 when id in param is not a number"', async function () {
-      // given
-      const url = '/api/admin/users/NOT_A_NUMBER';
-
-      // when
-      const response = await httpTestServer.request('PATCH', url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
   });
 
   describe('GET /api/admin/users/{id}', function () {
@@ -238,28 +227,6 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       // then
       expect(response.statusCode).to.equal(403);
       sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
-    });
-
-    it('returns BAD_REQUEST (400) when id in param is not a number"', async function () {
-      // given
-      const url = '/api/admin/users/NOT_A_NUMBER';
-
-      // when
-      const response = await httpTestServer.request('GET', url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('returns BAD_REQUEST (400) when id in params is out of range"', async function () {
-      // given
-      const url = '/api/admin/users/0';
-
-      // when
-      const response = await httpTestServer.request('GET', url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
     });
   });
 
@@ -298,15 +265,6 @@ describe('Integration | Identity Access Management | Application | Route | Admin
       sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
       sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
       sinon.assert.calledOnce(userAdminController.anonymizeUser);
-    });
-
-    it('returns 400 when id is not a number', async function () {
-      // when
-      const { statusCode, payload } = await httpTestServer.request('POST', '/api/admin/users/wrongId/anonymize');
-
-      // then
-      expect(statusCode).to.equal(400);
-      expect(JSON.parse(payload).errors[0].detail).to.equal('"id" must be a number');
     });
 
     it(`returns 403 when user don't have access (CERTIF | METIER)`, async function () {
@@ -387,20 +345,6 @@ describe('Integration | Identity Access Management | Application | Route | Admin
         });
       },
     );
-
-    it('returns 400 when id is not a number', async function () {
-      // when
-      const result = await httpTestServer.request('POST', '/api/admin/users/invalid-id/remove-authentication', {
-        data: {
-          attributes: {
-            type: 'EMAIL',
-          },
-        },
-      });
-
-      // then
-      expect(result.statusCode).to.equal(400);
-    });
 
     it(`returns 403 when user don't have access (CERTIF | METIER)`, async function () {
       // given

--- a/api/tests/identity-access-management/integration/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user/user.route.test.js
@@ -119,6 +119,7 @@ describe('Integration | Identity Access Management | Application | Route | User'
       it('returns a 403 HTTP status code', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
 
         const url = '/api/users/me';
         const headers = generateAuthenticatedUserRequestHeaders({ userId });
@@ -136,6 +137,8 @@ describe('Integration | Identity Access Management | Application | Route | User'
     it('returns controller success response HTTP code', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
       const headers = generateAuthenticatedUserRequestHeaders({ userId });
       sinon.stub(userController, 'getCertificationPointOfContact').callsFake((request, h) => h.response().code(200));
 
@@ -157,6 +160,8 @@ describe('Integration | Identity Access Management | Application | Route | User'
     it('should return 400 - Bad request when challengeType is not valid', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
       const headers = generateAuthenticatedUserRequestHeaders({ userId });
       const url = `/api/users/${userId}/has-seen-challenge-tooltip/invalid`;
 
@@ -170,6 +175,8 @@ describe('Integration | Identity Access Management | Application | Route | User'
     it('should return 200 when challengeType is valid', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
       const headers = generateAuthenticatedUserRequestHeaders({ userId });
       const url = `/api/users/${userId}/has-seen-challenge-tooltip/other`;
 

--- a/api/tests/identity-access-management/unit/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.route.test.js
@@ -59,32 +59,6 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
       sinon.assert.calledOnce(userAdminController.updateUserDetailsByAdmin);
     });
 
-    it('returns bad request when param id is not numeric', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(routesUnderTest);
-
-      const payload = { data: { attributes: { email: 'partial@update.net' } } };
-
-      // when
-      const result = await httpTestServer.request('PATCH', '/api/admin/users/not_number', payload);
-
-      // then
-      expect(result.statusCode).to.equal(400);
-    });
-
-    it('returns bad request when payload is not found', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(routesUnderTest);
-
-      // when
-      const result = await httpTestServer.request('PATCH', '/api/admin/users/12344');
-
-      // then
-      expect(result.statusCode).to.equal(400);
-    });
-
     it(`returns 403 when user don't have access (CERTIF | METIER)`, async function () {
       // given
       sinon.stub(userAdminController, 'updateUserDetailsByAdmin').returns('ok');
@@ -169,24 +143,6 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
         sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
         sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
         sinon.assert.calledOnce(userAdminController.addPixAuthenticationMethod);
-      });
-    });
-
-    describe('when id is not a number', function () {
-      it('returns 400', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(routesUnderTest);
-
-        // when
-        const { statusCode, payload } = await httpTestServer.request(
-          'POST',
-          '/api/admin/users/invalid-id/add-pix-authentication-method',
-        );
-
-        // then
-        expect(statusCode).to.equal(400);
-        expect(JSON.parse(payload).errors[0].detail).to.equal('"id" must be a number');
       });
     });
 
@@ -289,62 +245,6 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
         sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
         sinon.assert.calledOnce(userAdminController.reassignAuthenticationMethod);
       });
-    });
-
-    it('returns 400 when "userId" is not a number', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(routesUnderTest);
-
-      // when
-      const { statusCode, payload } = await httpTestServer.request(
-        'POST',
-        '/api/admin/users/invalid-id/authentication-methods/1',
-      );
-
-      // then
-      expect(statusCode).to.equal(400);
-      expect(JSON.parse(payload).errors[0].detail).to.equal('"userId" must be a number');
-    });
-
-    it('returns 400 when "authenticationMethodId" is not a number', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(routesUnderTest);
-
-      // when
-      const { statusCode, payload } = await httpTestServer.request(
-        'POST',
-        '/api/admin/users/1/authentication-methods/invalid-id',
-      );
-
-      // then
-      expect(statusCode).to.equal(400);
-      expect(JSON.parse(payload).errors[0].detail).to.equal('"authenticationMethodId" must be a number');
-    });
-
-    it('returns 400 when the payload contains an invalid user id', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(routesUnderTest);
-      const payload = {
-        data: {
-          attributes: {
-            'user-id': 'invalid-user-id',
-          },
-        },
-      };
-
-      // when
-      const { statusCode, result } = await httpTestServer.request(
-        'POST',
-        '/api/admin/users/1/authentication-methods/1',
-        payload,
-      );
-
-      // then
-      expect(statusCode).to.equal(400);
-      expect(result.errors[0].detail).to.equal('"data.attributes.user-id" must be a number');
     });
 
     it(`returns 403 when user don't have access (CERTIF | METIER)`, async function () {

--- a/api/tests/identity-access-management/unit/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.admin.route.test.js
@@ -24,7 +24,7 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
       await httpTestServer.register(routesUnderTest);
 
       const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
-      const payload = { data: { attributes: payloadAttributes } };
+      const payload = { data: { id: 12344, attributes: payloadAttributes } };
 
       // when
       const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);
@@ -47,7 +47,7 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
       await httpTestServer.register(routesUnderTest);
 
       const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
-      const payload = { data: { attributes: payloadAttributes } };
+      const payload = { data: { id: 12344, attributes: payloadAttributes } };
 
       // when
       const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);
@@ -98,7 +98,7 @@ describe('Unit | Identity Access Management | Application | Route | User', funct
       await httpTestServer.register(routesUnderTest);
 
       const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
-      const payload = { data: { attributes: payloadAttributes } };
+      const payload = { data: { id: 12344, attributes: payloadAttributes } };
 
       // when
       const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -1,6 +1,7 @@
 import { userController } from '../../../../../src/identity-access-management/application/user/user.controller.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import * as requestResponseUtils from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
@@ -208,9 +209,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       const cryptoService = {
         hashPassword: sinon.stub(),
       };
-      const localeService = {
-        getCanonicalLocale: sinon.stub(),
-      };
 
       dependencies = {
         userSerializer,
@@ -250,7 +248,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
 
           // then
           expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly(savedUser);
-          expect(dependencies.localeService.getCanonicalLocale).to.not.have.been.called;
           expect(response.source).to.deep.equal(expectedSerializedUser);
           expect(response.statusCode).to.equal(201);
         });
@@ -272,7 +269,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
             i18n: undefined,
           };
 
-          dependencies.localeService.getCanonicalLocale.returns(locale);
           dependencies.userSerializer.serialize.returns(expectedSerializedUser);
           usecases.createUser.resolves(savedUser);
 
@@ -300,7 +296,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
 
           // then
           expect(usecases.createUser).to.have.been.calledWithExactly(useCaseParameters);
-          expect(dependencies.localeService.getCanonicalLocale).to.have.been.calledWithExactly(locale);
           expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly(savedUser);
           expect(response.statusCode).to.equal(201);
         });
@@ -334,10 +329,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
         extractLocaleFromRequest: sinon.stub().returns(language),
       };
 
-      const localeService = {
-        getCanonicalLocale: sinon.stub().returns(locale),
-      };
-
       dependencies = { userSerializer, requestResponseUtils, localeService };
     });
 
@@ -369,7 +360,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       );
 
       // then
-      expect(dependencies.localeService.getCanonicalLocale).to.have.been.calledWithExactly(locale);
       expect(dependencies.requestResponseUtils.extractLocaleFromRequest).to.have.been.called;
       expect(usecases.upgradeToRealUser).to.have.been.calledWithExactly({
         userId,

--- a/api/tests/identity-access-management/unit/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.route.test.js
@@ -7,42 +7,6 @@ import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 const routesUnderTest = identityAccessManagementRoutes[0];
 
 describe('Unit | Identity Access Management | Application | Route | User', function () {
-  describe('POST /api/users', function () {
-    const method = 'POST';
-    const url = '/api/users';
-
-    context('Payload schema validation', function () {
-      it('should return HTTP 400 if payload does not exist', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(routesUnderTest);
-
-        const payload = null;
-
-        // when
-        const result = await httpTestServer.request(method, url, payload);
-
-        // then
-        expect(result.statusCode).to.equal(400);
-      });
-
-      it('should return HTTP 200 if payload is not empty and valid', async function () {
-        // given
-        sinon.stub(userController, 'createUser').returns('ok');
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(routesUnderTest);
-
-        const payload = { data: { attributes: {} } };
-
-        // when
-        const result = await httpTestServer.request(method, url, payload);
-
-        // then
-        expect(result.statusCode).to.equal(200);
-      });
-    });
-  });
-
   describe('GET /api/users/me', function () {
     const method = 'GET';
 

--- a/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserDetailsForAdmin_test.js
@@ -1,40 +1,45 @@
 import { UserDetailsForAdmin } from '../../../../../src/identity-access-management/domain/models/UserDetailsForAdmin.js';
-import { expect, sinon } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
-  let localeService;
-  let dependencies;
-
-  beforeEach(function () {
-    localeService = {
-      getCanonicalLocale: sinon.stub(),
-    };
-    dependencies = { localeService };
-  });
-
   describe('constructor', function () {
-    it('accepts no locale', function () {
-      // given
-      const users = [
-        new UserDetailsForAdmin({ locale: '' }, dependencies),
-        new UserDetailsForAdmin({ locale: null }, dependencies),
-        new UserDetailsForAdmin({ locale: undefined }, dependencies),
-      ];
+    context('locale', function () {
+      context('when there is no locale', function () {
+        ['', null, undefined].forEach((locale) => {
+          it(`returns null for ${locale}`, function () {
+            // when
+            const user = new UserDetailsForAdmin({ locale });
 
-      //then
-      expect(users).to.have.lengthOf(3);
-    });
+            //then
+            expect(user.locale).to.be.undefined;
+          });
+        });
+      });
 
-    it('validates and canonicalizes the locale', function () {
-      // given
-      localeService.getCanonicalLocale.returns('fr-BE');
+      context('when the locale is not supported', function () {
+        it('throws a RangeError', function () {
+          // given
+          const locale = 'fr-fr';
 
-      // when
-      const user = new UserDetailsForAdmin({ locale: 'fr-be' }, dependencies);
+          // when
+          const user = new UserDetailsForAdmin({ locale });
 
-      // then
-      expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
-      expect(user.locale).to.equal('fr-BE');
+          //then
+          expect(user.locale).to.equal('fr-FR');
+        });
+      });
+
+      context('when the locale is supported', function () {
+        ['fr', 'fr-FR', 'fr-BE'].forEach((locale) => {
+          it(`returns the locale ${locale}`, function () {
+            // when
+            const user = new UserDetailsForAdmin({ locale });
+
+            //then
+            expect(user.locale).to.equal(locale);
+          });
+        });
+      });
     });
   });
 

--- a/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserToCreate.test.js
@@ -3,28 +3,43 @@ import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Model | UserToCreate', function () {
   describe('constructor', function () {
-    it('accepts no locale', function () {
-      // given
-      const users = [
-        new UserToCreate({ locale: '' }),
-        new UserToCreate({ locale: null }),
-        new UserToCreate({ locale: undefined }),
-      ];
+    context('locale', function () {
+      context('when there is no locale', function () {
+        ['', null, undefined].forEach((locale) => {
+          it(`returns null for ${locale}`, function () {
+            // when
+            const user = new UserToCreate({ locale });
 
-      // then
-      expect(users).to.have.lengthOf(3);
-    });
+            //then
+            expect(user.locale).to.be.undefined;
+          });
+        });
+      });
 
-    it('validates and canonicalizes the locale', function () {
-      // given
-      const localeServiceStub = { getCanonicalLocale: sinon.stub().returns('fr-BE') };
+      context('when the locale is not supported', function () {
+        it('throws a RangeError', function () {
+          // given
+          const locale = 'fr-fr';
 
-      // when
-      const userToCreate = new UserToCreate({ locale: 'fr-be', dependencies: { localeService: localeServiceStub } });
+          // when
+          const user = new UserToCreate({ locale });
 
-      // then
-      expect(localeServiceStub.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
-      expect(userToCreate.locale).to.equal('fr-BE');
+          //then
+          expect(user.locale).to.equal('fr-FR');
+        });
+      });
+
+      context('when the locale is supported', function () {
+        ['fr', 'fr-FR', 'fr-BE'].forEach((locale) => {
+          it(`returns the locale ${locale}`, function () {
+            // when
+            const user = new UserToCreate({ locale });
+
+            //then
+            expect(user.locale).to.equal(locale);
+          });
+        });
+      });
     });
 
     it('should build a default user', function () {

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -98,7 +98,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           },
           {
             attribute: 'locale',
-            message: "La locale doit avoir l'une des valeurs suivantes : en, es, fr, fr-be, fr-fr, nl-be, nl",
+            message: "La locale doit avoir l'une des valeurs suivantes : en, es, fr, nl, fr-be, fr-fr, nl-be",
           },
           {
             attribute: 'locale',

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles-script.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles-script.test.js
@@ -98,7 +98,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.message).to.equal(`Échec de validation de l'entité.`);
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'locale',
-          message: `La locale doit avoir l'une des valeurs suivantes : en, es, fr, fr-be, fr-fr, nl-be, nl`,
+          message: `La locale doit avoir l'une des valeurs suivantes : en, es, fr, nl, fr-be, fr-fr, nl-be`,
         });
       });
     });

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -25,7 +25,6 @@ import {
   InvalidJuryLevelError,
   InvalidVerificationCodeError,
   LocaleFormatError,
-  LocaleNotSupportedError,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   NoCertificateForDivisionError,
   NotEnoughDaysPassedBeforeResetCampaignParticipationError,
@@ -256,25 +255,6 @@ describe('Shared | Unit | Application | ErrorManager', function () {
             'Given locale is in invalid format: "zzzz"',
             'INVALID_LOCALE_FORMAT',
             { locale: 'zzzz' },
-          );
-        });
-      });
-
-      context('When receiving LocaleNotSupportedError', function () {
-        it('instantiates a BadRequest error', function () {
-          // given
-          const error = new LocaleNotSupportedError('nl-BE');
-          sinon.stub(HttpErrors, 'BadRequestError');
-          const params = { request: {}, h: hFake, error };
-
-          // when
-          handle(params.request, params.h, params.error);
-
-          // then
-          expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
-            'Given locale is not supported : "nl-BE"',
-            'LOCALE_NOT_SUPPORTED',
-            { locale: 'nl-BE' },
           );
         });
       });

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -24,7 +24,6 @@ import {
   InvalidInputDataError,
   InvalidJuryLevelError,
   InvalidVerificationCodeError,
-  LocaleFormatError,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   NoCertificateForDivisionError,
   NotEnoughDaysPassedBeforeResetCampaignParticipationError,
@@ -237,27 +236,6 @@ describe('Shared | Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
-    });
-
-    context('Locale errors', function () {
-      context('When receiving LocaleFormatError', function () {
-        it('instantiates a BadRequest error', function () {
-          // given
-          const error = new LocaleFormatError('zzzz');
-          sinon.stub(HttpErrors, 'BadRequestError');
-          const params = { request: {}, h: hFake, error };
-
-          // when
-          handle(params.request, params.h, params.error);
-
-          // then
-          expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
-            'Given locale is in invalid format: "zzzz"',
-            'INVALID_LOCALE_FORMAT',
-            { locale: 'zzzz' },
-          );
-        });
-      });
     });
 
     context('when handling an OidcError', function () {

--- a/api/tests/shared/unit/domain/services/locale-service_test.js
+++ b/api/tests/shared/unit/domain/services/locale-service_test.js
@@ -1,30 +1,30 @@
 import { LocaleFormatError, LocaleNotSupportedError } from '../../../../../src/shared/domain/errors.js';
-import { getCanonicalLocale, getSupportedLanguages } from '../../../../../src/shared/domain/services/locale-service.js';
+import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Service | Locale', function () {
-  describe('#getCanonicalLocale', function () {
+  describe('getCanonicalLocale', function () {
     it('throws a LocaleFormatError error', function () {
       // when
-      const error = catchErrSync(getCanonicalLocale)('anInvalidLocale');
+      const error = catchErrSync(localeService.getCanonicalLocale)('anInvalidLocale');
 
-      //then
+      // then
       expect(error).to.be.instanceOf(LocaleFormatError);
     });
 
     it('throws a LocaleNotSupportedError error', function () {
       // when
-      const error = catchErrSync(getCanonicalLocale)('pt-PT');
+      const error = catchErrSync(localeService.getCanonicalLocale)('pt-PT');
 
-      //then
+      // then
       expect(error).to.be.instanceOf(LocaleNotSupportedError);
     });
 
     it('canonicalizes the given locale', function () {
       // given
-      const locale = getCanonicalLocale('fr-fr');
+      const locale = localeService.getCanonicalLocale('fr-fr');
 
-      //then
+      // then
       expect(locale).to.equal('fr-FR');
     });
   });
@@ -32,7 +32,7 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
   describe('getSupportedLanguages', function () {
     it('returns languages computed from the supported locales', function () {
       // when
-      const result = getSupportedLanguages();
+      const result = localeService.getSupportedLanguages();
 
       // then
       expect(result).to.deep.equal(['en', 'es', 'fr', 'nl']);

--- a/api/tests/shared/unit/domain/services/locale-service_test.js
+++ b/api/tests/shared/unit/domain/services/locale-service_test.js
@@ -1,34 +1,7 @@
-import { LocaleFormatError, LocaleNotSupportedError } from '../../../../../src/shared/domain/errors.js';
 import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
-import { catchErrSync, expect } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Service | Locale', function () {
-  describe('getCanonicalLocale', function () {
-    it('throws a LocaleFormatError error', function () {
-      // when
-      const error = catchErrSync(localeService.getCanonicalLocale)('anInvalidLocale');
-
-      // then
-      expect(error).to.be.instanceOf(LocaleFormatError);
-    });
-
-    it('throws a LocaleNotSupportedError error', function () {
-      // when
-      const error = catchErrSync(localeService.getCanonicalLocale)('pt-PT');
-
-      // then
-      expect(error).to.be.instanceOf(LocaleNotSupportedError);
-    });
-
-    it('canonicalizes the given locale', function () {
-      // given
-      const locale = localeService.getCanonicalLocale('fr-fr');
-
-      // then
-      expect(locale).to.equal('fr-FR');
-    });
-  });
-
   describe('getSupportedLanguages', function () {
     it('returns languages computed from the supported locales', function () {
       // when
@@ -36,6 +9,73 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
 
       // then
       expect(result).to.deep.equal(['en', 'es', 'fr', 'nl']);
+    });
+  });
+
+  describe('getNearestSupportedLocale', function () {
+    context('when given a supported locale in canonical form', function () {
+      it('returns the locale', function () {
+        // given
+        const name = 'fr-FR';
+
+        // when
+        const locale = localeService.getNearestSupportedLocale(name);
+
+        // then
+        expect(locale).to.equal('fr-FR');
+      });
+    });
+
+    context('when given a supported locale but not in canonical form', function () {
+      it('returns the canonical locale form', function () {
+        // given
+        const name = 'fr-fr';
+
+        // when
+        const locale = localeService.getNearestSupportedLocale(name);
+
+        // then
+        expect(locale).to.equal('fr-FR');
+      });
+    });
+
+    context('when given an unsupported locale but the base language is supported', function () {
+      it('returns the base language locale', function () {
+        // given
+        const name = 'fr-CA';
+
+        // when
+        const locale = localeService.getNearestSupportedLocale(name);
+
+        // then
+        expect(locale).to.equal('fr');
+      });
+    });
+
+    context('when given a locale and base language are both not supported', function () {
+      it('returns the default locale', function () {
+        // given
+        const name = 'br_FR';
+
+        // when
+        const locale = localeService.getNearestSupportedLocale(name);
+
+        // then
+        expect(locale).to.equal('fr');
+      });
+    });
+
+    context('when given an invalid name', function () {
+      it('returns the default locale', function () {
+        // given
+        const name = 'anInvalidLocaleName';
+
+        // when
+        const locale = localeService.getNearestSupportedLocale(name);
+
+        // then
+        expect(locale).to.equal('fr');
+      });
     });
   });
 });

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,7 +1,6 @@
 import { User } from '../../../../../../src/identity-access-management/domain/models/User.js';
-import { LocaleFormatError } from '../../../../../../src/shared/domain/errors.js';
 import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/user-serializer.js';
-import { catchErrSync, expect } from '../../../../../test-helper.js';
+import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serializer', function () {
   describe('#serialize', function () {
@@ -137,20 +136,6 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
 
       // then
       expect(user.id).to.be.undefined;
-    });
-
-    context('user with a invalid locale format', function () {
-      it('throws locale format error', function () {
-        // given
-        jsonUser.data.attributes.locale = 'zzzz';
-
-        // when
-        const error = catchErrSync(serializer.deserialize)(jsonUser);
-
-        // then
-        expect(error).to.be.instanceOf(LocaleFormatError);
-        expect(error.message).to.equal('Given locale is in invalid format: "zzzz"');
-      });
     });
   });
 });

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,5 +1,5 @@
 import { User } from '../../../../../../src/identity-access-management/domain/models/User.js';
-import { LocaleFormatError, LocaleNotSupportedError } from '../../../../../../src/shared/domain/errors.js';
+import { LocaleFormatError } from '../../../../../../src/shared/domain/errors.js';
 import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/user-serializer.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -150,20 +150,6 @@ describe('Unit | Shared | Infrastructure | Serializer | JSONAPI | user-serialize
         // then
         expect(error).to.be.instanceOf(LocaleFormatError);
         expect(error.message).to.equal('Given locale is in invalid format: "zzzz"');
-      });
-    });
-
-    context('user with a not supported locale', function () {
-      it('throws locale not supported error', function () {
-        // given
-        jsonUser.data.attributes.locale = 'jp';
-
-        // when
-        const error = catchErrSync(serializer.deserialize)(jsonUser);
-
-        // then
-        expect(error).to.be.instanceOf(LocaleNotSupportedError);
-        expect(error.message).to.equal('Given locale is not supported : "jp"');
       });
     });
   });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -7,7 +7,6 @@ import {
   ForbiddenAccess,
   InvalidTemporaryKeyError,
   LocaleFormatError,
-  LocaleNotSupportedError,
 } from '../../../src/shared/domain/errors.js';
 import { expect } from '../../test-helper.js';
 
@@ -256,10 +255,6 @@ describe('Unit | Domain | Errors', function () {
 
   it('exports LocaleFormatError', function () {
     expect(LocaleFormatError).to.exist;
-  });
-
-  it('exports LocaleNotSupportedError', function () {
-    expect(LocaleNotSupportedError).to.exist;
   });
 
   it('NotEnoughDaysPassedBeforeResetCampaignParticipationError error should have the correct wording', function () {

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -6,7 +6,6 @@ import {
   EntityValidationError,
   ForbiddenAccess,
   InvalidTemporaryKeyError,
-  LocaleFormatError,
 } from '../../../src/shared/domain/errors.js';
 import { expect } from '../../test-helper.js';
 
@@ -251,10 +250,6 @@ describe('Unit | Domain | Errors', function () {
 
   it('exports SendingEmailToInvalidEmailAddressError', function () {
     expect(errors.SendingEmailToInvalidEmailAddressError).to.exist;
-  });
-
-  it('exports LocaleFormatError', function () {
-    expect(LocaleFormatError).to.exist;
   });
 
   it('NotEnoughDaysPassedBeforeResetCampaignParticipationError error should have the correct wording', function () {


### PR DESCRIPTION
## 🔆 Problème

1. Les routes suivantes n’ont qu’une validation très incomplète des paramètres passés et, pour les 2 premières routes, aucune validation de la `locale` : 
  * `POST` `/api/users`
  * `PATCH` `/api/users`
  * `PATCH` `/api/admin/users`
2. La validation de la `locale` d’un utilisateur, réalisée à plusieurs endroits, avec la fonction `getCanonicalLocale` et les erreurs `LocaleNotSupportedError` et `LocaleFormatError` n’est ni claire ni pratique.

## ⛱️ Proposition

1. Ajouter de la validation à tous les points d’entrée de l’API : 
   * validation Joi sur tous les attributs des routes concernées
   * validation du cookie `locale` au niveau des routes concernées
2. Ajouter une fonction `localeService.getNearestSupportedLocale` pour s'assurer que la locale transmise est une locale supportée par Pix

Cette PR supprime les erreurs spécifiques `LocaleNotSupportedError` et `LocaleFormatError` car on ne veut pas faire d’actions particulières sur ces erreurs et donc on n’a pas besoin de définir des types d’erreur particuliers pour ces erreurs. 

## 🌊 Remarques

Grâce à cette PR on note que le passage des paramètres aux routes concernées est réalisé en envoyant beaucoup trop d’informations 🤢 L’avantage de mettre en place avec cette PR une validation de manière complète (sans le `allowUnknown: true`) est que cela met évidence qu‘il faut reprendre l’utilisation de cette API par les frontaux pour n’envoyer et n’autoriser que les informations nécessaires.

## 🏄 Pour tester

Tester les actions utilisant les routes suivantes : 
  * `POST` `/api/users`
  * `PATCH` `/api/users`
  * `PATCH` `/api/admin/users`
  
C'est à dire concrètement : 
* Sur Pix App `.pix.fr` créer un utilisateur
* Sur Pix App `.pix.org` créer un utilisateur
* Sur Pix App (`.pix.fr` ou `.pix.org` indifférent) passer un parcours simplifié (utilisateur anonyme) et à l’issue créer un compte
  * https://app-pr13053.review.pix.org/campagnes/AUTOCOUR1
* Sur Pix Orga `.pix.fr`
  * envoyer une invitation
  * accepter cette invitation en créant un nouveau compte
* Sur Pix Orga `.pix.org`
  * envoyer une invitation
  * accepter cette invitation en créant un nouveau compte
* Sur Pix Certif `.pix.fr`
  * envoyer une invitation
  * accepter cette invitation en créant un nouveau compte
* Sur Pix Certif `.pix.org`
  * envoyer une invitation
  * accepter cette invitation en créant un nouveau compte
* Sur Pix Admin `.pix.fr`
  * modifier les informations d'un compte utilisateur.


