### PR TITLE
[FEATURE] Permettre aux utilisateurs PixOrga de changer le nom et prenom de l'utilisateur (PIX-18729)

### DIFF
--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -63,12 +63,26 @@ const reconcileScoOrganizationLearnerAutomatically = async function (
   return h.response(dependencies.scoOrganizationLearnerSerializer.serializeIdentity(organizationLearner));
 };
 
+const updateOrganizationLearnerName = async function (request, h) {
+  const organizationLearnerId = request.params.organizationLearnerId;
+  const { firstName, lastName } = request.payload;
+
+  await usecases.updateOrganizationLearnerName({
+    organizationLearnerId,
+    firstName,
+    lastName,
+  });
+
+  return h.response().code(204);
+};
+
 const organizationLearnersController = {
   reconcileCommonOrganizationLearner,
   deleteOrganizationLearners,
   importOrganizationLearnerFromFeature,
   dissociate,
   reconcileScoOrganizationLearnerAutomatically,
+  updateOrganizationLearnerName,
 };
 
 export { organizationLearnersController };

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -40,6 +40,38 @@ const register = async (server) => {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/organizations/{organizationId}/organization-learners/{organizationLearnerId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+          {
+            method: securityPreHandlers.checkOrganizationDoesNotHaveFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
+            assign: 'organizationDoesNotHaveFeature',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            organizationLearnerId: identifiersType.organizationLearnerId,
+          }),
+          payload: Joi.object({
+            firstName: Joi.string().required(),
+            lastName: Joi.string().required(),
+          }),
+        },
+        handler: organizationLearnersController.updateOrganizationLearnerName,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
+            "- Elle permet la mise à jour du prénom et nom d'un prescrit",
+        ],
+        tags: ['api', 'organization-learners'],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/organizations/{organizationId}/import-organization-learners',
       config: {

--- a/api/src/prescription/learner-management/domain/errors.js
+++ b/api/src/prescription/learner-management/domain/errors.js
@@ -12,6 +12,12 @@ class OrganizationDoesNotHaveFeatureEnabledError extends DomainError {
   }
 }
 
+class OrganizationDoesHaveFeatureEnabledError extends DomainError {
+  constructor(message = 'The organization should not have the feature enabled') {
+    super(message);
+  }
+}
+
 class SiecleXmlImportError extends DomainError {
   constructor(code, meta) {
     super('An error occurred during Siecle XML import');
@@ -63,6 +69,7 @@ export {
   AggregateImportError,
   ComputeOrganizationLearnerCertificabilityJobProvidedDateError,
   CouldNotDeleteLearnersError,
+  OrganizationDoesHaveFeatureEnabledError,
   OrganizationDoesNotHaveFeatureEnabledError,
   OrganizationLearnerCertificabilityNotUpdatedError,
   OrganizationLearnerImportFormatNotFoundError,

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -110,6 +110,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {reconcileScoOrganizationLearnerAutomatically} reconcileScoOrganizationLearnerAutomatically
  * @property {replaceSupOrganizationLearners} replaceSupOrganizationLearners
  * @property {updateOrganizationLearnerImportFormats} updateOrganizationLearnerImportFormats
+ * @property {updateOrganizationLearnerName} updateOrganizationLearnerName
  * @property {updateStudentNumber} updateStudentNumber
  * @property {uploadCsvFile} uploadCsvFile
  * @property {uploadSiecleFile} uploadSiecleFile

--- a/api/src/prescription/learner-management/domain/usecases/update-organization-learner-name.js
+++ b/api/src/prescription/learner-management/domain/usecases/update-organization-learner-name.js
@@ -1,0 +1,14 @@
+const updateOrganizationLearnerName = async function ({
+  organizationLearnerId,
+  firstName,
+  lastName,
+  organizationLearnerRepository,
+}) {
+  await organizationLearnerRepository.updateName({
+    organizationLearnerId,
+    firstName,
+    lastName,
+  });
+};
+
+export { updateOrganizationLearnerName };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -383,6 +383,23 @@ const findOrganizationLearnerIdsBeforeImportFeatureFromOrganizationId = async fu
   return knexConn('view-active-organization-learners').where({ organizationId }).whereNull('attributes').pluck('id');
 };
 
+const updateName = async function ({ organizationLearnerId, firstName, lastName }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const updatedRows = await knexConn('organization-learners')
+    .where({ id: organizationLearnerId })
+    .whereNull('deletedAt')
+    .update({
+      firstName,
+      lastName,
+      updatedAt: new Date(),
+    });
+
+  if (updatedRows === 0) {
+    throw new NotFoundError(`Organization Learner not found for ID ${organizationLearnerId}`);
+  }
+};
+
 export {
   addOrUpdateOrganizationOfOrganizationLearners,
   countByUserId,
@@ -403,4 +420,5 @@ export {
   saveCommonOrganizationLearners,
   update,
   updateCertificability,
+  updateName,
 };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -20,6 +20,7 @@ import * as checkAdminMemberHasRoleSupportUseCase from './usecases/checkAdminMem
 import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
 import * as checkIfUserIsBlockedUseCase from './usecases/checkIfUserIsBlocked.js';
+import * as checkOrganizationDoesNotHaveFeatureUseCase from './usecases/checkOrganizationDoesNotHaveFeature.js';
 import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
 import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
 import * as checkUserBelongsToLearnersOrganizationUseCase from './usecases/checkUserBelongsToLearnersOrganization.js';
@@ -776,6 +777,21 @@ async function checkOrganizationHasFeature(request, h, dependencies = { checkOrg
   }
 }
 
+function checkOrganizationDoesNotHaveFeature(featureKey) {
+  return async function (request, h, dependencies = { checkOrganizationDoesNotHaveFeatureUseCase }) {
+    try {
+      const organizationId = request.params.organizationId || request.params.id;
+      await dependencies.checkOrganizationDoesNotHaveFeatureUseCase.execute({
+        organizationId,
+        featureKey,
+      });
+      return h.response(true);
+    } catch {
+      return _replyForbiddenError(h);
+    }
+  };
+}
+
 async function checkOrganizationAccess(request, h, dependencies = { checkOrganizationAccessUseCase }) {
   try {
     // yeah this is ugly. should rework that later.
@@ -829,6 +845,7 @@ const securityPreHandlers = {
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserIsMemberOfAnOrganization,
+  checkOrganizationDoesNotHaveFeature,
   checkUserIsAdminOfCertificationCenter,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,

--- a/api/src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js
+++ b/api/src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js
@@ -1,0 +1,14 @@
+import { OrganizationDoesHaveFeatureEnabledError } from '../../../prescription/learner-management/domain/errors.js';
+import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
+
+const execute = async ({ organizationId, featureKey, dependencies = { organizationFeatureRepository } }) => {
+  const isFeatureEnabled = await dependencies.organizationFeatureRepository.isFeatureEnabledForOrganization({
+    organizationId,
+    featureKey,
+  });
+  if (isFeatureEnabled) {
+    throw new OrganizationDoesHaveFeatureEnabledError();
+  }
+};
+
+export { execute };

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -555,4 +555,35 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
       expect(response.result).to.deep.equal(jsonApiError403);
     });
   });
+
+  describe('#makeCheckOrganizationDoesNotHaveFeature', function () {
+    it('should return a well formed JSON API error when organization has the enabled feature', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const { id: featureId } = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+      });
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId,
+        featureId,
+      });
+
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      const options = {
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/place-statistics`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
+  });
 });

--- a/api/tests/shared/integration/application/security-pre-handlers_test.js
+++ b/api/tests/shared/integration/application/security-pre-handlers_test.js
@@ -609,6 +609,81 @@ describe('Integration | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkOrganizationDoesNotHaveFeature', function () {
+    let httpServerTest;
+
+    beforeEach(async function () {
+      const moduleUnderTest = {
+        name: 'has-feature-test',
+        register: async function (server) {
+          server.route([
+            {
+              method: 'GET',
+              path: '/api/test/organizations/{organizationId}/features/{featureKey}',
+              handler: (r, h) => h.response().code(200),
+              config: {
+                auth: false,
+                pre: [
+                  {
+                    method: securityPreHandlers.checkOrganizationDoesNotHaveFeature(
+                      ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+                    ),
+                  },
+                ],
+              },
+            },
+          ]);
+        },
+      };
+      httpServerTest = new HttpTestServer();
+      await httpServerTest.register(moduleUnderTest);
+      httpServerTest.setupAuthentication();
+    });
+
+    it('should return 200 when organization does not have the feature', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const feature = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/test/organizations/${organizationId}/features/${feature.key}`,
+      };
+
+      // when
+      const response = await httpServerTest.requestObject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return a 403 when organization does not have an organization feature', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const feature = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      });
+      databaseBuilder.factory.buildOrganizationFeature({
+        featureId: feature.id,
+        organizationId,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/test/organizations/${organizationId}/features/fakeFeatureKey`,
+      };
+
+      // when
+      const response = await httpServerTest.requestObject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
   describe('#checkSchoolSessionIsActive', function () {
     let httpServerTest;
 

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -2007,6 +2007,139 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkOrganizationDoesNotHaveFeature', function () {
+    context('Successful case', function () {
+      let request;
+
+      beforeEach(function () {
+        request = {
+          params: { id: 1234 },
+        };
+      });
+
+      it('should authorize access to resource when the organization does NOT have feature enabled', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 1234;
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute.withArgs({ organizationId, featureKey }).resolves();
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.source).to.be.true;
+      });
+
+      it('should work with organizationId from params.organizationId', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 5678;
+        const request = {
+          params: { organizationId },
+        };
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute.withArgs({ organizationId, featureKey }).resolves();
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.source).to.be.true;
+        expect(checkOrganizationDoesNotHaveFeatureUseCaseStub.execute).to.have.been.calledOnceWithExactly({
+          organizationId,
+          featureKey,
+        });
+      });
+    });
+
+    context('Error cases', function () {
+      let request;
+
+      beforeEach(function () {
+        request = { params: { id: 1234 } };
+      });
+
+      it('should forbid resource access when organization DOES have feature enabled', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 1234;
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute
+          .withArgs({ organizationId, featureKey })
+          .rejects(new Error('Organization has feature enabled'));
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+
+      it('should forbid resource access when use case throws any error', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 1234;
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute
+          .withArgs({ organizationId, featureKey })
+          .rejects(new Error('Some unexpected error'));
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+
+      it('should handle different organization id sources correctly', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 9999;
+        const request = {
+          params: { organizationId },
+        };
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute
+          .withArgs({ organizationId, featureKey })
+          .rejects(new Error('Feature is enabled'));
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(checkOrganizationDoesNotHaveFeatureUseCaseStub.execute).to.have.been.calledOnceWithExactly({
+          organizationId,
+          featureKey,
+        });
+      });
+    });
+  });
+
   describe('#checkOrganizationAccess', function () {
     let request, checkOrganizationAccessUseCaseStub;
 

--- a/api/tests/shared/unit/application/validator/checkOrganizationDoesNotHaveFeature_test.js
+++ b/api/tests/shared/unit/application/validator/checkOrganizationDoesNotHaveFeature_test.js
@@ -1,0 +1,55 @@
+import { OrganizationDoesHaveFeatureEnabledError } from '../../../../../src/prescription/learner-management/domain/errors.js';
+import * as checkOrganizationDoesNotHaveFeatureUseCase from '../../../../../src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js';
+import { catchErr, expect, sinon } from '../../../../../tests/test-helper.js';
+
+describe('Unit | Application | Validator | checkOrganizationHasFeature', function () {
+  context('When organization does not have the feature enabled', function () {
+    it('should not throw', async function () {
+      // given
+      const organizationId = 'organizationId';
+      const featureKey = 'featureKey';
+      const organizationFeatureRepositoryStub = {
+        isFeatureEnabledForOrganization: sinon.stub(),
+      };
+
+      organizationFeatureRepositoryStub.isFeatureEnabledForOrganization
+        .withArgs({ organizationId, featureKey })
+        .resolves(false);
+
+      // when & then
+      expect(
+        async () =>
+          await checkOrganizationDoesNotHaveFeatureUseCase.execute({
+            organizationId,
+            featureKey,
+            dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
+          }),
+      ).to.not.throw();
+    });
+  });
+
+  context('When organization has the feature enabled', function () {
+    it('should throw', async function () {
+      // given
+      const organizationId = 'organizationId';
+      const featureKey = 'featureKey';
+      const organizationFeatureRepositoryStub = {
+        isFeatureEnabledForOrganization: sinon.stub(),
+      };
+
+      organizationFeatureRepositoryStub.isFeatureEnabledForOrganization
+        .withArgs({ organizationId, featureKey })
+        .resolves(true);
+
+      // when
+      const response = await catchErr(checkOrganizationDoesNotHaveFeatureUseCase.execute)({
+        organizationId,
+        featureKey,
+        dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
+      });
+
+      // then
+      expect(response).to.be.an.instanceOf(OrganizationDoesHaveFeatureEnabledError);
+    });
+  });
+});

--- a/orga/app/adapters/organization-participant.js
+++ b/orga/app/adapters/organization-participant.js
@@ -22,4 +22,14 @@ export default class OrganizationParticipantAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners`;
     return this.ajax(url, 'DELETE', { data: { listLearners: ids } });
   }
+
+  updateParticipantName(organizationId, learnerId, firstName, lastName) {
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners/${learnerId}`;
+    return this.ajax(url, 'PATCH', {
+      data: {
+        firstName,
+        lastName,
+      },
+    });
+  }
 }

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -25,6 +25,7 @@ import InElement from '../in-element';
 import SelectableList from '../selectable-list';
 import UiActionBar from '../ui/action-bar';
 import UiDeletionModal from '../ui/deletion-modal';
+import EditParticipantNameModal from '../ui/edit-participant-name-modal';
 import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip';
 import LearnerFilters from './learner-filters';
 
@@ -39,6 +40,9 @@ function stopPropagation(event) {
 
 export default class List extends Component {
   @tracked showDeletionModal = false;
+  @tracked showEditNameModal = false;
+  @tracked selectedParticipantForNameModification = null;
+
   @service currentUser;
   @service intl;
   @service locale;
@@ -88,7 +92,7 @@ export default class List extends Component {
   }
 
   get hasActionColumn() {
-    return this.currentUser.canActivateOralizationLearner;
+    return Boolean(this.actionsForParticipant().length);
   }
 
   get extraColumnRowInfo() {
@@ -118,6 +122,18 @@ export default class List extends Component {
   }
 
   @action
+  openEditNameModal(participant, event) {
+    event.stopPropagation();
+    this.selectedParticipantForNameModification = participant;
+    this.showEditNameModal = true;
+  }
+
+  @action
+  closeEditNameModal() {
+    this.showEditNameModal = false;
+  }
+
+  @action
   async deleteParticipants(selectedParticipants, resetParticipants) {
     await this.args.deleteParticipants(selectedParticipants);
     this.closeDeletionModal();
@@ -131,30 +147,34 @@ export default class List extends Component {
   }
 
   @action
-  addStopPropagationOnFunction(toggleParticipant, event) {
-    event.stopPropagation();
-    toggleParticipant();
-  }
-
-  @action
   actionsForParticipant(participant) {
-    if (!this.currentUser.canActivateOralizationLearner) {
-      return [];
+    const actions = [];
+
+    if (this.currentUser.canActivateOralizationLearner) {
+      const oralizationActivated = participant.extraColumns['ORALIZATION'];
+      actions.push([
+        {
+          label: oralizationActivated
+            ? this.intl.t('pages.organization-participants.table.actions.disable-oralization')
+            : this.intl.t('pages.organization-participants.table.actions.enable-oralization'),
+          onClick: () =>
+            this.args.toggleOralizationFeatureForParticipant(
+              participant.id,
+              this.currentUser.organization.id,
+              !oralizationActivated,
+            ),
+        },
+      ]);
     }
-    const oralizationActivated = participant.extraColumns['ORALIZATION'];
-    return [
-      {
-        label: oralizationActivated
-          ? this.intl.t('pages.organization-participants.table.actions.disable-oralization')
-          : this.intl.t('pages.organization-participants.table.actions.enable-oralization'),
-        onClick: () =>
-          this.args.toggleOralizationFeatureForParticipant(
-            participant.id,
-            this.currentUser.organization.id,
-            !oralizationActivated,
-          ),
-      },
-    ];
+
+    if (this.currentUser.canEditLearnerName) {
+      actions.push({
+        label: this.intl.t('components.ui.edit-participant-name-modal.label'),
+        onClick: this.openEditNameModal,
+      });
+    }
+
+    return actions;
   }
 
   <template>
@@ -362,7 +382,7 @@ export default class List extends Component {
                   >
                     <:default as |closeMenu|>
                       {{#each (this.actionsForParticipant participant) as |actionForPartipant|}}
-                        <DropdownItem @onClick={{actionForPartipant.onClick}} @closeMenu={{closeMenu}}>
+                        <DropdownItem @onClick={{fn actionForPartipant.onClick participant}} @closeMenu={{closeMenu}}>
                           {{actionForPartipant.label}}
                         </DropdownItem>
                       {{/each}}
@@ -397,6 +417,14 @@ export default class List extends Component {
             @showDeletionModal={{this.showDeletionModal}}
             @onTriggerAction={{fn this.deleteParticipants selectedParticipants reset}}
             @onCloseDeletionModal={{this.closeDeletionModal}}
+          />
+        {{/if}}
+
+        {{#if this.showEditNameModal}}
+          <EditParticipantNameModal
+            @participant={{this.selectedParticipantForNameModification}}
+            @show={{this.showEditNameModal}}
+            @onClose={{this.closeEditNameModal}}
           />
         {{/if}}
         <PixPaginationControl

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -13,6 +13,7 @@ import { CONNECTION_TYPES } from '../../helpers/connection-types';
 import ImportInformationBanner from '../import-information-banner';
 import InElement from '../in-element';
 import SelectableList from '../selectable-list';
+import EditParticipantNameModal from '../ui/edit-participant-name-modal';
 import EmptyState from '../ui/empty-state';
 import GenerateUsernamePasswordModal from './generate-username-password-modal';
 import ListActionBar from './list-action-bar';
@@ -44,6 +45,8 @@ export default class ScoList extends Component {
   @tracked isShowingAuthenticationMethodModal = false;
   @tracked showResetPasswordModal = false;
   @tracked showGenerateUsernamePasswordModal = false;
+  @tracked showEditNameModal = false;
+  @tracked selectedStudentForNameModification = null;
   @tracked divisions;
 
   @tracked affectedStudents = [];
@@ -124,6 +127,18 @@ export default class ScoList extends Component {
   }
 
   @action
+  openEditNameModal(student, event) {
+    event.stopPropagation();
+    this.selectedStudentForNameModification = student;
+    this.showEditNameModal = true;
+  }
+
+  @action
+  closeEditNameModal() {
+    this.showEditNameModal = false;
+  }
+
+  @action
   async generateUsernamePasswordForStudents(affectedStudents, resetSelectedStudents) {
     const affectedStudentsIds = affectedStudents.map((affectedStudents) => affectedStudents.id);
     try {
@@ -180,12 +195,6 @@ export default class ScoList extends Component {
     }
   }
 
-  @action
-  addStopPropagationOnFunction(toggleStudent, event) {
-    event.stopPropagation();
-    toggleStudent();
-  }
-
   <template>
     <ImportInformationBanner @importDetail={{@importDetail}} />
 
@@ -222,6 +231,8 @@ export default class ScoList extends Component {
               @student={{student}}
               @isStudentSelected={{isStudentSelected student}}
               @openAuthenticationMethodModal={{this.openAuthenticationMethodModal}}
+              @openEditNameModal={{this.openEditNameModal}}
+              @canEditLearnerName={{this.currentUser.canEditLearnerName}}
               @onToggleStudent={{fn withFunction (fn toggleStudent student) stopPropagation}}
               @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
             />
@@ -286,6 +297,12 @@ export default class ScoList extends Component {
         @student={{this.student}}
         @display={{this.isShowingAuthenticationMethodModal}}
         @onClose={{this.closeAuthenticationMethodModal}}
+      />
+
+      <EditParticipantNameModal
+        @participant={{this.selectedStudentForNameModification}}
+        @show={{this.showEditNameModal}}
+        @onClose={{this.closeEditNameModal}}
       />
     {{/let}}
   </template>

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -134,6 +134,11 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
           <Item @onClick={{fn @openAuthenticationMethodModal @student}}>
             {{t "pages.sco-organization-participants.actions.manage-account"}}
           </Item>
+          {{#if @canEditLearnerName}}
+            <Item @onClick={{fn @openEditNameModal @student}}>
+              {{t "components.ui.edit-participant-name-modal.label"}}
+            </Item>
+          {{/if}}
         </IconTrigger>
       {{/if}}</:cell>
   </PixTableColumn>

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -12,6 +12,7 @@ import ImportInformationBanner from '../import-information-banner';
 import InElement from '../in-element';
 import SelectableList from '../selectable-list';
 import DeletionModal from '../ui/deletion-modal';
+import EditParticipantNameModal from '../ui/edit-participant-name-modal';
 import EmptyState from '../ui/empty-state';
 import ActionBar from './action-bar';
 import EditStudentNumberModal from './modal/edit-student-number-modal';
@@ -24,6 +25,7 @@ export default class ListItems extends Component {
   @tracked selectedStudent = null;
   @tracked showDeletionModal = false;
   @tracked isShowingEditStudentNumberModal = false;
+  @tracked showEditNameModal = false;
   @tracked isLoadingGroups;
 
   constructor() {
@@ -92,6 +94,18 @@ export default class ListItems extends Component {
   }
 
   @action
+  openEditNameModal(student, event) {
+    event.stopPropagation();
+    this.selectedStudent = student;
+    this.showEditNameModal = true;
+  }
+
+  @action
+  closeEditNameModal() {
+    this.showEditNameModal = false;
+  }
+
+  @action
   async addResetOnFunction(wrappedFunction, resetParticipants, ...args) {
     await wrappedFunction(...args);
     resetParticipants();
@@ -126,6 +140,8 @@ export default class ListItems extends Component {
               @context={{context}}
               @isStudentSelected={{isStudentSelected student}}
               @openEditStudentNumberModal={{this.openEditStudentNumberModal}}
+              @openEditNameModal={{this.openEditNameModal}}
+              @canEditLearnerName={{this.currentUser.canEditLearnerName}}
               @isAdminInOrganization={{this.currentUser.isAdminInOrganization}}
               @onToggleStudent={{fn this.addStopPropagationOnFunction (fn toggleStudent student)}}
               @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
@@ -196,6 +212,12 @@ export default class ListItems extends Component {
         @onSubmit={{this.onSaveStudentNumber}}
       />
     {{/let}}
+
+    <EditParticipantNameModal
+      @participant={{this.selectedStudent}}
+      @show={{this.showEditNameModal}}
+      @onClose={{this.closeEditNameModal}}
+    />
   </template>
 }
 

--- a/orga/app/components/sup-organization-participant/table-row.gjs
+++ b/orga/app/components/sup-organization-participant/table-row.gjs
@@ -128,6 +128,11 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
           <Item @onClick={{fn @openEditStudentNumberModal @student}}>
             {{t "pages.sup-organization-participants.actions.edit-student-number"}}
           </Item>
+          {{#if @canEditLearnerName}}
+            <Item @onClick={{fn @openEditNameModal @student}}>
+              {{t "components.ui.edit-participant-name-modal.label"}}
+            </Item>
+          {{/if}}
         </IconTrigger>
       {{/if}}</:cell>
   </PixTableColumn>

--- a/orga/app/components/ui/edit-participant-name-modal.gjs
+++ b/orga/app/components/ui/edit-participant-name-modal.gjs
@@ -1,0 +1,128 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class EditParticipantNameModal extends Component {
+  @service notifications;
+  @service intl;
+  @service store;
+  @service currentUser;
+
+  @tracked firstName = '';
+  @tracked lastName = '';
+
+  @tracked isLoading = false;
+
+  errorMessage = 'Le nom ou le prénom ne peuvent pas être vides';
+
+  constructor(...args) {
+    super(...args);
+
+    this.firstName = this.args.participant?.firstName || '';
+    this.lastName = this.args.participant?.lastName || '';
+  }
+
+  submit(event) {
+    event.preventDefault();
+  }
+
+  @action
+  updateFirstName(event) {
+    this.firstName = event.target.value;
+  }
+
+  @action
+  updateLastName(event) {
+    this.lastName = event.target.value;
+  }
+
+  get hasChanges() {
+    return this.firstName !== this.args.participant?.firstName || this.lastName !== this.args.participant?.lastName;
+  }
+
+  get areFieldsValid() {
+    return Boolean(this.firstName.trim()) && Boolean(this.lastName.trim());
+  }
+
+  @action
+  async updateParticipantName() {
+    if (!this.areFieldsValid) {
+      return;
+    }
+
+    if (!this.hasChanges) {
+      this.notifications.success('Nom mis à jour avec succès');
+      return this.args.onClose();
+    }
+
+    this.isLoading = true;
+
+    try {
+      const adapter = this.store.adapterFor('organization-participant');
+
+      await adapter.updateParticipantName(
+        this.currentUser.organization.id,
+        this.args.participant.id,
+        this.firstName.trim(),
+        this.lastName.trim(),
+      );
+
+      this.args.participant.firstName = this.firstName.trim();
+      this.args.participant.lastName = this.lastName.trim();
+
+      this.notifications.success('Nom mis à jour avec succès');
+      this.args.onClose();
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue lors de la mise à jour du nom');
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <PixModal
+      @title={{t "components.ui.edit-participant-name-modal.label"}}
+      @showModal={{@show}}
+      @onCloseButtonClick={{@onClose}}
+    >
+      <:content>
+
+        <div class="name-edit-modal__content">
+          {{#unless this.areFieldsValid}}
+            {{t "components.ui.edit-participant-name-modal.error-message"}}
+          {{/unless}}
+
+          <PixInput
+            @id="firstName"
+            @value={{this.firstName}}
+            {{on "input" this.updateFirstName}}
+            @requiredLabel={{t "common.form.mandatory-fields-title"}}
+          >
+            <:label>{{t "components.ui.edit-participant-name-modal.fields.first-name"}}</:label>
+          </PixInput>
+
+          <PixInput @id="lastName" @value={{this.lastName}} {{on "input" this.updateLastName}} @requiredLabel={{true}}>
+            <:label>{{t "components.ui.edit-participant-name-modal.fields.last-name"}}</:label>
+          </PixInput>
+
+        </div>
+
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{@onClose}} @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+
+        <PixButton @triggerAction={{this.updateParticipantName}}>
+          {{t "common.actions.save"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -56,6 +56,10 @@ export default class CurrentUserService extends Service {
     return this.isAdminInOrganization && this.prescriber.hasCoverRateFeature;
   }
 
+  get canEditLearnerName() {
+    return this.isAdminInOrganization && !this.hasLearnerImportFeature && !this.organization.isManagingStudents;
+  }
+
   async load() {
     if (this.session.isAuthenticated) {
       try {

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -629,4 +629,8 @@ function routes() {
     };
     return json;
   });
+
+  this.patch('/organizations/:organizationId/organization-learners/:learnerId', function () {
+    return new Response(204);
+  });
 }

--- a/orga/tests/acceptance/organization-participant-list-test.js
+++ b/orga/tests/acceptance/organization-participant-list-test.js
@@ -1,4 +1,4 @@
-import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { t } from 'ember-intl/test-support';
@@ -40,7 +40,6 @@ module('Acceptance | Organization Participant List', function (hooks) {
         // when
         server.create('organization-participant', { organizationId, firstName: 'Xavier', lastName: 'Charles' });
 
-        await authenticateSession(user.id);
         const screen = await visit('/participants');
 
         // then
@@ -54,7 +53,6 @@ module('Acceptance | Organization Participant List', function (hooks) {
 
         server.create('organization-participant', { organizationId, firstName: 'Jean', lastName: 'Charles' });
 
-        await authenticateSession(user.id);
         const { getByLabelText } = await visit('/participants');
 
         // when
@@ -64,6 +62,41 @@ module('Acceptance | Organization Participant List', function (hooks) {
 
         // then
         assert.strictEqual(decodeURI(currentURL()), '/participants?certificability=["eligible"]');
+      });
+
+      test('it should successfully update participant name', async function (assert) {
+        // given
+        const organizationId = user.memberships.models[0].organizationId;
+        server.create('organization-participant', {
+          organizationId,
+          firstName: 'Jean',
+          lastName: 'Charles',
+        });
+        // Mock the API call
+
+        await authenticateSession(user.id);
+        const screen = await visit('/participants');
+
+        // when
+        const dropdownButton = screen.getByRole('button', { name: /afficher les actions/i });
+        await click(dropdownButton);
+
+        const editButton = screen.getByText(/modifier le/i);
+        await click(editButton);
+
+        const firstNameLabel = t('components.ui.edit-participant-name-modal.fields.first-name') + ' *';
+        const lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+
+        await fillByLabel(firstNameLabel, 'Pierre');
+        await fillByLabel(lastNameLabel, 'Martin');
+
+        await clickByName(t('common.actions.save'));
+
+        // then
+        assert.ok(await screen.findByText('Pierre'));
+        assert.ok(await screen.findByText('Martin'));
+        assert.notOk(screen.queryByText('Jean'));
+        assert.notOk(screen.queryByText('Charles'));
       });
     });
   });

--- a/orga/tests/acceptance/sco-organization-participant-list-test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list-test.js
@@ -403,5 +403,50 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
         });
       });
     });
+
+    module('When organization is SCO and not managing students', function (hooks) {
+      hooks.beforeEach(async function () {
+        user = createUserWithMembershipAndTermsOfServiceAccepted();
+        createPrescriberByUser({ user });
+
+        await authenticateSession(user.id);
+
+        const organizationId = user.memberships.models[0].organizationId;
+        server.create('organization-participant', {
+          organizationId,
+          firstName: 'Jean',
+          lastName: 'Charles',
+        });
+
+        await authenticateSession(user.id);
+      });
+
+      test('it should successfully update participant name', async function (assert) {
+        // given
+
+        const screen = await visit('/participants');
+
+        // when
+        const dropdownButton = screen.getByRole('button', { name: /afficher les actions/i });
+
+        await click(dropdownButton);
+        const editButton = screen.getByText(/modifier le/i);
+        await click(editButton);
+
+        const firstNameLabel = t('components.ui.edit-participant-name-modal.fields.first-name') + ' *';
+        const lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+
+        await fillByLabel(firstNameLabel, 'Pierre');
+        await fillByLabel(lastNameLabel, 'Martin');
+
+        await clickByName(t('common.actions.save'));
+
+        // then
+        assert.ok(await screen.findByText('Pierre'));
+        assert.ok(await screen.findByText('Martin'));
+        assert.notOk(screen.queryByText('Jean'));
+        assert.notOk(screen.queryByText('Charles'));
+      });
+    });
   });
 });

--- a/orga/tests/acceptance/sup-organization-participant-list-test.js
+++ b/orga/tests/acceptance/sup-organization-participant-list-test.js
@@ -135,5 +135,66 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
         assert.ok(within(modal).getByText('123'));
       });
     });
+
+    test('it should successfully update participant name', async function (assert) {
+      // given
+      const user = server.create('user', {
+        firstName: 'Harry',
+        lastName: 'Cover',
+        email: 'harry@cover.com',
+        lang: 'fr',
+        pixOrgaTermsOfServiceStatus: 'accepted',
+      });
+
+      const organization = server.create('organization', {
+        name: 'SUP Organization',
+        type: 'SUP',
+        isManagingStudents: false,
+      });
+
+      const memberships = server.create('membership', {
+        userId: user.id,
+        organizationId: organization.id,
+        organizationRole: 'ADMIN',
+      });
+
+      user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
+      user.memberships = [memberships];
+      createPrescriberByUser({ user });
+
+      await authenticateSession(user.id);
+
+      const organizationId = user.memberships.models[0].organizationId;
+      server.create('organization-participant', {
+        organizationId,
+        firstName: 'Jean',
+        lastName: 'Charles',
+      });
+      // Mock the API call
+
+      await authenticateSession(user.id);
+      const screen = await visit('/participants');
+
+      // when
+      const dropdownButton = screen.getByRole('button', { name: /afficher les actions/i });
+
+      await click(dropdownButton);
+      const editButton = screen.getByText(/modifier le/i);
+      await click(editButton);
+
+      const firstNameLabel = t('components.ui.edit-participant-name-modal.fields.first-name') + ' *';
+      const lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+
+      await clickByName(t('common.actions.save'));
+
+      // then
+      assert.ok(await screen.findByText('Pierre'));
+      assert.ok(await screen.findByText('Martin'));
+      assert.notOk(screen.queryByText('Jean'));
+      assert.notOk(screen.queryByText('Charles'));
+    });
   });
 });

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -62,6 +62,7 @@ function _addUserToOrganization(user, { externalId, organizationType } = {}) {
   const memberships = server.create('membership', {
     organizationId: organization.id,
     userId: user.id,
+    organizationRole: 'ADMIN',
   });
 
   user.userOrgaSettings = server.create('user-orga-setting', { user, organization });

--- a/orga/tests/integration/components/organization-participant/list-test.js
+++ b/orga/tests/integration/components/organization-participant/list-test.js
@@ -1091,6 +1091,147 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
     });
   });
 
+  module('edit modal functionality', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        canEditLearnerName = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      this.triggerFiltering = sinon.stub();
+      this.set('fullNameFilter', null);
+      this.set('certificabilityFilter', []);
+    });
+
+    test('it should display dropdown actions when user can edit learner name', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      // when
+      const screen = await render(hbs`<OrganizationParticipant::List
+        @participants={{this.participants}}
+        @triggerFiltering={{this.triggerFiltering}}
+        @onClickLearner={{this.noop}}
+        @fullName={{this.fullNameFilter}}
+        @certificabilityFilter={{this.certificabilityFilter}}
+      />`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('pages.sup-organization-participants.actions.show-actions') }));
+    });
+
+    test('it should open edit modal when clicking edit action', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      const screen = await render(hbs`<OrganizationParticipant::List
+        @participants={{this.participants}}
+        @triggerFiltering={{this.triggerFiltering}}
+        @onClickLearner={{this.noop}}
+        @fullName={{this.fullNameFilter}}
+        @certificabilityFilter={{this.certificabilityFilter}}
+      />`);
+
+      // when
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sup-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+
+      const editButton = screen.getByText(t('components.ui.edit-participant-name-modal.label'));
+      await click(editButton);
+
+      // then
+      assert.ok(screen.getByDisplayValue('Jean'));
+      assert.ok(screen.getByDisplayValue('Dupont'));
+    });
+
+    test('it should close edit modal when clicking close', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      const screen = await render(hbs`<OrganizationParticipant::List
+        @participants={{this.participants}}
+        @triggerFiltering={{this.triggerFiltering}}
+        @onClickLearner={{this.noop}}
+        @fullName={{this.fullNameFilter}}
+        @certificabilityFilter={{this.certificabilityFilter}}
+      />`);
+
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sup-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+
+      const editButton = screen.getByText(t('components.ui.edit-participant-name-modal.label'));
+      await click(editButton);
+
+      // when
+      const closeButton = screen.getByRole('button', {
+        name: t('common.actions.close'),
+      });
+      await click(closeButton);
+
+      // thenm
+      assert.notOk(screen.queryByDisplayValue('Jean'));
+      assert.notOk(screen.queryByDisplayValue('Dupont'));
+    });
+
+    test('it should not display dropdown actions when user cannot edit learner name', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        canEditLearnerName = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      // when
+      const screen = await render(hbs`<OrganizationParticipant::List
+        @participants={{this.participants}}
+        @triggerFiltering={{this.triggerFiltering}}
+        @onClickLearner={{this.noop}}
+        @fullName={{this.fullNameFilter}}
+        @certificabilityFilter={{this.certificabilityFilter}}
+      />`);
+
+      // then
+      assert.notOk(screen.queryByLabelText(t('pages.sup-organization-participants.actions.show-actions')));
+    });
+  });
+
   module('hide checkbox context', function () {
     test('when user is not admin of organisation', async function (assert) {
       //given

--- a/orga/tests/integration/components/sco-organization-participant/list-test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.js
@@ -1584,4 +1584,128 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       });
     });
   });
+
+  module('edit modal functionality', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        prescriber = {};
+        canEditLearnerName = true;
+        organization = store.createRecord('organization', {
+          id: '1',
+          divisions: [store.createRecord('division', { id: '3E', name: '3E' })],
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.set('divisions', []);
+      this.set('connectionTypes', []);
+      this.set('certificability', []);
+      this.set('search', null);
+    });
+
+    test('it should display dropdown actions when user can edit learner name', async function (assert) {
+      // given
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          username: 'jean.dupont0101',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @divisionsFilter={{this.divisions}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+      />`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }));
+    });
+
+    test('it should open edit modal when clicking edit action', async function (assert) {
+      // given
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          username: 'jean.dupont0101',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @divisionsFilter={{this.divisions}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+        @refreshValues={{this.noop}}
+      />`);
+
+      // when
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sco-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+      const editButton = screen.getByRole('button', { name: t('components.ui.edit-participant-name-modal.label') });
+
+      // then
+      assert.ok(editButton);
+      assert.dom(editButton).isNotDisabled();
+    });
+
+    test('it should not display dropdown actions when user cannot edit learner name', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        prescriber = {};
+        canEditLearnerName = false;
+        organization = store.createRecord('organization', {
+          id: '1',
+          divisions: [store.createRecord('division', { id: '3F', name: '3F' })],
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @divisionsFilter={{this.divisions}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+      />`);
+
+      // then
+      assert.notOk(
+        screen.queryByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }),
+      );
+    });
+  });
 });

--- a/orga/tests/integration/components/sup-organization-participant/list-test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list-test.js
@@ -607,8 +607,10 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
   });
 
   module('when user is admin of organisation', function (hooks) {
+    let store;
+
     hooks.beforeEach(function () {
-      const store = this.owner.lookup('service:store');
+      store = this.owner.lookup('service:store');
       const organization = store.createRecord('organization', { groups: [] });
 
       class CurrentUserStub extends Service {
@@ -1124,6 +1126,130 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
         //then
         assert.false(mainCheckbox.checked);
+      });
+    });
+
+    module('edit modal functionality', function (hooks) {
+      hooks.beforeEach(function () {
+        class CurrentUserStub extends Service {
+          canEditLearnerName = true;
+          isAdminInOrganization = true;
+          organization = store.createRecord('organization', {
+            isManagingStudents: false,
+            id: '1',
+          });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('groupsFilter', []);
+        this.set('search', null);
+      });
+
+      test('it should display dropdown actions when user can edit learner name', async function (assert) {
+        // given
+        const students = [
+          store.createRecord('sco-organization-participant', {
+            id: '1',
+            firstName: 'Jean',
+            lastName: 'Dupont',
+            username: 'jean.dupont0101',
+          }),
+        ];
+        this.set('students', students);
+
+        // when
+        const screen = await render(hbs`<SupOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @groupsFilter={{this.groupsFilter}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+      />`);
+
+        // then
+        assert.ok(screen.getByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }));
+      });
+
+      test('it should open edit modal when clicking edit action', async function (assert) {
+        // given
+        const students = [
+          store.createRecord('sco-organization-participant', {
+            id: '1',
+            firstName: 'Jean',
+            lastName: 'Dupont',
+            username: 'jean.dupont0101',
+            isAuthenticatedFromGar: false,
+          }),
+        ];
+        this.set('students', students);
+
+        const screen = await render(hbs`<SupOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @groupsFilter={{this.groupsFilter}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+        @refreshValues={{this.noop}}
+      />`);
+
+        // when
+        const dropdownButton = screen.getByRole('button', {
+          name: t('pages.sco-organization-participants.actions.show-actions'),
+        });
+        await click(dropdownButton);
+        const editButton = screen.getByRole('button', { name: t('components.ui.edit-participant-name-modal.label') });
+
+        // then
+        assert.ok(editButton);
+        assert.dom(editButton).isNotDisabled();
+      });
+
+      test('it should not display dropdown actions when user cannot edit learner name', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = {};
+          canEditLearnerName = false;
+          organization = store.createRecord('organization', {
+            id: '1',
+            divisions: [store.createRecord('division', { id: '3F', name: '3F' })],
+          });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        const students = [
+          store.createRecord('sco-organization-participant', {
+            id: '1',
+            firstName: 'Jean',
+            lastName: 'Dupont',
+            isAuthenticatedFromGar: false,
+          }),
+        ];
+        this.set('students', students);
+
+        // when
+        const screen = await render(hbs`<SupOrganizationParticipant::List
+        @students={{this.students}}
+        @onFilter={{this.noop}}
+        @searchFilter={{this.search}}
+        @groupsFilter={{this.groupsFilter}}
+        @connectionTypeFilter={{this.connectionTypes}}
+        @certificabilityFilter={{this.certificability}}
+        @onClickLearner={{this.noop}}
+        @onResetFilter={{this.noop}}
+      />`);
+
+        // then
+        assert.notOk(
+          screen.queryByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }),
+        );
       });
     });
   });

--- a/orga/tests/integration/components/ui/edit-participant-name-modal-test.gjs
+++ b/orga/tests/integration/components/ui/edit-participant-name-modal-test.gjs
@@ -1,0 +1,269 @@
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import EditParticipantNameModal from 'pix-orga/components/ui/edit-participant-name-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Ui::EditParticipantNameModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let closeStub;
+  let notificationsStub;
+  let storeStub;
+  let currentUserStub;
+  let adapterStub;
+  let participant;
+  let lastNameLabel;
+  let firstNameLabel;
+
+  hooks.beforeEach(function () {
+    participant = {
+      id: '123',
+      firstName: 'Jean',
+      lastName: 'Dupont',
+    };
+
+    closeStub = sinon.stub();
+    notificationsStub = this.owner.lookup('service:notifications');
+    storeStub = this.owner.lookup('service:store');
+    currentUserStub = this.owner.lookup('service:current-user');
+
+    adapterStub = {
+      updateParticipantName: sinon.stub(),
+    };
+
+    sinon.stub(notificationsStub, 'success');
+    sinon.stub(notificationsStub, 'error');
+    sinon.stub(storeStub, 'adapterFor').returns(adapterStub);
+
+    firstNameLabel = t('components.ui.edit-participant-name-modal.fields.first-name') + ' *';
+    lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+    lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+
+    currentUserStub.organization = { id: 'org-123' };
+  });
+
+  test('should render modal with participant data', async function (assert) {
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    assert.ok(screen.getByDisplayValue('Jean'));
+    assert.ok(screen.getByDisplayValue('Dupont'));
+  });
+
+  test('should pre-fill input fields with participant data', async function (assert) {
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    const firstNameInput = screen.getByDisplayValue('Jean');
+    const lastNameInput = screen.getByDisplayValue('Dupont');
+
+    assert.ok(firstNameInput);
+    assert.ok(lastNameInput);
+  });
+
+  test('should update firstName when typing in first name input', async function (assert) {
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    await fillByLabel(firstNameLabel, 'Pierre');
+
+    const firstNameInput = screen.getByDisplayValue('Pierre');
+    assert.ok(firstNameInput);
+  });
+
+  test('should update lastName when typing in last name input', async function (assert) {
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    await fillByLabel(lastNameLabel, 'Martin');
+
+    const lastNameInput = screen.getByDisplayValue('Martin');
+    assert.ok(lastNameInput);
+  });
+
+  module('validation', function () {
+    test('should show error message when first name is empty', async function (assert) {
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '');
+
+      assert.ok(screen.getByText(t('components.ui.edit-participant-name-modal.error-message')));
+    });
+
+    test('should show error message when last name is empty', async function (assert) {
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(lastNameLabel, '');
+
+      assert.ok(screen.getByText(t('components.ui.edit-participant-name-modal.error-message')));
+    });
+
+    test('should show error message when both names are empty', async function (assert) {
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '');
+      await fillByLabel(lastNameLabel, '');
+
+      assert.ok(screen.getByText(t('components.ui.edit-participant-name-modal.error-message')));
+    });
+
+    test('should not show error message when both fields are filled', async function (assert) {
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+
+      assert.notOk(screen.queryByText(t('components.ui.edit-participant-name-modal.error-message')));
+    });
+  });
+
+  module('save', function () {
+    test('should not call API when no changes are made', async function (assert) {
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.notCalled(adapterStub.updateParticipantName);
+      sinon.assert.calledWith(notificationsStub.success, 'Nom mis à jour avec succès');
+      sinon.assert.calledOnce(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should call API when changes are made', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(adapterStub.updateParticipantName, 'org-123', '123', 'Pierre', 'Martin');
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should update participant data and show success notification on successful save', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+      await clickByName(t('common.actions.save'));
+
+      assert.strictEqual(participant.firstName, 'Pierre');
+      assert.strictEqual(participant.lastName, 'Martin');
+      sinon.assert.calledWith(notificationsStub.success, 'Nom mis à jour avec succès');
+      sinon.assert.calledOnce(closeStub);
+    });
+
+    test('should show error notification on API failure', async function (assert) {
+      const error = new Error('API Error');
+      adapterStub.updateParticipantName.rejects(error);
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(notificationsStub.error, 'Une erreur est survenue lors de la mise à jour du nom');
+      sinon.assert.notCalled(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should not call API when fields are invalid', async function (assert) {
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.notCalled(adapterStub.updateParticipantName);
+      sinon.assert.notCalled(notificationsStub.success);
+      sinon.assert.notCalled(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should trim whitespace from names before saving', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '  Pierre  ');
+      await fillByLabel(lastNameLabel, '  Martin  ');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(adapterStub.updateParticipantName, 'org-123', '123', 'Pierre', 'Martin');
+      assert.strictEqual(participant.firstName, 'Pierre');
+      assert.strictEqual(participant.lastName, 'Martin');
+    });
+  });
+
+  module('close', function () {
+    test('should call onClose when cancel button is clicked', async function (assert) {
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await clickByName(t('common.actions.cancel'));
+
+      sinon.assert.calledOnce(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+  });
+});

--- a/orga/tests/unit/adapters/organization-participant-test.js
+++ b/orga/tests/unit/adapters/organization-participant-test.js
@@ -71,4 +71,26 @@ module('Unit | Adapters | organization-participant', function (hooks) {
       assert.ok(ajaxStub.calledWithExactly(url, 'DELETE'));
     });
   });
+
+  module('#updateParticipantName', () => {
+    test('should PATCH organization-learner name', async function (assert) {
+      // given
+      const organizationId = 1;
+      const learnerId = 2;
+      const firstName = 'John';
+      const lastName = 'Doe';
+
+      // when
+      adapter.updateParticipantName(organizationId, learnerId, firstName, lastName);
+
+      // then
+      const url = `${ENV.APP.API_HOST}/api/organizations/${organizationId}/organization-learners/${learnerId}`;
+      const expectedData = {
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+
+      assert.ok(ajaxStub.calledWithExactly(url, 'PATCH', { data: expectedData }));
+    });
+  });
 });

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -510,6 +510,56 @@ module('Unit | Service | current-user', function (hooks) {
         assert.false(currentUserService.canAccessStatisticsPage);
       });
     });
+
+    module('#canEditLearnerName', function () {
+      test('should return true if user is admin, organisation has no import feature and organization is not managing students', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.true(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if user is not admin', function (assert) {
+        currentUserService.isAdminInOrganization = false;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if user has import feature', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: true,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if organization is managing students', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: true,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+    });
   });
 
   module('user is not authenticated', function () {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -208,6 +208,7 @@
     "actions": {
       "back": "Retour",
       "cancel": "Annuler",
+      "save": "Enregistrer",
       "close": "Fermer",
       "confirm": "Confirmer",
       "global": "Actions",
@@ -393,6 +394,14 @@
       "deletion-modal": {
         "confirm-deletion": "Oui, je supprime",
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions"
+      },
+      "edit-participant-name-modal": {
+        "label": "Modifier le nom de l'utilisateur",
+        "error-message": "Le nom ou prénom de l'utilisateur ne peuvent pas être vide.",
+        "fields": {
+          "first-name": "Prénom",
+          "last-name": "Nom"
+        }
       }
     }
   },


### PR DESCRIPTION
## 🔆 Problème

Les utilisateurs de PixOrga souhaitent pouvoir modifier le nom des participants lorsque ceux ci ne sont pas crees via l'import. 

## ⛱️ Proposition

- Ajouter une modal sur PixOrga qui permette de changer le nom d'un utilisateur.
- Creer une route back qui gere le changement de nom

## 🏄 Pour tester

WIP