### PR TITLE
[FEATURE] Ajouter un champ feedback à l'élément QAB (PIX-18945)

### DIFF
--- a/api/src/devcomp/domain/models/element/qab/QAB.js
+++ b/api/src/devcomp/domain/models/element/qab/QAB.js
@@ -1,12 +1,13 @@
 import { QABCard } from './QABCard.js';
 
 class QAB {
-  constructor({ id, type, instruction, cards }) {
+  constructor({ id, type, instruction, cards, feedback }) {
     this.id = id;
     this.type = type;
     this.instruction = instruction;
     this.isAnswerable = true;
     this.cards = cards.map((card) => new QABCard(card));
+    this.feedback = feedback;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -135,7 +135,10 @@
                 "proposalB": "Faux",
                 "solution": "A"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": "<p>Continuez comme ça !</p>"
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -108,7 +108,7 @@ export class ModuleFactory {
       case 'video':
         return ModuleFactory.#buildVideo(element);
       case 'qab':
-        return new QAB(element);
+        return ModuleFactory.#buildQAB(element);
       case 'qcm':
         return ModuleFactory.#buildQCM(element);
       case 'qcu':
@@ -197,6 +197,16 @@ export class ModuleFactory {
       subtitles: element.subtitles,
       transcription: element.transcription,
       poster: element.poster,
+    });
+  }
+
+  static #buildQAB(element) {
+    return new QAB({
+      id: element.id,
+      type: element.type,
+      instruction: element.instruction,
+      cards: element.cards,
+      feedback: element.feedback,
     });
   }
 

--- a/api/tests/devcomp/unit/domain/models/element/qab/QAB_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/qab/QAB_test.js
@@ -34,6 +34,9 @@ describe('Unit | Devcomp | Domain | Models | Element | QAB', function () {
             solution: 'A',
           },
         ],
+        feedback: {
+          diagnosis: '<p>Continuez comme ça !</p>',
+        },
       });
 
       // Then
@@ -65,6 +68,9 @@ describe('Unit | Devcomp | Domain | Models | Element | QAB', function () {
           solution: 'A',
         }),
       ]);
+      expect(qab.feedback).deep.equal({
+        diagnosis: '<p>Continuez comme ça !</p>',
+      });
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
+import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
 
 const qabElementSchema = Joi.object({
   id: uuidSchema,
@@ -21,6 +22,7 @@ const qabElementSchema = Joi.object({
     .min(1)
     .max(6)
     .required(),
+  feedback: feedbackNeutralSchema.optional(),
 }).required();
 
 export { qabElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -233,6 +233,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
               solution: 'B',
             },
           ],
+          feedback: {
+            diagnosis: '<p>Continuez comme ça !</p>',
+          },
         };
 
         await qabElementSchema.validateAsync(sample, {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -992,7 +992,25 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                     type: 'qab',
                     instruction:
                       '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>',
-                    cards: [],
+                    cards: [
+                      {
+                        id: '4420c9f6-ae21-4401-a16c-41296d898a66',
+                        text: 'La Terre est plus proche du Soleil que Mars.',
+                        proposalA: 'Vrai',
+                        proposalB: 'Faux',
+                        solution: 'B',
+                      },
+                      {
+                        id: '52d99648-5904-4a66-9fb8-476ba4da9465',
+                        text: 'L’eau bout à 100°C au niveau de la mer.',
+                        proposalA: 'Vrai',
+                        proposalB: 'Faux',
+                        solution: 'A',
+                      },
+                    ],
+                    feedback: {
+                      diagnosis: '<p>Continuez comme ça !</p>',
+                    },
                   },
                 },
               ],


### PR DESCRIPTION
## 🔆 Problème

On veut afficher un feedback en dessous du score à la dernière étape du QAB.

## ⛱️ Proposition

Préparer cela en ajoutant le champ côté API

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Appeler l'API /api/modules/bac-a-sable
- Vérifier que le champ feedback est bien présent sur l'élément QAB (dans `included[2].components.element[0]`)
