### PR TITLE
[BUGFIX] Corriger l'affichage du pourcentage de réussite en fin de campagnes (PIX-18929).

### DIFF
--- a/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/src/shared/domain/read-models/participant-results/AssessmentResult.js
@@ -35,7 +35,6 @@ class AssessmentResult {
     this.validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
     this.masteryRate = this._computeMasteryRate(
       participationResults.masteryRate,
-      this.isShared,
       this.totalSkillsCount,
       this.validatedSkillsCount,
     );
@@ -98,10 +97,8 @@ class AssessmentResult {
     return remainingSecondsBeforeRetrying;
   }
 
-  _computeMasteryRate(masteryRate, isShared, totalSkillsCount, validatedSkillsCount) {
-    if (isShared) {
-      return masteryRate;
-    } else if (totalSkillsCount > 0) {
+  _computeMasteryRate(masteryRate, totalSkillsCount, validatedSkillsCount) {
+    if (totalSkillsCount > 0) {
       const rate = (validatedSkillsCount / totalSkillsCount).toPrecision(2);
       return parseFloat(rate);
     } else {

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -460,35 +460,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       });
     });
 
-    context('when the participation is shared', function () {
-      it('returns the mastery rate for the participation using the mastery rate stocked', async function () {
-        const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-        _buildCampaignSkills(campaignId);
-        const sharedAt = new Date('2020-01-02');
-        const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
-          userId,
-          campaignId,
-          status: CampaignParticipationStatuses.SHARED,
-          sharedAt,
-          masteryRate: 0.6,
-        });
-
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
-
-        await databaseBuilder.commit();
-        const participantResult = await participantResultRepository.get({
-          userId,
-          campaignId,
-          targetProfile,
-          badges: [],
-          locale: 'FR',
-        });
-        expect(participantResult.masteryRate).to.equal(0.6);
-        expect(participantResult.sharedAt).to.deep.equal(sharedAt);
-      });
-    });
-
     context('when there are several participations', function () {
       it('use the participation not improved yet', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -176,46 +176,6 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           });
         });
       });
-
-      context('when the participation is shared', function () {
-        it('return the mastery rate of the participation', function () {
-          const competences = [
-            {
-              competence: domainBuilder.buildCompetence({
-                id: 'rec1',
-                name: 'C1',
-                index: '1.1',
-              }),
-              area: domainBuilder.buildArea({
-                name: 'Domaine1',
-                color: 'Couleur1',
-              }),
-              targetedSkillIds: ['skill1', 'skill2', 'skill2'],
-            },
-          ];
-
-          const participationResults = {
-            campaignParticipationId: 12,
-            isCompleted: true,
-            knowledgeElements: [],
-            acquiredBadgeIds: [],
-            sharedAt: new Date('2021-09-25'),
-            status: CampaignParticipationStatuses.SHARED,
-            masteryRate: 0.5,
-          };
-
-          const assessmentResult = new AssessmentResult({
-            participationResults,
-            competences,
-            stages: [],
-            badgeResultsDTO: [],
-            isCampaignMultipleSendings: false,
-            isOrganizationLearnerActive: false,
-            isCampaignArchived: false,
-          });
-          expect(assessmentResult.masteryRate).to.equal(0.5);
-        });
-      });
     });
 
     it('computes the result by competences', function () {
@@ -676,8 +636,18 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const isCampaignMultipleSendings = true;
         const isOrganizationLearnerActive = true;
         const isCampaignArchived = false;
+        const ke = domainBuilder.buildKnowledgeElement({
+          skillId: 'recSkillComp1',
+          status: KnowledgeElement.StatusType.VALIDATED,
+          createdAt: new Date('2020-01-01'),
+        });
+        const targetedCompetence = {
+          competence: { id: 'competence1' },
+          area: {},
+          targetedSkillIds: ['recSkillComp1'],
+        };
         const participationResults = {
-          knowledgeElements: [],
+          knowledgeElements: [ke],
           acquiredBadgeIds: [],
           masteryRate: '1',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
@@ -687,7 +657,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
         const assessmentResult = new AssessmentResult({
           participationResults,
-          competences: [],
+          competences: [targetedCompetence],
           stages: [],
           badgeResultsDTO: [],
           campaignType: CampaignTypes.ASSESSMENT,
@@ -706,7 +676,6 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
-          masteryRate: '1',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           status: CampaignParticipationStatuses.SHARED,
           isDeleted: false,


### PR DESCRIPTION
## 🔆 Problème

Depuis le partage automatique des résultats, le masteryRate est erroné au premier chargement de la page. Cela est dû au fait que comme la participation est en status partagé, nous récupérons le masteryRate stocké en base, mais celui-ci n'a pas encore été calculé. Vive les jobs asynchrones. 

## ⛱️ Proposition

Comme dans tous les cas, nous avons toutes les informations pour calculer le masteryRate à la volé, nous n'utilisons pas celui en base, pour cet affichage. Bisous.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Activer l'envoie auto `isAutoSharedEnabled` 
- Aller sur Pix App
- Passer une campagne comme `PROASSMUL`et constater que la masteryRate est disponible directement.