### PR TITLE
[BUGFIX] Ignorer la case des emails des destinataires de résultats (PIX-12345)

### DIFF
--- a/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
+++ b/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
@@ -8,7 +8,7 @@ const getSessionResultsByResultRecipientEmail = async function ({
 }) {
   const session = await sharedSessionRepository.getWithCertificationCandidates({ id: sessionId });
   const certificationCandidateIdsForResultRecipient = _(session.certificationCandidates)
-    .filter({ resultRecipientEmail })
+    .filter((candidate) => candidate.resultRecipientEmail.toLowerCase() === resultRecipientEmail.toLowerCase())
     .map('id')
     .value();
 

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -155,7 +155,7 @@ async function _managerPrescriberEmails({ session, mailService, i18n }) {
 }
 
 function _distinctCandidatesResultRecipientEmails(certificationCandidates) {
-  return uniqBy(certificationCandidates, 'resultRecipientEmail')
+  return uniqBy(certificationCandidates, (candidate) => candidate.resultRecipientEmail?.toLowerCase())
     .map((candidate) => candidate.resultRecipientEmail)
     .filter(Boolean);
 }

--- a/api/tests/certification/results/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
@@ -44,15 +44,20 @@ describe('Certification | Results | Unit | Domain | Use Cases | get-session-resu
       resultRecipientEmail: 'matching@example.net',
       subscriptions: [domainBuilder.buildCoreSubscription()],
     });
+    const certificationCandidate3 = domainBuilder.buildCertificationCandidate({
+      id: 987,
+      resultRecipientEmail: 'MATCHING@example.net',
+      subscriptions: [domainBuilder.buildCoreSubscription()],
+    });
     const expectedSession = domainBuilder.certification.sessionManagement.buildSession({
-      certificationCandidates: [certificationCandidate1, certificationCandidate2],
+      certificationCandidates: [certificationCandidate1, certificationCandidate2, certificationCandidate3],
       date: '2019-06-06',
       time: '12:05:30',
     });
     sharedSessionRepository.getWithCertificationCandidates.withArgs({ id: 123 }).resolves(expectedSession);
     const certificationResult = domainBuilder.buildCertificationResult({ firstName: 'Buffy' });
     certificationResultRepository.findByCertificationCandidateIds
-      .withArgs({ certificationCandidateIds: [789] })
+      .withArgs({ certificationCandidateIds: [789, 987] })
       .resolves([certificationResult]);
 
     // when

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -27,6 +27,8 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
   const sessionDate = '2020-05-08';
   const recipient1 = 'email1@example.net';
   const recipient2 = 'email2@example.net';
+  const recipient2WithUpperCases = 'EMAIL2@EXAMPLE.NET';
+
   const certificationCenter = 'certificationCenter';
   let clock;
   let candidateWithRecipient1,
@@ -45,7 +47,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
       subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     candidate2WithRecipient2 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient2,
+      resultRecipientEmail: recipient2WithUpperCases,
       subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({


### PR DESCRIPTION
## 🔆 Problème

Pour deux candidats de la même session, si la même adresse mail est saisie dans le champ "E-mail du destinataire des résultats", mais l’une est saisie en majuscules et l’autre en minuscules,  alors deux mails distincts sont envoyés car le champ est sensible à la casse.

## ⛱️ Proposition

Rendre la fonction listant les adresses mail des destinataires des résultats insensible à la casse.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Activer MAILING_ENABLE
- Créer une session
- Y ajouter 2 candidats en renseignant la même adresse mail dans le champ "E-mail du destinataire des résultats" mais avec des casses différentes
- Leur faire passer la session (certif-success@example.net et perfect-profile-user@example.net)
- Finaliser et publier la session
- Vérifier que le destinataire des résultats à reçu un seul mail avec les résultats des deux candidats
