### PR TITLE
[BUGFIX] Récupérer les infos du badge certifiant et non certifié sur la page d'éligibilité (PIX-18953).

### DIFF
--- a/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -21,8 +21,8 @@ const findHighestCertifiable = async function ({ userId, limitDate = new Date() 
           campaignParticipationId: 'badge-acquisitions.campaignParticipationId',
           complementaryCertificationId: 'complementary-certification-badges.complementaryCertificationId',
           complementaryCertificationBadgeId: 'complementary-certification-badges.id',
-          complementaryCertificationBadgeImageUrl: 'complementary-certification-badges.imageUrl',
-          complementaryCertificationBadgeLabel: 'complementary-certification-badges.label',
+          complementaryCertificationBadgeImageUrl: 'badges.imageUrl',
+          complementaryCertificationBadgeLabel: 'badges.altMessage',
           complementaryCertificationBadgeLevel: 'complementary-certification-badges.level',
           complementaryCertificationBadgeDetachedAt: 'complementary-certification-badges.detachedAt',
         })

--- a/api/tests/certification/enrolment/acceptance/application/user-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/user-route_test.js
@@ -186,6 +186,7 @@ describe('Certification | Enrolment | Acceptance | Routes | User', function () {
       key: 'PARTNER_KEY',
       isCertifiable: true,
       targetProfileId,
+      imageUrl: 'http://my-badge-image-url.com',
     }).id;
     databaseBuilder.factory.buildBadgeCriterion({
       badgeId: cleaBadgeId,
@@ -272,8 +273,8 @@ describe('Certification | Enrolment | Acceptance | Routes | User', function () {
               'is-certifiable': true,
               'complementary-certifications': [
                 {
-                  imageUrl: 'http://badge-image-url.fr',
-                  label: 'PARTNER_LABEL',
+                  imageUrl: 'http://my-badge-image-url.com',
+                  label: 'alt message',
                   isOutdated: false,
                   isAcquiredExpectedLevel: false,
                 },

--- a/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/certification/shared/integration/domain/services/certification-badges-service_test.js
@@ -113,8 +113,8 @@ describe('Integration | Service | Certification-Badges Service', function () {
         complementaryCertificationId: complementaryCertification.id,
         complementaryCertificationKey: complementaryCertification.key,
         complementaryCertificationBadgeId: complementaryCertificationBadge.id,
-        complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
-        complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
+        complementaryCertificationBadgeLabel: badge.altMessage,
+        complementaryCertificationBadgeImageUrl: badge.imageUrl,
       });
       expect(badgeAcquisitions).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
     });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -46,8 +46,8 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           complementaryCertificationId: complementaryCertification.id,
           complementaryCertificationKey: complementaryCertification.key,
           complementaryCertificationBadgeId: complementaryCertificationBadge.id,
-          complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
-          complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
+          complementaryCertificationBadgeLabel: acquiredBadge.altMessage,
+          complementaryCertificationBadgeImageUrl: acquiredBadge.imageUrl,
           isOutdated: false,
         });
         expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
@@ -88,8 +88,8 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             complementaryCertificationId: complementaryCertification.id,
             complementaryCertificationKey: complementaryCertification.key,
             complementaryCertificationBadgeId: complementaryCertificationBadge.id,
-            complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
-            complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
+            complementaryCertificationBadgeLabel: acquiredBadge.altMessage,
+            complementaryCertificationBadgeImageUrl: acquiredBadge.imageUrl,
             isOutdated: false,
           });
           expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);
@@ -147,8 +147,8 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
           complementaryCertificationId: complementaryCertification.id,
           complementaryCertificationKey: complementaryCertification.key,
           complementaryCertificationBadgeId: complementaryCertificationBadge.id,
-          complementaryCertificationBadgeLabel: complementaryCertificationBadge.label,
-          complementaryCertificationBadgeImageUrl: complementaryCertificationBadge.imageUrl,
+          complementaryCertificationBadgeLabel: acquiredBadge.altMessage,
+          complementaryCertificationBadgeImageUrl: acquiredBadge.imageUrl,
           isOutdated: false,
         });
         expect(certifiableBadgesAcquiredByUser).to.deepEqualArray([expectedCertifiableBadgeAcquisition]);


### PR DESCRIPTION
## 🔆 Problème

La page de réconciliation (onglet “Certification”) l’onglet vert clair reprenant l'éligibilité du candidat n’affiche pas le badge certifiant mais le badge certifié (image + label).
Ce badge (image + label) n'est censé être visible que sur le certificat du candidat (en version SVG pour le et PDF pour la version téléchargeable) une fois obtenu lors de son test.

## ⛱️ Proposition

Remplacement de la table `complementary-certification-badges` par `badges` dans la requête de récupération des badges pour l'éligibilité

## 🌊 Remarques

Je n'ai pas modifié le nom `complementaryCertificationBadgeLabel` pour éviter du renommage sans valeur ajoutée.

## 🏄 Pour tester

- Se connecter avec `certif-success@example.net` sur pix-app
- Aller sur certifications
- Vérifier que les informations d'éligibilité CléA correspondent bien aux informations de la table `badges` et non `complementary-certification-badges`
