### PR TITLE
[TECH] Corriger le double déploiement des frontends à la création de RA

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -16,5 +16,10 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-22",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ]
 }

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -16,5 +16,10 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-22",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ]
 }

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -12,5 +12,10 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-22",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ]
 }

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -12,5 +12,10 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-22",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ]
 }

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -16,5 +16,10 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-22",
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox"
+    }
+  ]
 }


### PR DESCRIPTION
## 🔆 Problème

Lorsqu’on créé une RA frontend, on a souvent un double déploiement :
 - l’un déclenché par Scalingo avant que la désactivation du déploiement auto soit prise en compte
 - l’autre déclenché manuellement par pix-bot

On souhaite éviter ce double déploiement, et en particulier celui déclenché par Scalingo.

## ⛱️ Proposition

Provisionner un addon Postgres sur les RAs frontend afin de rallonger leur temps de création et de permettre de prendre en compte la désactivation du déploiement auto avant que Scalingo déclenche un premier déploiement.
L’addon est supprimé par pix-bot juste après la création de la RA.

## 🌊 Remarques

En attente de 1024pix/pix-bot#620

## 🏄 Pour tester

Vérifier que les applications front de cette PR n’ont pas subi de déploiement en double lors de leur création.