### PR TITLE
[FEATURE] Mettre à jour le feedback du schéma QAB (PIX-18964) (PIX-18900)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -440,7 +440,10 @@
                 "proposalB": "faux",
                 "solution": "A"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
@@ -521,7 +521,10 @@
                 "proposalB": "faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -306,7 +306,10 @@
                 "proposalB": "faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
@@ -696,7 +696,10 @@
                 "proposalB": "faux",
                 "solution": "A"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
@@ -528,7 +528,10 @@
                 "proposalB": "Flou et vague",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -681,7 +681,10 @@
                 "proposalB": "faux",
                 "solution": "A"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
@@ -647,7 +647,10 @@
                 "proposalB": "Faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
@@ -574,7 +574,10 @@
                 "proposalB": "faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -148,7 +148,10 @@
                 "proposalB": "faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]
@@ -599,7 +602,10 @@
                 "proposalB": "faux",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -463,7 +463,10 @@
                 "proposalB": "Le coeur",
                 "solution": "B"
               }
-            ]
+            ],
+            "feedback": {
+              "diagnosis": ""
+            }
           }
         }
       ]

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qab-schema.js
@@ -1,7 +1,6 @@
 import Joi from 'joi';
 
 import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
-import { feedbackNeutralSchema } from './feedback-neutral-schema.js';
 
 const qabElementSchema = Joi.object({
   id: uuidSchema,
@@ -22,7 +21,9 @@ const qabElementSchema = Joi.object({
     .min(1)
     .max(6)
     .required(),
-  feedback: feedbackNeutralSchema.optional(),
+  feedback: Joi.object({
+    diagnosis: htmlSchema.allow('').required(),
+  }).required(),
 }).required();
 
 export { qabElementSchema };


### PR DESCRIPTION
## 🔆 Problème

Après quelques tests sur les champs optionnels côté Joi et ce qui se passe côté modulix, nous nous sommes aperçus qu'on devait mettre un `allow('')` sur tous les WYSIWYG optionnels. 

## ⛱️ Proposition

Le faire sur le schéma du QAB côté feedback.

## 🌊 Remarques

- La PR https://github.com/1024pix/pix/pull/13065 doit être mergée avant !
- On n'utilise plus le schéma du feedback neutre car celui-ci a un champ diagnosis qui ne doit être pas vide. Cela est le cas sur les éléments QCU découverte et déclarative.
- Les modules ont été mis à jour pour refléter ce changement.

## 🏄 Pour tester
- Aller sur le module [bac-a-sable](https://app-pr13076.review.pix.fr/modules/bac-a-sable/passage)
- Faire le QAB et vérifier qu'il n'y a pas de régression !
