### PR TITLE
[FEATURE] Supprimer isCancelled des routes d'annulation et de désannulation d'une certification (PIX-18855).

### DIFF
--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -591,7 +591,7 @@ function routes() {
   this.patch('/admin/certification-courses/:id/cancel', (schema, request) => {
     const certificationId = request.params.id;
     const certificationToUpdate = schema.certifications.find(certificationId);
-    certificationToUpdate.update({ isCancelled: true, status: assessmentResultStatus.CANCELLED });
+    certificationToUpdate.update({ status: assessmentResultStatus.CANCELLED });
 
     return new Response(204);
   });
@@ -599,7 +599,7 @@ function routes() {
   this.patch('/admin/certification-courses/:id/uncancel', (schema, request) => {
     const certificationId = request.params.id;
     const certificationToUpdate = schema.certifications.find(certificationId);
-    certificationToUpdate.update({ isCancelled: false, status: assessmentResultStatus.REJECTED });
+    certificationToUpdate.update({ status: assessmentResultStatus.REJECTED });
 
     return new Response(204);
   });

--- a/api/src/certification/session-management/domain/usecases/cancel.js
+++ b/api/src/certification/session-management/domain/usecases/cancel.js
@@ -40,8 +40,4 @@ export const cancel = async function ({
   if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
     await certificationRescoringRepository.rescoreV2Certification({ event });
   }
-
-  // Note: update after event to ensure we doing it well, even when rescoring. Needeed this only for v2 certification
-  certificationCourse.cancel();
-  await certificationCourseRepository.update({ certificationCourse });
 };

--- a/api/src/certification/session-management/domain/usecases/uncancel.js
+++ b/api/src/certification/session-management/domain/usecases/uncancel.js
@@ -29,9 +29,6 @@ export const uncancel = async function ({
     throw new NotFinalizedSessionError();
   }
 
-  certificationCourse.uncancel();
-  await certificationCourseRepository.update({ certificationCourse });
-
   const event = new CertificationUncancelled({
     certificationCourseId: certificationCourse.getId(),
     juryId,

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -296,7 +296,6 @@ describe('Certification | Session-management | Acceptance | Application | Routes
         sessionId: session.id,
         createdAt: new Date('2024-01-15'),
         abortReason: 'candidate',
-        isCancelled: true,
       });
       databaseBuilder.factory.buildCertificationCandidate({
         userId: certificationCourse.userId,
@@ -396,15 +395,8 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           juryId: juryMember.id,
         })
         .first();
-      const certificationCourseUncancelled = await knex('certification-courses')
-        .where({
-          id: certificationCourse.id,
-        })
-        .first();
 
       expect(response.statusCode).to.equal(204);
-
-      expect(certificationCourseUncancelled.isCancelled).to.equal(false);
       expect(rejectedAssessmentResult).not.to.be.undefined;
       expect(
         await knex('certification-courses-last-assessment-results').where({

--- a/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/cancel_test.js
@@ -7,7 +7,7 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-help
 describe('Certification | Session-management | Unit | Domain | UseCases | cancel', function () {
   describe('when it is a v2 certification', function () {
     describe('when session is finalized', function () {
-      it('should cancel the certification course', async function () {
+      it('should cancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -19,9 +19,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           sessionId: session.id,
           version: AlgorithmEngineVersion.V2,
         });
-        sinon.spy(certificationCourse, 'cancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
@@ -31,7 +29,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           rescoreV2Certification: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         certificationRescoringRepository.rescoreV2Certification.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
@@ -45,8 +42,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         });
 
         // then
-        expect(certificationCourse.cancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly({ certificationCourse });
         expect(certificationRescoringRepository.rescoreV2Certification).to.have.been.calledWithExactly({
           event: new CertificationCancelled({
             certificationCourseId: certificationCourse.getId(),
@@ -57,7 +52,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
     });
 
     describe('when session is not finalized', function () {
-      it('should not cancel the certification course', async function () {
+      it('should not cancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -69,16 +64,13 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           sessionId: session.id,
           version: AlgorithmEngineVersion.V2,
         });
-        sinon.spy(certificationCourse, 'cancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
           get: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
         // when
@@ -90,8 +82,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         });
 
         // then
-        expect(certificationCourse.cancel).to.not.have.been.called;
-        expect(certificationCourseRepository.update).to.not.have.been.called;
         expect(error).to.be.instanceOf(NotFinalizedSessionError);
       });
     });
@@ -99,7 +89,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
 
   describe('when it is a v3 certification', function () {
     describe('when session is finalized', function () {
-      it('should cancel the certification course', async function () {
+      it('should cancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -111,9 +101,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           sessionId: session.id,
           version: AlgorithmEngineVersion.V3,
         });
-        sinon.spy(certificationCourse, 'cancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
@@ -123,7 +111,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           rescoreV3Certification: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         certificationRescoringRepository.rescoreV3Certification.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
@@ -137,8 +124,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         });
 
         // then
-        expect(certificationCourse.cancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly({ certificationCourse });
         expect(certificationRescoringRepository.rescoreV3Certification).to.have.been.calledWithExactly({
           event: new CertificationCancelled({
             certificationCourseId: certificationCourse.getId(),
@@ -149,7 +134,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
     });
 
     describe('when session is not finalized', function () {
-      it('should not cancel the certification course', async function () {
+      it('should not cancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -161,16 +146,13 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
           sessionId: session.id,
           version: AlgorithmEngineVersion.V3,
         });
-        sinon.spy(certificationCourse, 'cancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
           get: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
         // when
@@ -182,8 +164,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | cancel
         });
 
         // then
-        expect(certificationCourse.cancel).to.not.have.been.called;
-        expect(certificationCourseRepository.update).to.not.have.been.called;
         expect(error).to.be.instanceOf(NotFinalizedSessionError);
       });
     });

--- a/api/tests/certification/session-management/unit/domain/usecases/uncancel_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/uncancel_test.js
@@ -6,7 +6,7 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-help
 
 describe('Certification | Session-management | Unit | Domain | UseCases | uncancel', function () {
   describe('when certification is a V2', function () {
-    it('should uncancel the certification course', async function () {
+    it('should uncancel the certification', async function () {
       // given
       const juryId = 123;
       const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -18,9 +18,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         sessionId: session.id,
         version: AlgorithmEngineVersion.V2,
       });
-      sinon.spy(certificationCourse, 'uncancel');
       const certificationCourseRepository = {
-        update: sinon.stub(),
         get: sinon.stub(),
       };
       const certificationRescoringRepository = {
@@ -30,7 +28,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         get: sinon.stub(),
       };
       certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      certificationCourseRepository.update.resolves();
       certificationRescoringRepository.rescoreV2Certification.resolves();
       sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
@@ -44,8 +41,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
       });
 
       // then
-      expect(certificationCourse.uncancel).to.have.been.calledOnce;
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly({ certificationCourse });
       expect(certificationRescoringRepository.rescoreV2Certification).to.have.been.calledWithExactly({
         event: new CertificationUncancelled({
           certificationCourseId: certificationCourse.getId(),
@@ -55,7 +50,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
     });
 
     describe('when session is not finalized', function () {
-      it('should not uncancel the certification course', async function () {
+      it('should not uncancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -67,16 +62,13 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
           sessionId: session.id,
           version: AlgorithmEngineVersion.V2,
         });
-        sinon.spy(certificationCourse, 'uncancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
           get: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
         // when
@@ -88,15 +80,13 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         });
 
         // then
-        expect(certificationCourse.uncancel).to.not.have.been.called;
-        expect(certificationCourseRepository.update).to.not.have.been.called;
         expect(error).to.be.instanceOf(NotFinalizedSessionError);
       });
     });
   });
 
   describe('when certification is a V3', function () {
-    it('should uncancel the certification course', async function () {
+    it('should uncancel the certification', async function () {
       // given
       const juryId = 123;
       const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -108,9 +98,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         sessionId: session.id,
         version: AlgorithmEngineVersion.V3,
       });
-      sinon.spy(certificationCourse, 'uncancel');
       const certificationCourseRepository = {
-        update: sinon.stub(),
         get: sinon.stub(),
       };
       const certificationRescoringRepository = {
@@ -120,7 +108,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         get: sinon.stub(),
       };
       certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-      certificationCourseRepository.update.resolves();
       certificationRescoringRepository.rescoreV3Certification.resolves();
       sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
@@ -134,8 +121,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
       });
 
       // then
-      expect(certificationCourse.uncancel).to.have.been.calledOnce;
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly({ certificationCourse });
       expect(certificationRescoringRepository.rescoreV3Certification).to.have.been.calledWithExactly({
         event: new CertificationUncancelled({
           certificationCourseId: certificationCourse.getId(),
@@ -145,7 +130,7 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
     });
 
     describe('when session is not finalized', function () {
-      it('should not uncancel the certification course', async function () {
+      it('should not uncancel the certification', async function () {
         // given
         const juryId = 123;
         const session = domainBuilder.certification.sessionManagement.buildSession({
@@ -157,16 +142,13 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
           sessionId: session.id,
           version: AlgorithmEngineVersion.V3,
         });
-        sinon.spy(certificationCourse, 'uncancel');
         const certificationCourseRepository = {
-          update: sinon.stub(),
           get: sinon.stub(),
         };
         const sessionRepository = {
           get: sinon.stub(),
         };
         certificationCourseRepository.get.withArgs({ id: 123 }).resolves(certificationCourse);
-        certificationCourseRepository.update.resolves();
         sessionRepository.get.withArgs({ id: certificationCourse.getSessionId() }).resolves(session);
 
         // when
@@ -178,8 +160,6 @@ describe('Certification | Session-management | Unit | Domain | UseCases | uncanc
         });
 
         // then
-        expect(certificationCourse.uncancel).to.not.have.been.called;
-        expect(certificationCourseRepository.update).to.not.have.been.called;
         expect(error).to.be.instanceOf(NotFinalizedSessionError);
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Le statut d’une certification est définit par l’assessment-result.
Ce dernier peut être `validated` si le candidat réussit sa certification ou bien `rejected` s'il échoue.
Et pour le cas d’une certification annulée, on ne se basait pas sur la même chose => On dépendait de `certification-courses.isCancelled`. Or ce statut doit être traité comme les autres et un chantier a été fait pour fixer ça 🥳 

Maintenant que toutes les certifications annulées se basent sur le statut de l'`assessment-result`, on peut supprimer tranquillement la présence du `isCancelled`.

## ⛱️ Proposition

Supprimer isCancelled des routes d'annulation et de désannulation d'une certification.

Ces routes sont utilisées par le métier sur Pix Admin pour traiter des certifications après finalisation.

## 🌊 Remarques

Cette PR devra être mergé avec celle-ci pour plus de confort : https://github.com/1024pix/pix/pull/13105
En effet le code de l'annulation d'une certification V2 est intrinsèquement lié avec le scoring.

Même si on touche plus trop aux v2 et qu'on finira pas supprimer isCancelled, on va éviter les décalages d'infos entre isCancelled et le statut d'assessment-result en prod.

## 🏄 Pour tester

Sur Pix Admin : https://admin-pr13083.review.pix.fr/certifications/1

- Annuler la certif de max 
- Constater sur la page de détails que le statut affiche `annulée`
- Constater en BDD, coté certification-courses, que le isCancelled n'a pas été mis à jour
- Constater en BDD qu'un nouvel assessment-result a été créé en statut cancelled
- Désannuler la certif de max
- Constater sur la page de détails que le statut affiche `validée`
- isCancelled bouge pas
- Constater en BDD qu'un nouvel assessment-result a été créé en statut validated