### PR TITLE
[FEATURE] Créer le type d'élément `custom-draft` (PIX-18815)

### DIFF
--- a/api/scripts/modulix/get-elements-csv.js
+++ b/api/scripts/modulix/get-elements-csv.js
@@ -49,6 +49,7 @@ export function getElements(modules) {
     'text',
     'video',
     'custom',
+    'custom-draft',
   ];
 
   const elements = [];

--- a/api/src/devcomp/domain/models/element/CustomDraft.js
+++ b/api/src/devcomp/domain/models/element/CustomDraft.js
@@ -1,0 +1,30 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { Element } from './Element.js';
+
+class CustomDraft extends Element {
+  static #VALID_URL_PREFIX = 'https://1024pix.github.io/atelier-contenus';
+
+  constructor({ id, title, url, instruction, height }) {
+    super({ id, type: 'custom-draft' });
+
+    assertNotNullOrUndefined(title, 'The title is required for a custom-draft');
+    assertNotNullOrUndefined(url, 'The URL is required for a custom-draft');
+    if (!URL.canParse(url)) {
+      throw new DomainError('The URL must be a valid URL for a custom-draft');
+    }
+
+    assertNotNullOrUndefined(height, 'The height is required for an embed');
+
+    this.title = title;
+    this.url = url;
+    this.instruction = instruction;
+    this.height = height;
+
+    if (!URL.parse(url).href.startsWith(CustomDraft.#VALID_URL_PREFIX)) {
+      throw new DomainError('The custom-draft URL must be from "1024pix.github.io/atelier-contenus"');
+    }
+  }
+}
+
+export { CustomDraft };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -251,31 +251,18 @@
           "element": {
             "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
             "type": "text",
-            "content": "<p>Voici une iframe :</p>"
+            "content": "<p>Voici un Petit Objet Interactif expérimental :</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "f00133f5-0653-425b-a25f-3c9604820529",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/cartes2.html\" height=\"420\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "32e9196a-d854-4553-bb93-5a341213f6e2",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/videoCaroline.html\" height=\"800\"></iframe>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a5e32f35-889c-45aa-8151-2da532de4eeb",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/objectif.html\" height=\"600\"></iframe>"
+            "type": "custom-draft",
+            "title": "Retourner les cartes",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
+            "instruction": "<p>Retournez les cartes.</p>",
+            "height": 400
           }
         },
         {
@@ -283,7 +270,7 @@
           "element": {
             "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
             "type": "text",
-            "content": "<p>Elles ne sont autorisées qu'en béta.</p>"
+            "content": "<p>Ils ne sont autorisés qu'en béta.</p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -7,6 +7,7 @@ import { BlockText } from '../../domain/models/block/BlockText.js';
 import { ComponentElement } from '../../domain/models/component/ComponentElement.js';
 import { ComponentStepper } from '../../domain/models/component/ComponentStepper.js';
 import { Step } from '../../domain/models/component/Step.js';
+import { CustomDraft } from '../../domain/models/element/CustomDraft.js';
 import { CustomElement } from '../../domain/models/element/CustomElement.js';
 import { Download } from '../../domain/models/element/Download.js';
 import { Embed } from '../../domain/models/element/Embed.js';
@@ -93,6 +94,8 @@ export class ModuleFactory {
     switch (element.type) {
       case 'custom':
         return ModuleFactory.#buildCustom(element);
+      case 'custom-draft':
+        return ModuleFactory.#buildCustomDraft(element);
       case 'download':
         return ModuleFactory.#buildDownload(element);
       case 'embed':
@@ -135,6 +138,16 @@ export class ModuleFactory {
       id: element.id,
       tagName: element.tagName,
       props: element.props,
+    });
+  }
+
+  static #buildCustomDraft(element) {
+    return new CustomDraft({
+      id: element.id,
+      title: element.title,
+      url: element.url,
+      instruction: element.instruction,
+      height: element.height,
     });
   }
 

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -101,9 +101,10 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"\t"30701e93-1b4d-4da4-b018-fa756c07d53f"\t"qcm"\t"Les 3 piliers de Pix"\t6\t13\t"<p>Quels sont les 3 piliers de Pix&#8239;?</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t"Connaissez-vous bien Pix"\t7\t14\t"<p>Compléter le texte suivant :</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t"Embed non-auto"\t8\t15\t"<p>Vous participez à la visioconférence ci-dessous.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t16\t"<p>Vous visualisez un événement custom.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"cf436761-f56d-4b01-83f9-942afe9ce72c"\t"ed795d29-5f04-499c-a9c8-4019125c5cb1"\t"qab"\t"test qab"\t10\t17\t"<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t11\t18\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"`);
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"f00133f5-0653-425b-a25f-3c9604820529"\t"custom-draft"\t"Elément custom"\t9\t16\t"<p>Retournez les cartes.</p>"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t17\t"<p>Vous visualisez un événement custom.</p>"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"cf436761-f56d-4b01-83f9-942afe9ce72c"\t"ed795d29-5f04-499c-a9c8-4019125c5cb1"\t"qab"\t"test qab"\t10\t18\t"<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t11\t19\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"`);
     });
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -14,6 +14,6 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
     expect(modulesListAsCsv).to.be.a('string');
     expect(modulesListAsCsv).to
       .equal(`\ufeff"Module"\t"ModuleSlug"\t"ModuleLevel"\t"ModuleLink"\t"ModuleTotalGrains"\t"ModuleTotalActivities"\t"ModuleTotalLessons"\t"ModuleDuration"\t"ModuleTotalElements"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t11\t4\t2\t"=TEXT(5/24/60; ""mm:ss"")"\t18`);
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"bac-a-sable"\t"Débutant"\t"https://app.recette.pix.fr/modules/bac-a-sable"\t11\t4\t2\t"=TEXT(5/24/60; ""mm:ss"")"\t19`);
   });
 });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -405,6 +405,17 @@
         {
           "type": "element",
           "element": {
+            "id": "f00133f5-0653-425b-a25f-3c9604820529",
+            "type": "custom-draft",
+            "title": "Retourner les cartes",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
+            "instruction": "<p>Retournez les cartes.</p>",
+            "height": 450
+          }
+        },
+        {
+          "type": "element",
+          "element": {
             "id": "0e3315fd-98ad-492f-9046-4aa867495d85",
             "type": "custom",
             "isCompletionRequired": false,

--- a/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomDraft_test.js
@@ -1,0 +1,75 @@
+import { CustomDraft } from '../../../../../../src/devcomp/domain/models/element/CustomDraft.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | CustomDraft', function () {
+  describe('#constructor', function () {
+    it('should instanciate a CustomDraft with right properties', function () {
+      // Given
+      const props = {
+        id: 'id',
+        title: 'title',
+        url: 'https://1024pix.github.io/atelier-contenus/custom-draft.html',
+        instruction: '<p>instruction</p>',
+        height: 400,
+      };
+
+      // When
+      const customDraft = new CustomDraft(props);
+
+      // Then
+      expect(customDraft.id).to.equal('id');
+      expect(customDraft.type).to.equal('custom-draft');
+      expect(customDraft.title).to.equal('title');
+      expect(customDraft.url).to.equal('https://1024pix.github.io/atelier-contenus/custom-draft.html');
+      expect(customDraft.instruction).to.equal('<p>instruction</p>');
+      expect(customDraft.height).to.equal(400);
+    });
+  });
+
+  describe('A custom-draft without url', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () => new CustomDraft({ id: 'id', title: 'title', instruction: '<p>instruction</p>' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL is required for a custom-draft');
+    });
+  });
+
+  describe('A custom-draft with invalid url', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () => new CustomDraft({ id: 'id', title: 'title', url: 'url', instruction: '<p>instruction</p>' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The URL must be a valid URL for a custom-draft');
+    });
+  });
+
+  describe('When custom-draft URL is not from 1024pix.github.io/atelier-contenus', function () {
+    it('should throw an error', function () {
+      // given & when
+      const error = catchErrSync(
+        () =>
+          new CustomDraft({
+            id: 'id',
+            title: 'title',
+            url: 'https://images.pix.fr/coolcat.jpg',
+            instruction: '<p>instruction</p>',
+            height: 400,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The custom-draft URL must be from "1024pix.github.io/atelier-contenus"');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-draft-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-draft-element-schema.js
@@ -1,0 +1,14 @@
+import Joi from 'joi';
+
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
+
+const customDraftElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('custom-draft').required(),
+  title: htmlNotAllowedSchema.required(),
+  url: Joi.string().uri().required(),
+  instruction: htmlSchema.allow('').required(),
+  height: Joi.number().integer().min(0).max(550).required(),
+}).required();
+
+export { customDraftElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { customDraftElementSchema } from './element/custom-draft-element-schema.js';
 import { customElementSchema } from './element/custom-element-schema.js';
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
@@ -19,6 +20,7 @@ import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from './utils.js';
 
 const ALLOWED_ELEMENTS_SCHEMA = [
   { is: 'custom', then: customElementSchema },
+  { is: 'custom-draft', then: customDraftElementSchema },
   { is: 'download', then: downloadElementSchema },
   { is: 'embed', then: embedElementSchema },
   { is: 'expand', then: expandElementSchema },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { expect } from '../../../../../../test-helper.js';
+import { customDraftElementSchema } from './element/custom-draft-element-schema.js';
 import { customElementSchema } from './element/custom-element-schema.js';
 import { downloadElementSchema } from './element/download-schema.js';
 import { embedElementSchema } from './element/embed-schema.js';
@@ -76,6 +77,26 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
           expect(joiError).to.equal(undefined, formattedError);
         }
       });
+    });
+
+    it('should validate sample custom-draft structure', async function () {
+      try {
+        const sample = {
+          id: randomUUID(),
+          type: 'custom-draft',
+          title: 'Echange de mails',
+          url: 'https://1024pix.github.io/pixmail-alert_avast_b.html',
+          instruction: '<p>Vous participez à un échange de mail.</p>',
+          height: 400,
+        };
+
+        await customDraftElementSchema.validateAsync(sample, {
+          abortEarly: false,
+        });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
     });
 
     it('should validate sample download structure', async function () {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1,6 +1,7 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
+import { CustomElement } from '../../../../../src/devcomp/domain/models/element/CustomElement.js';
 import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
@@ -230,6 +231,97 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
     });
 
     describe('With ComponentElement', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Custom Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          details: {
+            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'discovery',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: 'cfec5a0e-2ed5-462f-8974-e5ca25faae39',
+                    type: 'custom',
+                    tagName: 'message-conversation',
+                    props: {
+                      title: 'Confessions nocturnes',
+                      messages: [
+                        {
+                          userName: 'Mel',
+                          direction: 'outgoing',
+                          content: "Ouais c'est qui là ?",
+                        },
+                        {
+                          userName: 'Vita',
+                          direction: 'incoming',
+                          content: "Mel, c'est Vi ouvre moi.",
+                        },
+                        {
+                          userName: 'Mel',
+                          direction: 'outgoing',
+                          content: 'Ça va Vi ?',
+                        },
+                        {
+                          userName: 'Mel',
+                          direction: 'outgoing',
+                          content: "T'as l'air bizarre. Qu'est ce qu'il y a ?",
+                        },
+                        {
+                          userName: 'Vita',
+                          direction: 'incoming',
+                          content: 'Non, ça va pas non.',
+                        },
+                        {
+                          userName: 'Mel',
+                          direction: 'outgoing',
+                          content: "Ben dis-moi, qu'est qu'il y a ?",
+                        },
+                        {
+                          userName: 'Vita',
+                          direction: 'incoming',
+                          content: 'Mel, assieds-toi faut que je te parle...',
+                        },
+                        {
+                          userName: 'Vita',
+                          direction: 'incoming',
+                          content: "J'ai passé ma journée dans le noir.",
+                        },
+                        {
+                          userName: 'Vita',
+                          direction: 'incoming',
+                          content: 'Mel, je le sens, je le sais, je le suis, il se fout de moi...',
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(CustomElement);
+      });
+
       it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
         // given
         const moduleData = {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1,6 +1,7 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
+import { CustomDraft } from '../../../../../src/devcomp/domain/models/element/CustomDraft.js';
 import { CustomElement } from '../../../../../src/devcomp/domain/models/element/CustomElement.js';
 import { Download } from '../../../../../src/devcomp/domain/models/element/Download.js';
 import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
@@ -320,6 +321,50 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
         // then
         expect(module.grains[0].components[0].element).to.be.an.instanceOf(CustomElement);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a CustomDraft Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          isBeta: true,
+          details: {
+            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            tabletSupport: 'comfortable',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'discovery',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: 'f00133f5-0653-425b-a25f-3c9604820529',
+                    type: 'custom-draft',
+                    title: 'Retourner les cartes',
+                    url: 'https://1024pix.github.io/atelier-contenus/RPE/cartes2.html',
+                    instruction: '<p>Retournez les cartes.</p>',
+                    height: 400,
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(CustomDraft);
       });
 
       it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
+import CustomDraftElement from 'mon-pix/components/module/element/custom-draft';
 import CustomElement from 'mon-pix/components/module/element/custom-element';
 import DownloadElement from 'mon-pix/components/module/element/download';
 import EmbedElement from 'mon-pix/components/module/element/embed';
@@ -36,6 +37,8 @@ export default class ModulixElement extends Component {
       <EmbedElement @embed={{@element}} @passageId={{@passageId}} @onAnswer={{@onElementAnswer}} />
     {{else if (eq @element.type "custom")}}
       <CustomElement @component={{@element}} @onAnswer={{@onElementAnswer}} />
+    {{else if (eq @element.type "custom-draft")}}
+      <CustomDraftElement @customDraft={{@element}} />
     {{else if (eq @element.type "expand")}}
       <ExpandElement @expand={{@element}} @onExpandToggle={{@onExpandToggle}} />
     {{else if (eq @element.type "separator")}}

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -1,0 +1,18 @@
+.element-custom-draft {
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__iframe {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    border: none;
+  }
+
+  &__reset {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -1,0 +1,59 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { action } from '@ember/object';
+import { t } from 'ember-intl';
+
+import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import didInsert from '../../../modifiers/modifier-did-insert';
+import ModuleElement from './module-element';
+
+export default class ModulixCustomDraft extends ModuleElement {
+  get heightStyle() {
+    return htmlUnsafe(`height: ${this.args.customDraft.height}px`);
+  }
+
+  @action
+  setIframeHtmlElement(htmlElement) {
+    this.iframe = htmlElement;
+  }
+
+  @action
+  resetEmbed() {
+    this.iframe.setAttribute('src', this.args.customDraft.url);
+    this.iframe.focus();
+  }
+
+  <template>
+    <div class="element-custom-draft element-custom">
+      {{#if @customDraft.instruction}}
+        <div class="element-custom-draft__instruction">
+          {{htmlUnsafe @customDraft.instruction}}
+        </div>
+      {{/if}}
+
+      <fieldset>
+        <legend>
+          <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
+          <span>{{t "pages.modulix.interactiveElement.label"}}</span>
+        </legend>
+
+        <iframe
+          class="element-custom-draft__iframe"
+          src={{@customDraft.url}}
+          title={{@customDraft.title}}
+          style={{this.heightStyle}}
+          {{didInsert this.setIframeHtmlElement}}
+        ></iframe>
+      </fieldset>
+
+      <div class="element-custom-draft__reset">
+        <PixButton
+          @iconBefore="refresh"
+          @variant="tertiary"
+          @triggerAction={{this.resetEmbed}}
+          aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
+        >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+      </div>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -20,6 +20,7 @@ export default class ModuleGrain extends Component {
 
   static AVAILABLE_ELEMENT_TYPES = [
     'custom',
+    'custom-draft',
     'download',
     'embed',
     'expand',

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -86,6 +86,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/instruction/recap' as *;
 @use '../components/module/component/stepper' as *;
 @use '../components/module/element/custom-element' as *;
+@use '../components/module/element/custom-draft' as *;
 @use '../components/module/element/download' as *;
 @use '../components/module/element/embed' as *;
 @use '../components/module/element/expand' as *;

--- a/mon-pix/tests/integration/components/module/custom-draft_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-draft_test.gjs
@@ -1,0 +1,72 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+// eslint-disable-next-line no-restricted-imports
+import { find } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ModulixCustomDraft from 'mon-pix/components/module/element/custom-draft';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | CustomDraft', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a customDraft with instruction', async function (assert) {
+    // given
+    const customDraft = {
+      id: 'id',
+      title: 'title',
+      url: 'https://example.org',
+      instruction: '<p>Instruction du POIC</p>',
+      height: 400,
+    };
+
+    // when
+    const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+
+    // then
+    assert.ok(screen);
+    const expectedIframe = screen.getByTitle(customDraft.title);
+    assert.strictEqual(expectedIframe.getAttribute('src'), customDraft.url);
+    assert.strictEqual(window.getComputedStyle(expectedIframe).getPropertyValue('height'), `${customDraft.height}px`);
+    assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') })).exists();
+    assert.dom(screen.getByText('Instruction du POIC')).exists();
+  });
+
+  test('should display a customDraft without instruction', async function (assert) {
+    // given
+    const customDraft = {
+      id: 'id',
+      title: 'title',
+      isCompletionRequired: false,
+      url: 'https://example.org',
+      height: 400,
+    };
+
+    // when
+    await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+
+    // then
+    assert.dom(find('.element-customDraft__instruction')).doesNotExist();
+  });
+
+  module('when user clicks on reset button', function () {
+    test('should focus on the iframe', async function (assert) {
+      // given
+      const customDraft = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://example.org',
+        height: 400,
+      };
+      const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+
+      // when
+      await clickByName(t('pages.modulix.buttons.embed.reset.ariaLabel'));
+
+      // then
+      const iframe = screen.getByTitle(customDraft.title);
+      assert.strictEqual(document.activeElement, iframe);
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -72,6 +72,24 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.strictEqual(findAll('qcu-image').length, 1);
   });
 
+  test('should display an element with an custom-draft element', async function (assert) {
+    // given
+    const element = {
+      id: 'f00133f5-0653-425b-a25f-3c9604820529',
+      type: 'custom-draft',
+      title: 'Retourner les cartes',
+      url: 'https://1024pix.github.io/atelier-contenus/RPE/cartes2.html',
+      instruction: '<p>Retournez les cartes.</p>',
+      height: 400,
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.dom(screen.getByTitle(element.title)).exists();
+  });
+
   test('should display an element with a text element', async function (assert) {
     // given
     const element = {


### PR DESCRIPTION
## 🔆 Problème

Notre vocabulaire d'échange entre pôles inclue un terme qui n'apparait pas dans le code.

Par ailleurs, il devient difficile de distinguer les éléments temporaires appelés "POIC" des embeds, des `iframe` dans des textes et des éléments custom.

Également, laisser libre accès aux `iframe` est un risque pour la sécurité de la plateforme.

## ⛱️ Proposition

Mettre à disposition un type d'élément `custom-draft` qui ressemble à la signature de l'élément `embed` mais un peu simplifié.

On les entoure du liseré indiquant que l'élément est interactif.

Pour le moment, les modules n'ont pas été migré pour éviter des conflits.

## 🌊 Remarques

Penser à mettre à jour Modulix Editor au merge.

Il faudra ensuite prévoir de limiter les usages des `iframe`.

Questions où je ne suis pas certain : 
- Faut-il forcer la hauteur ainsi ? Beaucoup de POIC custom ont été pimpé...
- Faut-il obliger la présence du `title` ? Oui pour raison accessibilité : https://www.w3.org/WAI/WCAG21/Techniques/html/H64

## 🏄 Pour tester

Dans le [bac-a-sable](https://app-pr13064.review.pix.fr/modules/bac-a-sable/passage), trouver l'iframe remplacée par un élément `custom-draft`.
