### PR TITLE
[FEATURE] Créer la colonne `target-profile-trainings.onlyForOrganizationIds` (PIX-18864)

### DIFF
--- a/api/db/migrations/20250801094559_add-target-profile-training-organizations-table.js
+++ b/api/db/migrations/20250801094559_add-target-profile-training-organizations-table.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'target-profile-training-organizations';
+
+/**
+ * Une ligne dans cette table permet à une organisation de recommander un CF par l'intermédiaire d'un PC.
+ * Le lien avec le profil cible est nécessaire car une organisation peut être relié au même CF pour plusieurs PC
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.integer('organizationId').unsigned();
+    table.foreign('organizationId').references('organizations.id');
+    table.integer('targetProfileTrainingId').unsigned();
+    table.foreign('targetProfileTrainingId').references('target-profile-trainings.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

On souhaite recommander des contenus formatifs uniquement à certaines organisations d'un profil cible.

## ⛱️ Proposition

Ajouter une colonne pour exclure une liste d'organisations d'accès à la relation profil cible / contenu formatif (`table target-profile-trainings`).

Par défaut on place la valeur `NULL` dans cette colonne pour indiquer que toutes les orgas y ont accès.

Si on demande à filtrer, alors on se base sur une relation entre `target-profiles-shares` et `target-profile-trainings.onlyForOrganizationIds`. Par défaut lorsqu'on créé un lien orga-PC sur un lien préfiltré, l'orga n'aura pas directement accès au CF, il faudra aller demander l'accès depuis la modale.

## 🌊 Remarques
RAS

## 🏄 Pour tester
- En local, lancer la commande `npm run db:migrate`.
- Vérifier que la colonne `onlyForOrganizationIds` dans la table `target-profile-trainings` est bien créée avec les valeures suivantes : 
  * `nullable`
  * default : `null`
  * type : JSONB
- Exécuter la commande `npm run rollback:latest`.
- Vérifier que la colonne est bien supprimée.
