### PR TITLE
[FEATURE] Afficher le feedback sur un élément QAB (PIX-18946)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -75,7 +75,7 @@
     },
     {
       "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
-      "type": "lesson",
+      "type": "activity",
       "title": "test qab",
       "components": [
         {

--- a/mon-pix/app/components/module/element/qab/_qab-score-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-score-card.scss
@@ -15,11 +15,4 @@
     font-weight: 900;
     text-align: center;
   }
-
-  &__retry-button {
-    padding: var(--pix-spacing-4x) var(--pix-spacing-10x);
-    font-weight: var(--pix-font-bold);
-    background: var(--pix-primary-10);
-    border-radius: var(--modulix-radius-s);
-  }
 }

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -22,6 +22,24 @@
   }
 
   &__feedback {
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.5s fade-in ease-in-out;
+
+      @keyframes fade-in {
+        0% {
+          opacity: 0;
+        }
+
+        33% {
+          opacity: 0;
+        }
+
+        100% {
+          opacity: 1;
+        }
+      }
+    }
+
     padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     color: var(--pix-neutral-800);
     background: var(--pix-orga-50);

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -21,6 +21,13 @@
     justify-items: center;
   }
 
+  &__feedback {
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    color: var(--pix-neutral-800);
+    background: var(--pix-orga-50);
+    border-radius: 16px;
+  }
+
   &__proposals {
     display: flex;
     flex-wrap: wrap;

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -46,6 +46,10 @@
     border-radius: 16px;
   }
 
+  &__retry-button {
+    margin-bottom: var(--pix-spacing-2x);
+  }
+
   &__proposals {
     display: flex;
     flex-wrap: wrap;

--- a/mon-pix/app/components/module/element/qab/qab-score-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-score-card.gjs
@@ -6,9 +6,6 @@ import { t } from 'ember-intl';
       <h1 class="qab-score-card__title">
         {{t "pages.modulix.qab.your_score" score=@score total=@total}}
       </h1>
-      <button onClick={{@onRetry}} type="button" class="qab-score-card__retry-button">
-        {{t "pages.modulix.qab.retry"}}
-      </button>
     </div>
   </div>
 </template>

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -38,6 +38,14 @@ export default class ModuleQab extends ModuleElement {
     return this.displayedCards[0];
   }
 
+  get feedback() {
+    return this.element.feedback.diagnosis;
+  }
+
+  get shouldDisplayFeedback() {
+    return this.shouldDisplayScore && this.element.feedback?.diagnosis.length > 0;
+  }
+
   @action
   isProposalSolution(option) {
     return this.currentCard.solution === option;
@@ -165,5 +173,10 @@ export default class ModuleQab extends ModuleElement {
         </div>
       </fieldset>
     </form>
+    {{#if this.shouldDisplayFeedback}}
+      <div class="element-qab__feedback" role="status" tabindex="-1">
+        {{htmlUnsafe this.feedback}}
+      </div>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -1,6 +1,8 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import QabCard from 'mon-pix/components/module/element/qab/qab-card';
 import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
@@ -150,7 +152,7 @@ export default class ModuleQab extends ModuleElement {
             {{/each}}
           {{/if}}
           {{#if this.shouldDisplayScore}}
-            <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}}/>
+            <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}} />
           {{/if}}
         </div>
         <div class="element-qab__proposals {{unless this.shouldDisplayCards 'element-qab__proposals--empty'}}">
@@ -177,6 +179,18 @@ export default class ModuleQab extends ModuleElement {
       <div class="element-qab__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.feedback}}
       </div>
+    {{/if}}
+    {{#if this.shouldDisplayScore}}
+      <PixButton
+        class="element-qab__retry-button"
+        @variant="tertiary"
+        @size="small"
+        @type="button"
+        @triggerAction={{this.onRetry}}
+        @iconAfter="refresh"
+      >
+        {{t "pages.modulix.qab.retry"}}
+      </PixButton>
     {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -150,7 +150,7 @@ export default class ModuleQab extends ModuleElement {
             {{/each}}
           {{/if}}
           {{#if this.shouldDisplayScore}}
-            <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}} @onRetry={{this.onRetry}} />
+            <QabScoreCard @score={{this.score}} @total={{this.numberOfCards}}/>
           {{/if}}
         </div>
         <div class="element-qab__proposals {{unless this.shouldDisplayCards 'element-qab__proposals--empty'}}">

--- a/mon-pix/tests/integration/components/module/proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/proposal-button_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import ProposalButton from 'mon-pix/components/module/component/proposal-button';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -54,11 +55,12 @@ module('Integration | Component | Module | ProposalButton', function (hooks) {
       const onSubmit = sinon.stub();
 
       // when
-      await render(
+      const screen = await render(
         <template>
           <form onSubmit={{onSubmit}}><ProposalButton @proposal={{proposal}} @isDisabled={{true}} /></form>
         </template>,
       );
+      await click(screen.getByRole('button', { name: 'Avant de mettre le dentifrice' }));
 
       // then
       sinon.assert.notCalled(onSubmit);

--- a/mon-pix/tests/integration/components/module/qab-proposal-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-proposal-button_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import QabProposalButton from 'mon-pix/components/module/element/qab/proposal-button';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -42,7 +43,7 @@ module('Integration | Component | Module | QabProposalButton', function (hooks) 
       const onSubmit = sinon.stub();
 
       // when
-      await render(
+      const screen = await render(
         <template>
           <form onSubmit={{onSubmit}}><QabProposalButton
               @text={{text}}
@@ -51,6 +52,7 @@ module('Integration | Component | Module | QabProposalButton', function (hooks) 
             /></form>
         </template>,
       );
+      await click(screen.getByRole('button', { name: 'Option B: Faux' }));
 
       // then
       sinon.assert.notCalled(onSubmit);

--- a/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
@@ -1,14 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
 import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | QabScoreCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display the score and a retry button', async function (assert) {
+  test('it should display the score', async function (assert) {
     // given
     const score = 4;
     const total = 5;
@@ -18,20 +17,5 @@ module('Integration | Component | Module | QabScoreCard', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Votre score : 4/5' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
-  });
-
-  module('when user clicks the retry button', function () {
-    test('should call the onRetry callback', async function (assert) {
-      // given
-      const onRetry = sinon.stub();
-      const screen = await render(<template><QabScoreCard @score={{4}} @total={{5}} @onRetry={{onRetry}} /></template>);
-
-      // when
-      await screen.getByRole('button', { name: 'Réessayer' }).click();
-
-      // then
-      assert.ok(onRetry.calledOnce);
-    });
   });
 });

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -130,7 +130,7 @@ module('Integration | Component | Module | QAB', function (hooks) {
     });
 
     module('when user answers the last card', function () {
-      test('should display the score card and call "onAnswer" function passed as argument', async function (assert) {
+      test('should display the score card, a feedback and call "onAnswer" function passed as argument', async function (assert) {
         // given
         const qabElement = _getQabElement();
         const onAnswerStub = sinon.stub();
@@ -150,6 +150,7 @@ module('Integration | Component | Module | QAB', function (hooks) {
         });
 
         assert.dom(screen.getByText('Votre score : 1/2')).exists();
+        assert.dom(screen.getByText('Continuez comme ça !')).exists();
         assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
       });
 
@@ -216,5 +217,8 @@ function _getQabElement(solution = 'A') {
         solution: 'B',
       },
     ],
+    feedback: {
+      diagnosis: '<p>Continuez comme ça !</p>',
+    },
   };
 }

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -154,6 +154,26 @@ module('Integration | Component | Module | QAB', function (hooks) {
         assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
       });
 
+      module('when there is no feedback', function () {
+        test('should also display the retry button', async function (assert) {
+          // given
+          const qabElement = { ..._getQabElement(), feedback: undefined };
+          const onAnswerStub = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template><ModuleQabElement @element={{qabElement}} @onAnswer={{onAnswerStub}} /></template>,
+          );
+          await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
+          await clock.tickAsync(NEXT_CARD_DELAY);
+          await click(screen.getByRole('button', { name: 'Option A: Vrai' }));
+          await clock.tickAsync(NEXT_CARD_DELAY);
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
+        });
+      });
+
       module('when user clicks the retry button', function () {
         test('should reset the component, display the first card and send an event', async function (assert) {
           // given


### PR DESCRIPTION
## 🔆 Problème

On veut afficher un feedback sur un élément QAB.

## ⛱️ Proposition

Le faire

## 🌊 Remarques
- La PR https://github.com/1024pix/pix/pull/13062 doit être mergée avant.
- Une animation a été ajoutée sur l'affichage du feedback. A voir ensemble pour ajuster tout cela !
- Le type du grain contenant l'élément QAB a été changé en activité pour enlever le fond.

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr13065.review.pix.fr/modules/bac-a-sable/passage)
- Passer les activités jusqu'à arriver au QAB
- Répondre aux questions jusqu'à arriver sur la carte de score.
- Vérifier qu'un feedback s'affiche maintenant avec le bouton réessayer.
