### PR TITLE
[FEATURE] Suppression du bandeau hors CleA avant entrée en certification (PIX-18926).

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -28,6 +28,16 @@ const getCertificationCandidateSubscription = async function ({
     id: session.certificationCenterId,
   });
 
+  if (!center.isHabilitated(certificationCandidate.complementaryCertification.key)) {
+    return new CertificationCandidateSubscription({
+      id: certificationCandidateId,
+      sessionId: certificationCandidate.sessionId,
+      eligibleSubscriptions: [],
+      nonEligibleSubscription: null,
+      sessionVersion: session.version,
+    });
+  }
+
   let eligibleSubscriptions = [];
   let nonEligibleSubscription = null;
   const certifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
@@ -64,21 +74,19 @@ const getCertificationCandidateSubscription = async function ({
     });
   }
 
-  if (center.isHabilitated(certificationCandidate.complementaryCertification.key)) {
-    const isSubscriptionEligible =
-      doubleCertificationCertifiableBadgeAcquisition.complementaryCertificationKey ===
-      certificationCandidate.complementaryCertification.key;
+  const isSubscriptionEligible =
+    doubleCertificationCertifiableBadgeAcquisition.complementaryCertificationKey ===
+    certificationCandidate.complementaryCertification.key;
 
-    if (isSubscriptionEligible) {
-      eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
-        return {
-          label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
-          type: subscription.type,
-        };
-      });
-    } else {
-      nonEligibleSubscription = certificationCandidate.complementaryCertification;
-    }
+  if (isSubscriptionEligible) {
+    eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
+      return {
+        label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
+        type: subscription.type,
+      };
+    });
+  } else {
+    nonEligibleSubscription = certificationCandidate.complementaryCertification;
   }
 
   return new CertificationCandidateSubscription({

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -42,16 +42,7 @@ const getCertificationCandidateSubscription = async function ({
     !doubleCertificationCertifiableBadgeAcquisition &&
     certificationCandidate.complementaryCertification.key === ComplementaryCertificationKeys.CLEA
   ) {
-    return new CertificationCandidateSubscription({
-      id: certificationCandidateId,
-      sessionId: certificationCandidate.sessionId,
-      eligibleSubscriptions,
-      nonEligibleSubscription: {
-        label: certificationCandidate.complementaryCertification.label,
-        type: 'COMPLEMENTARY',
-      },
-      sessionVersion: session.version,
-    });
+    return _uneligibleCertificationCandidateSubscription(certificationCandidate, session);
   }
 
   if (!doubleCertificationCertifiableBadgeAcquisition) {
@@ -88,6 +79,19 @@ function _emptyCertificationCandidateSubscription(candidate, session) {
     sessionId: candidate.sessionId,
     eligibleSubscriptions: [],
     nonEligibleSubscription: null,
+    sessionVersion: session.version,
+  });
+}
+
+function _uneligibleCertificationCandidateSubscription(candidate, session) {
+  return new CertificationCandidateSubscription({
+    id: candidate.id,
+    sessionId: candidate.sessionId,
+    eligibleSubscriptions: [],
+    nonEligibleSubscription: {
+      label: candidate.complementaryCertification.label,
+      type: 'COMPLEMENTARY',
+    },
     sessionVersion: session.version,
   });
 }

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -14,7 +14,7 @@ const getCertificationCandidateSubscription = async function ({
 
   const session = await sessionRepository.get({ id: certificationCandidate.sessionId });
 
-  if (certificationCandidate.complementaryCertification?.key !== ComplementaryCertificationKeys.CLEA) {
+  if (!certificationCandidate.isEnrolledToDoubleCertification()) {
     return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -15,13 +15,7 @@ const getCertificationCandidateSubscription = async function ({
   const session = await sessionRepository.get({ id: certificationCandidate.sessionId });
 
   if (!certificationCandidate.complementaryCertification) {
-    return new CertificationCandidateSubscription({
-      id: certificationCandidateId,
-      sessionId: certificationCandidate.sessionId,
-      eligibleSubscriptions: [],
-      nonEligibleSubscription: null,
-      sessionVersion: session.version,
-    });
+    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
   const center = await centerRepository.getById({
@@ -29,13 +23,7 @@ const getCertificationCandidateSubscription = async function ({
   });
 
   if (!center.isHabilitated(certificationCandidate.complementaryCertification.key)) {
-    return new CertificationCandidateSubscription({
-      id: certificationCandidateId,
-      sessionId: certificationCandidate.sessionId,
-      eligibleSubscriptions: [],
-      nonEligibleSubscription: null,
-      sessionVersion: session.version,
-    });
+    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
   let eligibleSubscriptions = [];
@@ -64,14 +52,10 @@ const getCertificationCandidateSubscription = async function ({
       },
       sessionVersion: session.version,
     });
-  } else if (!doubleCertificationCertifiableBadgeAcquisition) {
-    return new CertificationCandidateSubscription({
-      id: certificationCandidateId,
-      sessionId: certificationCandidate.sessionId,
-      eligibleSubscriptions,
-      nonEligibleSubscription: null,
-      sessionVersion: session.version,
-    });
+  }
+
+  if (!doubleCertificationCertifiableBadgeAcquisition) {
+    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
   const isSubscriptionEligible =
@@ -97,5 +81,15 @@ const getCertificationCandidateSubscription = async function ({
     sessionVersion: session.version,
   });
 };
+
+function _emptyCertificationCandidateSubscription(candidate, session) {
+  return new CertificationCandidateSubscription({
+    id: candidate.id,
+    sessionId: candidate.sessionId,
+    eligibleSubscriptions: [],
+    nonEligibleSubscription: null,
+    sessionVersion: session.version,
+  });
+}
 
 export { getCertificationCandidateSubscription };

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -14,7 +14,7 @@ const getCertificationCandidateSubscription = async function ({
 
   const session = await sessionRepository.get({ id: certificationCandidate.sessionId });
 
-  if (!certificationCandidate.complementaryCertification) {
+  if (certificationCandidate.complementaryCertification?.key !== ComplementaryCertificationKeys.CLEA) {
     return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
@@ -36,22 +36,7 @@ const getCertificationCandidateSubscription = async function ({
       certifiableBadgeAcquisition.complementaryCertificationKey === ComplementaryCertificationKeys.CLEA,
   );
 
-  if (
-    !doubleCertificationCertifiableBadgeAcquisition &&
-    certificationCandidate.complementaryCertification.key === ComplementaryCertificationKeys.CLEA
-  ) {
-    return _uneligibleCertificationCandidateSubscription(certificationCandidate, session);
-  }
-
   if (!doubleCertificationCertifiableBadgeAcquisition) {
-    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
-  }
-
-  const isSubscriptionNonEligible =
-    doubleCertificationCertifiableBadgeAcquisition.complementaryCertificationKey !==
-    certificationCandidate.complementaryCertification.key;
-
-  if (isSubscriptionNonEligible) {
     return _uneligibleCertificationCandidateSubscription(certificationCandidate, session);
   }
 

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -52,23 +52,10 @@ const getCertificationCandidateSubscription = async function ({
     certificationCandidate.complementaryCertification.key;
 
   if (isSubscriptionNonEligible) {
-    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
+    return _uneligibleCertificationCandidateSubscription(certificationCandidate, session);
   }
 
-  const eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
-    return {
-      label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
-      type: subscription.type,
-    };
-  });
-
-  return new CertificationCandidateSubscription({
-    id: certificationCandidateId,
-    sessionId: certificationCandidate.sessionId,
-    eligibleSubscriptions,
-    nonEligibleSubscription: null,
-    sessionVersion: session.version,
-  });
+  return _eligibleCertificationCandidateSubscriptions(certificationCandidate, session);
 };
 
 function _emptyCertificationCandidateSubscription(candidate, session) {
@@ -90,6 +77,23 @@ function _uneligibleCertificationCandidateSubscription(candidate, session) {
       label: candidate.complementaryCertification.label,
       type: 'COMPLEMENTARY',
     },
+    sessionVersion: session.version,
+  });
+}
+
+function _eligibleCertificationCandidateSubscriptions(candidate, session) {
+  const eligibleSubscriptions = candidate.subscriptions.map((subscription) => {
+    return {
+      label: subscription.type === 'COMPLEMENTARY' ? candidate.complementaryCertification.label : null,
+      type: subscription.type,
+    };
+  });
+
+  return new CertificationCandidateSubscription({
+    id: candidate.id,
+    sessionId: candidate.sessionId,
+    eligibleSubscriptions,
+    nonEligibleSubscription: null,
     sessionVersion: session.version,
   });
 }

--- a/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js
@@ -26,8 +26,6 @@ const getCertificationCandidateSubscription = async function ({
     return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
-  let eligibleSubscriptions = [];
-  let nonEligibleSubscription = null;
   const certifiableBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
     userId: certificationCandidate.userId,
     limitDate: certificationCandidate.reconciledAt,
@@ -49,26 +47,26 @@ const getCertificationCandidateSubscription = async function ({
     return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
 
-  const isSubscriptionEligible =
-    doubleCertificationCertifiableBadgeAcquisition.complementaryCertificationKey ===
+  const isSubscriptionNonEligible =
+    doubleCertificationCertifiableBadgeAcquisition.complementaryCertificationKey !==
     certificationCandidate.complementaryCertification.key;
 
-  if (isSubscriptionEligible) {
-    eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
-      return {
-        label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
-        type: subscription.type,
-      };
-    });
-  } else {
-    nonEligibleSubscription = certificationCandidate.complementaryCertification;
+  if (isSubscriptionNonEligible) {
+    return _emptyCertificationCandidateSubscription(certificationCandidate, session);
   }
+
+  const eligibleSubscriptions = certificationCandidate.subscriptions.map((subscription) => {
+    return {
+      label: subscription.type === 'COMPLEMENTARY' ? certificationCandidate.complementaryCertification.label : null,
+      type: subscription.type,
+    };
+  });
 
   return new CertificationCandidateSubscription({
     id: certificationCandidateId,
     sessionId: certificationCandidate.sessionId,
     eligibleSubscriptions,
-    nonEligibleSubscription,
+    nonEligibleSubscription: null,
     sessionVersion: session.version,
   });
 };

--- a/api/src/shared/domain/models/CertificationCandidate.js
+++ b/api/src/shared/domain/models/CertificationCandidate.js
@@ -104,6 +104,10 @@ class CertificationCandidate {
   isEnrolledToComplementaryOnly() {
     return this.subscriptions.length === 1 && this.subscriptions[0].isComplementary();
   }
+
+  isEnrolledToDoubleCertification() {
+    return this.subscriptions.length === 2;
+  }
 }
 
 CertificationCandidate.BILLING_MODES = BILLING_MODES;

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -1,4 +1,5 @@
 import { getCertificationCandidateSubscription } from '../../../../../../src/certification/enrolment/domain/usecases/get-certification-candidate-subscription.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Enrolment | Unit | Domain | UseCase | get-certification-candidate-subscription', function () {
@@ -38,71 +39,142 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
 
   context('when certification center is not habilitated', function () {
     context('when the candidate is registered and eligible to one complementary certification', function () {
-      it('should return the candidate without eligible complementary certification', async function () {
-        // given
+      context('when the complementary certification is a doubled certification', function () {
+        it('should return the candidate with a non eligible complementary certification', async function () {
+          // given
 
-        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
+          const complementaryCertification = domainBuilder.buildComplementaryCertification({
+            key: ComplementaryCertificationKeys.CLEA,
+          });
 
-        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-          badge: domainBuilder.buildBadge({
-            key: 'PIX+_BADGE',
-            isCertifiable: true,
-          }),
-          complementaryCertification,
+          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            badge: domainBuilder.buildBadge({
+              key: 'PIX+_BADGE',
+              isCertifiable: true,
+            }),
+            complementaryCertification,
+          });
+
+          const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
+            ...certificationCandidateData,
+            complementaryCertification,
+          });
+
+          const center = domainBuilder.certification.enrolment.buildCenter({
+            habilitations: [],
+          });
+
+          certificationCandidateRepository.getWithComplementaryCertification
+            .withArgs({ id: certificationCandidateId })
+            .resolves(candidateWithComplementaryCertification);
+
+          sessionRepository.get.withArgs({ id: sessionId }).resolves(
+            domainBuilder.certification.enrolment.buildSession({
+              certificationCenterId: 777,
+              version: 2,
+            }),
+          );
+
+          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId, limitDate: candidateWithComplementaryCertification.reconciledAt })
+            .resolves([certifiableBadgeAcquisition]);
+
+          // when
+          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+            certificationCandidateId,
+            certificationBadgesService,
+            certificationCandidateRepository,
+            centerRepository,
+            sessionRepository,
+          });
+
+          // then
+          expect(certificationCandidateSubscription).to.deep.equal(
+            domainBuilder.buildCertificationCandidateSubscription({
+              id: certificationCandidateId,
+              sessionId,
+              eligibleSubscriptions: [],
+              nonEligibleSubscription: {
+                label: complementaryCertification.label,
+                type: 'COMPLEMENTARY',
+              },
+              sessionVersion: 2,
+            }),
+          );
         });
+      });
 
-        const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
-          ...certificationCandidateData,
-          complementaryCertification,
+      context('when the complementary certification is a not doubled certification', function () {
+        it('should return the candidate without eligible complementary certification', async function () {
+          // given
+
+          const complementaryCertification = domainBuilder.buildComplementaryCertification({
+            key: 'PIX+',
+          });
+
+          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            badge: domainBuilder.buildBadge({
+              key: 'PIX+_BADGE',
+              isCertifiable: true,
+            }),
+            complementaryCertification,
+          });
+
+          const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
+            ...certificationCandidateData,
+            complementaryCertification,
+          });
+
+          const center = domainBuilder.certification.enrolment.buildCenter({
+            habilitations: [],
+          });
+
+          certificationCandidateRepository.getWithComplementaryCertification
+            .withArgs({ id: certificationCandidateId })
+            .resolves(candidateWithComplementaryCertification);
+
+          sessionRepository.get.withArgs({ id: sessionId }).resolves(
+            domainBuilder.certification.enrolment.buildSession({
+              certificationCenterId: 777,
+              version: 2,
+            }),
+          );
+
+          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId, limitDate: candidateWithComplementaryCertification.reconciledAt })
+            .resolves([certifiableBadgeAcquisition]);
+
+          // when
+          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+            certificationCandidateId,
+            certificationBadgesService,
+            certificationCandidateRepository,
+            centerRepository,
+            sessionRepository,
+          });
+
+          // then
+          expect(certificationCandidateSubscription).to.deep.equal(
+            domainBuilder.buildCertificationCandidateSubscription({
+              id: certificationCandidateId,
+              sessionId,
+              eligibleSubscriptions: [],
+              nonEligibleSubscription: null,
+              sessionVersion: 2,
+            }),
+          );
         });
-
-        const center = domainBuilder.certification.enrolment.buildCenter({
-          habilitations: [],
-        });
-
-        certificationCandidateRepository.getWithComplementaryCertification
-          .withArgs({ id: certificationCandidateId })
-          .resolves(candidateWithComplementaryCertification);
-
-        sessionRepository.get.withArgs({ id: sessionId }).resolves(
-          domainBuilder.certification.enrolment.buildSession({
-            certificationCenterId: 777,
-            version: 2,
-          }),
-        );
-
-        centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-        certificationBadgesService.findStillValidBadgeAcquisitions
-          .withArgs({ userId })
-          .resolves([certifiableBadgeAcquisition]);
-
-        // when
-        const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-          certificationCandidateId,
-          certificationBadgesService,
-          certificationCandidateRepository,
-          centerRepository,
-          sessionRepository,
-        });
-
-        // then
-        expect(certificationCandidateSubscription).to.deep.equal(
-          domainBuilder.buildCertificationCandidateSubscription({
-            id: certificationCandidateId,
-            sessionId,
-            eligibleSubscriptions: [],
-            nonEligibleSubscription: null,
-            sessionVersion: 2,
-          }),
-        );
       });
     });
   });
 
   context('when certification center is habilitated', function () {
     context('when the candidate is not registered but eligible to one complementary certification', function () {
-      it('should return the candidate without any complementary certification', async function () {
+      it('should return the candidate without any eligible complementary certification', async function () {
         // given
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
@@ -167,83 +239,158 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
     });
 
     context('when the candidate is registered and eligible to one complementary certification', function () {
-      it('should return the candidate with one complementary certification', async function () {
-        // given
-        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
+      context('when the complementary certification is a not doubled certification', function () {
+        it('should return the candidate without any eligible complementary certification', async function () {
+          // given
+          const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
-        const center = domainBuilder.certification.enrolment.buildCenter({
-          habilitations: [
-            domainBuilder.certification.enrolment.buildHabilitation({
-              key: 'PIX+',
-            }),
-          ],
-        });
-
-        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-          badge: domainBuilder.buildBadge({
-            key: 'PIX+_BADGE',
-            isCertifiable: true,
-          }),
-          complementaryCertificationKey: complementaryCertification.key,
-          complementaryCertification,
-        });
-
-        const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
-          ...certificationCandidateData,
-          complementaryCertification,
-          subscriptions: [
-            domainBuilder.certification.enrolment.buildComplementarySubscription({
-              certificationCandidateId,
-              complementaryCertificationId: complementaryCertification.id,
-            }),
-          ],
-        });
-        certificationCandidateRepository.getWithComplementaryCertification
-          .withArgs({ id: certificationCandidateId })
-          .resolves(candidateWithoutComplementaryCertification);
-
-        sessionRepository.get.withArgs({ id: sessionId }).resolves(
-          domainBuilder.certification.enrolment.buildSession({
-            certificationCenterId: 777,
-            version: 2,
-          }),
-        );
-
-        centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-        certificationBadgesService.findStillValidBadgeAcquisitions
-          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
-          .resolves([certifiableBadgeAcquisition]);
-
-        // when
-        const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-          certificationCandidateId,
-          certificationBadgesService,
-          certificationCandidateRepository,
-          centerRepository,
-          sessionRepository,
-        });
-
-        // then
-        expect(certificationCandidateSubscription).to.deep.equal(
-          domainBuilder.buildCertificationCandidateSubscription({
-            id: certificationCandidateId,
-            sessionId,
-            eligibleSubscriptions: [
-              {
-                label: 'Complementary certification name',
-                type: 'COMPLEMENTARY',
-              },
+          const center = domainBuilder.certification.enrolment.buildCenter({
+            habilitations: [
+              domainBuilder.certification.enrolment.buildHabilitation({
+                key: 'PIX+',
+              }),
             ],
-            nonEligibleSubscription: null,
-            sessionVersion: 2,
-          }),
-        );
+          });
+
+          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            badge: domainBuilder.buildBadge({
+              key: 'PIX+_BADGE',
+              isCertifiable: true,
+            }),
+            complementaryCertificationKey: complementaryCertification.key,
+            complementaryCertification,
+          });
+
+          const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
+            ...certificationCandidateData,
+            complementaryCertification,
+            subscriptions: [
+              domainBuilder.certification.enrolment.buildComplementarySubscription({
+                certificationCandidateId,
+                complementaryCertificationId: complementaryCertification.id,
+              }),
+            ],
+          });
+          certificationCandidateRepository.getWithComplementaryCertification
+            .withArgs({ id: certificationCandidateId })
+            .resolves(candidateWithoutComplementaryCertification);
+
+          sessionRepository.get.withArgs({ id: sessionId }).resolves(
+            domainBuilder.certification.enrolment.buildSession({
+              certificationCenterId: 777,
+              version: 2,
+            }),
+          );
+
+          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
+            .resolves([certifiableBadgeAcquisition]);
+
+          // when
+          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+            certificationCandidateId,
+            certificationBadgesService,
+            certificationCandidateRepository,
+            centerRepository,
+            sessionRepository,
+          });
+
+          // then
+          expect(certificationCandidateSubscription).to.deep.equal(
+            domainBuilder.buildCertificationCandidateSubscription({
+              id: certificationCandidateId,
+              sessionId,
+              eligibleSubscriptions: [],
+              nonEligibleSubscription: null,
+              sessionVersion: 2,
+            }),
+          );
+        });
+      });
+
+      context('when the complementary certification is a doubled certification', function () {
+        it('should return the candidate with one eligible complementary certification', async function () {
+          // given
+          const complementaryCertification = domainBuilder.buildComplementaryCertification({
+            key: ComplementaryCertificationKeys.CLEA,
+          });
+
+          const center = domainBuilder.certification.enrolment.buildCenter({
+            habilitations: [
+              domainBuilder.certification.enrolment.buildHabilitation({
+                key: ComplementaryCertificationKeys.CLEA,
+              }),
+            ],
+          });
+
+          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            badge: domainBuilder.buildBadge({
+              key: 'PIX+_BADGE',
+              isCertifiable: true,
+            }),
+            complementaryCertificationKey: complementaryCertification.key,
+            complementaryCertification,
+          });
+
+          const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
+            ...certificationCandidateData,
+            complementaryCertification,
+            subscriptions: [
+              domainBuilder.certification.enrolment.buildComplementarySubscription({
+                certificationCandidateId,
+                complementaryCertificationId: complementaryCertification.id,
+              }),
+            ],
+          });
+          certificationCandidateRepository.getWithComplementaryCertification
+            .withArgs({ id: certificationCandidateId })
+            .resolves(candidateWithoutComplementaryCertification);
+
+          sessionRepository.get.withArgs({ id: sessionId }).resolves(
+            domainBuilder.certification.enrolment.buildSession({
+              certificationCenterId: 777,
+              version: 2,
+            }),
+          );
+
+          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
+            .resolves([certifiableBadgeAcquisition]);
+
+          // when
+          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+            certificationCandidateId,
+            certificationBadgesService,
+            certificationCandidateRepository,
+            centerRepository,
+            sessionRepository,
+          });
+
+          // then
+          expect(certificationCandidateSubscription).to.deep.equal(
+            domainBuilder.buildCertificationCandidateSubscription({
+              id: certificationCandidateId,
+              sessionId,
+              eligibleSubscriptions: [
+                {
+                  label: 'Complementary certification name',
+                  type: 'COMPLEMENTARY',
+                },
+              ],
+              nonEligibleSubscription: null,
+              sessionVersion: 2,
+            }),
+          );
+        });
       });
     });
 
     context('when the candidate is registered and not eligible to any complementary certification', function () {
-      it('should return the candidate without any complementary certification', async function () {
+      it('should return the candidate without any eligible complementary certification', async function () {
         // given
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
@@ -306,11 +453,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
             id: certificationCandidateId,
             sessionId,
             eligibleSubscriptions: [],
-            nonEligibleSubscription: {
-              id: 1,
-              key: 'PIX+',
-              label: 'Complementary certification name',
-            },
+            nonEligibleSubscription: null,
             sessionVersion: 2,
           }),
         );

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -40,19 +40,30 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
   context('when certification center is not habilitated', function () {
     context('when the candidate is registered and eligible to one complementary certification', function () {
       context('when the complementary certification is a doubled certification', function () {
-        it('should return the candidate with a non eligible complementary certification', async function () {
+        it('should return the candidate without any subscription', async function () {
           // given
 
           const complementaryCertification = domainBuilder.buildComplementaryCertification({
             key: ComplementaryCertificationKeys.CLEA,
           });
 
+          const badge = domainBuilder.buildBadge({
+            key: ComplementaryCertificationKeys.CLEA,
+            isCertifiable: true,
+          });
+
+          const complementaryCertificationBadge =
+            domainBuilder.certification.complementary.buildComplementaryCertificationBadge({
+              badgeId: badge.id,
+              complementaryCertificationId: complementaryCertification.id,
+            });
+
           const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            badge: domainBuilder.buildBadge({
-              key: 'PIX+_BADGE',
-              isCertifiable: true,
-            }),
-            complementaryCertification,
+            badgeId: badge.id,
+            badgeKey: badge.key,
+            complementaryCertificationId: complementaryCertification.id,
+            complementaryCertificationKey: complementaryCertification.key,
+            complementaryCertificationBadgeId: complementaryCertificationBadge.id,
           });
 
           const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
@@ -96,10 +107,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
               id: certificationCandidateId,
               sessionId,
               eligibleSubscriptions: [],
-              nonEligibleSubscription: {
-                label: complementaryCertification.label,
-                type: 'COMPLEMENTARY',
-              },
+              nonEligibleSubscription: null,
               sessionVersion: 2,
             }),
           );

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -37,179 +37,188 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
     };
   });
 
-  context('when certification center is not habilitated', function () {
-    context('when the candidate is registered and eligible to one complementary certification', function () {
-      context('when the complementary certification is a doubled certification', function () {
-        it('should return the candidate without any subscription', async function () {
-          // given
-
-          const complementaryCertification = domainBuilder.buildComplementaryCertification({
-            key: ComplementaryCertificationKeys.CLEA,
-          });
-
-          const badge = domainBuilder.buildBadge({
-            key: ComplementaryCertificationKeys.CLEA,
-            isCertifiable: true,
-          });
-
-          const complementaryCertificationBadge =
-            domainBuilder.certification.complementary.buildComplementaryCertificationBadge({
-              badgeId: badge.id,
-              complementaryCertificationId: complementaryCertification.id,
-            });
-
-          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            badgeId: badge.id,
-            badgeKey: badge.key,
-            complementaryCertificationId: complementaryCertification.id,
-            complementaryCertificationKey: complementaryCertification.key,
-            complementaryCertificationBadgeId: complementaryCertificationBadge.id,
-          });
-
-          const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
-            ...certificationCandidateData,
-            complementaryCertification,
-          });
-
-          const center = domainBuilder.certification.enrolment.buildCenter({
-            habilitations: [],
-          });
-
-          certificationCandidateRepository.getWithComplementaryCertification
-            .withArgs({ id: certificationCandidateId })
-            .resolves(candidateWithComplementaryCertification);
-
-          sessionRepository.get.withArgs({ id: sessionId }).resolves(
-            domainBuilder.certification.enrolment.buildSession({
-              certificationCenterId: 777,
-              version: 2,
-            }),
-          );
-
-          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-          certificationBadgesService.findStillValidBadgeAcquisitions
-            .withArgs({ userId, limitDate: candidateWithComplementaryCertification.reconciledAt })
-            .resolves([certifiableBadgeAcquisition]);
-
-          // when
-          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-            certificationCandidateId,
-            certificationBadgesService,
-            certificationCandidateRepository,
-            centerRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(certificationCandidateSubscription).to.deep.equal(
-            domainBuilder.buildCertificationCandidateSubscription({
-              id: certificationCandidateId,
-              sessionId,
-              eligibleSubscriptions: [],
-              nonEligibleSubscription: null,
-              sessionVersion: 2,
-            }),
-          );
-        });
+  context('when the candidate is not enrolled to any complementary certification', function () {
+    it('returns an empty certification candidate subscription', async function () {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...certificationCandidateData,
+        complementaryCertification: null,
+        subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId })],
       });
 
-      context('when the complementary certification is a not doubled certification', function () {
-        it('should return the candidate without eligible complementary certification', async function () {
-          // given
+      certificationCandidateRepository.getWithComplementaryCertification
+        .withArgs({ id: certificationCandidateId })
+        .resolves(certificationCandidate);
 
-          const complementaryCertification = domainBuilder.buildComplementaryCertification({
-            key: 'PIX+',
-          });
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(
+        domainBuilder.certification.enrolment.buildSession({
+          certificationCenterId: 777,
+          version: 2,
+        }),
+      );
 
-          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            badge: domainBuilder.buildBadge({
-              key: 'PIX+_BADGE',
-              isCertifiable: true,
-            }),
-            complementaryCertification,
-          });
-
-          const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
-            ...certificationCandidateData,
-            complementaryCertification,
-          });
-
-          const center = domainBuilder.certification.enrolment.buildCenter({
-            habilitations: [],
-          });
-
-          certificationCandidateRepository.getWithComplementaryCertification
-            .withArgs({ id: certificationCandidateId })
-            .resolves(candidateWithComplementaryCertification);
-
-          sessionRepository.get.withArgs({ id: sessionId }).resolves(
-            domainBuilder.certification.enrolment.buildSession({
-              certificationCenterId: 777,
-              version: 2,
-            }),
-          );
-
-          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-          certificationBadgesService.findStillValidBadgeAcquisitions
-            .withArgs({ userId, limitDate: candidateWithComplementaryCertification.reconciledAt })
-            .resolves([certifiableBadgeAcquisition]);
-
-          // when
-          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-            certificationCandidateId,
-            certificationBadgesService,
-            certificationCandidateRepository,
-            centerRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(certificationCandidateSubscription).to.deep.equal(
-            domainBuilder.buildCertificationCandidateSubscription({
-              id: certificationCandidateId,
-              sessionId,
-              eligibleSubscriptions: [],
-              nonEligibleSubscription: null,
-              sessionVersion: 2,
-            }),
-          );
-        });
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+        centerRepository,
+        sessionRepository,
       });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [],
+          nonEligibleSubscription: null,
+          sessionVersion: 2,
+        }),
+      );
     });
   });
 
-  context('when certification center is habilitated', function () {
-    context('when the candidate is not registered but eligible to one complementary certification', function () {
-      it('should return the candidate without any eligible complementary certification', async function () {
-        // given
-        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
+  context('when the candidate is enrolled to a "simple" complementary certification', function () {
+    it('returns an empty certification candidate subscription', async function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        key: 'PIX+SOMETHING',
+      });
 
-        const center = domainBuilder.certification.enrolment.buildCenter({
-          habilitations: [
-            domainBuilder.certification.enrolment.buildHabilitation({
-              key: 'PIX+',
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...certificationCandidateData,
+        complementaryCertification,
+        subscriptions: [
+          domainBuilder.certification.enrolment.buildComplementarySubscription({
+            certificationCandidateId,
+            complementaryCertificationId: complementaryCertification.id,
+          }),
+        ],
+      });
+
+      certificationCandidateRepository.getWithComplementaryCertification
+        .withArgs({ id: certificationCandidateId })
+        .resolves(certificationCandidate);
+
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(
+        domainBuilder.certification.enrolment.buildSession({
+          certificationCenterId: 777,
+          version: 2,
+        }),
+      );
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+        centerRepository,
+        sessionRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [],
+          nonEligibleSubscription: null,
+          sessionVersion: 2,
+        }),
+      );
+    });
+  });
+
+  context('when the center is not habilitated for the candidate whatever complementary certification', function () {
+    it('returns an empty certification candidate subscription', async function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        key: ComplementaryCertificationKeys.CLEA,
+      });
+
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...certificationCandidateData,
+        complementaryCertification,
+        subscriptions: [
+          domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId }),
+          domainBuilder.certification.enrolment.buildComplementarySubscription({
+            certificationCandidateId,
+            complementaryCertificationId: complementaryCertification.id,
+          }),
+        ],
+      });
+
+      const center = domainBuilder.certification.enrolment.buildCenter({
+        habilitations: [],
+      });
+
+      certificationCandidateRepository.getWithComplementaryCertification
+        .withArgs({ id: certificationCandidateId })
+        .resolves(certificationCandidate);
+
+      sessionRepository.get.withArgs({ id: sessionId }).resolves(
+        domainBuilder.certification.enrolment.buildSession({
+          certificationCenterId: 777,
+          version: 2,
+        }),
+      );
+
+      centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+      // when
+      const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+        certificationCandidateId,
+        certificationBadgesService,
+        certificationCandidateRepository,
+        centerRepository,
+        sessionRepository,
+      });
+
+      // then
+      expect(certificationCandidateSubscription).to.deep.equal(
+        domainBuilder.buildCertificationCandidateSubscription({
+          id: certificationCandidateId,
+          sessionId,
+          eligibleSubscriptions: [],
+          nonEligibleSubscription: null,
+          sessionVersion: 2,
+        }),
+      );
+    });
+  });
+
+  context(
+    'when the candidate is enrolled to a simple certification but got the double certification badge',
+    function () {
+      it('returns an empty certification candidate subscription', async function () {
+        // given
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({
+          key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+        });
+
+        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+          complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+        });
+
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...certificationCandidateData,
+          complementaryCertification,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId,
+              complementaryCertificationId: complementaryCertification.id,
             }),
           ],
         });
 
-        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-          badge: domainBuilder.buildBadge({
-            key: 'PIX+_BADGE',
-            isCertifiable: true,
-          }),
-          complementaryCertification,
+        const center = domainBuilder.certification.enrolment.buildCenter({
+          habilitations: [complementaryCertification],
         });
 
-        const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
-          ...certificationCandidateData,
-          complementaryCertification: null,
-          subscriptions: [],
-        });
         certificationCandidateRepository.getWithComplementaryCertification
           .withArgs({ id: certificationCandidateId })
-          .resolves(candidateWithoutComplementaryCertification);
+          .resolves(certificationCandidate);
 
         sessionRepository.get.withArgs({ id: sessionId }).resolves(
           domainBuilder.certification.enrolment.buildSession({
@@ -221,7 +230,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
         centerRepository.getById.withArgs({ id: 777 }).resolves(center);
 
         certificationBadgesService.findStillValidBadgeAcquisitions
-          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
+          .withArgs({ userId, limitDate: certificationCandidate.reconciledAt })
           .resolves([certifiableBadgeAcquisition]);
 
         // when
@@ -244,194 +253,36 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
           }),
         );
       });
-    });
+    },
+  );
 
-    context('when the candidate is registered and eligible to one complementary certification', function () {
-      context('when the complementary certification is a not doubled certification', function () {
-        it('should return the candidate without any eligible complementary certification', async function () {
-          // given
-          const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
-
-          const center = domainBuilder.certification.enrolment.buildCenter({
-            habilitations: [
-              domainBuilder.certification.enrolment.buildHabilitation({
-                key: 'PIX+',
-              }),
-            ],
-          });
-
-          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            badge: domainBuilder.buildBadge({
-              key: 'PIX+_BADGE',
-              isCertifiable: true,
-            }),
-            complementaryCertificationKey: complementaryCertification.key,
-            complementaryCertification,
-          });
-
-          const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
-            ...certificationCandidateData,
-            complementaryCertification,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId,
-                complementaryCertificationId: complementaryCertification.id,
-              }),
-            ],
-          });
-          certificationCandidateRepository.getWithComplementaryCertification
-            .withArgs({ id: certificationCandidateId })
-            .resolves(candidateWithoutComplementaryCertification);
-
-          sessionRepository.get.withArgs({ id: sessionId }).resolves(
-            domainBuilder.certification.enrolment.buildSession({
-              certificationCenterId: 777,
-              version: 2,
-            }),
-          );
-
-          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-          certificationBadgesService.findStillValidBadgeAcquisitions
-            .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
-            .resolves([certifiableBadgeAcquisition]);
-
-          // when
-          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-            certificationCandidateId,
-            certificationBadgesService,
-            certificationCandidateRepository,
-            centerRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(certificationCandidateSubscription).to.deep.equal(
-            domainBuilder.buildCertificationCandidateSubscription({
-              id: certificationCandidateId,
-              sessionId,
-              eligibleSubscriptions: [],
-              nonEligibleSubscription: null,
-              sessionVersion: 2,
-            }),
-          );
-        });
-      });
-
-      context('when the complementary certification is a doubled certification', function () {
-        it('should return the candidate with one eligible complementary certification', async function () {
-          // given
-          const complementaryCertification = domainBuilder.buildComplementaryCertification({
-            key: ComplementaryCertificationKeys.CLEA,
-          });
-
-          const center = domainBuilder.certification.enrolment.buildCenter({
-            habilitations: [
-              domainBuilder.certification.enrolment.buildHabilitation({
-                key: ComplementaryCertificationKeys.CLEA,
-              }),
-            ],
-          });
-
-          const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            badge: domainBuilder.buildBadge({
-              key: 'PIX+_BADGE',
-              isCertifiable: true,
-            }),
-            complementaryCertificationKey: complementaryCertification.key,
-            complementaryCertification,
-          });
-
-          const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
-            ...certificationCandidateData,
-            complementaryCertification,
-            subscriptions: [
-              domainBuilder.certification.enrolment.buildComplementarySubscription({
-                certificationCandidateId,
-                complementaryCertificationId: complementaryCertification.id,
-              }),
-            ],
-          });
-          certificationCandidateRepository.getWithComplementaryCertification
-            .withArgs({ id: certificationCandidateId })
-            .resolves(candidateWithoutComplementaryCertification);
-
-          sessionRepository.get.withArgs({ id: sessionId }).resolves(
-            domainBuilder.certification.enrolment.buildSession({
-              certificationCenterId: 777,
-              version: 2,
-            }),
-          );
-
-          centerRepository.getById.withArgs({ id: 777 }).resolves(center);
-
-          certificationBadgesService.findStillValidBadgeAcquisitions
-            .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
-            .resolves([certifiableBadgeAcquisition]);
-
-          // when
-          const certificationCandidateSubscription = await getCertificationCandidateSubscription({
-            certificationCandidateId,
-            certificationBadgesService,
-            certificationCandidateRepository,
-            centerRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(certificationCandidateSubscription).to.deep.equal(
-            domainBuilder.buildCertificationCandidateSubscription({
-              id: certificationCandidateId,
-              sessionId,
-              eligibleSubscriptions: [
-                {
-                  label: 'Complementary certification name',
-                  type: 'COMPLEMENTARY',
-                },
-              ],
-              nonEligibleSubscription: null,
-              sessionVersion: 2,
-            }),
-          );
-        });
-      });
-    });
-
-    context('when the candidate is registered and not eligible to any complementary certification', function () {
-      it('should return the candidate without any eligible complementary certification', async function () {
+  context('when the candidate is enrolled to a double certification', function () {
+    context('but did not get the associated badge', function () {
+      it('returns an uneligible double certification candidate subscription', async function () {
         // given
-        const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
-
-        const center = domainBuilder.certification.enrolment.buildCenter({
-          habilitations: [
-            domainBuilder.certification.enrolment.buildHabilitation({
-              key: 'PIX+',
-            }),
-          ],
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({
+          key: ComplementaryCertificationKeys.CLEA,
         });
 
-        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-          badge: domainBuilder.buildBadge({
-            key: 'PIX+_BADGE',
-            isCertifiable: true,
-          }),
-          complementaryCertificationKey: 'OTHER PIX+ KEY',
-          complementaryCertification,
-        });
-
-        const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
           ...certificationCandidateData,
           complementaryCertification,
           subscriptions: [
+            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId }),
             domainBuilder.certification.enrolment.buildComplementarySubscription({
               certificationCandidateId,
               complementaryCertificationId: complementaryCertification.id,
             }),
           ],
         });
+
+        const center = domainBuilder.certification.enrolment.buildCenter({
+          habilitations: [complementaryCertification],
+        });
+
         certificationCandidateRepository.getWithComplementaryCertification
           .withArgs({ id: certificationCandidateId })
-          .resolves(candidateWithoutComplementaryCertification);
+          .resolves(certificationCandidate);
 
         sessionRepository.get.withArgs({ id: sessionId }).resolves(
           domainBuilder.certification.enrolment.buildSession({
@@ -443,8 +294,8 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
         centerRepository.getById.withArgs({ id: 777 }).resolves(center);
 
         certificationBadgesService.findStillValidBadgeAcquisitions
-          .withArgs({ userId, limitDate: certificationCandidateData.reconciledAt })
-          .resolves([certifiableBadgeAcquisition]);
+          .withArgs({ userId, limitDate: certificationCandidate.reconciledAt })
+          .resolves([]);
 
         // when
         const certificationCandidateSubscription = await getCertificationCandidateSubscription({
@@ -461,6 +312,99 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-certificatio
             id: certificationCandidateId,
             sessionId,
             eligibleSubscriptions: [],
+            nonEligibleSubscription: {
+              label: 'Complementary certification name',
+              type: 'COMPLEMENTARY',
+            },
+            sessionVersion: 2,
+          }),
+        );
+      });
+    });
+
+    context('and got the associated badge', function () {
+      it('returns an eligible double certification candidate subscription', async function () {
+        // given
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({
+          key: ComplementaryCertificationKeys.CLEA,
+        });
+
+        const badge = domainBuilder.buildBadge({
+          key: ComplementaryCertificationKeys.CLEA,
+          isCertifiable: true,
+        });
+
+        const complementaryCertificationBadge =
+          domainBuilder.certification.complementary.buildComplementaryCertificationBadge({
+            badgeId: badge.id,
+            complementaryCertificationId: complementaryCertification.id,
+          });
+
+        const certifiableBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+          badgeId: badge.id,
+          badgeKey: badge.key,
+          complementaryCertificationId: complementaryCertification.id,
+          complementaryCertificationKey: complementaryCertification.key,
+          complementaryCertificationBadgeId: complementaryCertificationBadge.id,
+        });
+
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...certificationCandidateData,
+          complementaryCertification,
+          subscriptions: [
+            domainBuilder.certification.enrolment.buildCoreSubscription({ certificationCandidateId }),
+            domainBuilder.certification.enrolment.buildComplementarySubscription({
+              certificationCandidateId,
+              complementaryCertificationId: complementaryCertification.id,
+            }),
+          ],
+        });
+
+        const center = domainBuilder.certification.enrolment.buildCenter({
+          habilitations: [complementaryCertification],
+        });
+
+        certificationCandidateRepository.getWithComplementaryCertification
+          .withArgs({ id: certificationCandidateId })
+          .resolves(certificationCandidate);
+
+        sessionRepository.get.withArgs({ id: sessionId }).resolves(
+          domainBuilder.certification.enrolment.buildSession({
+            certificationCenterId: 777,
+            version: 2,
+          }),
+        );
+
+        centerRepository.getById.withArgs({ id: 777 }).resolves(center);
+
+        certificationBadgesService.findStillValidBadgeAcquisitions
+          .withArgs({ userId, limitDate: certificationCandidate.reconciledAt })
+          .resolves([certifiableBadgeAcquisition]);
+
+        // when
+        const certificationCandidateSubscription = await getCertificationCandidateSubscription({
+          certificationCandidateId,
+          certificationBadgesService,
+          certificationCandidateRepository,
+          centerRepository,
+          sessionRepository,
+        });
+
+        // then
+        expect(certificationCandidateSubscription).to.deep.equal(
+          domainBuilder.buildCertificationCandidateSubscription({
+            id: certificationCandidateId,
+            sessionId,
+            eligibleSubscriptions: [
+              {
+                label: null,
+                type: 'CORE',
+              },
+              {
+                label: 'Complementary certification name',
+                type: 'COMPLEMENTARY',
+              },
+            ],
             nonEligibleSubscription: null,
             sessionVersion: 2,
           }),

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -34,7 +34,7 @@
 .congratulations-banner__complementary-certifications {
   display: flex;
   flex-direction: column;
-  margin: 0 auto;
+  margin: var(--pix-spacing-2x);
   padding: 16px 32px;
   background-color: var(--pix-success-50);
   border-radius: 16px;


### PR DESCRIPTION
## 🔆 Problème

Sur l'écran de saisie du code d’accès candidat (après les écrans d’instruction et avant la première question), supprimer l’alerte en jaune qui signale une absence d'éligibilité du candidat à la certification Pix+ à laquelle il est inscrit sauf s'il s'agit d'une double certification CléA.

## ⛱️ Proposition

• Filtre sur les acquisitions du candidat pour ne récupérer que le badge CléA.
• "Un peu" de réécriture pour essayer de rendre le tout plus clair 🫠 

## 🌊 Remarques

Un comportement "bancale" a été observé au cours du développement.

En cas d'éligibilité du candidat à une complémentaire, seront remontées par le usecase la CORE et la COMPLEMENTARY en tant que eligibleSubscriptions.
En cas de non éligibilité du candidat (pas ou plus éligible) à la complémentaire, sera uniquement remontée la COMPLEMENTARY en tant que nonEligibleSubscription . Quid de la souscription CORE ? Celle-ci est purement et simplement laissée de côté pour ne remonter qu'un `[]` dans `eligibleSubscriptions`

Un travail sera amené à être fait pour remettre tout ça d'équerre mais dans une autre PR.

## 🏄 Pour tester

- Se connecter à Pix-Certif avec `certif-prescriptor@example.net`
- Créer une nouvelle session et y inscrire un candidat en double certificaton Pix/Cléa
- Se connecter à Pix-App avec `certif-success@example.net`
- Rentrer dans la session de certification en vérifiant bien que celui-ci est éligible à CleA tout au long du processus d'entrée en certification
- Créer une nouvelle session et y inscrire un candidat en double certificaton Pix/Cléa
- Sur Pix-App, perdre l'éligibilité à CléA en remettant à zéro une compétence du candidat
- Rentrer dans la session de certification en vérifiant bien que celui-ci est uniquement certifiable avant la réconciliation et inscrit à CleA mais non éligible au moment de l'insertion du code candidat

🎉  🎲  Bonus pour le fun : 

- Créer une nouvelle session et y inscrire un candidat en certification complémentaire Pix+ Droit
- Passer et réussir la campagne `KXMJZE887` de façon à obtenir le badge certifiant
- Rentrer dans la session de certification en vérifiant bien que celui-ci n'est pas éligible à Pix+Droit tout au long du processus d'entrée en certification