### PR TITLE
[FEATURE] Créer la table target-profile-training-organizations (PIX-18864)

### DIFF
--- a/api/db/migrations/20250801094559_add-target-profile-training-organizations-table.js
+++ b/api/db/migrations/20250801094559_add-target-profile-training-organizations-table.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'target-profile-training-organizations';
+
+/**
+ * Une ligne dans cette table permet à une organisation de recommander un CF par l'intermédiaire d'un PC.
+ * Le lien avec le profil cible est nécessaire car une organisation peut être relié au même CF pour plusieurs PC
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    const comment =
+      'Table permettant de filtrer les organisations ' +
+      'pour lesquelles on veut recommander un contenu formatif ' +
+      'par l’intermédiaire d’un profil cible';
+
+    table.increments('id').primary();
+    table.integer('organizationId').references('organizations.id');
+    table.integer('targetProfileTrainingId').references('target-profile-trainings.id');
+    table.comment(comment);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

On souhaite recommander des contenus formatifs uniquement à certaines organisations d'un profil cible.

## ⛱️ Proposition

Ajouter une table pour faire la liaison entre :

- la relation profil cible / contenu formatif (table target-profile-training)
- l'organisation concernée 


## 🌊 Remarques

- Après plusieurs discussions sur la [PR](https://github.com/1024pix/pix/pull/13087) précédente, nous pensons que c'est la meilleure solution dans ce contexte pour garder les clés étrangères.
- Pas de migration de données à faire car s'il n'y pas de ligne dans la table, alors pas de filtres dessus.

## 🏄 Pour tester

- En local, lancer la commande npm run db:migrate.
- Vérifier qu'une table `target-profile-training-organizations` est bien créée avec les bons champs.
- Exécuter la commande npm run rollback:latest.
- Vérifier que la table est bien supprimée.

