### PR TITLE
[FEATURE] Ajout d'une route pour changer le nom des participants (PIX-18970)

### DIFF
--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -63,12 +63,26 @@ const reconcileScoOrganizationLearnerAutomatically = async function (
   return h.response(dependencies.scoOrganizationLearnerSerializer.serializeIdentity(organizationLearner));
 };
 
+const updateOrganizationLearnerName = async function (request, h) {
+  const organizationLearnerId = request.params.organizationLearnerId;
+  const { firstName, lastName } = request.payload;
+
+  await usecases.updateOrganizationLearnerName({
+    organizationLearnerId,
+    firstName,
+    lastName,
+  });
+
+  return h.response().code(204);
+};
+
 const organizationLearnersController = {
   reconcileCommonOrganizationLearner,
   deleteOrganizationLearners,
   importOrganizationLearnerFromFeature,
   dissociate,
   reconcileScoOrganizationLearnerAutomatically,
+  updateOrganizationLearnerName,
 };
 
 export { organizationLearnersController };

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -40,6 +40,46 @@ const register = async (server) => {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/organizations/{organizationId}/organization-learners/{organizationLearnerId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+          {
+            method: securityPreHandlers.checkOrganizationLearnerBelongsToOrganization,
+            assign: 'organizationLearnerBelongsToOrganization',
+          },
+          {
+            method: securityPreHandlers.checkOrganizationIsNotManagingStudents,
+            assign: 'organizationIsNotManagingStudents',
+          },
+          {
+            method: securityPreHandlers.checkOrganizationDoesNotHaveFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
+            assign: 'organizationDoesNotHaveFeature',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            organizationLearnerId: identifiersType.organizationLearnerId,
+          }),
+          payload: Joi.object({
+            firstName: Joi.string().required(),
+            lastName: Joi.string().required(),
+          }),
+        },
+        handler: organizationLearnersController.updateOrganizationLearnerName,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
+            "- Elle permet la mise à jour du prénom et nom d'un prescrit",
+        ],
+        tags: ['api', 'organization-learners'],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/organizations/{organizationId}/import-organization-learners',
       config: {

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearner.js
@@ -97,8 +97,7 @@ class OrganizationLearner {
     this.thirdName = null;
 
     if (this.birthdate) {
-      const birthdate = dayjs(this.birthdate).set('date', 1).set('month', 0).format('YYYY-MM-DD');
-      this.birthdate = birthdate;
+      this.birthdate = dayjs(this.birthdate).set('date', 1).set('month', 0).format('YYYY-MM-DD');
     }
 
     this.birthCity = null;
@@ -122,6 +121,11 @@ class OrganizationLearner {
   detachUser() {
     this.userId = null;
     this.updatedAt = new Date();
+  }
+
+  updateName(firstName, lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
   }
 
   delete(userId, isAnonymizedWithDeletionEnabled) {

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -110,6 +110,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {reconcileScoOrganizationLearnerAutomatically} reconcileScoOrganizationLearnerAutomatically
  * @property {replaceSupOrganizationLearners} replaceSupOrganizationLearners
  * @property {updateOrganizationLearnerImportFormats} updateOrganizationLearnerImportFormats
+ * @property {updateOrganizationLearnerName} updateOrganizationLearnerName
  * @property {updateStudentNumber} updateStudentNumber
  * @property {uploadCsvFile} uploadCsvFile
  * @property {uploadSiecleFile} uploadSiecleFile

--- a/api/src/prescription/learner-management/domain/usecases/update-organization-learner-name.js
+++ b/api/src/prescription/learner-management/domain/usecases/update-organization-learner-name.js
@@ -1,0 +1,12 @@
+const updateOrganizationLearnerName = async ({
+  organizationLearnerId,
+  firstName,
+  lastName,
+  organizationLearnerRepository,
+}) => {
+  const organizationLearner = await organizationLearnerRepository.getLearnerInfo(organizationLearnerId);
+  organizationLearner.updateName(firstName, lastName);
+  return await organizationLearnerRepository.update(organizationLearner);
+};
+
+export { updateOrganizationLearnerName };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -382,7 +382,6 @@ const findOrganizationLearnerIdsBeforeImportFeatureFromOrganizationId = async fu
   const knexConn = DomainTransaction.getConnection();
   return knexConn('view-active-organization-learners').where({ organizationId }).whereNull('attributes').pluck('id');
 };
-
 export {
   addOrUpdateOrganizationOfOrganizationLearners,
   countByUserId,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -22,6 +22,7 @@ import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuth
 import * as checkIfUserIsBlockedUseCase from './usecases/checkIfUserIsBlocked.js';
 import * as checkOrganizationDoesNotHaveFeatureUseCase from './usecases/checkOrganizationDoesNotHaveFeature.js';
 import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
+import * as checkOrganizationIsNotManagingStudentsUseCase from './usecases/checkOrganizationIsNotManagingStudents.js';
 import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
 import * as checkUserBelongsToLearnersOrganizationUseCase from './usecases/checkUserBelongsToLearnersOrganization.js';
 import * as checkUserBelongsToOrganizationUseCase from './usecases/checkUserBelongsToOrganization.js';
@@ -799,6 +800,31 @@ async function checkOrganizationAccess(request, h, dependencies = { checkOrganiz
     return _replyForbiddenError(h);
   }
 }
+
+async function checkOrganizationIsNotManagingStudents(
+  request,
+  h,
+  dependencies = {
+    checkOrganizationIsNotManagingStudentsUseCase,
+  },
+) {
+  if (_noCredentials(request)) {
+    return _replyForbiddenError(h);
+  }
+
+  const organizationId = request.params.organizationId || request.params.id;
+
+  const isOrganizationNotManagingStudents = await dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute({
+    organizationId,
+  });
+
+  if (!isOrganizationNotManagingStudents) {
+    return _replyForbiddenError(h);
+  }
+
+  return h.response(true);
+}
+
 function checkOrganizationDoesNotHaveFeature(featureKey) {
   return async function (request, h, dependencies = { checkOrganizationDoesNotHaveFeatureUseCase }) {
     const organizationId = request.params.organizationId || request.params.id;
@@ -836,6 +862,7 @@ const securityPreHandlers = {
   checkUserBelongsToSupOrganizationAndManagesStudents,
   checkUserCanDisableHisOrganizationMembership,
   checkUserDoesNotBelongsToScoOrganizationManagingStudents,
+  checkOrganizationIsNotManagingStudents,
   checkUserIsAdminInOrganization,
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -20,6 +20,7 @@ import * as checkAdminMemberHasRoleSupportUseCase from './usecases/checkAdminMem
 import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
 import * as checkIfUserIsBlockedUseCase from './usecases/checkIfUserIsBlocked.js';
+import * as checkOrganizationDoesNotHaveFeatureUseCase from './usecases/checkOrganizationDoesNotHaveFeature.js';
 import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
 import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
 import * as checkUserBelongsToLearnersOrganizationUseCase from './usecases/checkUserBelongsToLearnersOrganization.js';
@@ -798,6 +799,16 @@ async function checkOrganizationAccess(request, h, dependencies = { checkOrganiz
     return _replyForbiddenError(h);
   }
 }
+function checkOrganizationDoesNotHaveFeature(featureKey) {
+  return async function (request, h, dependencies = { checkOrganizationDoesNotHaveFeatureUseCase }) {
+    const organizationId = request.params.organizationId || request.params.id;
+    const organizationDoesNotHaveFeature = await dependencies.checkOrganizationDoesNotHaveFeatureUseCase.execute({
+      organizationId,
+      featureKey,
+    });
+    return organizationDoesNotHaveFeature ? h.response(true) : _replyForbiddenError(h);
+  };
+}
 
 function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
@@ -829,6 +840,7 @@ const securityPreHandlers = {
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserIsMemberOfAnOrganization,
+  checkOrganizationDoesNotHaveFeature,
   checkUserIsAdminOfCertificationCenter,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -24,6 +24,7 @@ import * as checkOrganizationDoesNotHaveFeatureUseCase from './usecases/checkOrg
 import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
 import * as checkOrganizationIsNotManagingStudentsUseCase from './usecases/checkOrganizationIsNotManagingStudents.js';
 import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
+import * as checkOrganizationLearnerBelongsToOrganizationUseCase from './usecases/checkOrganizationLearnerBelongsToOrganization.js';
 import * as checkUserBelongsToLearnersOrganizationUseCase from './usecases/checkUserBelongsToLearnersOrganization.js';
 import * as checkUserBelongsToOrganizationUseCase from './usecases/checkUserBelongsToOrganization.js';
 import * as checkUserBelongsToOrganizationManagingStudentsUseCase from './usecases/checkUserBelongsToOrganizationManagingStudents.js';
@@ -836,6 +837,26 @@ function checkOrganizationDoesNotHaveFeature(featureKey) {
   };
 }
 
+async function checkOrganizationLearnerBelongsToOrganization(
+  request,
+  h,
+  dependencies = { checkOrganizationLearnerBelongsToOrganizationUseCase },
+) {
+  const organizationId = request.params.organizationId;
+  const organizationLearnerId = request.params.organizationLearnerId;
+
+  try {
+    const organizationLearnerBelongsToOrganization =
+      await dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute(
+        organizationId,
+        organizationLearnerId,
+      );
+    return organizationLearnerBelongsToOrganization ? h.response(true) : _replyNotFoundError(h);
+  } catch {
+    return _replyForbiddenError(h);
+  }
+}
+
 function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
 }
@@ -863,6 +884,7 @@ const securityPreHandlers = {
   checkUserCanDisableHisOrganizationMembership,
   checkUserDoesNotBelongsToScoOrganizationManagingStudents,
   checkOrganizationIsNotManagingStudents,
+  checkOrganizationLearnerBelongsToOrganization,
   checkUserIsAdminInOrganization,
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,

--- a/api/src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js
+++ b/api/src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js
@@ -1,0 +1,12 @@
+import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
+
+const execute = async ({ organizationId, featureKey, dependencies = { organizationFeatureRepository } }) => {
+  const featureEnabledForOrganization =
+    await dependencies.organizationFeatureRepository.isFeatureEnabledForOrganization({
+      organizationId,
+      featureKey,
+    });
+  return !featureEnabledForOrganization;
+};
+
+export { execute };

--- a/api/src/shared/application/usecases/checkOrganizationIsNotManagingStudents.js
+++ b/api/src/shared/application/usecases/checkOrganizationIsNotManagingStudents.js
@@ -1,0 +1,15 @@
+import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
+
+const execute = async function ({
+  organizationId,
+
+  dependencies = {
+    organizationRepository,
+  },
+}) {
+  const organization = await dependencies.organizationRepository.get(organizationId);
+
+  return !organization.isManagingStudents;
+};
+
+export { execute };

--- a/api/src/shared/application/usecases/checkOrganizationLearnerBelongsToOrganization.js
+++ b/api/src/shared/application/usecases/checkOrganizationLearnerBelongsToOrganization.js
@@ -1,0 +1,12 @@
+import * as organizationLearnerRepository from '../../../prescription/learner-management/infrastructure/repositories/organization-learner-repository.js';
+
+const execute = async function (
+  organizationId,
+  organizationLearnerId,
+  dependencies = { organizationLearnerRepository },
+) {
+  const organizationLearner = await dependencies.organizationLearnerRepository.getLearnerInfo(organizationLearnerId);
+  return organizationLearner.organizationId === Number(organizationId);
+};
+
+export { execute };

--- a/api/tests/prescription/learner-management/integration/domain/usecases/update-organization-learner-name_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/update-organization-learner-name_test.js
@@ -1,0 +1,32 @@
+import { usecases } from '../../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | update-organization-learner-name', function () {
+  describe('#updateOrganizationLearnerName', function () {
+    it('should update organization learner first name and last name', async function () {
+      // given
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.updateOrganizationLearnerName({
+        organizationLearnerId: organizationLearner.id,
+        firstName: 'Jane',
+        lastName: 'Smith',
+      });
+
+      // then
+      const updatedLearner = await knex('organization-learners')
+        .select('firstName', 'lastName', 'updatedAt')
+        .where({ id: organizationLearner.id })
+        .first();
+
+      expect(updatedLearner.firstName).to.equal('Jane');
+      expect(updatedLearner.lastName).to.equal('Smith');
+      expect(updatedLearner.updatedAt).to.be.a('date');
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearner_test.js
@@ -216,4 +216,17 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
       expect(organizationLearner.updatedAt).deep.equal(now);
     });
   });
+
+  describe('#updateName', function () {
+    it('should update first and last name', function () {
+      const organizationLearner = domainBuilder.buildOrganizationLearner({
+        firstName: 'Hippopotamus',
+        lastName: 'nivea',
+      });
+
+      organizationLearner.updateName('Spilogale', 'Americanum');
+      expect(organizationLearner.firstName).deep.equal('Spilogale');
+      expect(organizationLearner.lastName).deep.equal('Americanum');
+    });
+  });
 });

--- a/api/tests/shared/integration/application/security-pre-handlers_test.js
+++ b/api/tests/shared/integration/application/security-pre-handlers_test.js
@@ -758,6 +758,116 @@ describe('Integration | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkOrganizationLearnerBelongsToOrganization', function () {
+    let httpServerTest;
+
+    beforeEach(async function () {
+      const moduleUnderTest = {
+        name: 'security-test',
+        register: async function (server) {
+          server.route([
+            {
+              method: 'PATCH',
+              path: '/api/organizations/{organizationId}/organization-learners/{organizationLearnerId}',
+              handler: (r, h) => h.response().code(200),
+              config: {
+                pre: [
+                  {
+                    method: (request, h) =>
+                      securityPreHandlers.checkOrganizationLearnerBelongsToOrganization(request, h),
+                  },
+                ],
+              },
+            },
+          ]);
+        },
+      };
+      httpServerTest = new HttpTestServer();
+      await httpServerTest.register(moduleUnderTest);
+      httpServerTest.setupAuthentication();
+    });
+
+    describe('when organization learner belongs to the organization', function () {
+      it('returns 200', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const organization = databaseBuilder.factory.buildOrganization();
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'John',
+          lastName: 'Doe',
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organization.id}/organization-learners/${organizationLearner.id}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await httpServerTest.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('when organization learner does not belong to the organization', function () {
+      it('returns 404', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const targetOrganization = databaseBuilder.factory.buildOrganization();
+        const otherOrganization = databaseBuilder.factory.buildOrganization();
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: otherOrganization.id,
+          firstName: 'John',
+          lastName: 'Doe',
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${targetOrganization.id}/organization-learners/${organizationLearner.id}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await httpServerTest.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    describe('when organization learner is deleted', function () {
+      it('returns 403', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const organization = databaseBuilder.factory.buildOrganization();
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'John',
+          lastName: 'Doe',
+          deletedAt: new Date(),
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organization.id}/organization-learners/${organizationLearner.id}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        };
+
+        // when
+        const response = await httpServerTest.requestObject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
   describe('#checkOrganizationIsNotManagingStudents', function () {
     let httpServerTest;
 

--- a/api/tests/shared/integration/application/usecases/checkOrganizationLearnerBelongsToOrganization.test.js
+++ b/api/tests/shared/integration/application/usecases/checkOrganizationLearnerBelongsToOrganization.test.js
@@ -1,0 +1,56 @@
+import { execute } from '../../../../../src/shared/application/usecases/checkOrganizationLearnerBelongsToOrganization.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Shared | Application | UseCase | checkOrganizationLearnerBelongsToOrganization', function () {
+  describe('#execute', function () {
+    it('should return true when organization learner belongs to the organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: organization.id,
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await execute(organization.id, organizationLearner.id);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when organization learner belongs to a different organization', async function () {
+      // given
+      const targetOrganization = databaseBuilder.factory.buildOrganization();
+      const otherOrganization = databaseBuilder.factory.buildOrganization();
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: otherOrganization.id,
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await execute(targetOrganization.id, organizationLearner.id);
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should throw NotFoundError when organization learner does not exist', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const nonExistentOrganizationLearnerId = 999999;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(execute)(organization.id, nonExistentOrganizationLearnerId);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`Student not found for ID ${nonExistentOrganizationLearnerId}`);
+    });
+  });
+});

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -2143,4 +2143,60 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
       });
     });
   });
+  describe('#checkOrganizationDoesNotHaveFeature', function () {
+    context('Successful case', function () {
+      let request;
+
+      beforeEach(function () {
+        request = {
+          params: { id: 1234 },
+        };
+      });
+
+      it('should authorize access to resource when the organization does NOT have feature enabled', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 1234;
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute.withArgs({ organizationId, featureKey }).resolves(true);
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      let request;
+
+      beforeEach(function () {
+        request = { params: { id: 1234 } };
+      });
+
+      it('should forbid resource access when organization does have feature enabled', async function () {
+        const featureKey = 'SOME_FEATURE';
+        const organizationId = 1234;
+
+        const checkOrganizationDoesNotHaveFeatureUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        checkOrganizationDoesNotHaveFeatureUseCaseStub.execute.withArgs({ organizationId, featureKey }).resolves(false);
+
+        const checkOrganizationDoesNotHaveFeature = securityPreHandlers.checkOrganizationDoesNotHaveFeature(featureKey);
+        const response = await checkOrganizationDoesNotHaveFeature(request, hFake, {
+          checkOrganizationDoesNotHaveFeatureUseCase: checkOrganizationDoesNotHaveFeatureUseCaseStub,
+        });
+
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+    });
+  });
 });

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -2143,6 +2143,124 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
       });
     });
   });
+  describe('#checkOrganizationIsNotManagingStudents', function () {
+    let checkOrganizationIsNotManagingStudentsUseCaseStub;
+    let dependencies;
+
+    beforeEach(function () {
+      checkOrganizationIsNotManagingStudentsUseCaseStub = { execute: sinon.stub() };
+      dependencies = {
+        checkOrganizationIsNotManagingStudentsUseCase: checkOrganizationIsNotManagingStudentsUseCaseStub,
+      };
+    });
+
+    context('Successful cases', function () {
+      context('when organization is not managing students', function () {
+        it('should authorize access when organization id is in request params', async function () {
+          // given
+          const request = {
+            auth: {
+              credentials: {
+                accessToken: 'valid.access.token',
+                userId: 1234,
+              },
+            },
+            params: {
+              organizationId: 5678,
+            },
+          };
+          dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute.resolves(true);
+
+          // when
+          const response = await securityPreHandlers.checkOrganizationIsNotManagingStudents(
+            request,
+            hFake,
+            dependencies,
+          );
+
+          // then
+          expect(response.source).to.be.true;
+          expect(dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute).to.have.been.calledWith({
+            organizationId: 5678,
+          });
+        });
+
+        it('should authorize access when organization id is in request params as id', async function () {
+          // given
+          const request = {
+            auth: {
+              credentials: {
+                accessToken: 'valid.access.token',
+                userId: 1234,
+              },
+            },
+            params: {
+              id: 5678,
+            },
+          };
+          dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute.resolves(true);
+
+          // when
+          const response = await securityPreHandlers.checkOrganizationIsNotManagingStudents(
+            request,
+            hFake,
+            dependencies,
+          );
+
+          // then
+          expect(response.source).to.be.true;
+          expect(dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute).to.have.been.calledWith({
+            organizationId: 5678,
+          });
+        });
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid resource access when user was not previously authenticated', async function () {
+        // given
+        const request = {
+          params: {
+            organizationId: 5678,
+          },
+        };
+
+        // when
+        const response = await securityPreHandlers.checkOrganizationIsNotManagingStudents(request, hFake, dependencies);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute).not.to.have.been.called;
+      });
+
+      it('should forbid resource access when organization is managing students', async function () {
+        // given
+        const request = {
+          auth: {
+            credentials: {
+              accessToken: 'valid.access.token',
+              userId: 1234,
+            },
+          },
+          params: {
+            organizationId: 5678,
+          },
+        };
+        dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute.resolves(false);
+
+        // when
+        const response = await securityPreHandlers.checkOrganizationIsNotManagingStudents(request, hFake, dependencies);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(dependencies.checkOrganizationIsNotManagingStudentsUseCase.execute).to.have.been.calledWith({
+          organizationId: 5678,
+        });
+      });
+    });
+  });
   describe('#checkOrganizationDoesNotHaveFeature', function () {
     context('Successful case', function () {
       let request;

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -2143,6 +2143,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
       });
     });
   });
+
   describe('#checkOrganizationIsNotManagingStudents', function () {
     let checkOrganizationIsNotManagingStudentsUseCaseStub;
     let dependencies;
@@ -2261,6 +2262,7 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
       });
     });
   });
+
   describe('#checkOrganizationDoesNotHaveFeature', function () {
     context('Successful case', function () {
       let request;
@@ -2314,6 +2316,117 @@ describe('Shared | Unit | Application | SecurityPreHandlers', function () {
 
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
+      });
+    });
+  });
+
+  describe('#checkOrganizationLearnerBelongsToOrganization', function () {
+    let checkOrganizationLearnerBelongsToOrganizationUseCaseStub;
+    let dependencies;
+
+    beforeEach(function () {
+      checkOrganizationLearnerBelongsToOrganizationUseCaseStub = { execute: sinon.stub() };
+      dependencies = {
+        checkOrganizationLearnerBelongsToOrganizationUseCase: checkOrganizationLearnerBelongsToOrganizationUseCaseStub,
+      };
+    });
+
+    context('Successful cases', function () {
+      it('should authorize access when organization learner belongs to the organization', async function () {
+        // given
+        const request = {
+          auth: {
+            credentials: {
+              accessToken: 'valid.access.token',
+              userId: 1234,
+            },
+          },
+          params: {
+            organizationId: 5678,
+            organizationLearnerId: 9999,
+          },
+        };
+        dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute.resolves(true);
+
+        // when
+        const response = await securityPreHandlers.checkOrganizationLearnerBelongsToOrganization(
+          request,
+          hFake,
+          dependencies,
+        );
+
+        // then
+        expect(response.source).to.be.true;
+        expect(dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute).to.have.been.calledWith(
+          5678,
+          9999,
+        );
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid resource access when organization learner does not belong to the organization', async function () {
+        // given
+        const request = {
+          auth: {
+            credentials: {
+              accessToken: 'valid.access.token',
+              userId: 1234,
+            },
+          },
+          params: {
+            organizationId: 5678,
+            organizationLearnerId: 9999,
+          },
+        };
+        dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute.resolves(false);
+
+        // when
+        const response = await securityPreHandlers.checkOrganizationLearnerBelongsToOrganization(
+          request,
+          hFake,
+          dependencies,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(response.isTakeOver).to.be.true;
+        expect(dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute).to.have.been.calledWith(
+          5678,
+          9999,
+        );
+      });
+
+      it('should forbid resource access when use case throws an error', async function () {
+        // given
+        const request = {
+          auth: {
+            credentials: {
+              accessToken: 'valid.access.token',
+              userId: 1234,
+            },
+          },
+          params: {
+            organizationId: 5678,
+            organizationLearnerId: 9999,
+          },
+        };
+        dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute.rejects(new Error('Some error'));
+
+        // when
+        const response = await securityPreHandlers.checkOrganizationLearnerBelongsToOrganization(
+          request,
+          hFake,
+          dependencies,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+        expect(dependencies.checkOrganizationLearnerBelongsToOrganizationUseCase.execute).to.have.been.calledWith(
+          5678,
+          9999,
+        );
       });
     });
   });

--- a/api/tests/shared/unit/application/usecases/checkOrganizationDoesNotHaveFeature_test.js
+++ b/api/tests/shared/unit/application/usecases/checkOrganizationDoesNotHaveFeature_test.js
@@ -1,7 +1,7 @@
 import * as checkOrganizationDoesNotHaveFeatureUseCase from '../../../../../src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js';
-import { expect, sinon } from '../../../../../tests/test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Application | Validator | checkOrganizationDoesNotHaveFeature', function () {
+describe('Unit | Application | Use Case | checkOrganizationDoesNotHaveFeature', function () {
   context('When organization does not have the feature enabled', function () {
     it('should return true', async function () {
       // given

--- a/api/tests/shared/unit/application/usecases/checkOrganizationIsNotManagingStudents_test.js
+++ b/api/tests/shared/unit/application/usecases/checkOrganizationIsNotManagingStudents_test.js
@@ -1,0 +1,41 @@
+import * as usecase from '../../../../../src/shared/application/usecases/checkOrganizationIsNotManagingStudents.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | Use Case | checkOrganizationIsNotManagingStudents', function () {
+  context('When organization is not managing students', function () {
+    it('should return true', async function () {
+      // given
+      const organizationRepositoryStub = { get: sinon.stub() };
+      const dependencies = {
+        organizationRepository: organizationRepositoryStub,
+      };
+
+      const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
+      dependencies.organizationRepository.get.resolves(organization);
+
+      // when
+      const response = await usecase.execute({ organizationId: organization.id, dependencies });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('When organization is managing students', function () {
+    it('should return false', async function () {
+      // given
+      const organizationRepositoryStub = { get: sinon.stub() };
+      const dependencies = {
+        organizationRepository: organizationRepositoryStub,
+      };
+      const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
+      dependencies.organizationRepository.get.resolves(organization);
+
+      // when
+      const response = await usecase.execute({ organizationId: organization.id, dependencies });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+});

--- a/api/tests/shared/unit/application/validator/checkOrganizationDoesNotHaveFeature_test.js
+++ b/api/tests/shared/unit/application/validator/checkOrganizationDoesNotHaveFeature_test.js
@@ -1,0 +1,54 @@
+import * as checkOrganizationDoesNotHaveFeatureUseCase from '../../../../../src/shared/application/usecases/checkOrganizationDoesNotHaveFeature.js';
+import { expect, sinon } from '../../../../../tests/test-helper.js';
+
+describe('Unit | Application | Validator | checkOrganizationDoesNotHaveFeature', function () {
+  context('When organization does not have the feature enabled', function () {
+    it('should return true', async function () {
+      // given
+      const organizationId = 'organizationId';
+      const featureKey = 'featureKey';
+      const organizationFeatureRepositoryStub = {
+        isFeatureEnabledForOrganization: sinon.stub(),
+      };
+
+      organizationFeatureRepositoryStub.isFeatureEnabledForOrganization
+        .withArgs({ organizationId, featureKey })
+        .resolves(false);
+
+      // when
+      const response = await checkOrganizationDoesNotHaveFeatureUseCase.execute({
+        organizationId,
+        featureKey,
+        dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
+      });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('When organization has the feature enabled', function () {
+    it('should return false', async function () {
+      // given
+      const organizationId = 'organizationId';
+      const featureKey = 'featureKey';
+      const organizationFeatureRepositoryStub = {
+        isFeatureEnabledForOrganization: sinon.stub(),
+      };
+
+      organizationFeatureRepositoryStub.isFeatureEnabledForOrganization
+        .withArgs({ organizationId, featureKey })
+        .resolves(true);
+
+      // when
+      const response = await checkOrganizationDoesNotHaveFeatureUseCase.execute({
+        organizationId,
+        featureKey,
+        dependencies: { organizationFeatureRepository: organizationFeatureRepositoryStub },
+      });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Le support est fréquemment amené à renommer des comptes, par nécessité des usagers suite à un changement d'état civil ou suite à des erreurs ou volonté de pseudonymat. 

Renommer un compte ne modifie pas les informations du prescrit.
Une personne restera donc avec son deadname/pseudo/erreur dans les résultats affichés dans Pix Orga pour les prescripteurs. 
C’est problématique voire violent pour certain(e)s. 

## ⛱️ Proposition

Ajouter une route qui permettra à l'avenir de modifier les noms des participants

## 🌊 Remarques

- Il n'y a aucune règle de validation sur les noms et prenoms, il n'y en a pas non plus à l'inscription.
- Il n'y a qu'une route pour tous les types d'organisation: Sco, sup ou "pro". Dans les trois cas, il faut appliquer les mêmes règles de validation. 

## 🏄 Pour tester

- Connecte toi a [PixOrga](https://orga-pr13097.review.pix.fr/)
- Va sur la page des participants avec l'organisation Pro Classic
- Exécute du gros bash ( au besoin change l'id du learner et modifie et le nom, un jeu de mots est exigé par contre )
``` sh
ORGANISATION_ID=1005
LEARNER_ID=107452
REVIEW_URL="https://api-pr13097.review.pix.fr/api/"
FIRST_NAME="Untruk"
LAST_NAME="Ridikulee"
ACCESS_TOKEN=$( \
  curl "$REVIEW_URL/token" \
    --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' \
  | jq -r .access_token \
)
curl "$REVIEW_URL/organizations/$ORGANISATION_ID/organization-learners/$LEARNER_ID" -X 'PATCH' -H 'content-type: application/vnd.api+json' -H "Authorization: Bearer $ACCESS_TOKEN" --data-raw "{\"firstName\":\"$FIRST_NAME\",\"lastName\":\"$LAST_NAME\"}"
```
- Vérifie que le nom choisi apparaît bien sur la liste