### PR TITLE
[FEATURE] Afficher la bordure des Custom element seulement si ils sont interactifs (PIX-18999)

### DIFF
--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -1,3 +1,4 @@
+import { metadata } from '@1024pix/epreuves-components/metadata';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { t } from 'ember-intl';
@@ -13,15 +14,27 @@ export default class ModulixCustomElement extends ModuleElement {
     container.append(customElement);
   }
 
+  get isInteractive() {
+    if (metadata[this.args.component.tagName] !== undefined) {
+      return metadata[this.args.component.tagName].isInteractive;
+    } else {
+      return true;
+    }
+  }
+
   <template>
     <div class="element-custom">
-      <fieldset>
-        <legend>
-          <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
-          <span>{{t "pages.modulix.interactiveElement.label"}}</span>
-        </legend>
+      {{#if this.isInteractive}}
+        <fieldset>
+          <legend>
+            <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
+            <span>{{t "pages.modulix.interactiveElement.label"}}</span>
+          </legend>
+          <div {{didInsert this.mountCustomElement}} />
+        </fieldset>
+      {{else}}
         <div {{didInsert this.mountCustomElement}} />
-      </fieldset>
+      {{/if}}
     </div>
   </template>
 }


### PR DESCRIPTION
## 🔆 Problème

Aujourd'hui tous les custom elements ont une bordure où on indique "Élément interactif". Certains éléments ne sont pas interactifs.

## ⛱️ Proposition

Afficher la bordure des Custom element seulement si ils sont interactifs grâce aux métadonnées fournies par `@1024pix/epreuves-components`

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier que les éléments ont une bordure ou non sur https://app-pr13102.review.pix.fr/modules/demo-epreuves-components/passage
