### PR TITLE
[BUGFIX]  Corriger le fait qu'on ne peut plus passer à la carte suivante sur les Flashcards (PIX-18939

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -133,12 +133,6 @@ export default class ModulixFlashcards extends Component {
 
   @action
   async onSelfAssessment(userAssessment) {
-    const selfAssessmentData = {
-      userAssessment,
-      cardId: this.currentCard.id,
-    };
-    this.args.onSelfAssessment(selfAssessmentData);
-
     this.passageEvents.record({
       type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
       data: {

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -216,14 +216,8 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         // given
         const { flashcards } = _getFlashcards();
 
-        const onSelfAssessmentStub = sinon.stub();
-
         // when
-        const screen = await render(
-          <template>
-            <ModulixFlashcards @flashcards={{flashcards}} @onSelfAssessment={{onSelfAssessmentStub}} />
-          </template>,
-        );
+        const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
         await clickByName(t('pages.modulix.buttons.flashcards.answers.no'));
@@ -231,8 +225,6 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         // then
         assert.ok(screen.getByText('Qui a écrit le Dormeur du Val ?'));
         assert.ok(screen.getByText(t('pages.modulix.flashcards.position', { currentCardPosition: 2, totalCards: 2 })));
-        assert.true(onSelfAssessmentStub.calledOnce);
-
         assert.ok(
           passageEventsService.record.calledWith({
             type: 'FLASHCARDS_CARD_AUTO_ASSESSED',
@@ -252,17 +244,10 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         const { flashcards } = _getFlashcards();
 
         const onAnswerStub = sinon.stub();
-        const onSelfAssessmentStub = sinon.stub();
 
         // when
         const screen = await render(
-          <template>
-            <ModulixFlashcards
-              @flashcards={{flashcards}}
-              @onAnswer={{onAnswerStub}}
-              @onSelfAssessment={{onSelfAssessmentStub}}
-            />
-          </template>,
+          <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
         );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
@@ -307,17 +292,10 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       const { flashcards } = _getFlashcards();
 
       const onAnswerStub = sinon.stub();
-      const onSelfAssessment = sinon.stub();
 
       // when
       const screen = await render(
-        <template>
-          <ModulixFlashcards
-            @flashcards={{flashcards}}
-            @onAnswer={{onAnswerStub}}
-            @onSelfAssessment={{onSelfAssessment}}
-          />
-        </template>,
+        <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
       );
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
       await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
@@ -338,17 +316,10 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       const { flashcards } = _getFlashcards();
 
       const onAnswerStub = sinon.stub();
-      const onSelfAssessmentStub = sinon.stub();
 
       // when
       const screen = await render(
-        <template>
-          <ModulixFlashcards
-            @flashcards={{flashcards}}
-            @onAnswer={{onAnswerStub}}
-            @onSelfAssessment={{onSelfAssessmentStub}}
-          />
-        </template>,
+        <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
       );
       await clickByName(t('pages.modulix.buttons.flashcards.start'));
       await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));
@@ -373,17 +344,10 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
         const { flashcards, firstCard } = _getFlashcards();
 
         const onAnswerStub = sinon.stub();
-        const onSelfAssessmentStub = sinon.stub();
 
         // when
         const screen = await render(
-          <template>
-            <ModulixFlashcards
-              @flashcards={{flashcards}}
-              @onAnswer={{onAnswerStub}}
-              @onSelfAssessment={{onSelfAssessmentStub}}
-            />
-          </template>,
+          <template><ModulixFlashcards @flashcards={{flashcards}} @onAnswer={{onAnswerStub}} /></template>,
         );
         await clickByName(t('pages.modulix.buttons.flashcards.start'));
         await clickByName(t('pages.modulix.buttons.flashcards.seeAnswer'));


### PR DESCRIPTION
## 🔆 Problème

Lorsqu’on répond à une carte dans l'élément flashcards, une erreur dans la console se produit : 

`TypeError: this.args.onSelfAssessment is not a function`

## ⛱️ Proposition

Corriger cela en supprimant cet appel qui est déprécié. C'était utilisé pour appeler Matomo / Plausible et cette ligne a été oublié lors de la suppression de ces appels…

## 🌊 Remarques

- Les tests n'ont pas remonté ce bug car la fonction était toujours passée dans les cas testés.. 

## 🏄 Pour tester

- Aller sur le module [decouverte-de-l-ent](https://app-pr13057.review.pix.fr/modules/decouverte-de-l-ent/passage)
- Aller jusqu'à la flashcards
- Vérifier qu'on peut maintenant bien passer à la carte suivante.
