### PR TITLE
[FEATURE] Relayer l'info de modération d'un message adressé au LLM au front, et persister l'info dans le Chat (PIX-18943)

### DIFF
--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -34,19 +34,28 @@ export class Chat {
 
   /**
    * @param {string=} message
+   * @param {boolean=} shouldBeCountedAsAPrompt
    * @param {boolean=} shouldBeForwardedToLLM
    * @param {boolean=} haveVictoryConditionsBeenFulfilled
+   * @param {boolean} wasModerated
    */
-  addUserMessage(message, shouldBeForwardedToLLM, haveVictoryConditionsBeenFulfilled) {
+  addUserMessage(
+    message,
+    shouldBeCountedAsAPrompt,
+    shouldBeForwardedToLLM,
+    haveVictoryConditionsBeenFulfilled,
+    wasModerated,
+  ) {
     if (!message) return;
     this.messages.push(
       new Message({
         content: message,
         isFromUser: true,
-        shouldBeCountedAsAPrompt: shouldBeForwardedToLLM,
+        shouldBeCountedAsAPrompt,
         shouldBeForwardedToLLM,
         shouldBeRenderedInPreview: true,
         haveVictoryConditionsBeenFulfilled,
+        wasModerated,
       }),
     );
   }
@@ -172,6 +181,7 @@ export class Message {
    * @param {boolean} params.shouldBeCountedAsAPrompt
    * @param {boolean=} params.hasAttachmentBeenSubmittedAlongWithAPrompt
    * @param {boolean=} params.haveVictoryConditionsBeenFulfilled
+   * @param {boolean=} params.wasModerated
    */
   constructor({
     content,
@@ -183,6 +193,7 @@ export class Message {
     shouldBeCountedAsAPrompt,
     hasAttachmentBeenSubmittedAlongWithAPrompt,
     haveVictoryConditionsBeenFulfilled,
+    wasModerated,
   }) {
     this.content = content;
     this.isFromUser = isFromUser;
@@ -193,6 +204,7 @@ export class Message {
     this.shouldBeCountedAsAPrompt = !!shouldBeCountedAsAPrompt;
     this.hasAttachmentBeenSubmittedAlongWithAPrompt = hasAttachmentBeenSubmittedAlongWithAPrompt;
     this.haveVictoryConditionsBeenFulfilled = haveVictoryConditionsBeenFulfilled;
+    this.wasModerated = wasModerated;
   }
 
   get isAttachment() {
@@ -225,6 +237,7 @@ export class Message {
       shouldBeCountedAsAPrompt: this.shouldBeCountedAsAPrompt,
       hasAttachmentBeenSubmittedAlongWithAPrompt: this.hasAttachmentBeenSubmittedAlongWithAPrompt,
       haveVictoryConditionsBeenFulfilled: this.haveVictoryConditionsBeenFulfilled,
+      wasModerated: this.wasModerated,
     };
   }
 

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -18,6 +18,7 @@ export function serialize(chat) {
         attachmentName: current.attachmentName,
         isFromUser: true,
         haveVictoryConditionsBeenFulfilled: next.haveVictoryConditionsBeenFulfilled,
+        wasModerated: next.wasModerated,
       });
 
       messagesForPreview = messagesForPreview.toSpliced(i, 2, mergedMessage);
@@ -34,12 +35,15 @@ export function serialize(chat) {
     context: chat.configuration.context,
     totalInputTokens: chat.totalInputTokens,
     totalOutputTokens: chat.totalOutputTokens,
-    messages: messagesForPreview.map(({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled }) => ({
-      content,
-      attachmentName,
-      isFromUser,
-      haveVictoryConditionsBeenFulfilled,
-      isAttachmentValid: Boolean(attachmentName && chat.isAttachmentValid(attachmentName)),
-    })),
+    messages: messagesForPreview.map(
+      ({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled, wasModerated }) => ({
+        content,
+        attachmentName,
+        isFromUser,
+        haveVictoryConditionsBeenFulfilled,
+        wasModerated,
+        isAttachmentValid: Boolean(attachmentName && chat.isAttachmentValid(attachmentName)),
+      }),
+    ),
   };
 }

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -16,8 +16,9 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  * @typedef {Object} StreamCapture
  * @property {string[]} LLMMessageParts - Accumulated message chunks.
  * @property {boolean=} haveVictoryConditionsBeenFulfilled - Whether victory conditions were fulfilled during this exchange or not
- * @property {number=} inputTokens
- * @property {number=} outputTokens
+ * @property {number} inputTokens
+ * @property {number} outputTokens
+ * @property {boolean} wasModerated
  */
 
 /**
@@ -50,6 +51,7 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
     haveVictoryConditionsBeenFulfilled: undefined,
     inputTokens: 0,
     outputTokens: 0,
+    wasModerated: false,
   };
   pipeline(
     readableStream,

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -8,12 +8,17 @@ export function getTransform(streamCapture) {
   return new Transform({
     objectMode: true,
     transform(chunk, _encoding, callback) {
-      const { message, isValid, usage } = chunk;
+      const { message, isValid, usage, wasModerated } = chunk;
       let data = '';
 
       if (isValid) {
-        data += getVictoryConditionsSuccessEvent();
         streamCapture.haveVictoryConditionsBeenFulfilled = true;
+        data += getVictoryConditionsSuccessEvent();
+      }
+
+      if (wasModerated) {
+        streamCapture.wasModerated = true;
+        data += getMessageModeratedEvent();
       }
 
       if (message) {
@@ -39,4 +44,8 @@ function getFormattedMessage(message) {
 
 function getVictoryConditionsSuccessEvent() {
   return 'event: victory-conditions-success\ndata: \n\n';
+}
+
+function getMessageModeratedEvent() {
+  return 'event: user-message-moderated\ndata: \n\n';
 }

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -313,6 +313,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isFromUser: true,
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
           {
             content: 'coucou LLM1',
@@ -320,6 +321,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isFromUser: false,
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
           {
             content: 'un message',
@@ -327,6 +329,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isFromUser: true,
             isAttachmentValid: true,
             haveVictoryConditionsBeenFulfilled: true,
+            wasModerated: undefined,
           },
           {
             content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
@@ -334,6 +337,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isFromUser: false,
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
         ],
       });

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -15,7 +15,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addUserMessage(message, true);
+      chat.addUserMessage(message, false, false, false, false);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -29,17 +29,19 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
         },
         {
           content: 'un message pas vide',
           attachmentName: undefined,
           attachmentContext: undefined,
           isFromUser: true,
-          shouldBeForwardedToLLM: true,
+          shouldBeForwardedToLLM: false,
           shouldBeRenderedInPreview: true,
-          shouldBeCountedAsAPrompt: true,
+          shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-          haveVictoryConditionsBeenFulfilled: undefined,
+          haveVictoryConditionsBeenFulfilled: false,
+          wasModerated: false,
         },
       ]);
     });
@@ -54,9 +56,9 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addUserMessage('');
-      chat.addUserMessage(null);
-      chat.addUserMessage();
+      chat.addUserMessage('', false, false, false, false);
+      chat.addUserMessage(null, false, false, false, false);
+      chat.addUserMessage(undefined, false, false, false, false);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -70,11 +72,12 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
         },
       ]);
     });
 
-    it('should set shouldBeCountedAsAPrompt at false if shouldBeForwardedToLLM is also false', function () {
+    it('should set shouldBeCountedAsAPrompt at true if given true', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
@@ -84,7 +87,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addUserMessage('some content', false);
+      chat.addUserMessage('some content', true, false, false, false);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -95,14 +98,15 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           isFromUser: true,
           shouldBeForwardedToLLM: false,
           shouldBeRenderedInPreview: true,
-          shouldBeCountedAsAPrompt: false,
+          shouldBeCountedAsAPrompt: true,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-          haveVictoryConditionsBeenFulfilled: undefined,
+          haveVictoryConditionsBeenFulfilled: false,
+          wasModerated: false,
         },
       ]);
     });
 
-    it('should set shouldBeCountedAsAPrompt at true if shouldBeForwardedToLLM is also true', function () {
+    it('should set shouldBeForwardedToLLM at true if given true', function () {
       // given
       const chat = new Chat({
         id: 'some-chat-id',
@@ -112,7 +116,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addUserMessage('some content', true);
+      chat.addUserMessage('some content', false, true, false, false);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -123,9 +127,10 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           isFromUser: true,
           shouldBeForwardedToLLM: true,
           shouldBeRenderedInPreview: true,
-          shouldBeCountedAsAPrompt: true,
+          shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
-          haveVictoryConditionsBeenFulfilled: undefined,
+          haveVictoryConditionsBeenFulfilled: false,
+          wasModerated: false,
         },
       ]);
     });
@@ -140,7 +145,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addUserMessage('some content', true, true);
+      chat.addUserMessage('some content', false, false, true, false);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -149,11 +154,41 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           attachmentName: undefined,
           attachmentContext: undefined,
           isFromUser: true,
-          shouldBeForwardedToLLM: true,
+          shouldBeForwardedToLLM: false,
           shouldBeRenderedInPreview: true,
-          shouldBeCountedAsAPrompt: true,
+          shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: true,
+          wasModerated: false,
+        },
+      ]);
+    });
+
+    it('should set wasModerated at true if given as true', function () {
+      // given
+      const chat = new Chat({
+        id: 'some-chat-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
+        hasAttachmentContextBeenAdded: false,
+        messages: [],
+      });
+
+      // when
+      chat.addUserMessage('some content', false, false, false, true);
+
+      // then
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'some content',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: true,
+          shouldBeForwardedToLLM: false,
+          shouldBeRenderedInPreview: true,
+          shouldBeCountedAsAPrompt: false,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: false,
+          wasModerated: true,
         },
       ]);
     });
@@ -184,6 +219,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
         },
         {
           content: 'un message pas vide',
@@ -195,6 +231,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
         },
       ]);
     });
@@ -225,6 +262,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
         },
       ]);
     });
@@ -269,6 +307,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -280,6 +319,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -291,6 +331,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -302,6 +343,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeCountedAsAPrompt: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -342,6 +384,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -353,6 +396,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -364,6 +408,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -375,6 +420,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeCountedAsAPrompt: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -418,6 +464,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -429,6 +476,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -440,6 +488,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -480,6 +529,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -491,6 +541,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -502,6 +553,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -547,6 +599,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -558,6 +611,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -569,6 +623,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -609,6 +664,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -620,6 +676,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -631,6 +688,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -674,6 +732,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -685,6 +744,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -696,6 +756,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -736,6 +797,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: 'some answer',
@@ -747,6 +809,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: false,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
               {
                 content: undefined,
@@ -758,6 +821,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 shouldBeRenderedInPreview: true,
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
+                wasModerated: undefined,
               },
             ]);
           });
@@ -1122,6 +1186,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeRenderedInPreview: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'message llm 1',
@@ -1133,6 +1198,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeForwardedToLLM: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
           ],
         });
@@ -1192,6 +1258,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeRenderedInPreview: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'message llm 1',
@@ -1203,6 +1270,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeForwardedToLLM: true,
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
           ],
         });
@@ -1229,6 +1297,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeCountedAsAPrompt: true,
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: true,
+            wasModerated: true,
           }),
           new Message({
             content: 'message llm 1',
@@ -1280,6 +1349,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: true,
           },
           {
             content: 'message llm 1',
@@ -1291,6 +1361,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
           {
             content: undefined,
@@ -1302,6 +1373,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
             haveVictoryConditionsBeenFulfilled: true,
+            wasModerated: undefined,
           },
           {
             content: undefined,
@@ -1313,6 +1385,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: false,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
         ],
       });
@@ -1339,6 +1412,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: true,
           },
           {
             content: 'message llm 1',
@@ -1350,6 +1424,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
           {
             content: undefined,
@@ -1361,6 +1436,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeRenderedInPreview: true,
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
             haveVictoryConditionsBeenFulfilled: true,
+            wasModerated: undefined,
           },
           {
             content: undefined,
@@ -1371,6 +1447,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeForwardedToLLM: true,
             shouldBeRenderedInPreview: false,
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+            wasModerated: undefined,
           },
         ],
       };
@@ -1393,6 +1470,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               shouldBeCountedAsAPrompt: true,
               shouldBeForwardedToLLM: true,
               shouldBeRenderedInPreview: true,
+              wasModerated: true,
             }),
             new Message({
               content: 'message llm 1',

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -55,6 +55,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             isFromUser: true,
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
           {
             content: 'Bonjour comment puis-je vous aider ?',
@@ -62,6 +63,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             isFromUser: false,
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
+            wasModerated: undefined,
           },
         ],
       });
@@ -90,12 +92,14 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               shouldBeRenderedInPreview: false,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             }),
             new Message({
               content: 'Bonjour comment puis-je vous aider ?',
               isFromUser: false,
               shouldBeRenderedInPreview: true,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             }),
           ],
         });
@@ -119,6 +123,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: false,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             },
           ],
         });
@@ -178,6 +183,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               shouldBeRenderedInPreview: true,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             }),
           ],
         });
@@ -201,6 +207,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -208,6 +215,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: false,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'Que contient ce fichier ?',
@@ -215,6 +223,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: true,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
@@ -222,6 +231,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: false,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
@@ -229,6 +239,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             },
           ],
         });
@@ -288,6 +299,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               shouldBeRenderedInPreview: true,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             }),
           ],
         });
@@ -311,6 +323,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -318,6 +331,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: false,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: undefined,
@@ -325,6 +339,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: true,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: undefined,
             },
             {
               content: 'Que contient ce fichier ?',
@@ -332,6 +347,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
@@ -339,6 +355,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: false,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: undefined,
@@ -346,6 +363,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
+              wasModerated: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
@@ -353,6 +371,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isFromUser: true,
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
+              wasModerated: true,
             },
           ],
         });


### PR DESCRIPTION
## 🔆 Problème

Les messages modérés (c'est à dire non traités par poc-llm car celui-ci a estimé que le message n'était pas approprié) ne sont pas gérés proprement.

## ⛱️ Proposition

Dans un premier temps, il faut relayer l'info de modération d'un message au front pour qu'ensuite celui-ci affiche un message adapté.

Côté API :
- Transformer l'info, depuis la réponse stream de poc-llm, en SSE (wasModerated:true ==> event: user-message-moderated
- Persister l'info au niveau du message concerné
- S'assurer que l'info remonte aussi dans le cas d'un rechargement de conversation en preview

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
