### PR TITLE
[FEATURE] Permettre l'utilisation de `pix-carousel` dans les modules (PIX-18963)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
+++ b/api/src/devcomp/infrastructure/datasources/conversion/joi-to-json-schema.js
@@ -212,7 +212,9 @@ function getAlternativeSwitchCaseJsonSchema(switchCase) {
   const childJsonSchema = convertFromType(switchCase.then);
 
   const optionalTitle =
-    getOptionalTitleBasedOnChildrenType(switchCase) || getOptionalTitleBasedOnSiblingTagName(switchCase);
+    getOptionalTitleBasedOnTitleMetadata(switchCase) ||
+    getOptionalTitleBasedOnChildrenType(switchCase) ||
+    getOptionalTitleBasedOnSiblingTagName(switchCase);
   if (optionalTitle !== undefined) {
     childJsonSchema.title = optionalTitle;
   }
@@ -220,12 +222,16 @@ function getAlternativeSwitchCaseJsonSchema(switchCase) {
   return childJsonSchema;
 }
 
+function getOptionalTitleBasedOnTitleMetadata(switchCase) {
+  return switchCase.then?.metas?.find(({ title }) => title)?.title;
+}
+
 function getOptionalTitleBasedOnSiblingTagName(switchCase) {
   return switchCase.is?.allow[1];
 }
 
 function getOptionalTitleBasedOnChildrenType(switchCase) {
-  return switchCase.then.keys.type?.allow[0];
+  return switchCase.then.keys?.type?.allow[0];
 }
 
 function findRule(rules, ruleName) {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -532,6 +532,74 @@
           }
         }
       ]
+    },
+    {
+      "id": "fc38e052-ed9f-4d68-b09f-515b7069ad86",
+      "type": "lesson",
+      "title": "pix-carousel",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "7c2efda7-1839-4b58-8673-ab32294cc788",
+            "type": "text",
+            "content": "<p>pix-carousel</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "b04ef581-48f2-4543-9bf4-e1e87c4fa396",
+            "type": "custom",
+            "tagName": "pix-carousel",
+            "props": {
+              "aspectRatio": 1.84,
+              "titleLevel": 2,
+              "type": "image",
+              "randomSlides": false,
+              "disableAnimation": false,
+              "slides": [
+                {
+                  "title": "Situation A",
+                  "description": "Super description!",
+                  "displayWidth": 624,
+                  "image": {
+                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                    "alt": "une alternative A avec des \"double quotes\""
+                  }
+                },
+                {
+                  "title": "Situation B",
+                  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc at imperdiet libero, eget suscipit enim. Proin in nibh id ligula tempus suscipit eu at dolor. Fusce tincidunt gravida turpis, a sagittis ex bibendum nec. Morbi hendrerit lectus sed libero tristique, non luctus diam ultricies. Cras in quam consectetur, tempor quam id, euismod turpis. Duis faucibus erat lectus, blandit mattis lectus euismod quis. Duis imperdiet volutpat metus at varius. Nunc vitae mattis leo, ac vehicula urna. Mauris euismod eleifend lorem quis porta. Quisque ac diam sollicitudin nisl convallis ullamcorper. Donec ut suscipit arcu.",
+                  "displayWidth": 624,
+                  "image": {
+                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                    "alt": "une alternative B"
+                  }
+                },
+                {
+                  "title": "Liste non ordonnée",
+                  "description": "\n  <ul>\n<li>Ruben</li>\n       <li>Chase</li>\n         <li>Zooma</li>\n         <li>Stela</li>\n       </ul>\n     ",
+                  "displayWidth": 624,
+                  "image": {
+                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                    "alt": "hehe je suis un alt"
+                  }
+                },
+                {
+                  "title": "Liste ordonnée",
+                  "description": "<ol>\n   <li>Ruben</li>\n <li>Chase</li>\n  <li>Zooma</li>\n         <li>Stela</li>\n       </ol>\n",
+                  "displayWidth": 624,
+                  "image": {
+                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                    "alt": "halte là !"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -86,6 +86,63 @@ const messageConversationPropsSchema = Joi.object({
     .required(),
 }).required();
 
+const licenseSchema = Joi.object({
+  name: Joi.string().required(),
+  attribution: Joi.string().required(),
+  url: Joi.string().required(),
+});
+
+const slideImageSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().allow('').required(),
+  displayWidth: Joi.number().min(0).required(),
+  image: Joi.object({
+    src: Joi.string().required(),
+    alt: Joi.string().required(),
+  }).required(),
+  license: licenseSchema.optional(),
+});
+
+const slideTextSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().allow('').required(),
+  text: Joi.string().required(),
+});
+
+const slideImageTextSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().allow('').required(),
+  displayHeight: Joi.number().min(0).required(),
+  text: Joi.string().required(),
+  image: Joi.object({
+    src: Joi.string().required(),
+    alt: Joi.string().required(),
+  }).required(),
+});
+
+const commonFields = {
+  aspectRatio: Joi.number().min(0).required(),
+  randomSlides: Joi.boolean().required(),
+  titleLevel: Joi.number().integer().min(0).max(6).required(),
+  disableAnimation: Joi.boolean().required(),
+};
+
+const pixCarouselPropsSchema = Joi.object({
+  type: Joi.string().valid('image', 'image-text', 'text').required(),
+  slides: Joi.alternatives()
+    .conditional('type', {
+      switch: [
+        { is: 'image', then: Joi.array().items(slideImageSchema) },
+        { is: 'image-text', then: Joi.array().items(slideImageTextSchema) },
+        { is: 'text', then: Joi.array().items(slideTextSchema) },
+      ],
+    })
+    .required(),
+  ...commonFields,
+})
+  .meta({ title: 'pix-carousel' })
+  .required();
+
 const customElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
@@ -96,6 +153,7 @@ const customElementSchema = Joi.object({
       'llm-compare-messages',
       'llm-prompt-select',
       'message-conversation',
+      'pix-carousel',
       'qcu-image',
     )
     .required(),
@@ -107,6 +165,7 @@ const customElementSchema = Joi.object({
         { is: 'llm-compare-messages', then: llmCompareMessagesPropsSchema },
         { is: 'llm-prompt-select', then: llmPromptSelectPropsSchema },
         { is: 'message-conversation', then: messageConversationPropsSchema },
+        { is: 'pix-carousel', then: pixCarouselPropsSchema },
         { is: 'qcu-image', then: imageQuizPropsSchema },
       ],
       otherwise: Joi.object().required(),

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.7.0",
+        "@1024pix/epreuves-components": "^0.8.1",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.7.0.tgz",
-      "integrity": "sha512-Fc4UsJ4hsUDUQ869w3ua7mwNTU+3fvX0n2FFgqcyoD90pKTTixRRAHi/6zJAVZgXKx/s6cezDHR3Xkw7/o/d5w==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.8.1.tgz",
+      "integrity": "sha512-fF0jZsYDc0MJP0ASAIymftTZ8dgiy95QUQLbu5/ey+0DLEgcoXLXAHtc8ArizNbo2ZxD8Px8Jrd99aA5rqQ3Zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.7.0",
+    "@1024pix/epreuves-components": "^0.8.1",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.7.0",
+        "@1024pix/epreuves-components": "^0.8.1",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.7.0.tgz",
-      "integrity": "sha512-Fc4UsJ4hsUDUQ869w3ua7mwNTU+3fvX0n2FFgqcyoD90pKTTixRRAHi/6zJAVZgXKx/s6cezDHR3Xkw7/o/d5w==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.8.1.tgz",
+      "integrity": "sha512-fF0jZsYDc0MJP0ASAIymftTZ8dgiy95QUQLbu5/ey+0DLEgcoXLXAHtc8ArizNbo2ZxD8Px8Jrd99aA5rqQ3Zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.7.0",
+    "@1024pix/epreuves-components": "^0.8.1",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",


### PR DESCRIPTION
## 🔆 Problème

Le composant `pix-carousel` a été mis à disposition dans la version  8 de `@1024pix/epreuves-components`.

## ⛱️ Proposition

Ajouter le schéma Joi des props de ce composant.
Mettre à jour le package.
Mettre à jour le module d'exposition des POIs.

## 🌊 Remarques

La détection du titre du schéma a été modifiée afin de pouvoir personnaliser celui-ci (nous avons eu un problème où le titre détecté n'était pas logique).

## 🏄 Pour tester

- Ouvrir le module `demo-epreuves-components`.
- Descendre jusqu'à la fin du module.
- Constater que `pix-carousel` s'affiche.