### PR TITLE
[FEATURE] Changer la manière de calculer l'avancement d'un module pour un utilisateur (PIX-18938)

### DIFF
--- a/api/src/devcomp/domain/models/module/UserModuleStatus.js
+++ b/api/src/devcomp/domain/models/module/UserModuleStatus.js
@@ -26,9 +26,9 @@ class UserModuleStatus {
       return StatusesEnumValues.NOT_STARTED;
     }
 
-    const mostRecentPassage = this.#findMostRecentPassage(this.passages);
+    const hasTerminatedPassage = this.#hasTerminatedPassage(this.passages);
 
-    if (!mostRecentPassage.terminatedAt) {
+    if (!hasTerminatedPassage) {
       return StatusesEnumValues.IN_PROGRESS;
     } else {
       return StatusesEnumValues.COMPLETED;
@@ -43,11 +43,8 @@ class UserModuleStatus {
     }
   }
 
-  #findMostRecentPassage(passages) {
-    const sortedPassages = passages.sort((p1, p2) => {
-      return p2.updatedAt.getTime() - p1.updatedAt.getTime();
-    });
-    return sortedPassages[0];
+  #hasTerminatedPassage(passages) {
+    return passages.some((passage) => passage.terminatedAt);
   }
 }
 

--- a/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/UserModuleStatus_test.js
@@ -134,7 +134,7 @@ describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', functio
     });
 
     describe('when passages passed are not empty', function () {
-      context('when the most recent passage does not have a terminatedAt attribute', function () {
+      context('when all passages do not have a "terminatedAt" attribute', function () {
         it('should return IN_PROGRESS', function () {
           // given
           const nowMinusOneHour = new Date(now.getTime() - 3600);
@@ -145,7 +145,7 @@ describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', functio
               userId,
               createdAt: nowMinusOneHour,
               updatedAt: nowMinusOneHour,
-              terminatedAt: nowMinusOneHour,
+              terminatedAt: null,
             }),
             new Passage({
               id: 2,
@@ -165,7 +165,7 @@ describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', functio
           expect(status).to.equal('IN_PROGRESS');
         });
       });
-      context('when the most recent passage has a terminatedAt attribute', function () {
+      context('when a passage has a "terminatedAt" attribute', function () {
         it('should set the status attribute to COMPLETED', function () {
           // given
           const nowMinusOneHour = new Date(now.getTime() - 3600);
@@ -184,7 +184,7 @@ describe('Unit | Devcomp | Domain | Models | Module | UserModuleStatus', functio
               userId,
               createdAt: now,
               updatedAt: now,
-              terminatedAt: now,
+              terminatedAt: null,
             }),
           ];
           const userModuleStatus = new UserModuleStatus({ userId, moduleId, passages });


### PR DESCRIPTION
## 🔆 Problème

On considère qu'un utilisateur a terminé un module si le dernier passage qu'il a fait a un champ `terminatedAt` lors du calcul de son avancement.
Ce n'est plus le cas maintenant. On veut que s'il a terminé un module, alors le status sera toujours `TERMINATED` même s'il recommence sans le terminer ensuite.

## ⛱️ Proposition

Faire cela.

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI au vert ✅ 
