### PR TITLE
[BUGFIX] X-Forwarded-Host sans modification pour les RA

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -27,6 +27,7 @@ log_format keyvalue
 access_log off;
 
 <%
+  is_not_review_app  = ENV['REVIEW_APP'] != 'true'
   canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
   canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
   server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
@@ -139,7 +140,11 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-Host $http_host;
+    # Review apps url must keep their original hostname (we do not Scalingo internal urls)
+    <% if is_not_review_app %>
+      proxy_set_header X-Forwarded-Host ${http_host};
+    <% end %>
+
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # Set X-Forwarded-For header to be able to know the remote client IP

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -27,6 +27,7 @@ log_format keyvalue
 access_log off;
 
 <%
+  is_not_review_app  = ENV['REVIEW_APP'] != 'true'
   canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
   canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
   server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
@@ -143,7 +144,10 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-Host $http_host;
+    # Review apps url must keep their original hostname (we do not Scalingo internal urls)
+    <% if is_not_review_app %>
+      proxy_set_header X-Forwarded-Host ${http_host};
+    <% end %>
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # Set X-Forwarded-For header to be able to know the remote client IP

--- a/junior/servers.conf.erb
+++ b/junior/servers.conf.erb
@@ -26,6 +26,9 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+<%
+  is_not_review_app  = ENV['REVIEW_APP'] != 'true'
+%>
 upstream api {
     <%
     # We compute the API host from the front app name, examples:
@@ -121,7 +124,10 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-Host $http_host;
+    # Review apps url must keep their original hostname (we do not Scalingo internal urls)
+    <% if is_not_review_app %>
+      proxy_set_header X-Forwarded-Host ${http_host};
+    <% end %>
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # Set X-Forwarded-For header to be able to know the remote client IP

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -27,6 +27,7 @@ log_format keyvalue
 access_log off;
 
 <%
+  is_not_review_app  = ENV['REVIEW_APP'] != 'true'
   canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
   canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
   server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
@@ -146,7 +147,10 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-Host $http_host;
+    # Review apps url must keep their original hostname (we do not Scalingo internal urls)
+    <% if is_not_review_app %>
+      proxy_set_header X-Forwarded-Host ${http_host};
+    <% end %>
     proxy_set_header X-Forwarded-Proto $scheme;
 
     proxy_buffering off;

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -27,6 +27,7 @@ log_format keyvalue
 access_log off;
 
 <%
+  is_not_review_app  = ENV['REVIEW_APP'] != 'true'
   canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
   canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
   server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
@@ -143,7 +144,10 @@ server {
     proxy_set_header X-Source-Front <%= ENV['APP'] %>;
 
     # Set X-Forwarded-xxx headers for the API to compute getForwardedOrigin
-    proxy_set_header X-Forwarded-Host $http_host;
+    # Review apps url must keep their original hostname (we do not Scalingo internal urls)
+    <% if is_not_review_app %>
+      proxy_set_header X-Forwarded-Host ${http_host};
+    <% end %>
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # Set X-Forwarded-For header to be able to know the remote client IP


### PR DESCRIPTION
## 🔆 Problème

Pix Admin n'est plus accessible suite aux modifications sur le pix-review-router au niveau du X-Forwarded-Host
Du fait on ne peut plus s'authentifier via login / mot de passe car cela ne respecte pas l'implementation dans `api/src/identity-access-management/infrastructure/utils/network.js` pour le cas des RA.

## ⛱️ Proposition

* Une regle, base sur une variable d'env deja presente, pour ne pas reecrire au niveau des nginx front le X-Forwarded-Host  uniquement dans le cas des RA

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

* Verifier que sur Pix Admin on peut se logger via login / mot de passe
* Aller sur pix admin et changer l'url pour https://admin-pr13100.review.pix.fr/api/healthcheck/forwarded-origin
  * Cela doit renvoyer la meme url que dans la barre d'adresse 
