### PR TITLE
[FEATURE] Suppression de isCancelled dans le check de vérification en entrée de certification (PIX-16048).

### DIFF
--- a/api/src/certification/enrolment/domain/models/PixCertification.js
+++ b/api/src/certification/enrolment/domain/models/PixCertification.js
@@ -1,15 +1,13 @@
 export class PixCertification {
-  constructor({ pixScore, status, isCancelled, isRejectedForFraud }) {
+  constructor({ pixScore, status, isRejectedForFraud }) {
     /**
      * @param {Object} props
      * @param {number} props.pixScore
      * @param {string} props.status
-     * @param {boolean} props.isCancelled - will be removed
      * @param {boolean} props.isRejectedForFraud
      *    */
     this.pixScore = pixScore;
     this.status = status;
-    this.isCancelled = isCancelled;
     this.isRejectedForFraud = isRejectedForFraud;
   }
 }

--- a/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
+++ b/api/src/certification/enrolment/domain/usecases/verify-candidate-subscriptions.js
@@ -23,7 +23,7 @@ import { CertificationCandidateEligibilityError } from '../errors.js';
  *
  * @returns {Promise<void>} if candidate is deemed eligible
  * @throws {UserNotAuthorizedToCertifyError} candidate is not certifiable for CORE
- * @throws {CertificationCandidateEligibilityError} candidate is not eligibile to his complementary
+ * @throws {CertificationCandidateEligibilityError} candidate is not eligible to his complementary
  */
 export async function verifyCandidateSubscriptions({
   candidate,
@@ -124,24 +124,17 @@ function _doesNeedEligibilityCheck(session, candidate) {
 }
 
 function _hasValidCoreCertification(userPixCertifications) {
-  // isCancelled will be removed
   return _.some(
     userPixCertifications,
-    (certification) =>
-      certification.status === AssessmentResult.status.VALIDATED &&
-      !certification.isCancelled &&
-      !certification.isRejectedForFraud,
+    (certification) => certification.status === AssessmentResult.status.VALIDATED && !certification.isRejectedForFraud,
   );
 }
 
 function _getHighestUserValidPixScore(userPixCertifications) {
-  // isCancelled will be removed
   const validPixCertifications = _.chain(userPixCertifications)
     .filter(
       (pixCertification) =>
-        pixCertification.status === AssessmentResult.status.VALIDATED &&
-        !pixCertification.isCancelled &&
-        !pixCertification.isRejectedForFraud,
+        pixCertification.status === AssessmentResult.status.VALIDATED && !pixCertification.isRejectedForFraud,
     )
     .sortBy('pixScore')
     .value();

--- a/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/pix-certification-repository.js
@@ -2,14 +2,8 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { PixCertification } from '../../domain/models/PixCertification.js';
 
 export async function findByUserId({ userId }) {
-  // isCancelled will be removed
   const results = await knex('certification-courses')
-    .select(
-      'certification-courses.isRejectedForFraud',
-      'certification-courses.isCancelled',
-      'assessment-results.pixScore',
-      'assessment-results.status',
-    )
+    .select('certification-courses.isRejectedForFraud', 'assessment-results.pixScore', 'assessment-results.status')
     .join(
       'certification-courses-last-assessment-results',
       'certification-courses-last-assessment-results.certificationCourseId',

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/pix-certification-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/pix-certification-repository_test.js
@@ -39,13 +39,11 @@ describe('Certification | Enrolment | Integration | Repository | PixCertificatio
           domainBuilder.certification.enrolment.buildPixCertification({
             pixScore: 400,
             status: 'validated',
-            isCancelled: false,
             isRejectedForFraud: false,
           }),
           domainBuilder.certification.enrolment.buildPixCertification({
             pixScore: 500,
             status: 'validated',
-            isCancelled: false,
             isRejectedForFraud: false,
           }),
         ];

--- a/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-subscriptions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/verify-candidate-subscriptions_test.js
@@ -157,19 +157,16 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
         domainBuilder.certification.enrolment.buildPixCertification({
           pixScore: 123,
           status: AssessmentResult.status.CANCELLED,
-          isCancelled: true,
           isRejectedForFraud: false,
         }),
         domainBuilder.certification.enrolment.buildPixCertification({
           pixScore: 123,
           status: AssessmentResult.status.VALIDATED,
-          isCancelled: false,
           isRejectedForFraud: true,
         }),
         domainBuilder.certification.enrolment.buildPixCertification({
           pixScore: 123,
           status: AssessmentResult.status.REJECTED,
-          isCancelled: false,
           isRejectedForFraud: false,
         }),
       ].forEach((pixCertification) => {
@@ -227,7 +224,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
             domainBuilder.certification.enrolment.buildPixCertification({
               pixScore: 250,
               status: AssessmentResult.status.VALIDATED,
-              isCancelled: false,
               isRejectedForFraud: false,
             }),
           ]);
@@ -274,7 +270,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
             domainBuilder.certification.enrolment.buildPixCertification({
               pixScore: 250,
               status: AssessmentResult.status.VALIDATED,
-              isCancelled: false,
               isRejectedForFraud: false,
             }),
           ]);
@@ -338,7 +333,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
             domainBuilder.certification.enrolment.buildPixCertification({
               pixScore: 250,
               status: AssessmentResult.status.VALIDATED,
-              isCancelled: false,
               isRejectedForFraud: false,
             }),
           ]);
@@ -404,7 +398,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
             domainBuilder.certification.enrolment.buildPixCertification({
               pixScore: 100,
               status: AssessmentResult.status.VALIDATED,
-              isCancelled: false,
               isRejectedForFraud: false,
             }),
           ]);
@@ -471,7 +464,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
               domainBuilder.certification.enrolment.buildPixCertification({
                 pixScore: 300,
                 status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
                 isRejectedForFraud: false,
               }),
             ]);
@@ -538,7 +530,6 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | verify-candidate
               domainBuilder.certification.enrolment.buildPixCertification({
                 pixScore: 300,
                 status: AssessmentResult.status.VALIDATED,
-                isCancelled: false,
                 isRejectedForFraud: false,
               }),
             ]);

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-pix-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-pix-certification.js
@@ -4,13 +4,11 @@ import { AssessmentResult } from '../../../../../../src/shared/domain/models/ind
 const buildPixCertification = function ({
   pixScore = 123,
   status = AssessmentResult.status.VALIDATED,
-  isCancelled = false,
   isRejectedForFraud = false,
 } = {}) {
   return new PixCertification({
     pixScore,
     status,
-    isCancelled,
     isRejectedForFraud,
   });
 };


### PR DESCRIPTION
## 🔆 Problème
Le statut d’une certification est définit par l’assessment-result.
Ce dernier peut être `validated` si le candidat réussit sa certification ou bien `rejected` s'il échoue.
Et pour le cas d’une certification annulée, on ne se basait pas sur la même chose => On dépendait de `certification-courses.isCancelled`. Or ce statut doit être traité comme les autres et un chantier a été fait pour fixer ça 🥳 

Maintenant que toutes les certifications annulées se basent sur le statut de l'`assessment-result`, on peut supprimer tranquillement la présence du `isCancelled`.

## ⛱️ Proposition

Suppression de isCancelled dans le check de vérification en entrée de certification (lorsque le candidat remplit le formulaire pour entrer en certification sur Pix App).

## 🏄 Pour tester

Vu avec Alex, ce code se trouve dans un check `_doesNeedEligibilityCheck` concernant une pix+ passé seul (sans le core donc)
Aujourd'hui, comme on ne fait pas passer ce type de certification et qu'un chantier est en cours pour reprendre le code concernant cette partie, il n'est pas nécessaire de tester fonctionnellement.

<img width="421" height="603" alt="Capture d’écran 2025-08-05 à 13 59 08" src="https://github.com/user-attachments/assets/9152c200-f140-4733-be0e-9633c4ace781" />


Par contre coté tech, il peut être intéressant de check que les fichiers impactés ne sont pas appelées par d'autres routes que j'ai loupé.
