### PR TITLE
[FEATURE] Créer une api interne pour récupérer les modules recommandés lors de participations à des campagnes (PIX-18924)

### DIFF
--- a/api/src/devcomp/application/api/models/RecommendedModule.js
+++ b/api/src/devcomp/application/api/models/RecommendedModule.js
@@ -1,0 +1,8 @@
+class RecommendedModule {
+  constructor({ id, moduleId } = {}) {
+    this.id = id;
+    this.moduleId = moduleId;
+  }
+}
+
+export { RecommendedModule };

--- a/api/src/devcomp/application/api/recommended-modules-api.js
+++ b/api/src/devcomp/application/api/recommended-modules-api.js
@@ -1,0 +1,17 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+import { usecases } from '../../domain/usecases/index.js';
+import { RecommendedModule } from './models/RecommendedModule.js';
+
+const findByCampaignParticipationIds = async ({ campaignParticipationIds }) => {
+  if (campaignParticipationIds.length === 0) {
+    throw new DomainError('campaignParticipationIds can not be empty');
+  }
+
+  const recommendedModules = await usecases.findRecommendedModulesByCampaignParticipationIds({
+    campaignParticipationIds,
+  });
+
+  return recommendedModules.map((module) => new RecommendedModule(module));
+};
+
+export { findByCampaignParticipationIds };

--- a/api/src/devcomp/domain/read-models/UserRecommendedModule.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedModule.js
@@ -1,0 +1,8 @@
+class UserRecommendedModule {
+  constructor({ id, moduleId } = {}) {
+    this.id = id;
+    this.moduleId = moduleId;
+  }
+}
+
+export { UserRecommendedModule };

--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
@@ -1,0 +1,23 @@
+import { UserRecommendedModule } from '../read-models/UserRecommendedModule.js';
+
+export const findRecommendedModulesByCampaignParticipationIds = async function ({
+  campaignParticipationIds,
+  moduleRepository,
+  userRecommendedTrainingRepository,
+}) {
+  const userRecommendedTrainings = await userRecommendedTrainingRepository.findModulesByCampaignParticipationIds({
+    campaignParticipationIds,
+  });
+  const userRecommendedModules = await Promise.all(
+    userRecommendedTrainings.map(async ({ id, link }) => {
+      const regexp = /^\/modules\/([a-z0-9-]*)/;
+
+      const result = regexp.exec(link);
+      const slug = result[1];
+      const module = await moduleRepository.getBySlug({ slug });
+      return { id, moduleId: module.id };
+    }),
+  );
+
+  return userRecommendedModules.map((module) => new UserRecommendedModule(module));
+};

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -20,6 +20,19 @@ const findByCampaignParticipationId = async function ({ campaignParticipationId,
   return trainings.map(_toDomain);
 };
 
+const findModulesByCampaignParticipationIds = async function ({ campaignParticipationIds }) {
+  const knexConn = DomainTransaction.getConnection();
+  const moduleLinks = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME)
+    .select('trainings.*')
+    .innerJoin('trainings', 'trainings.id', `${USER_RECOMMENDED_TRAININGS_TABLE_NAME}.trainingId`)
+    .where({ isDisabled: false, type: 'modulix' })
+    .whereIn('campaignParticipationId', campaignParticipationIds)
+    .distinct('trainings.id')
+    .orderBy('trainings.id', 'asc');
+
+  return moduleLinks.map(_toDomain);
+};
+
 const hasRecommendedTrainings = async function ({ userId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn(USER_RECOMMENDED_TRAININGS_TABLE_NAME).select(1).where({ userId }).first();
@@ -33,7 +46,13 @@ const deleteCampaignParticipationIds = async ({ campaignParticipationIds }) => {
     .whereIn('campaignParticipationId', campaignParticipationIds);
 };
 
-export { deleteCampaignParticipationIds, findByCampaignParticipationId, hasRecommendedTrainings, save };
+export {
+  deleteCampaignParticipationIds,
+  findByCampaignParticipationId,
+  findModulesByCampaignParticipationIds,
+  hasRecommendedTrainings,
+  save,
+};
 
 function _toDomain(training) {
   return new UserRecommendedTraining({ ...training });

--- a/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
@@ -1,0 +1,50 @@
+import { RecommendedModule } from '../../../../../src/devcomp/application/api/models/RecommendedModule.js';
+import * as recommendedModulesApi from '../../../../../src/devcomp/application/api/recommended-modules-api.js';
+import { DomainError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Devcomp | Application | Api | RecommendedModules', function () {
+  describe('#findByCampaignParticipationIds', function () {
+    it('should return a list recommended modules', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ userId }).id;
+      const trainingId = databaseBuilder.factory.buildTraining({
+        type: 'modulix',
+        link: '/modules/adresse-ip-publique-et-vous/details',
+      }).id;
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        campaignParticipationId,
+        trainingId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await recommendedModulesApi.findByCampaignParticipationIds({
+        campaignParticipationIds: [campaignParticipationId],
+      });
+
+      // then
+      const expectedResult = [
+        new RecommendedModule({ id: trainingId, moduleId: '5df14039-803b-4db4-9778-67e4b84afbbd' }),
+      ];
+
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    context('if campaignParticipationIds is empty', function () {
+      it('should throw a DomainError error', async function () {
+        // given & when
+        const error = await catchErr(recommendedModulesApi.findByCampaignParticipationIds)({
+          campaignParticipationIds: [],
+        });
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('campaignParticipationIds can not be empty');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -1,0 +1,44 @@
+import { UserRecommendedModule } from '../../../../../src/devcomp/domain/read-models/UserRecommendedModule.js';
+import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByCampaignParticipationIds', function () {
+  it('it returns recommended modules for given participation ids', async function () {
+    // given
+    const { id: campaignParticipationId1, userId } = databaseBuilder.factory.buildCampaignParticipation();
+    const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
+
+    const moduleId = '5df14039-803b-4db4-9778-67e4b84afbbd';
+    const training = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: '/modules/adresse-ip-publique-et-vous/details',
+    });
+    const secondModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+    const secondTraining = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: '/modules/bien-ecrire-son-adresse-mail/details',
+    });
+
+    databaseBuilder.factory.buildUserRecommendedTraining({
+      userId,
+      trainingId: training.id,
+      campaignParticipationId: campaignParticipationId1,
+    }).id;
+    databaseBuilder.factory.buildUserRecommendedTraining({
+      userId,
+      trainingId: secondTraining.id,
+      campaignParticipationId: campaignParticipationId2,
+    }).id;
+    await databaseBuilder.commit();
+
+    const recommendedModules = await usecases.findRecommendedModulesByCampaignParticipationIds({
+      campaignParticipationIds: [campaignParticipationId1, campaignParticipationId2],
+    });
+
+    expect(recommendedModules).to.have.lengthOf(2);
+    expect(recommendedModules[0]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[0]).to.be.deep.equal({ id: training.id, moduleId });
+    expect(recommendedModules[1]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[1]).to.be.deep.equal({ id: secondTraining.id, moduleId: secondModuleId });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre des parcours combinés, nous avons besoin d'afficher à l'utilisateur les modulix recommandés à l'issue d'une campagne de diagnostique. La recommandation de modulix n'appartient pas au même bounded context que le parcours combiné.

## ⛱️ Proposition

Ajouter une api interne pour récupérer les modules recommandés lors de participations à des campagnes.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

La CI est verte 🍏 
