### PR TITLE
[BUGFIX] Réparer l'affichage d'analyse d'une campagne lorsqu'il y a beaucoup de participations (PIX-18957).  

### DIFF
--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -195,7 +195,7 @@ async function _getTargetProfileAndSkills(targetProfileId, profileType) {
     }
 
     const targetProfile = await knex('target-profiles').select('name', 'id').where({ id: targetProfileId }).first();
-    return { targetProfile, allSkills };
+    return { targetProfile, skills: allSkills };
   }
   _log('Création du profil cible...');
   const competences = await competenceRepository.listPixCompetencesOnly();
@@ -244,7 +244,7 @@ async function _createCampaign({ organizationId, campaignType, targetProfileId, 
     .insert({
       name: `Campaign_${organizationId}_${targetProfileId}`,
       code,
-      ownerId: 1,
+      ownerId: adminMemberId,
       organizationId,
       creatorId: adminMemberId,
       targetProfileId,


### PR DESCRIPTION
## 🔆 Problème

Actuellement, sur les campagnes avec beaucoup de participations (notre exemple en a 20 000), l'appel à l'API tombe en erreur et fait crasher le container avec un OOM. 

## ⛱️ Proposition

Récupérer les KE par batch plus petit pour éviter de tout casser.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- ~~Utiliser le script de génération de campaign `scripts/data-generation/generate-campaign-with-participants.js --organizationId 1000 --participantCount 20000 --targetProfileId 6000 --campaignType assessment`~~ le script ne fonctionne plus en l'état
- Se connecter sur Pix Orga, aller sur la campaign dans l'onglet analyse et constater le fonctionnement  
