### PR TITLE
[FEATURE] Changer l'algo de détection de local  avec cookie dans PixApp (PIX-18780)

### DIFF
--- a/high-level-tests/e2e/cypress/support/index.js
+++ b/high-level-tests/e2e/cypress/support/index.js
@@ -21,6 +21,8 @@ import { disableAnimation } from "./disable-animation";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+const BROWSER_LOCALE = 'fr';
+
 beforeEach(() => {
   cy.exec('npm run db:empty');
 
@@ -32,6 +34,8 @@ beforeEach(() => {
   // see https://gist.github.com/cvan/576eb41ab5d382660c14e3831c33c6ea
   // for source code inspiration
   cy.on('window:before:load', (cyWindow) => {
+    Object.defineProperty(cyWindow.navigator, 'language', { value: BROWSER_LOCALE })
+    Object.defineProperty(cyWindow.navigator, 'languages', { value: [BROWSER_LOCALE] })
     disableAnimation(cyWindow);
   });
 

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -10,7 +10,7 @@ export default BaseAuthenticator.extend({
   serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token/anonymous`,
 
   async authenticate({ campaignCode }) {
-    const bodyObject = { campaign_code: campaignCode, lang: this.locale.currentLocale };
+    const bodyObject = { campaign_code: campaignCode, lang: this.locale.currentLanguage };
 
     const body = Object.keys(bodyObject)
       .map((k) => `${k}=${encodeURIComponent(bodyObject[k])}`)

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -15,7 +15,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       method: 'POST',
       headers: {
         Accept: 'application/json',
-        'Accept-Language': this.locale.currentLocale,
+        'Accept-Language': this.locale.currentLanguage, // todo(locale): should be accept language
         'Content-Type': 'application/json',
       },
     };

--- a/mon-pix/app/components/authentication/login-or-register-oidc.gjs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.gjs
@@ -149,10 +149,6 @@ export default class LoginOrRegisterOidcComponent extends Component {
     return this.oidcIdentityProviders[this.args.identityProviderSlug]?.organizationName;
   }
 
-  get currentLanguage() {
-    return this.locale.currentLocale;
-  }
-
   get cguUrl() {
     return this.url.cguUrl;
   }

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -88,7 +88,7 @@ export default class SignupForm extends Component {
     this.isLoading = true;
 
     try {
-      user.lang = this.locale.currentLocale;
+      user.lang = this.locale.currentLanguage;
       const wasAnonymousBeforeSaving = user.isAnonymous;
       await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
       if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && wasAnonymousBeforeSaving) {

--- a/mon-pix/app/components/campaign-start-block.gjs
+++ b/mon-pix/app/components/campaign-start-block.gjs
@@ -96,7 +96,7 @@ export default class CampaignStartBlock extends Component {
   }
 
   get legalText() {
-    if (this.featureToggles.featureToggles.isAutoShareEnabled && this.campaignType === 'assessment') {
+    if (this.featureToggles.featureToggles?.isAutoShareEnabled && this.campaignType === 'assessment') {
       return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal-with-auto-share`);
     }
     return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal`);

--- a/mon-pix/app/components/certifications/certificate-information/download-pdf.gjs
+++ b/mon-pix/app/components/certifications/certificate-information/download-pdf.gjs
@@ -22,7 +22,7 @@ export default class DownloadPdf extends Component {
   async downloadAttestation() {
     this.errorMessage = null;
     const certificationId = this.args.certificate.id;
-    const lang = this.locale.currentLocale;
+    const lang = this.locale.currentLanguage;
 
     const url = `/api/attestation/${certificationId}?isFrenchDomainExtension=${this.currentDomain.isFranceDomain}&lang=${lang}`;
 

--- a/mon-pix/app/components/certifications/list/item.gjs
+++ b/mon-pix/app/components/certifications/list/item.gjs
@@ -72,7 +72,7 @@ export default class Item extends Component {
   async downloadAttestation() {
     this.errorMessage = null;
     const certificationId = this.args.certification.id;
-    const lang = this.locale.currentLocale;
+    const lang = this.locale.currentLanguage;
 
     const url = `/api/attestation/${certificationId}?isFrenchDomainExtension=${this.currentDomain.isFranceDomain}&lang=${lang}`;
 

--- a/mon-pix/app/components/locale-switcher.gjs
+++ b/mon-pix/app/components/locale-switcher.gjs
@@ -17,7 +17,7 @@ export default class LocaleSwitcher extends Component {
 
   constructor() {
     super(...arguments);
-    this.selectedLocale = this.args.defaultValue || this.locale.currentLocale;
+    this.selectedLocale = this.args.defaultValue || this.locale.currentLanguage;
   }
 
   @action

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -11,7 +11,7 @@ export default class textWithMultipleLang extends Helper {
     if (isHTMLSafe(text)) {
       text = text.toString();
     }
-    const lang = this.locale.currentLocale;
+    const lang = this.locale.currentLanguage;
     const listOfLocales = this.locale.supportedLocales;
     let outputText = _clean(text, listOfLocales);
     if (text && listOfLocales.includes(lang)) {

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,16 +1,26 @@
-import Service from '@ember/service';
+import Service, { service } from '@ember/service';
 import last from 'lodash/last';
 import PixWindow from 'mon-pix/utils/pix-window';
 
 const FRANCE_TLD = 'fr';
 
 export default class CurrentDomainService extends Service {
+  @service location;
+
   getExtension() {
     return last(PixWindow.getLocationHostname().split('.'));
   }
 
   get isFranceDomain() {
     return this.getExtension() === FRANCE_TLD;
+  }
+
+  get domain() {
+    const { host, hostname } = new URL(this.location.href);
+
+    if (this.isLocalhost) return hostname;
+
+    return host.split('.').slice(-2).join('.');
   }
 
   get isLocalhost() {

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -4,39 +4,60 @@
 
 import { getOwner } from '@ember/application';
 import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import LanguageDetector from 'i18next-browser-languagedetector';
 import ENV from 'mon-pix/config/environment';
-
 const { DEFAULT_LOCALE, SUPPORTED_LOCALES, COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
 
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
+const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
+
+const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
 
 const PIX_LANGUAGES = [
-  { value: 'fr', originalName: 'Français', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'en', originalName: 'English', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'nl', originalName: 'Nederlands', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'es', originalName: 'Español', shouldBeDisplayedInLanguageSwitcher: false },
+  { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
+  { value: 'en', nativeName: 'English', displayedInSwitcher: true },
+  { value: 'nl', nativeName: 'Nederlands', displayedInSwitcher: true },
+  { value: 'es', nativeName: 'Español', displayedInSwitcher: false },
 ];
+
+const COOKIE_LOCALE = 'locale';
 
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+  @service featureToggles;
   @service intl;
   @service dayjs;
 
-  get supportedLocales() {
-    return SUPPORTED_LOCALES;
-  }
+  @tracked __currentLocale = DEFAULT_LOCALE;
 
   get currentLocale() {
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+    if (localeCookieEnabled) {
+      return this.__currentLocale;
+    }
+
     return this.intl.primaryLocale;
+  }
+
+  get currentLanguage() {
+    const language = this.#getLanguageFromLocale(this.currentLocale);
+    return this.#getNearestSupportedLanguage(language);
+  }
+
+  /**
+   * Returns all locales supported by this application
+   */
+  get supportedLocales() {
+    return SUPPORTED_LOCALES;
   }
 
   /**
@@ -44,6 +65,13 @@ export default class LocaleService extends Service {
    */
   get pixLocales() {
     return PIX_LOCALES;
+  }
+
+  /**
+   * Returns all locales available in challenges of the Pix platform
+   */
+  get pixChallengeLocales() {
+    return PIX_CHALLENGE_LOCALES;
   }
 
   /**
@@ -56,20 +84,13 @@ export default class LocaleService extends Service {
 
   get acceptLanguageHeader() {
     if (this.currentDomain.isFranceDomain) return FRENCH_FRANCE_LOCALE;
-    return this.currentLocale;
-  }
-
-  /**
-   * Returns all locales available in challenges of the Pix platform
-   */
-  get pixChallengeLocales() {
-    return PIX_CHALLENGE_LOCALES;
+    return this.currentLanguage;
   }
 
   get switcherDisplayedLanguages() {
-    return PIX_LANGUAGES.filter(
-      (elem) => this.supportedLocales.includes(elem.value) && elem.shouldBeDisplayedInLanguageSwitcher,
-    ).map((elem) => ({ value: elem.value, label: elem.originalName }));
+    return PIX_LANGUAGES.filter((elem) => this.supportedLocales.includes(elem.value) && elem.displayedInSwitcher).map(
+      (elem) => ({ value: elem.value, label: elem.nativeName }),
+    );
   }
 
   isSupportedLocale(locale) {
@@ -82,50 +103,126 @@ export default class LocaleService extends Service {
   }
 
   setCurrentLocale(locale) {
-    this.intl.setLocale(locale);
-    this.dayjs.setLocale(locale);
+    let nearestLocale = locale;
+
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+    if (localeCookieEnabled) {
+      nearestLocale = this.#getNearestSupportedLocale(locale);
+      this.#setCookieLocale(nearestLocale);
+      this.__currentLocale = nearestLocale;
+    }
+
+    const language = this.#getLanguageFromLocale(nearestLocale);
+    this.intl.setLocale(language);
+    this.dayjs.setLocale(language);
 
     // metricsService may not be available for the different front apps
     const metricsService = getOwner(this).lookup('service:metrics');
     if (metricsService) {
-      metricsService.context.locale = locale;
+      metricsService.context.locale = nearestLocale;
     }
   }
 
-  detectBestLocale({ language, user }) {
+  setBestLocale({ user, queryParams }) {
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+
+    let locale;
+    if (localeCookieEnabled) {
+      locale = this.#detectBestLocale({ queryParams });
+    } else {
+      locale = this.#detectBestLocaleLegacy({ user, queryParams });
+    }
+    this.setCurrentLocale(locale);
+  }
+
+  #detectBestLocaleLegacy({ user, queryParams }) {
     if (this.currentDomain.isFranceDomain) {
-      this.setCurrentLocale(FRENCH_INTERNATIONAL_LOCALE);
-      this.#setLocaleCookie(FRENCH_FRANCE_LOCALE);
-      return;
+      this.#setCookieLocale(FRENCH_FRANCE_LOCALE);
+      return FRENCH_INTERNATIONAL_LOCALE;
     }
 
-    if (language) {
-      const supportedLanguage = this.#findSupportedLanguage(language);
-      this.setCurrentLocale(supportedLanguage);
-      return;
+    if (queryParams?.lang) {
+      return this.#getNearestSupportedLanguage(queryParams?.lang);
     }
 
     if (user?.lang) {
-      const supportedLanguage = this.#findSupportedLanguage(user.lang);
-      this.setCurrentLocale(supportedLanguage);
-      return;
+      return this.#getNearestSupportedLanguage(user.lang);
     }
 
-    this.setCurrentLocale(DEFAULT_LOCALE);
+    return DEFAULT_LOCALE;
   }
 
-  #findSupportedLanguage(language) {
-    return this.pixLanguages.filter((pixLanguage) => this.supportedLocales.includes(pixLanguage)).includes(language)
-      ? language
-      : DEFAULT_LOCALE;
+  #detectBestLocale({ queryParams }) {
+    const { isFranceDomain } = this.currentDomain;
+    const languageDetector = new LanguageDetector();
+
+    languageDetector.addDetector({
+      name: 'pix-domains',
+      lookup() {
+        if (isFranceDomain) return FRENCH_FRANCE_LOCALE;
+        return null;
+      },
+    });
+
+    languageDetector.addDetector({
+      name: 'pix-query-params',
+      lookup() {
+        if (queryParams?.lang) return queryParams?.lang;
+        if (queryParams?.locale) return queryParams?.locale;
+        return null;
+      },
+    });
+
+    languageDetector.init(null, {
+      order: ['pix-domains', 'pix-query-params', 'cookie', 'navigator'],
+      lookupCookie: COOKIE_LOCALE,
+    });
+
+    const detectedLocale = languageDetector.detect();
+    return this.#getNearestSupportedLocale(detectedLocale);
   }
 
-  #setLocaleCookie(locale) {
-    const cookie = this.cookies.exists('locale');
-    if (cookie) return;
+  #getNearestSupportedLocale(locale) {
+    if (!locale) return DEFAULT_LOCALE;
 
-    this.cookies.write('locale', locale, {
-      domain: `pix.${this.currentDomain.getExtension()}`,
+    // When 'fr-FR' for org domain, always returns 'fr' instead
+    if (!this.currentDomain.isFranceDomain && locale === FRENCH_FRANCE_LOCALE) {
+      return FRENCH_INTERNATIONAL_LOCALE;
+    }
+
+    try {
+      const intlLocale = new Intl.Locale(locale);
+
+      if (this.supportedLocales.includes(intlLocale.toString())) {
+        return intlLocale.toString();
+      }
+
+      const localeMatch = this.supportedLocales.find((l) => new Intl.Locale(l).language === intlLocale.language);
+      if (localeMatch) return localeMatch;
+
+      return DEFAULT_LOCALE;
+    } catch {
+      return DEFAULT_LOCALE;
+    }
+  }
+
+  #getNearestSupportedLanguage(language) {
+    const supportedLanguages = this.pixLanguages.filter((pixLanguage) => this.supportedLocales.includes(pixLanguage));
+    return supportedLanguages.includes(language) ? language : DEFAULT_LANGUAGE;
+  }
+
+  #getLanguageFromLocale(locale) {
+    if (!locale) return DEFAULT_LANGUAGE;
+    try {
+      return new Intl.Locale(locale).language;
+    } catch {
+      return DEFAULT_LANGUAGE;
+    }
+  }
+
+  #setCookieLocale(locale) {
+    this.cookies.write(COOKIE_LOCALE, locale, {
+      domain: `.${this.currentDomain.domain}`,
       maxAge: COOKIE_LOCALE_LIFESPAN_IN_SECONDS,
       path: '/',
       sameSite: 'Strict',

--- a/mon-pix/app/services/location.js
+++ b/mon-pix/app/services/location.js
@@ -1,6 +1,10 @@
 import Service from '@ember/service';
 
 export default class LocationService extends Service {
+  get href() {
+    return window.location.href;
+  }
+
   replace(url) {
     window.location.replace(url);
   }

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -54,8 +54,8 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleUserLanguageAndLocale(transition = null) {
-    const queryParamLanguage = transition?.to?.queryParams?.lang;
-    await this._loadCurrentUserAndLocale(queryParamLanguage);
+    const queryParams = transition?.to?.queryParams;
+    await this._loadCurrentUserAndLocale(queryParams);
   }
 
   get redirectionUrl() {
@@ -116,9 +116,9 @@ export default class CurrentSessionService extends SessionService {
     userIdForLearnerAssociationStorage.remove();
   }
 
-  async _loadCurrentUserAndLocale(language) {
+  async _loadCurrentUserAndLocale(queryParams) {
     await this.currentUser.load();
-    this.locale.detectBestLocale({ language, user: this.currentUser.user });
+    this.locale.setBestLocale({ user: this.currentUser.user, queryParams });
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -18,8 +18,7 @@ export default class UrlBaseService extends Service {
   }
 
   get serverStatusUrl() {
-    const currentLocale = this.locale.currentLocale;
-    return `https://status.pix.org/?locale=${currentLocale}`;
+    return `https://status.pix.org/?locale=${this.locale.currentLanguage}`;
   }
 
   get pixAppUrl() {

--- a/mon-pix/app/templates/authenticated/user-trainings.gjs
+++ b/mon-pix/app/templates/authenticated/user-trainings.gjs
@@ -21,7 +21,7 @@ import Header from 'mon-pix/components/training/header';
           <PixPagination
             @pagination={{@model.trainings.meta.pagination}}
             @pageOptions={{@controller.pageOptions}}
-            @locale={{@controller.locale.currentLocale}}
+            @locale={{@controller.locale.currentLanguage}}
             @isCondensed="true"
           />
         </div>

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.gjs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.gjs
@@ -18,7 +18,7 @@ import Sidebar from 'mon-pix/components/user-tutorials/filters/sidebar';
         <PixPagination
           @pagination={{@model.recommendedTutorials.meta.pagination}}
           @pageOptions={{@controller.pageOptions}}
-          @locale={{@controller.locale.currentLocale}}
+          @locale={{@controller.locale.currentLanguage}}
           @isCondensed="true"
         />
       {{else}}

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.gjs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.gjs
@@ -11,7 +11,7 @@ import SavedEmpty from 'mon-pix/components/tutorials/saved-empty';
         <PixPagination
           @pagination={{@model.savedTutorials.meta.pagination}}
           @pageOptions={{@controller.pageOptions}}
-          @locale={{@controller.locale.currentLocale}}
+          @locale={{@controller.locale.currentLanguage}}
           @isCondensed="true"
         />
       {{else}}

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -2,6 +2,10 @@ function getLocationHash() {
   return window.location.hash;
 }
 
+function getLocationHost() {
+  return window.location.host;
+}
+
 function getLocationHostname() {
   return window.location.hostname;
 }
@@ -20,6 +24,7 @@ function reload() {
 
 const PixWindow = {
   getLocationHash,
+  getLocationHost,
   getLocationHostname,
   getLocationHref,
   replace,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function (environment) {
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-app-local',
       DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
-      SUPPORTED_LOCALES: ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'],
+      SUPPORTED_LOCALES: ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'],
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -78,6 +78,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",
         "globals": "^16.0.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "js-yaml": "^4.0.0",
         "jwt-decode": "^4.0.0",
         "loader.js": "^4.7.0",
@@ -31617,6 +31618,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",
     "globals": "^16.0.0",
+    "i18next-browser-languagedetector": "^8.2.0",
     "js-yaml": "^4.0.0",
     "jwt-decode": "^4.0.0",
     "loader.js": "^4.7.0",

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record-test.js
@@ -1,7 +1,6 @@
 /* eslint ember/no-classic-classes: 0 */
 
 import { visit } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, currentURL, fillIn, settled } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
@@ -393,13 +392,8 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
 
   test('should display on reset passord form a quit button redirecting to login page ', async function (assert) {
     // given
-    const replaceLocationStub = sinon.stub().resolves();
-    this.owner.register(
-      'service:location',
-      Service.extend({
-        replace: replaceLocationStub,
-      }),
-    );
+    const locationService = this.owner.lookup('service:location');
+    sinon.stub(locationService, 'replace');
 
     const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
@@ -409,6 +403,6 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
     await click(screen.getByText(t('common.actions.quit')));
 
     // then
-    assert.ok(replaceLocationStub.calledWith('/?lang=fr'));
+    assert.ok(locationService.replace.calledWith('/?lang=fr'));
   });
 });

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -1,5 +1,4 @@
 import { visit } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, currentURL, fillIn, settled } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
@@ -15,14 +14,11 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  let assignLocationStub;
+  let locationService;
 
   hooks.beforeEach(async function () {
-    assignLocationStub = sinon.stub().returns();
-    class LocationServiceStub extends Service {
-      assign = assignLocationStub;
-    }
-    this.owner.register('service:location', LocationServiceStub);
+    locationService = this.owner.lookup('service:location');
+    sinon.stub(locationService, 'assign');
   });
 
   module('when the user has not performed an authentication to the OIDC Provider', function () {
@@ -42,7 +38,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
         await unabortedVisit('/connexion/oidc-partner');
 
         // then
-        assert.ok(assignLocationStub.calledWith('https://oidc/connexion/oauth2/authorize'));
+        assert.ok(locationService.assign.calledWith('https://oidc/connexion/oauth2/authorize'));
       });
     });
   });

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -1,5 +1,4 @@
 import { visit } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
@@ -98,16 +97,6 @@ module('Acceptance | User account page', function (hooks) {
       module('When not in France domain', () => {
         test('it displays locale switcher on click on "Choisir ma langue"', async function (assert) {
           // given
-          class CurrentDomainStubService extends Service {
-            get isFranceDomain() {
-              return false;
-            }
-
-            getExtension = sinon.stub().returns('org');
-          }
-
-          this.owner.register('service:currentDomain', CurrentDomainStubService);
-
           const screen = await visit('/mon-compte');
 
           // when
@@ -124,15 +113,8 @@ module('Acceptance | User account page', function (hooks) {
       module('When in France domain', () => {
         test('it does not display language menu link', async function (assert) {
           // given
-          class CurrentDomainStubService extends Service {
-            get isFranceDomain() {
-              return true;
-            }
-
-            getExtension = sinon.stub().returns('fr');
-          }
-
-          this.owner.register('service:currentDomain', CurrentDomainStubService);
+          const domainService = this.owner.lookup('service:currentDomain');
+          sinon.stub(domainService, 'getExtension').returns('fr');
 
           const screen = await visit('/mon-compte');
 

--- a/mon-pix/tests/acceptance/user-logged-menu-test.js
+++ b/mon-pix/tests/acceptance/user-logged-menu-test.js
@@ -5,10 +5,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import { authenticateByEmail } from '../helpers/authentication';
+import setupIntl from '../helpers/setup-intl.js';
 
 module('Acceptance | User account', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('When in profile', function () {
     test('should open tests page when click on menu', async function (assert) {

--- a/mon-pix/tests/helpers/setup-intl.js
+++ b/mon-pix/tests/helpers/setup-intl.js
@@ -1,10 +1,19 @@
+import { getContext, settled } from '@ember/test-helpers';
 import { setupIntl as setupIntlFromEmberIntl } from 'ember-intl/test-support';
+
+export async function setCurrentLocale(locale) {
+  const { owner } = getContext();
+
+  const localeService = owner.lookup('service:locale');
+  localeService.setCurrentLocale(locale);
+
+  await settled();
+}
 
 export default function setupIntl(hooks, locale = 'fr') {
   setupIntlFromEmberIntl(hooks, locale);
 
-  hooks.beforeEach(function () {
-    this.dayjs = this.owner.lookup('service:dayjs');
-    this.dayjs.setLocale(locale);
+  hooks.beforeEach(async function () {
+    await setCurrentLocale(locale);
   });
 }

--- a/mon-pix/tests/integration/components/assessment-banner-test.js
+++ b/mon-pix/tests/integration/components/assessment-banner-test.js
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
@@ -90,11 +89,8 @@ module('Integration | Component | assessment-banner', function (hooks) {
 
   module('when the text to speech feature toggle is enabled', function (hooks) {
     hooks.beforeEach(async function () {
-      this.owner.lookup('service:store');
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isTextToSpeechButtonEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isTextToSpeechButtonEnabled: true });
     });
 
     module('when displayTextToSpeechActivationButton is true', function () {
@@ -170,11 +166,8 @@ module('Integration | Component | assessment-banner', function (hooks) {
 
   module('when the text to speech feature toggle is disabled', function (hooks) {
     hooks.beforeEach(async function () {
-      this.owner.lookup('service:store');
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isTextToSpeechButtonEnabled: false };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isTextToSpeechButtonEnabled: false });
     });
 
     test('it should not display text to speech toggle button', async function (assert) {

--- a/mon-pix/tests/integration/components/authentication-layout/footer_test.gjs
+++ b/mon-pix/tests/integration/components/authentication-layout/footer_test.gjs
@@ -1,25 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import Footer from 'mon-pix/components/authentication-layout/footer';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Authentication-layout | footer', function (hooks) {
   setupIntlRenderingTest(hooks);
   test('it displays a locale switcher when url has org extension', async function (assert) {
-    //given
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return false;
-      }
-
-      getExtension() {
-        return 'org';
-      }
-    }
-
-    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
     //when
     const screen = await render(<template><Footer /></template>);
 
@@ -29,17 +17,9 @@ module('Integration | Component | Authentication-layout | footer', function (hoo
   });
   test('it displays no locale switcher when url has fr extension', async function (assert) {
     //given
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return true;
-      }
+    const domainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(domainService, 'getExtension').returns('fr');
 
-      getExtension() {
-        return 'fr';
-      }
-    }
-
-    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
     //when
     const screen = await render(<template><Footer /></template>);
 

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -1,12 +1,12 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
-import { setLocale, t } from 'ember-intl/test-support';
+import { t } from 'ember-intl/test-support';
 import PasswordResetDemandForm from 'mon-pix/components/authentication/password-reset-demand/password-reset-demand-form';
-import { ENGLISH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { setCurrentLocale } from '../../../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 const I18N_KEYS = {
@@ -115,10 +115,9 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
         requestManagerService.request.resolves({ response: { ok: true, status: 201 } });
 
         const email = 'someone@example.net';
-        const locale = ENGLISH_INTERNATIONAL_LOCALE;
+        await setCurrentLocale('en');
 
         // when
-        await setLocale(locale);
         const screen = await render(<template><PasswordResetDemandForm /></template>);
 
         await fillByLabel(t(I18N_KEYS.emailInput), email);
@@ -131,7 +130,7 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
 
         const tryAgainLink = await screen.queryByRole('link', { name: t(I18N_KEYS.tryAgainLink) });
         assert.dom(tryAgainLink).exists();
-        assert.strictEqual(tryAgainLink.getAttribute('href'), `/mot-de-passe-oublie?lang=${locale}`);
+        assert.strictEqual(tryAgainLink.getAttribute('href'), `/mot-de-passe-oublie?lang=en`);
       });
     });
 

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-form-test.gjs
@@ -1,5 +1,4 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import PasswordResetDemandForm from 'mon-pix/components/authentication/password-reset-demand/password-reset-demand-form';
@@ -31,17 +30,10 @@ module('Integration | Component | Authentication | PasswordResetDemand | passwor
 
   test('it displays all elements of component successfully', async function (assert) {
     // given
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return true;
-      }
+    const domainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(domainService, 'getExtension').returns('fr');
 
-      getExtension() {
-        return '.fr';
-      }
-    }
-    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
+    // when
     const screen = await render(<template><PasswordResetDemandForm /></template>);
 
     // then

--- a/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-received-info-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/password-reset-demand/password-reset-demand-received-info-test.gjs
@@ -1,9 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setLocale, t } from 'ember-intl/test-support';
+import { t } from 'ember-intl/test-support';
 import PasswordResetDemandReceivedInfo from 'mon-pix/components/authentication/password-reset-demand/password-reset-demand-received-info';
-import { ENGLISH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 import { module, test } from 'qunit';
 
+import { setCurrentLocale } from '../../../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module(
@@ -36,17 +36,16 @@ module(
 
     test('it displays a link with a lang query param equal to the app locale', async function (assert) {
       // given
-      const locale = ENGLISH_INTERNATIONAL_LOCALE;
+      await setCurrentLocale('en');
 
       // when
-      await setLocale(locale);
       const screen = await render(<template><PasswordResetDemandReceivedInfo /></template>);
 
       // then
       const tryAgainLink = await screen.queryByRole('link', {
         name: t('components.authentication.password-reset-demand-received-info.try-again'),
       });
-      assert.strictEqual(tryAgainLink.getAttribute('href'), `/mot-de-passe-oublie?lang=${locale}`);
+      assert.strictEqual(tryAgainLink.getAttribute('href'), `/mot-de-passe-oublie?lang=en`);
     });
   },
 );

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -1,5 +1,4 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -13,12 +12,8 @@ module('Integration | Component | campaign-start-block', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    class FeatureTogglesStub extends Service {
-      featureToggles = {
-        isAutoShareEnabled: false,
-      };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
+    const featureToggles = this.owner.lookup('service:featureToggles');
+    sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: false });
   });
 
   module('When the organization has a logo and landing page text', function () {
@@ -164,12 +159,8 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should display legal with auto share', async function (assert) {
         // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = {
-            isAutoShareEnabled: true,
-          };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
 
         // when
         const screen = await render(

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -69,12 +69,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         test('it should not display the quest result if the flag is false', async function (assert) {
           // given
           stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione', isAnonymous: true });
-
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isQuestEnabled: false };
-          }
-
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const featureToggles = this.owner.lookup('service:featureToggles');
+          sinon.stub(featureToggles, 'featureToggles').value({ isQuestEnabled: false });
 
           this.set('campaign', {
             customResultPageText: 'My custom result page text',
@@ -122,11 +118,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
 
           test('it should not display the quest result if the flag is true', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { isQuestEnabled: true };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ isQuestEnabled: true });
 
             this.set('campaign', {
               customResultPageText: 'My custom result page text',
@@ -165,11 +158,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
 
           test('it should display the quest result if the flag is true', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { isQuestEnabled: true };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ isQuestEnabled: true });
 
             this.set('campaign', {
               customResultPageText: 'My custom result page text',
@@ -288,11 +278,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         module('when feature toggle upgradeToRealUserEnabled is true', function () {
           test('it should not display a sign in button', async function (assert) {
             //given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { upgradeToRealUserEnabled: true };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
 
             stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione', isAnonymous: true });
             this.set('campaign', {
@@ -583,10 +570,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         module('when feature toggle upgradeToRealUserEnabled is false', function () {
           test('it should not display a sign in button', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { upgradeToRealUserEnabled: false };
-            }
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: false });
 
             // when
             const screen = await render(
@@ -612,11 +597,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         module('when feature toggle upgradeToRealUserEnabled is true', function () {
           test('it should display a sign in button', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { upgradeToRealUserEnabled: true };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
 
             // when
             const screen = await render(
@@ -642,11 +624,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         module('when feature toggle upgradeToRealUserEnabled is true ', function () {
           test('it should display only an inscription link', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { upgradeToRealUserEnabled: true };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
 
             stubCurrentUserService(this.owner, { isAnonymous: true });
 
@@ -675,11 +654,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         module('when feature toggle upgradeToRealUserEnabled is false', function () {
           test('it should display only a connection link', async function (assert) {
             // given
-            class FeatureTogglesStub extends Service {
-              featureToggles = { upgradeToRealUserEnabled: false };
-            }
-
-            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            const featureToggles = this.owner.lookup('service:featureToggles');
+            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: false });
 
             stubCurrentUserService(this.owner, { isAnonymous: true });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/retry-or-reset-block-test.js
@@ -1,8 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { clickByLabel } from '../../../../../../helpers/click-by-label';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
@@ -90,12 +90,8 @@ module(
 
     module('with auto share enabled', function (hooks) {
       hooks.beforeEach(function () {
-        class FeatureTogglesStub extends Service {
-          featureToggles = {
-            isAutoShareEnabled: true,
-          };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
       });
 
       test('should display retry message with auto share', async function (assert) {
@@ -160,12 +156,8 @@ module(
 
       module('with auto share enabled', function (hooks) {
         hooks.beforeEach(function () {
-          class FeatureTogglesStub extends Service {
-            featureToggles = {
-              isAutoShareEnabled: true,
-            };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const featureToggles = this.owner.lookup('service:featureToggles');
+          sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
         });
 
         test('should display retry message with auto share', async function (assert) {

--- a/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
+++ b/mon-pix/tests/integration/components/certifications/certificate-information/competences-details-test.gjs
@@ -1,10 +1,10 @@
 import { render, within } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click, tab } from '@ember/test-helpers';
 import userEvent from '@testing-library/user-event';
 import { t } from 'ember-intl/test-support';
 import CompetencesDetails from 'mon-pix/components/certifications/certificate-information/competences-details';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -56,13 +56,9 @@ module('Integration | Component | Certifications | Certificate | Competences det
     module('when domain is fr', function () {
       test('should display a link to the results explanation', async function (assert) {
         // given
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
 
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
         const store = this.owner.lookup('service:store');
         const certification = store.createRecord('certification', {
           birthdate: '2000-01-22',
@@ -88,12 +84,6 @@ module('Integration | Component | Certifications | Certificate | Competences det
       module('when user is a french reader', function () {
         test('should display a link to the results explanation', async function (assert) {
           // given
-          class CurrentDomainServiceStub extends Service {
-            get isFranceDomain() {
-              return false;
-            }
-          }
-          this.owner.register('service:currentDomain', CurrentDomainServiceStub);
           stubCurrentUserService(this.owner, { lang: 'fr' });
           const store = this.owner.lookup('service:store');
           const certification = store.createRecord('certification', {
@@ -119,12 +109,6 @@ module('Integration | Component | Certifications | Certificate | Competences det
       module('when user is not a french reader', function () {
         test('should not display a link to the results explanation', async function (assert) {
           // given
-          class CurrentDomainServiceStub extends Service {
-            get isFranceDomain() {
-              return false;
-            }
-          }
-          this.owner.register('service:currentDomain', CurrentDomainServiceStub);
           stubCurrentUserService(this.owner, { lang: 'en' });
           const store = this.owner.lookup('service:store');
           const certification = store.createRecord('certification', {

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -201,11 +201,8 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
     module('Text to speech button:', function () {
       module('when FT_ENABLE_TEXT_TO_SPEECH_BUTTON is enabled', function (hooks) {
         hooks.beforeEach(async function () {
-          this.owner.lookup('service:store');
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isTextToSpeechButtonEnabled: true };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const featureToggles = this.owner.lookup('service:featureToggles');
+          sinon.stub(featureToggles, 'featureToggles').value({ isTextToSpeechButtonEnabled: true });
         });
 
         module('when the assessment is not a certification', function () {
@@ -355,11 +352,8 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
 
       module('when FT_ENABLE_TEXT_TO_SPEECH_BUTTON is disabled', function (hooks) {
         hooks.beforeEach(async function () {
-          this.owner.lookup('service:store');
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isTextToSpeechButtonEnabled: false };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const featureToggles = this.owner.lookup('service:featureToggles');
+          sinon.stub(featureToggles, 'featureToggles').value({ isTextToSpeechButtonEnabled: false });
         });
 
         module('when the assessment is not a certification', function () {

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -1,9 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -403,11 +403,8 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should display link on new dashboard banner when domain is pix.fr', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
       stubCurrentUserService(
         this.owner,
@@ -421,7 +418,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
         { withStoreStubbed: false },
       );
 
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -439,12 +435,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should hide link on new dashboard banner when domain is pix.org', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
       stubCurrentUserService(
         this.owner,
         {
@@ -457,7 +447,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
         { withStoreStubbed: false },
       );
 
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner-test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner-test.js
@@ -1,12 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setLocale, t } from 'ember-intl/test-support';
+import { t } from 'ember-intl/test-support';
 import ENV from 'mon-pix/config/environment';
 import PixWindow from 'mon-pix/utils/pix-window';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import { stubCurrentUserService, stubSessionService } from '../../helpers/service-stubs';
+import { setCurrentLocale } from '../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | data-protection-policy-information-banner', function (hooks) {
@@ -112,10 +113,10 @@ module('Integration | Component | data-protection-policy-information-banner', fu
           module('when user language is "en"', function () {
             test('displays the data protection policy banner in english', async function (assert) {
               // given
+              await setCurrentLocale('en');
               stubCurrentUserService(this.owner, { shouldSeeDataProtectionPolicyInformationBanner: true });
               _stubWindowLocationHostname('pix.org');
               _communicationBannerIsNotDisplayed();
-              setLocale('en');
 
               // when
               const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
@@ -137,10 +138,10 @@ module('Integration | Component | data-protection-policy-information-banner', fu
           module('when user language is "nl"', function () {
             test('displays the data protection policy banner in dutch', async function (assert) {
               // given
+              await setCurrentLocale('nl');
               stubCurrentUserService(this.owner, { shouldSeeDataProtectionPolicyInformationBanner: true });
               _stubWindowLocationHostname('pix.org');
               _communicationBannerIsNotDisplayed();
-              setLocale('nl');
 
               // when
               const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);

--- a/mon-pix/tests/integration/components/footer/footer-links-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-links-test.js
@@ -1,8 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -39,17 +39,7 @@ module('Integration | Component | Footer', function (hooks) {
     });
   });
 
-  module('when url does not have frenchDomainExtension', function (hooks) {
-    hooks.beforeEach(function () {
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-    });
-
+  module('when url does not have frenchDomainExtension', function () {
     test('does not display the student data policy', async function (assert) {
       // when
       const screen = await render(hbs`<Footer::FooterLinks />}`);
@@ -63,13 +53,8 @@ module('Integration | Component | Footer', function (hooks) {
 
   module('when url has frenchDomainExtension', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
     });
 
     test('displays the student data policy', async function (assert) {

--- a/mon-pix/tests/integration/components/footer/footer-test.js
+++ b/mon-pix/tests/integration/components/footer/footer-test.js
@@ -1,8 +1,8 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -28,17 +28,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.dom(screen.getByText(`${t('navigation.copyrights')} ${new Date().getFullYear()} Pix`)).exists();
   });
 
-  module('when url does not have frenchDomainExtension', function (hooks) {
-    hooks.beforeEach(function () {
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-    });
-
+  module('when url does not have frenchDomainExtension', function () {
     test('does not display marianne logo', async function (assert) {
       // when
       const screen = await render(hbs`<Footer />`);
@@ -50,13 +40,8 @@ module('Integration | Component | Footer', function (hooks) {
 
   module('when url does have frenchDomainExtension', function (hooks) {
     hooks.beforeEach(function () {
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
     });
 
     test('displays marianne logo', async function (assert) {

--- a/mon-pix/tests/integration/components/global/app-navigation-test.gjs
+++ b/mon-pix/tests/integration/components/global/app-navigation-test.gjs
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import { t } from 'ember-intl/test-support';
 import AppNavigation from 'mon-pix/components/global/app-navigation';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -27,12 +28,9 @@ module('Integration | Component | Global | App Navigation', function (hooks) {
 
     module('when it is the french domain', function () {
       test('it should only display the Pix logo', async function (assert) {
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+        // given
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
 
         // when
         const screen = await render(<template><AppNavigation /></template>);

--- a/mon-pix/tests/integration/components/header-details-test.gjs
+++ b/mon-pix/tests/integration/components/header-details-test.gjs
@@ -1,7 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -67,14 +67,10 @@ module('Integration | Component | Certifications | Certificate information | Hea
 
   module('when domain is french', function (hooks) {
     hooks.beforeEach(function () {
-      stubCurrentUserService(this.owner, { lang: 'fr' });
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      stubCurrentUserService(this.owner, { lang: 'fr' });
     });
 
     module('when certification is delivered after 2022-01-01', function () {
@@ -152,14 +148,6 @@ module('Integration | Component | Certifications | Certificate information | Hea
     test('should not display the professionalizing warning', async function (assert) {
       // given
       stubCurrentUserService(this.owner, { lang: 'en' });
-
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
       const store = this.owner.lookup('service:store');
       const certification = store.createRecord('certification', {

--- a/mon-pix/tests/integration/components/inaccessible-campaign-test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign-test.js
@@ -2,9 +2,9 @@
 /* eslint ember/require-tagless-components: 0 */
 
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
@@ -12,9 +12,6 @@ module('Integration | Component | inaccessible-campaign', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('should not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
-    // given
-    this.owner.register('service:currentDomain', Service.extend({ isFranceDomain: false }));
-
     // when
     await render(hbs`<InaccessibleCampaign />`);
 
@@ -24,7 +21,8 @@ module('Integration | Component | inaccessible-campaign', function (hooks) {
 
   test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
     // given
-    this.owner.register('service:currentDomain', Service.extend({ isFranceDomain: true }));
+    const domainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(domainService, 'getExtension').returns('fr');
 
     // when
     await render(hbs`<InaccessibleCampaign />`);

--- a/mon-pix/tests/test-helper.js
+++ b/mon-pix/tests/test-helper.js
@@ -1,10 +1,21 @@
 import { setApplication } from '@ember/test-helpers';
+import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 
 import Application from '../app';
 import config from '../config/environment';
+
+// Set default browser locale
+const BROWSER_LOCALE = 'fr';
+Object.defineProperty(window.navigator, 'language', { value: BROWSER_LOCALE, configurable: true });
+Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], configurable: true });
+
+// Reset all cookies before each test to avoid side-effects
+QUnit.hooks.beforeEach(function () {
+  clearAllCookies();
+});
 
 setApplication(Application.create(config.APP));
 setup(QUnit.assert);

--- a/mon-pix/tests/unit/components/certifications/certificate-information/download-pdf-test.gjs
+++ b/mon-pix/tests/unit/components/certifications/certificate-information/download-pdf-test.gjs
@@ -11,12 +11,8 @@ module('Unit | Component | Certifications | Certificate information | download p
   module('when domain is french', function () {
     test('should call file saver with isFrenchDomainExtension set to true in url', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {

--- a/mon-pix/tests/unit/components/certifications/certificate-information/download-pdf-test.gjs
+++ b/mon-pix/tests/unit/components/certifications/certificate-information/download-pdf-test.gjs
@@ -18,10 +18,6 @@ module('Unit | Component | Certifications | Certificate information | download p
       }
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
-      class IntlServiceStub extends Service {
-        primaryLocale = 'fr';
-      }
-      this.owner.register('service:intl', IntlServiceStub);
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
@@ -46,17 +42,6 @@ module('Unit | Component | Certifications | Certificate information | download p
   module('when domain is not french', function () {
     test('should call file saver with isFrenchDomainExtension set to false in url', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
-      class IntlServiceStub extends Service {
-        primaryLocale = 'fr';
-      }
-      this.owner.register('service:intl', IntlServiceStub);
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;

--- a/mon-pix/tests/unit/components/certifications/list/item-test.gjs
+++ b/mon-pix/tests/unit/components/certifications/list/item-test.gjs
@@ -11,12 +11,8 @@ module('Unit | Component | Certifications | List | item', function (hooks) {
   module('when domain is french', function () {
     test('should call file saver with isFrenchDomainExtension set to true in url', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {

--- a/mon-pix/tests/unit/components/certifications/list/item-test.gjs
+++ b/mon-pix/tests/unit/components/certifications/list/item-test.gjs
@@ -18,10 +18,6 @@ module('Unit | Component | Certifications | List | item', function (hooks) {
       }
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
-      class IntlServiceStub extends Service {
-        primaryLocale = 'fr';
-      }
-      this.owner.register('service:intl', IntlServiceStub);
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
@@ -46,17 +42,6 @@ module('Unit | Component | Certifications | List | item', function (hooks) {
   module('when domain is not french', function () {
     test('should call file saver with isFrenchDomainExtension set to false in url', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
-      class IntlServiceStub extends Service {
-        primaryLocale = 'fr';
-      }
-      this.owner.register('service:intl', IntlServiceStub);
       const fileSaverSaveStub = sinon.stub();
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -25,7 +25,7 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
     },
   ].forEach((expected) => {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
-      textWithMultipleLangHelper.locale.currentLocale = expected.lang;
+      textWithMultipleLangHelper.locale.currentLanguage = expected.lang;
 
       assert.strictEqual(
         textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(),

--- a/mon-pix/tests/unit/models/certification-test.js
+++ b/mon-pix/tests/unit/models/certification-test.js
@@ -1,6 +1,6 @@
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Unit | Model | certification', function (hooks) {
   setupTest(hooks);
@@ -26,12 +26,8 @@ module('Unit | Model | certification', function (hooks) {
   module('#shouldDisplayProfessionalizingWarning', function () {
     module('when domain is french', function (hooks) {
       hooks.beforeEach(function () {
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
       });
 
       module('when version is 2', function () {
@@ -58,13 +54,6 @@ module('Unit | Model | certification', function (hooks) {
     module('when domain is not french', function () {
       test('should be false', function (assert) {
         // given
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return false;
-          }
-        }
-
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
         const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
 
         // when / then
@@ -75,13 +64,8 @@ module('Unit | Model | certification', function (hooks) {
     module('when version is not 2', function () {
       test('should be false', function (assert) {
         // given
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
-
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
         const model = store.createRecord('certification', { deliveredAt: '2022-01-01', version: 3 });
 
         // when / then

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -14,7 +14,7 @@ module('Unit | Services | session', function (hooks) {
   hooks.beforeEach(function () {
     sessionService = this.owner.lookup('service:session');
     sessionService.currentUser = { load: sinon.stub(), user: null };
-    sessionService.locale = { detectBestLocale: sinon.stub() };
+    sessionService.locale = { setBestLocale: sinon.stub() };
     sessionService._getRouteAfterInvalidation = sinon.stub();
 
     routerService = this.owner.lookup('service:router');
@@ -93,7 +93,7 @@ module('Unit | Services | session', function (hooks) {
 
       // then
       sinon.assert.calledOnce(sessionService.currentUser.load);
-      sinon.assert.calledWith(sessionService.locale.detectBestLocale, { user, language: undefined });
+      sinon.assert.calledWith(sessionService.locale.setBestLocale, { user, queryParams: undefined });
       assert.ok(true);
     });
 
@@ -151,7 +151,7 @@ module('Unit | Services | session', function (hooks) {
 
       // then
       sinon.assert.calledOnce(sessionService.currentUser.load);
-      sinon.assert.calledWith(sessionService.locale.detectBestLocale, { language: 'es', user });
+      sinon.assert.calledWith(sessionService.locale.setBestLocale, { queryParams: { lang: 'es' }, user });
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/services/url-base-test.js
+++ b/mon-pix/tests/unit/services/url-base-test.js
@@ -2,13 +2,14 @@
 // If you need a change, modify the original file and
 // propagate the changes in the copies in all the fronts.
 
-import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import ENV from 'mon-pix/config/environment';
 import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'mon-pix/services/url-base';
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { setCurrentLocale } from '../../helpers/setup-intl.js';
 
 const { SUPPORTED_LOCALES } = ENV.APP;
 
@@ -20,13 +21,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the application home url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.homeUrl;
 
       // then
-      assert.strictEqual(homeUrl, '/?lang=en');
+      assert.strictEqual(homeUrl, '/?lang=fr');
     });
   });
 
@@ -34,13 +34,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the Pix server status url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.serverStatusUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=fr');
     });
   });
 
@@ -92,7 +91,7 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
     });
 
-    test('returns the Pix app forgotten password url for a locale', function (assert) {
+    test('returns the Pix app forgotten password url for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
@@ -100,7 +99,7 @@ module('Unit | Service | url-base', function (hooks) {
       const domainService = this.owner.lookup('service:current-domain');
       sinon.stub(domainService, 'getExtension').returns('fr');
 
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.pixAppForgottenPasswordUrl;
@@ -111,10 +110,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrl', function () {
-    test('returns the Pix website url for the current locale', function (assert) {
+    test('returns the Pix website url for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl();
@@ -123,10 +122,10 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://pix.org/en');
     });
 
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
@@ -137,10 +136,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrlFor', function () {
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrlFor('CGU');
@@ -150,12 +149,12 @@ module('Unit | Service | url-base', function (hooks) {
     });
 
     module('when the tld is fr', function () {
-      test('returns the Pix website url for the tld fr', function (assert) {
+      test('returns the Pix website url for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor();
@@ -164,12 +163,12 @@ module('Unit | Service | url-base', function (hooks) {
         assert.strictEqual(homeUrl, 'https://pix.fr');
       });
 
-      test('returns the Pix website url and path for the tld fr', function (assert) {
+      test('returns the Pix website url and path for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor('CGU');

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -1,8 +1,9 @@
-import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { setCurrentLocale } from '../../helpers/setup-intl.js';
 
 module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
@@ -29,12 +30,12 @@ module('Unit | Service | url', function (hooks) {
         expectedShowcaseLinkText: "Pix.org's Homepage",
       },
     ].forEach(function (testCase) {
-      test(`gets "${testCase.expectedShowcaseUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function (assert) {
+      test(`gets "${testCase.expectedShowcaseUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, async function (assert) {
         // given
         const service = this.owner.lookup('service:url');
         service.definedHomeUrl = '/';
         sinon.stub(service.currentDomain, 'getExtension').returns(testCase.currentDomainExtension);
-        setLocale([testCase.language]);
+        await setCurrentLocale(testCase.language);
 
         // when
         const showcase = service.showcase;
@@ -58,10 +59,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
     });
 
-    test('returns the Pix website CGU URL for a locale', function (assert) {
+    test('returns the Pix website CGU URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const cguUrl = service.cguUrl;
@@ -83,10 +84,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
     });
 
-    test('returns the Pix website data protection policy URL for a locale', function (assert) {
+    test('returns the Pix website data protection policy URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -108,10 +109,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
     });
 
-    test('returns the Pix website legal notice URL for a locale', function (assert) {
+    test('returns the Pix website legal notice URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const legalNoticeUrl = service.legalNoticeUrl;
@@ -133,10 +134,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite');
     });
 
-    test('returns the Pix website accessibility URL for a locale', function (assert) {
+    test('returns the Pix website accessibility URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const accessibilityUrl = service.accessibilityUrl;
@@ -158,10 +159,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(supportHomeUrl, 'https://pix.org/fr/support');
     });
 
-    test('returns the Pix website support URL for a locale', function (assert) {
+    test('returns the Pix website support URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const supportHomeUrl = service.supportHomeUrl;
@@ -186,10 +187,10 @@ module('Unit | Service | url', function (hooks) {
       );
     });
 
-    test('returns the Pix website certification results explanation URL for a locale', function (assert) {
+    test('returns the Pix website certification results explanation URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const certificationResultsExplanationUrl = service.certificationResultsExplanationUrl;


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'algorithme de détection de locale ne gère pas tous les cas que l'on souhaite lorsque l'utilisateur charge l'application. De plus, il n'y a pas de source de vérité pour la locale courante.

## ⛱️ Proposition

**Sous feature toggle `useLocale`**

- Modifier l'algorithme de détection des locales suivant ces priorités:
  - si domaine `.fr`, alors `locale='fr-FR'`
  - si query parameter `locale`, alors `locale=locale`
  - si query parameter `lang`, alors `locale=lang`
  - si cookie `locale` présent, alors `locale=<valeur du cookie>`
  - sinon `locale=<locale du navigateur>`

- Quand on détecte la locale on s'assure qu'elle est supportée par l'application, en déterminant la locale la plus proche supportée, exemple:
  - `fr` => `fr`
  - `fr-fr` => `fr-FR`
  - `fr-BE` => `fr-BE`, `nl-BE` => `nl-BE`
  - `fr-CA` => `fr`, `nl-NL` => `nl`
  - Non supporté => locale par défaut

- Quand on détecte la locale, ou qu'elle est changée (ex: LocaleSwitcher), elle est stockée  dans un cookie `locale` qui sera la source de vérité de la locale courante pour le domaine.

- Dans le service `locale`
  - La fonction `currentLocale` retournera **toujours** la locale du cookie.
  - La fonction `currentLanguage` retournera la langue déduite de la locale courante.

**Normalement, quand le FT `useLocale` est activé, l'ensemble de l'application reste fonctionnel et inchangé. Seules la détection des locales et leur priorisation changent.**

## 🌊 Remarques

- Pour l'algorithme de détection des locales, nous utilisons la librairie `https://github.com/i18next/i18next-browser-languageDetector`
- À certains endroits, il est nécessaire d'utiliser `currentLanguage` au lieu de `currentLocale` pour conserver la rétro-compatibilité de certaines features.

## 🏄 Pour tester

⚠️ Il est conseillé de réaliser les tests en **navigation privée**.

**Non régression :**
Quand le feature toggle `useLocale` est désactivé, la détection des locales est la même qu'aujourd'hui.

**Quand le feature toggle `useLocale` est activé :**
Nouveaux comportement (sur `pix.fr`):
- https://app-pr13061.review.pix.fr
- La locale est toujours stockée dans le cookie `locale`
- Sur pix.fr, la locale sera toujours `fr-FR` (comme précédement)

Nouveaux comportement (sur `pix.org`):
- https://app-pr13061.review.pix.org
- La locale est toujours stockée dans le cookie `locale`
- La détection des locales suit l'algorithme expliqué dans la proposition.
- La première fois où l'utilisateur arrive, on détermine la locale supportée la plus proche par rapport à la locale du navigateur.
- La locale peut être changée via : 
  - les locale switchers
  - les paramètres de requêtes `lang` ou `locale`
- Quand un utilisateur revient on utilise le cookie `locale`, s'il est présent.

S'assurer qu'en changeant les locales, on accède aux contenus localisés.