### PR TITLE
[FEATURE] Modifier le texte de la carte de score (PIX-18967) (PIX-18900)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab-score-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-score-card.scss
@@ -3,16 +3,22 @@
 .qab-score-card {
   .qab-card__container {
     flex-direction: column;
-    gap: var(--pix-spacing-4x);
+    gap: var(--pix-spacing-1x);
     background: var(--pix-primary-700);
     border-color: var(--pix-primary-700);
   }
 
-  &__title {
-    @extend %pix-title-m;
-
+  &__title, &__subtitle {
     color: var(--pix-neutral-0);
     font-weight: 900;
     text-align: center;
+  }
+
+  &__title {
+    @extend %pix-title-m;
+  }
+
+  &__subtitle {
+    @extend %pix-title-xs;
   }
 }

--- a/mon-pix/app/components/module/element/qab/qab-score-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-score-card.gjs
@@ -4,8 +4,11 @@ import { t } from 'ember-intl';
   <div class="qab-card qab-score-card">
     <div class="qab-card__container">
       <h1 class="qab-score-card__title">
-        {{t "pages.modulix.qab.your_score" score=@score total=@total}}
+        {{t "pages.modulix.qab.score.title"}}
       </h1>
+      <h2 class="qab-score-card__subtitle">
+        {{t "pages.modulix.qab.score.yourScore" score=@score total=@total}}
+      </h2>
     </div>
   </div>
 </template>

--- a/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
@@ -7,7 +7,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | QabScoreCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display the score', async function (assert) {
+  test('it should display a title and the score', async function (assert) {
     // given
     const score = 4;
     const total = 5;
@@ -16,6 +16,7 @@ module('Integration | Component | Module | QabScoreCard', function (hooks) {
     const screen = await render(<template><QabScoreCard @score={{score}} @total={{total}} /></template>);
 
     // then
+    assert.dom(screen.getByRole('heading', { name: 'Série terminée' })).exists();
     assert.dom(screen.getByRole('heading', { name: 'Votre score : 4/5' })).exists();
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1752,7 +1752,10 @@
         "correct-answer": "Correct answer",
         "incorrect-answer": "Incorrect answer",
         "retry": "Retry",
-        "your_score": "Your score: {score}/{total}"
+        "score": {
+          "title": "Series completed",
+          "yourScore": "Your score: {score}/{total}"
+        }
       },
       "qcm": {
         "direction": "Select several answers."

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1738,7 +1738,10 @@
         "correct-answer": "Respuesta correcta",
         "incorrect-answer": "Respuesta incorrecta",
         "retry": "Volver a intentarlo",
-        "your_score": "Tu puntuación : {score}/{total}"
+        "score": {
+          "title": "Serie terminada",
+          "yourScore": "Tu puntuación : {score}/{total}"
+        }
       },
       "qcm": {
         "direction": "Seleccione varias respuestas."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1752,7 +1752,10 @@
         "correct-answer": "Bonne réponse !",
         "incorrect-answer": "Mauvaise réponse.",
         "retry": "Réessayer",
-        "your_score": "Votre score : {score}/{total}"
+        "score": {
+          "title": "Série terminée",
+          "yourScore": "Votre score : {score}/{total}"
+        }
       },
       "qcm": {
         "direction": "Sélectionnez plusieurs réponses."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1741,7 +1741,10 @@
         "correct-answer": "Correct antwoord",
         "incorrect-answer": "Onjuist antwoord",
         "retry": "Probeer het opnieuw",
-        "your_score": "Je score : {score}/{totalScore}"
+        "score": {
+          "title": "Serie beëindigd",
+          "yourScore": "Je score : {score}/{totalScore}"
+        }
       },
       "qcm": {
         "direction": "Kies meerdere antwoorden."


### PR DESCRIPTION
## 🔆 Problème

Suite à l'ajout des feedback sur le QAB, on veut mettre à jour les textes sur la carte de score avec une mention "Série terminée"

## ⛱️ Proposition

Le faire.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr13079.review.pix.fr/modules/bac-a-sable/details).
- Passer jusqu'au 3ème grain et répondre aux questions du QAB.
- Constater, lors de l'affichage du score, l'apparition d'un texte "Série terminée".
