### PR TITLE
[FEATURE] Migrer les POIC d'iframe/embed vers l'élément `custom-draft`

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -112,12 +112,11 @@
           "type": "element",
           "element": {
             "id": "46dd0846-573d-408f-abe3-76cd0c4e67c8",
-            "type": "embed",
-            "isCompletionRequired": false,
+            "type": "custom-draft",
             "title": "simulateur 1FA",
             "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_1FA_v1.html",
-            "instruction": "<p></p>",
-            "height": 600
+            "instruction": "",
+            "height": 550
           }
         }
       ]
@@ -219,12 +218,11 @@
           "type": "element",
           "element": {
             "id": "0cf6b85d-9b0a-4b41-a317-0be1b36a81fb",
-            "type": "embed",
-            "isCompletionRequired": false,
+            "type": "custom-draft",
             "title": "simulateur 2FA",
             "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_2FA_v1.html",
-            "instruction": "<p></p>",
-            "height": 320
+            "instruction": "",
+            "height": 550
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -128,12 +128,15 @@
                 {
                   "id": "24829c18-2220-4cb8-9749-296d8c314353",
                   "type": "text",
-                  "content": "<p>Taper sur une touche, c’est <strong>appuyer une fois</strong> dessus et <strong>relâcher immédiatement</strong>.</p><p><span aria-hidden=\"true\">👇</span> Préparez-vous à utiliser votre clavier et suivez les instructions pour taper vos premières touches.</p>"
+                  "content": "<p>Taper sur une touche, c’est <strong>appuyer une fois</strong> dessus et <strong>relâcher immédiatement</strong>.</p>"
                 },
                 {
                   "id": "274d2a22-5c45-40a3-87e2-13f650f49560",
-                  "type": "text",
-                  "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-1-zones/index.html\" height=\"445\"></iframe>"
+                  "type": "custom-draft",
+                  "title": "Élément interactif",
+                  "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-1-zones/index.html",
+                  "instruction": "<p><span aria-hidden=\"true\">👇</span> Préparez-vous à utiliser votre clavier et suivez les instructions pour taper vos premières touches.</p>",
+                  "height": 445
                 }
               ]
             }
@@ -204,17 +207,12 @@
         {
           "type": "element",
           "element": {
-            "id": "cfff35e1-f84d-48b1-95ae-4cc7f2ff79e0",
-            "type": "text",
-            "content": "<p><strong>Dans l’espace ci-dessous, cliquez dans la zone indiquée, puis tapez les mots demandés.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "62b13b03-4b39-4893-a3ac-5b55c5a4b0a2",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-2-saisie-1er-mots/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-2-saisie-1er-mots/index.html",
+            "instruction": "<p><strong>Dans l’espace ci-dessous, cliquez dans la zone indiquée, puis tapez les mots demandés.</strong></p>",
+            "height": 445
           }
         }
       ]
@@ -463,17 +461,12 @@
         {
           "type": "element",
           "element": {
-            "id": "5cea384d-f3bd-450c-b250-f6fb9a34cafa",
-            "type": "text",
-            "content": "<p><strong>Dans la zone ci-dessous, vous allez corriger une liste de courses en vous aidant des touches espace, entrée, effacer et des flèches.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "247c064e-8d6f-4b8c-9298-0a12f0643e27",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-3-listedecourse/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-3-listedecourse/index.html",
+            "instruction": "<p><strong>Dans la zone ci-dessous, vous allez corriger une liste de courses en vous aidant des touches espace, entrée, effacer et des flèches.</strong></p>",
+            "height": 445
           }
         },
         {
@@ -712,17 +705,12 @@
         {
           "type": "element",
           "element": {
-            "id": "2e384ac8-402c-4745-b187-3cb7fc3eb916",
-            "type": "text",
-            "content": "<p><strong>Dans la zone de texte ci-dessous, modifiez la phrase qui apparaît pour écrire :&nbsp;</strong> </p><p>«Quelle bonne idée d'avoir mis de la purée de cornichons dans le bac à glaçons.»<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "ddec6ee3-178f-4ab5-862a-fc776e9ff6f4",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-bossfinal2/index.html\" height=\"394\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-bossfinal2/index.html",
+            "instruction": "<p><strong>Dans la zone de texte ci-dessous, modifiez la phrase qui apparaît pour écrire :&nbsp;</strong> </p><p>«Quelle bonne idée d'avoir mis de la purée de cornichons dans le bac à glaçons.»<br></p>",
+            "height": 394
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -219,17 +219,12 @@
         {
           "type": "element",
           "element": {
-            "id": "566fe41a-c2fc-4745-bb0c-ea9a0d25eba6",
-            "type": "text",
-            "content": "<p><strong>Tapez chaque prénom ci-dessous avec une majuscule :</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "3b6efd13-0d4d-461c-a61a-15a58b46383a",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-majuscules/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-majuscules/index.html",
+            "instruction": "<p><strong>Tapez chaque prénom ci-dessous avec une majuscule :</strong></p>",
+            "height": 445
           }
         }
       ]
@@ -469,17 +464,12 @@
         {
           "type": "element",
           "element": {
-            "id": "276fb20d-3957-4c39-a1ff-c8a2cc235a0f",
-            "type": "text",
-            "content": "<p><strong>Dans la zone ci-dessous, tapez les caractères demandés grâce à la touche Alt Gr :</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "d74e4428-accc-44c4-b206-105d4dee8e12",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-AltGr/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-AltGr/index.html",
+            "instruction": "<p><strong>Dans la zone ci-dessous, tapez les caractères demandés grâce à la touche Alt Gr :</strong></p>",
+            "height": 445
           }
         }
       ]
@@ -612,17 +602,12 @@
         {
           "type": "element",
           "element": {
-            "id": "ca8c63e7-b192-4c9a-8f99-a4e54a2ea826",
-            "type": "text",
-            "content": "<p><strong>Dans l'espace ci-dessous, pour chaque niveau, tapez les caractères à l’écran dans la zone de texte pour les faire disparaître avant le temps imparti.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "0f0010c2-b794-49d3-9182-f813e416d317",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-jeuautomatisationtimerlong/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-jeuautomatisationtimerlong/index.html",
+            "instruction": "<p><strong>Dans l'espace ci-dessous, pour chaque niveau, tapez les caractères à l’écran dans la zone de texte pour les faire disparaître avant le temps imparti.</strong></p>",
+            "height": 445
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
@@ -100,17 +100,12 @@
         {
           "type": "element",
           "element": {
-            "id": "0d9bafd7-0845-484f-9fd4-c4123c30377b",
-            "type": "text",
-            "content": "<p><strong>Voici les photos de 3 personnes&nbsp;: sont-elles vraies ou fausses ?</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "9cad8650-9381-4d1e-92e5-81c68c7748a5",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-trivisage.html\" height=\"650\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-trivisage.html",
+            "instruction": "<p><strong>Voici les photos de 3 personnes&nbsp;: sont-elles vraies ou fausses ?</strong></p>",
+            "height": 550
           }
         }
       ]
@@ -195,8 +190,11 @@
           "type": "element",
           "element": {
             "id": "c5a52a17-163e-4969-8704-fab8f5ee500a",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-videoCaroline.html\" height=\"550\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-videoCaroline.html",
+            "instruction": "",
+            "height": 550
           }
         }
       ]
@@ -263,17 +261,12 @@
         {
           "type": "element",
           "element": {
-            "id": "7004de22-c4af-4e4e-ac47-1e08122e6de2",
-            "type": "text",
-            "content": "<p><strong>Pour chaque exemple de deepfake, choisissez la bonne réponse.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "652c79cc-b2d4-4279-9d95-8495fa81d56c",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-objectif.html\" height=\"600\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-objectif.html",
+            "instruction": "<p><strong>Pour chaque exemple de deepfake, choisissez la bonne réponse.</strong></p>",
+            "height": 550
           }
         }
       ]
@@ -552,17 +545,12 @@
         {
           "type": "element",
           "element": {
-            "id": "634ce6a5-46c4-4027-ac3b-9cc3fd36a13f",
-            "type": "text",
-            "content": "<p><strong>Lisez l’article ci-dessous, puis répondez aux questions.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "79936024-306f-4a46-b39e-db21e9c49a31",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-articlequestions.html\" height=\"625\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-articlequestions.html",
+            "instruction": "<p><strong>Lisez l’article ci-dessous, puis répondez aux questions.</strong></p>",
+            "height": 550
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -45,8 +45,11 @@
           "type": "element",
           "element": {
             "id": "a27b96cf-a0a7-45df-866a-313a1bd6caaf",
-            "type": "text",
-            "content": "<p> Derrière ces deux lettres, « I » et « A », se cache l'<strong>Intelligence Artificielle</strong>.<br><strong>À votre avis, de quand date l'expression « intelligence artificielle » ?</strong>&nbsp;⌛</p><iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-frise.html\" height=\"325\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-frise.html",
+            "instruction": "<p> Derrière ces deux lettres, « I » et « A », se cache l'<strong>Intelligence Artificielle</strong>.<br><strong>À votre avis, de quand date l'expression « intelligence artificielle » ?</strong>&nbsp;⌛</p>",
+            "height": 325
           }
         }
       ]
@@ -76,15 +79,18 @@
           "element": {
             "id": "937b62e7-c4f5-479a-8e1f-afbe7881fa92",
             "type": "text",
-            "content": "<p>Et si on regardait plus précisément ce qu'est l'IA ? Pour cela, partons de l’ordinateur !<br><strong>Selon vous, que peut faire un ordinateur ?</strong></p>"
+            "content": "<p>Et si on regardait plus précisément ce qu'est l'IA ? Pour cela, partons de l’ordinateur !</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "183c3094-b691-44ca-a75c-baed6b3c93c6",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-ordinateur.html\" height=\"650\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-ordinateur.html",
+            "instruction": "<p><strong>Selon vous, que peut faire un ordinateur ?</strong></p>",
+            "height": 550
           }
         }
       ]
@@ -129,15 +135,18 @@
           "element": {
             "id": "8dba133c-906f-4793-939f-015df7d2acce",
             "type": "text",
-            "content": "<p>Mariam est équipée de nombreux appareils électroniques.<br><strong>Survolez l'image pour explorer son salon pour trouver les appareils et les services qui utilisent des logiciels d'intelligence artificielle.</strong></p>"
+            "content": "<p>Mariam est équipée de nombreux appareils électroniques.</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "a066ebc9-7f82-439b-85c3-aa2e8686e52a",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-image-interactive.html\" height=\"520\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-image-interactive.html",
+            "instruction": "<p><strong>Survolez l'image pour explorer son salon pour trouver les appareils et les services qui utilisent des logiciels d'intelligence artificielle.</strong></p>",
+            "height": 520
           }
         },
         {
@@ -199,15 +208,18 @@
           "element": {
             "id": "a2b1291d-6043-4582-ac69-337835330c07",
             "type": "text",
-            "content": "<p>L’IA est aussi utilisée dans des secteurs d’activité professionnelle.<br>Voyons l'exemple de<strong> la reconnaissance d’image</strong>.&nbsp;🔎🖼️</p><p><strong>Retournez les cartes ci-dessous pour des exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité.</strong></p>"
+            "content": "<p>L’IA est aussi utilisée dans des secteurs d’activité professionnelle.<br>Voyons l'exemple de<strong> la reconnaissance d’image</strong>.&nbsp;🔎🖼️</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "c4a0562d-60f8-48b3-8489-2c8c195597b8",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-cartes.html\" height=\"590\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-cartes.html",
+            "instruction": "<p><strong>Retournez les cartes ci-dessous pour des exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité.</strong></p>",
+            "height": 550
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
@@ -94,15 +94,18 @@
           "element": {
             "id": "3147aedb-8fc2-4510-aad8-fa7f35e77dd7",
             "type": "text",
-            "content": "<p>Découvrez ci-dessous plusieurs exemples de réponses données par des logiciels d'IA générative. Ces exemples sont inspirés de réponses réelles.<br>Pour chacun des exemples, indiquez votre niveau de confiance en la réponse donnée par un logiciel d'IA générative.</p>"
+            "content": "<p>Découvrez ci-dessous plusieurs exemples de réponses données par des logiciels d'IA générative. Ces exemples sont inspirés de réponses réelles.</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "44ab1d9c-5cad-4bec-81ea-416dfd913635",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/LSI/ia-hallu-carousel.html \" height=\"600\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-hallu-carousel.html",
+            "instruction": "<p>Pour chacun des exemples, indiquez votre niveau de confiance en la réponse donnée par un logiciel d'IA générative.</p>",
+            "height": 550
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
@@ -79,17 +79,12 @@
         {
           "type": "element",
           "element": {
-            "id": "a89cbfef-8266-4bfd-a8d9-142999989c1b",
-            "type": "text",
-            "content": "<p>Cliquez sur les différentes zones de la conversation pour en apprendre plus.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "88af557c-e8f8-4bce-bc72-4f3aa35262fa",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/NAI/decouverteinterfaceIA.html\" height=\"600\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/NAI/decouverteinterfaceIA.html",
+            "instruction": "<p>Cliquez sur les différentes zones de la conversation pour en apprendre plus.</p>",
+            "height": 550
           }
         },
         {
@@ -167,17 +162,12 @@
         {
           "type": "element",
           "element": {
-            "id": "0a3d0ea4-e017-40a1-ae8c-b95275325a02",
-            "type": "text",
-            "content": "<p>Glissez et déposez chaque prompt dans la zone où l'on écrit les prompts.</p><p>Observez la réponse du logiciel d'IA générative.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "4f730efe-b5ff-4d66-ba0d-b0105d347dc4",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/NAI/observationreponseia.html\" height=\"500\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/NAI/observationreponseia.html",
+            "instruction": "<p>Glissez et déposez chaque prompt dans la zone où l'on écrit les prompts.</p><p>Observez la réponse du logiciel d'IA générative.</p>",
+            "height": 500
           }
         },
         {
@@ -257,15 +247,18 @@
           "element": {
             "id": "0a0f1cf5-3f03-448c-b551-93d51482ab33",
             "type": "text",
-            "content": "<p>Cette fois-ci, Gustave cherche une recette de gâteau pour 10 personnes.🍰Mais il est allergique au chocolat.🍫</p><p>Glissez et déposez les prompts suivants dans le champ de saisie et observez les réponses du logiciel d'IA générative.</p>"
+            "content": "<p>Cette fois-ci, Gustave cherche une recette de gâteau pour 10 personnes.🍰Mais il est allergique au chocolat.🍫</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "19a2c102-618f-497d-b68f-48a9bb72d1d7",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/NAI/Promptgateaupistache.html\" height=\"400\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/NAI/Promptgateaupistache.html",
+            "instruction": "<p>Glissez et déposez les prompts suivants dans le champ de saisie et observez les réponses du logiciel d'IA générative.</p>",
+            "height": 400
           }
         },
         {
@@ -435,17 +428,12 @@
         {
           "type": "element",
           "element": {
-            "id": "23a7796e-475a-467c-b2b1-f45e3a09c2ce",
-            "type": "text",
-            "content": "<p>Glissez et déposez le verbe qui convient le plus pour compléter chaque prompt ci-dessous en fonction des réponses de l'IA générative.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "63c7f73f-b9b1-4c9b-a983-29b5dc8030b9",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/NAI/glisserdeposerlesbonsverbes.html\" height=\"500\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/NAI/glisserdeposerlesbonsverbes.html",
+            "instruction": "<p>Glissez et déposez le verbe qui convient le plus pour compléter chaque prompt ci-dessous en fonction des réponses de l'IA générative.</p>",
+            "height": 500
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
@@ -95,15 +95,18 @@
           "element": {
             "id": "bbc2cbde-08d2-4869-a6d3-61ac27865f5a",
             "type": "text",
-            "content": "<p>Que se passe-t-il quand on fait une demande à un logiciel d’IA générative ?</p><p>Cliquez sur \"Commencer\" pour voir le trajet d'une demande à un logiciel d'IA générative</p>"
+            "content": "<p>Que se passe-t-il quand on fait une demande à un logiciel d’IA générative ?</p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "9cb3a20f-cedf-45c9-8910-1e8086fdd728",
-            "type": "text",
-            "content": "<iframe title=\"Trajet de la requête\" src=\"https://1024pix.github.io/atelier-contenus/FRI/protoAffichageProcessus02.html\" height=\"400\"></iframe>"
+            "type": "custom-draft",
+            "title": "Trajet de la requête",
+            "url": "https://1024pix.github.io/atelier-contenus/FRI/protoAffichageProcessus02.html",
+            "instruction": "<p>Cliquez sur \"Commencer\" pour voir le trajet d'une demande à un logiciel d'IA générative</p>",
+            "height": 400
           }
         },
         {
@@ -210,8 +213,11 @@
           "type": "element",
           "element": {
             "id": "6f6f9dd0-6252-44ee-b4b3-3ff40e8d1151",
-            "type": "text",
-            "content": "<iframe title=\"Traitement de la requête\" src=\"https://1024pix.github.io/atelier-contenus/FRI/affichageProcessusTraitementRequete.html\" height=\"500\"></iframe>"
+            "type": "custom-draft",
+            "title": "Traitement de la requête",
+            "url": "https://1024pix.github.io/atelier-contenus/FRI/affichageProcessusTraitementRequete.html",
+            "instruction": "",
+            "height": 500
           }
         }
       ]
@@ -276,15 +282,18 @@
           "element": {
             "id": "8286afa8-20b5-4e86-99bc-7daf29f91363",
             "type": "text",
-            "content": "<p>Imaginons que <strong>plusieurs personnes demandent la même chose en même temps</strong> à un logiciel d’IA générative. </p><p> Testez la <strong>capacité de calcul</strong> et la <strong>consommation électrique</strong> d’un supercalculateur en choisissant la demande et le nombre de requêtes. Puis répondez aux questions suivantes</p>"
+            "content": "<p>Imaginons que <strong>plusieurs personnes demandent la même chose en même temps</strong> à un logiciel d’IA générative. </p>"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "a44b87c8-ecf4-45dd-9cf7-1dc90492ef91",
-            "type": "text",
-            "content": "<iframe title=\"Requêtes multiples\" src=\"https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementInferenceSpinner02.html\" height=\"500\"></iframe>"
+            "type": "custom-draft",
+            "title": "Requêtes multiples",
+            "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementInferenceSpinner02.html",
+            "instruction": "<p> Testez la <strong>capacité de calcul</strong> et la <strong>consommation électrique</strong> d’un supercalculateur en choisissant la demande et le nombre de requêtes. Puis répondez aux questions suivantes</p>",
+            "height": 500
           }
         },
         {
@@ -764,8 +773,11 @@
           "type": "element",
           "element": {
             "id": "98bf1662-2985-452d-ba51-1d625f43bebb",
-            "type": "text",
-            "content": "<iframe title=\"Transfert impact\" src=\"https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementTransfert04.html\" height=\"800\"></iframe>"
+            "type": "custom-draft",
+            "title": "Transfert impact",
+            "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementTransfert04.html",
+            "instruction": "",
+            "height": 550
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
@@ -163,15 +163,18 @@
           "element": {
             "id": "77fa2e62-b572-40ed-ad92-2b6433efaf45",
             "type": "text",
-            "content": "<p>Gustave a envoyé les invitations pour le tournoi. Il a hâte !&nbsp; </p><p>Mais certaines personnes ne lui ont pas encore répondu…&nbsp; <br>Il veut écrire un message de relance mais il hésite sur la manière de le formuler.🤔 <br>Testez différents tons de messages avec l’IA.</p>\n"
+            "content": "<p>Gustave a envoyé les invitations pour le tournoi. Il a hâte !&nbsp; </p><p>Mais certaines personnes ne lui ont pas encore répondu…&nbsp; <br>Il veut écrire un message de relance mais il hésite sur la manière de le formuler.🤔 <br></p>\n"
           }
         },
         {
           "type": "element",
           "element": {
             "id": "4f35bf9d-e319-4a6d-b1f5-dc0a84f2139d",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/JTE/testerleton.html\" height=\"450\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/JTE/testerleton.html",
+            "instruction": "<p>Testez différents tons de messages avec l’IA.</p>",
+            "height": 450
           }
         }
       ]
@@ -614,8 +617,11 @@
           "type": "element",
           "element": {
             "id": "c992a84d-933f-4a33-8485-5b64cacd6aea",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/JTE/actualitestournoi.html\" height=\"900\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/JTE/actualitestournoi.html",
+            "instruction": "",
+            "height": 550
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
@@ -303,8 +303,11 @@
                 },
                 {
                   "id": "cccad926-00ec-456b-be8d-d864ad4b1ba8",
-                  "type": "text",
-                  "content": "<iframe title=\"conversation 1\" src=\"https://1024pix.github.io/atelier-contenus/RPE/ia-fonctionnement-debutant-poi2.html\" height=\"700\"></iframe>"
+                  "type": "custom-draft",
+                  "title": "conversation 1",
+                  "url": "https://1024pix.github.io/atelier-contenus/RPE/ia-fonctionnement-debutant-poi2.html",
+                  "instruction": "",
+                  "height": 550
                 },
                 {
                   "id": "fe0257bb-baa6-4c93-8341-4ee38a6a1a25",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -440,17 +440,12 @@
         {
           "type": "element",
           "element": {
-            "id": "d82abd07-8f51-442a-abfc-4ac939e7f27d",
-            "type": "text",
-            "content": "<p><strong>Observez les trois réponses que pourrait donner un logiciel d'IA générative à la demande d'un utilisateur, puis répondez à la question suivante.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "227a574b-c8b4-4c52-b339-423a2e676ed8",
-            "type": "text",
-            "content": "<iframe title=\"Preferences utilisateurs\" src=\"https://1024pix.github.io/atelier-contenus/MGO/ia-dec-pref-users\" height=\"500\"></iframe>"
+            "type": "custom-draft",
+            "title": "Preferences utilisateurs",
+            "url": "https://1024pix.github.io/atelier-contenus/MGO/ia-dec-pref-users",
+            "instruction": "<p><strong>Observez les trois réponses que pourrait donner un logiciel d'IA générative à la demande d'un utilisateur, puis répondez à la question suivante.</strong></p>",
+            "height": 500
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -267,8 +267,11 @@
           "type": "element",
           "element": {
             "id": "57d7453d-58a9-43f0-830c-f5f392b06f9e",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris1-DeplacerPointeur/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris1-DeplacerPointeur/index.html",
+            "instruction": "",
+            "height": 445
           }
         },
         {
@@ -304,17 +307,12 @@
         {
           "type": "element",
           "element": {
-            "id": "88dfe182-930b-4066-a9bb-7b6eba9cd9ae",
-            "type": "text",
-            "content": "\n<p><strong>👉Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong><br>Trois mots vont apparaître. Ce sont les noms des boutons de la souris.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "564448dc-6485-4918-a2c1-4452b2552650",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-3boutonsouris/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-3boutonsouris/index.html",
+            "instruction": "<p><strong>👉Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong><br>Trois mots vont apparaître. Ce sont les noms des boutons de la souris.</p>",
+            "height": 445
           }
         },
         {
@@ -446,17 +444,12 @@
         {
           "type": "element",
           "element": {
-            "id": "80070528-b2ca-4e93-99a6-bc495a6029ef",
-            "type": "text",
-            "content": "<p><strong>Dans la zone ci-dessous, faites un clic sur chaque élément lorsqu'il apparait.</strong><br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "73b6a6d3-8c76-46e9-ae1f-d208d5bf1960",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erclicsgauchesV2/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erclicsgauchesV2/index.html",
+            "instruction": "<p><strong>Dans la zone ci-dessous, faites un clic sur chaque élément lorsqu'il apparait.</strong></p>",
+            "height": 445
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -126,8 +126,11 @@
                 },
                 {
                   "id": "7aac23e0-6642-4ca4-928f-50e074dabc77",
-                  "type": "text",
-                  "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-molette2image/test image scroll-02-02.jpg\" width=\"788\" height=\"340\"></iframe>"
+                  "type": "custom-draft",
+                  "title": "Élément interactif",
+                  "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-molette2image/test%20image%20scroll-02-02.jpg",
+                  "instruction": "",
+                  "height": 340
                 }
               ]
             },
@@ -326,17 +329,12 @@
         {
           "type": "element",
           "element": {
-            "id": "aa057bdd-af4f-4ed1-985e-c98158db7f9d",
-            "type": "text",
-            "content": "<p>👉 <strong>Faites un double-clic sur chaque élément qui apparaît ci-dessous.</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
             "id": "be1b5866-6475-4bed-a775-e07be73f156e",
-            "type": "text",
-            "content": "<iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erdoublesclics/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erdoublesclics/index.html",
+            "instruction": "<p>👉 <strong>Faites un double-clic sur chaque élément qui apparaît ci-dessous.</strong></p>",
+            "height": 445
           }
         }
       ]
@@ -503,8 +501,11 @@
           "type": "element",
           "element": {
             "id": "fc26348a-dea8-4010-bfa6-efd0252b9516",
-            "type": "text",
-            "content": "<p><strong>Dans la zone ci-dessous, entraînez-vous à faire un clic droit puis un clic gauche à la suite.</strong></p><p><br></p><iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-clicdroitpuisgauche/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-clicdroitpuisgauche/index.html",
+            "instruction": "<p><strong>Dans la zone ci-dessous, entraînez-vous à faire un clic droit puis un clic gauche à la suite.</strong></p>",
+            "height": 445
           }
         }
       ]
@@ -567,8 +568,11 @@
           "type": "element",
           "element": {
             "id": "fe6818f4-ad9d-4b5e-bc58-b18cd1d6cee8",
-            "type": "text",
-            "content": "<p>Récapitulons tout ce que vous venez de voir dans ce module. <br></p><p><strong>Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong> <br>Pour chaque bouton, suivez les consignes.</p><iframe title=\"dnd\" src=\"https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-recap3boutonsbleu/index.html\" height=\"445\"></iframe>"
+            "type": "custom-draft",
+            "title": "Élément interactif",
+            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-recap3boutonsbleu/index.html",
+            "instruction": "<p>Récapitulons tout ce que vous venez de voir dans ce module. <br></p><p><strong>Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong> <br>Pour chaque bouton, suivez les consignes.</p>",
+            "height": 445
           }
         },
         {


### PR DESCRIPTION
## 🔆 Problème

Il devient difficile de distinguer les éléments temporaires appelés "POIC" des embeds, des `iframe` dans des textes et des éléments custom.

Laisser libre accès aux `iframe` est un risque pour la sécurité de la plateforme.

## ⛱️ Proposition
Migrer toutes les références à atelier-contenus vers le nouvel élément `custom-draft`.

Les objets dans `bases-clavier-1`, `bases-clavier-2`, `utiliser-souris-ordinateur-1` et `utiliser-souris-ordinateur-2` ont été conçus avec GDevelop avant qu'on ne parle de POI, pas certain qu'il faille les considérer de la même manière.

## 🌊 Remarques

RAS

## 🏄 Pour tester
Vérifier que les modules utilisés à l'extérieur sont toujours correctement utilisables.

- https://app-pr13070.review.pix.fr/modules/au-dela-des-mots-de-passe/passage (2 objets)
- https://app-pr13070.review.pix.fr/modules/bases-clavier-1/passage (4 objets)
- https://app-pr13070.review.pix.fr/modules/bases-clavier-2/passage (3 objets)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-deepfakes/passage (4 objets)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-dit-ia/passage (4 objets)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-hallu/passage (1 objet)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-premier-prompt/passage (4 objets)
- https://app-pr13070.review.pix.fr/modules/les-ia-generatives-consomment/passage (4 objets)
- https://app-pr13070.review.pix.fr/modules/tmp-prompt-intermediaire/passage (3 objets)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-fonctionnement-debut/passage (1 objet)
- https://app-pr13070.review.pix.fr/modules/tmp-ia-int-mgo/passage (2 objets)
- https://app-pr13070.review.pix.fr/modules/utiliser-souris-ordinateur-1/passage (3 objets)
- https://app-pr13070.review.pix.fr/modules/utiliser-souris-ordinateur-2/passage (4 objets)
