### PR TITLE
[FEATURE] Ajouter une api interne pour récuperer les orga learners et ses participations depuis un orga Id et user Id (PIX-18922)

### DIFF
--- a/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-with-participations-api.js
@@ -67,3 +67,11 @@ export async function find({ userIds }) {
     },
   );
 }
+
+export async function getByUserIdAndOrganizationId({ userId, organizationId }) {
+  const organizationLearnerWithParticipation = await usecases.getOrganizationLearnerWithParticipations({
+    userId,
+    organizationId,
+  });
+  return new OrganizationLearnerWithParticipations(organizationLearnerWithParticipation);
+}

--- a/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
+++ b/api/src/prescription/organization-learner/application/api/read-models/OrganizationLearnerWithParticipations.js
@@ -2,7 +2,6 @@ export class OrganizationLearnerWithParticipations {
   constructor({ organizationLearner, organization, campaignParticipations, tagNames }) {
     this.organizationLearner = {
       id: organizationLearner.id,
-      MEFCode: organizationLearner.MEFCode,
     };
     this.organization = {
       id: organization.id,

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-with-participations.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-with-participations.js
@@ -1,0 +1,25 @@
+export const getOrganizationLearnerWithParticipations = async function ({
+  organizationId,
+  userId,
+  organizationLearnerRepository,
+  organizationRepository,
+  campaignParticipationOverviewRepository,
+  tagRepository,
+}) {
+  const organizationLearnerId = await organizationLearnerRepository.getIdByUserIdAndOrganizationId({
+    organizationId,
+    userId,
+  });
+  const organization = await organizationRepository.get(organizationId);
+  const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByOrganizationLearnerId({
+    organizationLearnerId,
+  });
+  const tags = await tagRepository.findByIds(organization.tags.map((tag) => tag.id));
+
+  return {
+    organizationLearner: { id: organizationLearnerId },
+    organization,
+    campaignParticipations: campaignParticipationOverviews,
+    tagNames: tags.map((tag) => tag.name),
+  };
+};

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -175,10 +175,22 @@ async function getAttestationStatusForOrganizationLearnersAndKey({
   });
 }
 
+async function getIdByUserIdAndOrganizationId({ organizationId, userId }) {
+  const row = await knex('view-active-organization-learners')
+    .where('organizationId', organizationId)
+    .andWhere('userId', userId)
+    .first('id');
+  if (!row) {
+    throw new NotFoundError(`Learner not found for organization ID ${organizationId} and user Id ${userId}.`);
+  }
+  return row.id;
+}
+
 export {
   findOrganizationLearnersByDivisions,
   findPaginatedLearners,
   get,
   getAttestationsForOrganizationLearnersAndKey,
   getAttestationStatusForOrganizationLearnersAndKey,
+  getIdByUserIdAndOrganizationId,
 };

--- a/api/src/quest/domain/models/Eligibility.js
+++ b/api/src/quest/domain/models/Eligibility.js
@@ -2,7 +2,6 @@ export class Eligibility {
   constructor({ organizationLearner, organization, campaignParticipations = [] }) {
     this.organizationLearner = {
       id: organizationLearner?.id,
-      MEFCode: organizationLearner?.MEFCode,
     };
     this.organization = organization;
     this.campaignParticipations = campaignParticipations;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
@@ -1,0 +1,56 @@
+import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | UseCases | get-organization-learner-with-participations', function () {
+  it('should return organization learner with participations', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization();
+    const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId: organization.id,
+    });
+    const tags = [
+      databaseBuilder.factory.buildTag({ name: 'AEFE' }),
+      databaseBuilder.factory.buildTag({ name: 'AGRI' }),
+    ];
+    for (const tag of tags) {
+      databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag.id });
+    }
+    const firstTargetProfileId = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organization.id,
+    }).id;
+    const firstCampaign = databaseBuilder.factory.buildCampaign({ targetProfileId: firstTargetProfileId });
+    const firstCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: firstCampaign.id,
+      userId,
+      organizationLearnerId,
+    });
+
+    const secondTargetProfileId = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: organization.id,
+    }).id;
+    const secondCampaign = databaseBuilder.factory.buildCampaign({ targetProfileId: secondTargetProfileId });
+    const secondCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: secondCampaign.id,
+      userId,
+      organizationLearnerId,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getOrganizationLearnerWithParticipations({ userId, organizationId: organization.id });
+
+    // then
+    expect(result.organizationLearner.id).to.equal(organizationLearnerId);
+
+    expect(result.organization).to.be.an.instanceOf(Organization);
+    expect(result.organization.id).to.equal(organization.id);
+
+    expect(result.campaignParticipations).to.have.lengthOf(2);
+    expect(result.campaignParticipations[0]).to.be.an.instanceOf(CampaignParticipationOverview);
+    expect(result.campaignParticipations[1]).to.be.an.instanceOf(CampaignParticipationOverview);
+    const participationOverviewIds = result.campaignParticipations.map((participation) => participation.id);
+    expect(participationOverviewIds).to.have.members([firstCampaignParticipation.id, secondCampaignParticipation.id]);
+  });
+});

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -935,4 +935,25 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       });
     });
   });
+  describe('#getIdByUserIdAndOrganizationId', function () {
+    it('should throw if no organization learner is found', async function () {
+      const result = await catchErr(organizationLearnerRepository.getIdByUserIdAndOrganizationId)({
+        organizationId: 1,
+        userId: 123,
+      });
+
+      expect(result).to.be.instanceOf(NotFoundError);
+      expect(result.message).to.equal('Learner not found for organization ID 1 and user Id 123.');
+    });
+    it('should return existing organization learner for given id', async function () {
+      const organizationId = await databaseBuilder.factory.buildOrganization().id;
+      const userId = await databaseBuilder.factory.buildUser().id;
+      const organizationLearnerId = await databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId })
+        .id;
+      await databaseBuilder.commit();
+
+      const result = await organizationLearnerRepository.getIdByUserIdAndOrganizationId({ organizationId, userId });
+      expect(result).to.equal(organizationLearnerId);
+    });
+  });
 });

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerWithParticipations_test.js
@@ -39,7 +39,6 @@ describe('Unit | Application| API | Models | OrganizationLearnerWithParticipatio
     );
     expect(organizationLearnerWithParticipations.organizationLearner).to.deep.equal({
       id: organizationLearner.id,
-      MEFCode: organizationLearner.MEFCode,
     });
     expect(organizationLearnerWithParticipations.organization).to.deep.equal({
       id: organization.id,

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -72,4 +72,51 @@ describe('Unit | API | Organization Learner With Participations', function () {
       ]);
     });
   });
+
+  describe('#getByUserIdAndOrganizationId', function () {
+    it('should call the usecase and return OrganizationLearnerWithParticipations list', async function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const organization = domainBuilder.buildOrganization();
+      const organizationLearner = domainBuilder.buildOrganizationLearner({ userId: user.id, organization });
+      const campaignParticipations = [
+        domainBuilder.buildCampaignParticipationOverview(),
+        domainBuilder.buildCampaignParticipationOverview(),
+      ];
+      const tagNames = ['tagName1', 'tagName1'];
+
+      const useCaseStub = sinon.stub(usecases, 'getOrganizationLearnerWithParticipations');
+      useCaseStub
+        .withArgs({ organizationId: organization.id, userId: user.id })
+        .resolves({ organizationLearner, organization, campaignParticipations, tagNames });
+
+      // when
+      const apiResponse = await organizationLearnersWithParticipationsApi.getByUserIdAndOrganizationId({
+        userId: user.id,
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(useCaseStub).to.be.called;
+
+      expect(apiResponse).to.be.instanceOf(OrganizationLearnerWithParticipations);
+      expect(apiResponse).to.deep.equal({
+        organizationLearner: {
+          id: organizationLearner.id,
+        },
+        organization: {
+          id: organization.id,
+          isManagingStudents: organization.isManagingStudents,
+          tags: tagNames,
+          type: organization.type,
+        },
+        campaignParticipations: campaignParticipations.map(({ id, targetProfileId, status, campaignName }) => ({
+          id,
+          targetProfileId,
+          status,
+          campaignName,
+        })),
+      });
+    });
+  });
 });

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-with-participations-api_test.js
@@ -38,7 +38,6 @@ describe('Unit | API | Organization Learner With Participations', function () {
         {
           organizationLearner: {
             id: organizationLearner1.id,
-            MEFCode: organizationLearner1.MEFCode,
           },
           organization: {
             id: organization1.id,
@@ -56,7 +55,6 @@ describe('Unit | API | Organization Learner With Participations', function () {
         {
           organizationLearner: {
             id: organizationLearner2.id,
-            MEFCode: organizationLearner2.MEFCode,
           },
           organization: {
             id: organization2.id,

--- a/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
@@ -8,13 +8,13 @@ describe('Quest | Unit | Infrastructure | repositories | eligibility', function 
   describe('#find', function () {
     it('should call organizationLearnersWithParticipations api', async function () {
       // given
-      const mefCode = Symbol('organizationLearnerMefCode');
+      const organizationLearnerId = Symbol('organizationLearnerId');
       const organization = Symbol('organization');
       const targetProfileId = Symbol('targetProfileId');
       const apiResponseSymbol = [
         {
           organizationLearner: {
-            MEFCode: mefCode,
+            id: organizationLearnerId,
           },
           organization,
           campaignParticipations: [{ targetProfileId }],
@@ -35,8 +35,8 @@ describe('Quest | Unit | Infrastructure | repositories | eligibility', function 
       // then
       expect(result[0]).to.be.an.instanceof(Eligibility);
       expect(result[0].organization).to.equal(organization);
+      expect(result[0].organizationLearner.id).to.equal(organizationLearnerId);
       expect(result[0].campaignParticipations[0].targetProfileId).to.equal(targetProfileId);
-      expect(result[0].organizationLearner.MEFCode).to.equal(mefCode);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre des parcours combinés, nous avons besoin d'afficher à l'utilisateur les modulix recommandés à l'issue d'une campagne de diagnostique. La recommandation de modulix n'appartient pas au même bounded context que le parcours combiné.

## ⛱️ Proposition
Ajouter une api interne pour récupérer l'organization learner depuis un id d'orga et de son user id, ainsi que les participations associées

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

La CI est verte 🍏 
