### PR TITLE
[FEATURE] Changer l'algo de détection de local avec cookie dans PixAdmin (PIX-18977)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -92,7 +92,7 @@ export default class IndexController extends Controller {
   async copyResultsDownloadLink() {
     try {
       const adapter = this.store.adapterFor('session');
-      const link = await adapter.getDownloadLink({ id: this.model.id, lang: this.locale.currentLocale });
+      const link = await adapter.getDownloadLink({ id: this.model.id, lang: this.locale.currentLanguage });
       await navigator.clipboard.writeText(link.sessionResultsLink);
       this._displaySuccessTooltip();
     } catch {

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -14,6 +14,6 @@ export default class ApplicationRoute extends Route {
 
     await this.currentUser.load();
 
-    this.locale.detectBestLocale({ user: this.currentUser.user });
+    this.locale.setBestLocale({ user: this.currentUser.user });
   }
 }

--- a/admin/app/services/current-domain.js
+++ b/admin/app/services/current-domain.js
@@ -1,14 +1,25 @@
-import Service from '@ember/service';
+import Service, { service } from '@ember/service';
 import last from 'lodash/last';
 
 const FRANCE_TLD = 'fr';
 
 export default class CurrentDomainService extends Service {
+  @service location;
+
   get isFranceDomain() {
     return this.getExtension() === FRANCE_TLD;
   }
 
   getExtension() {
-    return last(location.hostname.split('.'));
+    const { hostname } = new URL(this.location.href);
+    return last(hostname.split('.'));
+  }
+
+  get domain() {
+    const { host, hostname } = new URL(this.location.href);
+
+    if (hostname === 'localhost') return hostname;
+
+    return host.split('.').slice(-2).join('.');
   }
 }

--- a/admin/app/services/feature-toggles.js
+++ b/admin/app/services/feature-toggles.js
@@ -3,7 +3,13 @@ import Service, { service } from '@ember/service';
 export default class FeatureTogglesService extends Service {
   @service store;
 
+  _featureToggles = undefined;
+
+  get featureToggles() {
+    return this._featureToggles;
+  }
+
   async load() {
-    this.featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+    this._featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
   }
 }

--- a/admin/app/services/locale.js
+++ b/admin/app/services/locale.js
@@ -4,6 +4,8 @@
 
 import { getOwner } from '@ember/application';
 import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import LanguageDetector from 'i18next-browser-languagedetector';
 import ENV from 'pix-admin/config/environment';
 
 const { DEFAULT_LOCALE, SUPPORTED_LOCALES, COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
@@ -12,31 +14,51 @@ export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
+const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
+
+const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
 const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
 
 const PIX_LANGUAGES = [
-  { value: 'fr', originalName: 'Français', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'en', originalName: 'English', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'nl', originalName: 'Nederlands', shouldBeDisplayedInLanguageSwitcher: true },
-  { value: 'es', originalName: 'Español', shouldBeDisplayedInLanguageSwitcher: false },
+  { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
+  { value: 'en', nativeName: 'English', displayedInSwitcher: true },
+  { value: 'nl', nativeName: 'Nederlands', displayedInSwitcher: true },
+  { value: 'es', nativeName: 'Español', displayedInSwitcher: false },
 ];
+
+const COOKIE_LOCALE = 'locale';
 
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+  @service featureToggles;
   @service intl;
   @service dayjs;
 
-  get supportedLocales() {
-    return SUPPORTED_LOCALES;
-  }
+  @tracked __currentLocale = DEFAULT_LOCALE;
 
   get currentLocale() {
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+    if (localeCookieEnabled) {
+      return this.__currentLocale;
+    }
+
     return this.intl.primaryLocale;
+  }
+
+  get currentLanguage() {
+    const language = this.#getLanguageFromLocale(this.currentLocale);
+    return this.#getNearestSupportedLanguage(language);
+  }
+
+  /**
+   * Returns all locales supported by this application
+   */
+  get supportedLocales() {
+    return SUPPORTED_LOCALES;
   }
 
   /**
@@ -44,6 +66,13 @@ export default class LocaleService extends Service {
    */
   get pixLocales() {
     return PIX_LOCALES;
+  }
+
+  /**
+   * Returns all locales available in challenges of the Pix platform
+   */
+  get pixChallengeLocales() {
+    return PIX_CHALLENGE_LOCALES;
   }
 
   /**
@@ -56,20 +85,13 @@ export default class LocaleService extends Service {
 
   get acceptLanguageHeader() {
     if (this.currentDomain.isFranceDomain) return FRENCH_FRANCE_LOCALE;
-    return this.currentLocale;
-  }
-
-  /**
-   * Returns all locales available in challenges of the Pix platform
-   */
-  get pixChallengeLocales() {
-    return PIX_CHALLENGE_LOCALES;
+    return this.currentLanguage;
   }
 
   get switcherDisplayedLanguages() {
-    return PIX_LANGUAGES.filter(
-      (elem) => this.supportedLocales.includes(elem.value) && elem.shouldBeDisplayedInLanguageSwitcher,
-    ).map((elem) => ({ value: elem.value, label: elem.originalName }));
+    return PIX_LANGUAGES.filter((elem) => this.supportedLocales.includes(elem.value) && elem.displayedInSwitcher).map(
+      (elem) => ({ value: elem.value, label: elem.nativeName }),
+    );
   }
 
   isSupportedLocale(locale) {
@@ -82,50 +104,126 @@ export default class LocaleService extends Service {
   }
 
   setCurrentLocale(locale) {
-    this.intl.setLocale(locale);
-    this.dayjs.setLocale(locale);
+    let nearestLocale = locale;
+
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+    if (localeCookieEnabled) {
+      nearestLocale = this.#getNearestSupportedLocale(locale);
+      this.#setCookieLocale(nearestLocale);
+      this.__currentLocale = nearestLocale;
+    }
+
+    const language = this.#getLanguageFromLocale(nearestLocale);
+    this.intl.setLocale(language);
+    this.dayjs.setLocale(language);
 
     // metricsService may not be available for the different front apps
     const metricsService = getOwner(this).lookup('service:metrics');
     if (metricsService) {
-      metricsService.context.locale = locale;
+      metricsService.context.locale = nearestLocale;
     }
   }
 
-  detectBestLocale({ language, user }) {
+  setBestLocale({ user, queryParams }) {
+    const localeCookieEnabled = this.featureToggles.featureToggles?.useLocale;
+
+    let locale;
+    if (localeCookieEnabled) {
+      locale = this.#detectBestLocale({ queryParams });
+    } else {
+      locale = this.#detectBestLocaleLegacy({ user, queryParams });
+    }
+    this.setCurrentLocale(locale);
+  }
+
+  #detectBestLocaleLegacy({ user, queryParams }) {
     if (this.currentDomain.isFranceDomain) {
-      this.setCurrentLocale(FRENCH_INTERNATIONAL_LOCALE);
-      this.#setLocaleCookie(FRENCH_FRANCE_LOCALE);
-      return;
+      this.#setCookieLocale(FRENCH_FRANCE_LOCALE);
+      return FRENCH_INTERNATIONAL_LOCALE;
     }
 
-    if (language) {
-      const supportedLanguage = this.#findSupportedLanguage(language);
-      this.setCurrentLocale(supportedLanguage);
-      return;
+    if (queryParams?.lang) {
+      return this.#getNearestSupportedLanguage(queryParams?.lang);
     }
 
     if (user?.lang) {
-      const supportedLanguage = this.#findSupportedLanguage(user.lang);
-      this.setCurrentLocale(supportedLanguage);
-      return;
+      return this.#getNearestSupportedLanguage(user.lang);
     }
 
-    this.setCurrentLocale(DEFAULT_LOCALE);
+    return DEFAULT_LOCALE;
   }
 
-  #findSupportedLanguage(language) {
-    return this.pixLanguages.filter((pixLanguage) => this.supportedLocales.includes(pixLanguage)).includes(language)
-      ? language
-      : DEFAULT_LOCALE;
+  #detectBestLocale({ queryParams }) {
+    const { isFranceDomain } = this.currentDomain;
+    const languageDetector = new LanguageDetector();
+
+    languageDetector.addDetector({
+      name: 'pix-domains',
+      lookup() {
+        if (isFranceDomain) return FRENCH_FRANCE_LOCALE;
+        return null;
+      },
+    });
+
+    languageDetector.addDetector({
+      name: 'pix-query-params',
+      lookup() {
+        if (queryParams?.lang) return queryParams?.lang;
+        if (queryParams?.locale) return queryParams?.locale;
+        return null;
+      },
+    });
+
+    languageDetector.init(null, {
+      order: ['pix-domains', 'pix-query-params', 'cookie', 'navigator'],
+      lookupCookie: COOKIE_LOCALE,
+    });
+
+    const detectedLocale = languageDetector.detect();
+    return this.#getNearestSupportedLocale(detectedLocale);
   }
 
-  #setLocaleCookie(locale) {
-    const cookie = this.cookies.exists('locale');
-    if (cookie) return;
+  #getNearestSupportedLocale(locale) {
+    if (!locale) return DEFAULT_LOCALE;
 
-    this.cookies.write('locale', locale, {
-      domain: `pix.${this.currentDomain.getExtension()}`,
+    // When 'fr-FR' for org domain, always returns 'fr' instead
+    if (!this.currentDomain.isFranceDomain && locale === FRENCH_FRANCE_LOCALE) {
+      return FRENCH_INTERNATIONAL_LOCALE;
+    }
+
+    try {
+      const intlLocale = new Intl.Locale(locale);
+
+      if (this.supportedLocales.includes(intlLocale.toString())) {
+        return intlLocale.toString();
+      }
+
+      const localeMatch = this.supportedLocales.find((l) => new Intl.Locale(l).language === intlLocale.language);
+      if (localeMatch) return localeMatch;
+
+      return DEFAULT_LOCALE;
+    } catch {
+      return DEFAULT_LOCALE;
+    }
+  }
+
+  #getNearestSupportedLanguage(language) {
+    const supportedLanguages = this.pixLanguages.filter((pixLanguage) => this.supportedLocales.includes(pixLanguage));
+    return supportedLanguages.includes(language) ? language : DEFAULT_LANGUAGE;
+  }
+
+  #getLanguageFromLocale(locale) {
+    if (!locale) return DEFAULT_LANGUAGE;
+    try {
+      return new Intl.Locale(locale).language;
+    } catch {
+      return DEFAULT_LANGUAGE;
+    }
+  }
+
+  #setCookieLocale(locale) {
+    this.cookies.write(COOKIE_LOCALE, locale, {
+      domain: `.${this.currentDomain.domain}`,
       maxAge: COOKIE_LOCALE_LIFESPAN_IN_SECONDS,
       path: '/',
       sameSite: 'Strict',

--- a/admin/app/services/location.js
+++ b/admin/app/services/location.js
@@ -1,6 +1,10 @@
 import Service from '@ember/service';
 
 export default class LocationService extends Service {
+  get href() {
+    return window.location.href;
+  }
+
   replace(url) {
     return location.replace(url);
   }

--- a/admin/app/services/url-base.js
+++ b/admin/app/services/url-base.js
@@ -18,8 +18,7 @@ export default class UrlBaseService extends Service {
   }
 
   get serverStatusUrl() {
-    const currentLocale = this.locale.currentLocale;
-    return `https://status.pix.org/?locale=${currentLocale}`;
+    return `https://status.pix.org/?locale=${this.locale.currentLanguage}`;
   }
 
   get pixAppUrl() {

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -29,7 +29,7 @@ module.exports = function (environment) {
       API_HOST: process.env.API_HOST || '',
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
       DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
-      SUPPORTED_LOCALES: ['en', 'fr'],
+      SUPPORTED_LOCALES: ['en', 'fr', 'fr-FR'],
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {
           CODE: '400',

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-qunit": "^8.2.4",
         "globals": "^16.3.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "joi": "^17.13.3",
         "js-base64": "^3.7.7",
         "jwt-decode": "^4.0.0",
@@ -25076,6 +25077,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -34,6 +34,7 @@
         "ember-cli-matomo-tag-manager": "^1.3.1",
         "ember-cli-mirage": "^3.0.4",
         "ember-cli-sass": "^11.0.1",
+        "ember-cookies": "^1.3.0",
         "ember-cp-validations": "^7.0.0",
         "ember-data": "^5.6.0",
         "ember-dayjs": "^0.12.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -66,6 +66,7 @@
     "ember-cli-matomo-tag-manager": "^1.3.1",
     "ember-cli-mirage": "^3.0.4",
     "ember-cli-sass": "^11.0.1",
+    "ember-cookies": "^1.3.0",
     "ember-cp-validations": "^7.0.0",
     "ember-data": "^5.6.0",
     "ember-dayjs": "^0.12.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-qunit": "^8.2.4",
     "globals": "^16.3.0",
+    "i18next-browser-languagedetector": "^8.2.0",
     "joi": "^17.13.3",
     "js-base64": "^3.7.7",
     "jwt-decode": "^4.0.0",

--- a/admin/tests/helpers/setup-intl.js
+++ b/admin/tests/helpers/setup-intl.js
@@ -1,11 +1,20 @@
+import { getContext, settled } from '@ember/test-helpers';
 import { setupIntl as setupIntlFromEmberIntl, t } from 'ember-intl/test-support';
 
-export default function setupIntl(hooks, locale = ['fr']) {
-  setupIntlFromEmberIntl(hooks, locale[0]);
+export async function setCurrentLocale(locale) {
+  const { owner } = getContext();
 
-  hooks.beforeEach(function () {
-    this.dayjs = this.owner.lookup('service:dayjs');
-    this.dayjs.setLocale(locale[0]);
+  const localeService = owner.lookup('service:locale');
+  localeService.setCurrentLocale(locale);
+
+  await settled();
+}
+
+export default function setupIntl(hooks, locale = 'fr') {
+  setupIntlFromEmberIntl(hooks, locale);
+
+  hooks.beforeEach(async function () {
+    await setCurrentLocale(locale);
   });
 }
 

--- a/admin/tests/test-helper.js
+++ b/admin/tests/test-helper.js
@@ -1,10 +1,21 @@
 import { setApplication } from '@ember/test-helpers';
+import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 
 import Application from '../app';
 import config from '../config/environment';
+
+// Set default browser locale
+const BROWSER_LOCALE = 'fr';
+Object.defineProperty(window.navigator, 'language', { value: BROWSER_LOCALE, configurable: true });
+Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], configurable: true });
+
+// Reset all cookies before each test to avoid side-effects
+QUnit.hooks.beforeEach(function () {
+  clearAllCookies();
+});
 
 setup(QUnit.assert);
 setApplication(Application.create(config.APP));

--- a/admin/tests/unit/services/current-domain-test.js
+++ b/admin/tests/unit/services/current-domain-test.js
@@ -1,0 +1,103 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | currentDomain', function (hooks) {
+  setupTest(hooks);
+
+  module('#getExtension', function () {
+    module('when location is FR TLD', function () {
+      test(`returns fr`, function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const extension = service.getExtension();
+
+        // then
+        assert.strictEqual(extension, 'fr');
+      });
+    });
+
+    module('when location is ORG TLD', function () {
+      test(`returns org`, function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.org/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const extension = service.getExtension();
+
+        // then
+        assert.strictEqual(extension, 'org');
+      });
+    });
+  });
+
+  module('#isFranceDomain', function () {
+    module('when location is FR TLD', function () {
+      test('returns true', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const isFranceDomain = service.isFranceDomain;
+
+        // then
+        assert.true(isFranceDomain);
+      });
+    });
+
+    module('when location is ORG TLD', function () {
+      test('returns false', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.org/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const isFranceDomain = service.isFranceDomain;
+
+        // then
+        assert.false(isFranceDomain);
+      });
+    });
+  });
+
+  module('#domain', function () {
+    module('when location is localhost', function () {
+      test('returns locahost as domain', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('http://localhost:4200/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const domain = service.domain;
+
+        // then
+        assert.strictEqual(domain, 'localhost');
+      });
+    });
+
+    module('when location is not localhost', function () {
+      test('returns the last 2-parts segment', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const domain = service.domain;
+
+        // then
+        assert.strictEqual(domain, 'pix.fr');
+      });
+    });
+  });
+});

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -8,35 +8,24 @@ import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntl, { setCurrentLocale } from '../../helpers/setup-intl.js';
+
 const { DEFAULT_LOCALE } = ENV.APP;
 
 module('Unit | Services | locale', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks, 'fr');
 
   let localeService;
-  let cookiesService;
   let currentDomainService;
-  let dayjsService;
-  let intlService;
   let metricsService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl']);
-
-    cookiesService = this.owner.lookup('service:cookies');
-    sinon.stub(cookiesService, 'write');
-    sinon.stub(cookiesService, 'exists');
+    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
-
-    dayjsService = this.owner.lookup('service:dayjs');
-    sinon.stub(dayjsService, 'setLocale');
-
-    intlService = this.owner.lookup('service:intl');
-    sinon.stub(intlService, 'primaryLocale');
-    sinon.stub(intlService, 'setLocale');
 
     class metricsServiceStub extends Service {
       context = {};
@@ -45,13 +34,59 @@ module('Unit | Services | locale', function (hooks) {
     metricsService = this.owner.lookup('service:metrics');
   });
 
+  module('currentLocale', function () {
+    module('when useLocale feature toggle is disabled', function () {
+      test('returns the intl locale', function (assert) {
+        // given
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr-BE');
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      module('when current locale is not set', function () {
+        test('returns the default locale', function (assert) {
+          // when
+          const currentLocale = localeService.currentLocale;
+
+          // then
+          assert.strictEqual(currentLocale, 'fr');
+        });
+      });
+
+      module('when current locale is set', function () {
+        test('returns the current locale', function (assert) {
+          // given
+          localeService.setCurrentLocale('fr-BE');
+
+          // when
+          const currentLocale = localeService.currentLocale;
+
+          // then
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+    });
+  });
+
   module('pixLocales', function () {
     test('returns the locales available in the Pix Platform', function (assert) {
       // when
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 
@@ -67,10 +102,10 @@ module('Unit | Services | locale', function (hooks) {
 
   module('acceptLanguageHeader', function () {
     module('when the domain is pix.fr', function () {
-      test('always returns fr-FR', function (assert) {
+      test('always returns fr-FR', async function (assert) {
         // given
         currentDomainService.getExtension.returns('fr');
-        sinon.stub(intlService, 'primaryLocale').value('en');
+        await setCurrentLocale('en');
 
         // when
         const acceptLanguageHeader = localeService.acceptLanguageHeader;
@@ -81,16 +116,16 @@ module('Unit | Services | locale', function (hooks) {
     });
 
     module('when the domain is pix.org', function () {
-      test('always returns the current locale', function (assert) {
+      test('always returns the current locale', async function (assert) {
         // given
         currentDomainService.getExtension.returns('org');
-        sinon.stub(intlService, 'primaryLocale').value('nl-BE');
+        await setCurrentLocale('nl');
 
         // when
         const acceptLanguageHeader = localeService.acceptLanguageHeader;
 
         // then
-        assert.strictEqual(acceptLanguageHeader, 'nl-BE');
+        assert.strictEqual(acceptLanguageHeader, 'nl');
       });
     });
   });
@@ -150,30 +185,71 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    test('set app locale', function (assert) {
-      // given
-      const locale = DEFAULT_LOCALE;
+    module('when useLocale feature toggle is disabled', function () {
+      test('set app locale', function (assert) {
+        // given
+        const dayjsService = this.owner.lookup('service:dayjs');
+        sinon.stub(dayjsService, 'setLocale');
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'setLocale');
+        const locale = DEFAULT_LOCALE;
 
-      // when
-      localeService.setCurrentLocale(locale);
+        // when
+        localeService.setCurrentLocale(locale);
 
-      // then
-      sinon.assert.calledWith(intlService.setLocale, locale);
-      sinon.assert.calledWith(dayjsService.setLocale, locale);
-      assert.strictEqual(metricsService.context.locale, locale);
+        // then
+        sinon.assert.calledWith(intlService.setLocale, locale);
+        sinon.assert.calledWith(dayjsService.setLocale, locale);
+        assert.strictEqual(metricsService.context.locale, locale);
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      test('set app locale in the cookies', function (assert) {
+        // given
+        const dayjsService = this.owner.lookup('service:dayjs');
+        sinon.stub(dayjsService, 'setLocale');
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'setLocale');
+        const cookiesService = this.owner.lookup('service:cookies');
+        sinon.stub(cookiesService, 'write');
+        const locale = 'nl-BE';
+
+        // when
+        localeService.setCurrentLocale(locale);
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'nl-BE');
+        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+        sinon.assert.calledWith(intlService.setLocale, 'nl');
+        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+        assert.strictEqual(metricsService.context.locale, 'nl-BE');
+      });
     });
   });
 
-  module('detectBestLocale', function () {
-    module('when the current domain is "fr"', function () {
-      module('when there is no cookie locale', function () {
+  module('setBestLocale', function () {
+    module('when useLocale feature toggle is disabled', function () {
+      module('when the current domain is "fr"', function () {
         test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
           // given
-          cookiesService.exists.returns(false);
+          const dayjsService = this.owner.lookup('service:dayjs');
+          sinon.stub(dayjsService, 'setLocale');
+          const intlService = this.owner.lookup('service:intl');
+          sinon.stub(intlService, 'setLocale');
+          const cookiesService = this.owner.lookup('service:cookies');
+          sinon.stub(cookiesService, 'write');
+          sinon.stub(cookiesService, 'exists').returns(false);
           currentDomainService.getExtension.returns('fr');
 
           // when
-          localeService.detectBestLocale({ language: null, user: null });
+          localeService.setBestLocale({ queryParams: null, user: null });
 
           // then
           sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
@@ -183,100 +259,59 @@ module('Unit | Services | locale', function (hooks) {
         });
       });
 
-      module('when there is already a cookie locale', function () {
-        test('sets the locale with "fr" and does not update cookie locale', function (assert) {
-          // given
-          cookiesService.exists.returns(true);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.detectBestLocale({ language: null, user: null });
-
-          // then
-          sinon.assert.notCalled(cookiesService.write);
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
-      });
-    });
-
-    module('when the current domain extension is "org"', function () {
-      module('when no current user', function () {
-        module('when there is no overriding language', function () {
-          test('sets the the default locale', async function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-
-            // when
-            localeService.detectBestLocale({ language: null, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-            sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-            assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-          });
-        });
-
-        module('when the overriding language is supported', function () {
-          test('sets the locale with the overriding language', function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-            const language = 'es';
-
-            // when
-            localeService.detectBestLocale({ language, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, 'es');
-            sinon.assert.calledWith(dayjsService.setLocale, 'es');
-            assert.strictEqual(metricsService.context.locale, 'es');
-          });
-        });
-
-        module('when the overriding language is not supported', function () {
-          test('sets the default locale', function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-            const badLanguage = 'xxx';
-
-            // when
-            localeService.detectBestLocale({ language: badLanguage, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-            sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-            assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-          });
-        });
-      });
-
-      module('when user is loaded', function () {
-        module('when there is no overriding language', function () {
-          module('when the user language is supported', function () {
-            test('sets the locale with the user language', async function (assert) {
+      module('when the current domain extension is "org"', function () {
+        module('when no current user', function () {
+          module('when there is no overriding language', function () {
+            test('sets the the default locale', async function (assert) {
               // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
               currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
 
               // when
-              localeService.detectBestLocale({ language: null, user });
+              localeService.setBestLocale({ queryParams: null, user: null });
 
               // then
-              sinon.assert.calledWith(intlService.setLocale, 'nl');
-              sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-              assert.strictEqual(metricsService.context.locale, 'nl');
+              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
+              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
+              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
             });
           });
 
-          module('when the user language is not supported', function () {
-            test('sets the default locale', async function (assert) {
+          module('when the overriding language is supported', function () {
+            test('sets the locale with the overriding language', function (assert) {
               // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
               currentDomainService.getExtension.returns('org');
-              const user = { lang: 'tlh' }; // tlh: Klingon locale
+              const queryParams = { lang: 'es' };
 
               // when
-              localeService.detectBestLocale({ language: null, user });
+              localeService.setBestLocale({ queryParams, user: null });
+
+              // then
+              sinon.assert.calledWith(intlService.setLocale, 'es');
+              sinon.assert.calledWith(dayjsService.setLocale, 'es');
+              assert.strictEqual(metricsService.context.locale, 'es');
+            });
+          });
+
+          module('when the overriding language is not supported', function () {
+            test('sets the default locale', function (assert) {
+              // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
+              currentDomainService.getExtension.returns('org');
+              const queryParams = { lang: 'xxx' };
+
+              // when
+              localeService.setBestLocale({ queryParams, user: null });
 
               // then
               sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
@@ -286,20 +321,190 @@ module('Unit | Services | locale', function (hooks) {
           });
         });
 
-        module('when the overriding language is given', function () {
-          test('sets the locale with the overriding language', function (assert) {
+        module('when user is loaded', function () {
+          module('when there is no overriding language', function () {
+            module('when the user language is supported', function () {
+              test('sets the locale with the user language', async function (assert) {
+                // given
+                const dayjsService = this.owner.lookup('service:dayjs');
+                sinon.stub(dayjsService, 'setLocale');
+                const intlService = this.owner.lookup('service:intl');
+                sinon.stub(intlService, 'setLocale');
+                currentDomainService.getExtension.returns('org');
+                const user = { lang: 'nl' };
+
+                // when
+                localeService.setBestLocale({ queryParams: null, user });
+
+                // then
+                sinon.assert.calledWith(intlService.setLocale, 'nl');
+                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+                assert.strictEqual(metricsService.context.locale, 'nl');
+              });
+            });
+
+            module('when the user language is not supported', function () {
+              test('sets the default locale', async function (assert) {
+                // given
+                const dayjsService = this.owner.lookup('service:dayjs');
+                sinon.stub(dayjsService, 'setLocale');
+                const intlService = this.owner.lookup('service:intl');
+                sinon.stub(intlService, 'setLocale');
+                currentDomainService.getExtension.returns('org');
+                const user = { lang: 'tlh' }; // tlh: Klingon locale
+
+                // when
+                localeService.setBestLocale({ queryParams: null, user });
+
+                // then
+                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
+                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
+                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
+              });
+            });
+          });
+
+          module('when the overriding language is given', function () {
+            test('sets the locale with the overriding language', function (assert) {
+              // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
+              currentDomainService.getExtension.returns('org');
+              const user = { lang: 'nl' };
+              const queryParams = { lang: 'es' };
+
+              // when
+              localeService.setBestLocale({ queryParams, user });
+
+              // then
+              sinon.assert.calledWith(intlService.setLocale, 'es');
+              sinon.assert.calledWith(dayjsService.setLocale, 'es');
+              assert.strictEqual(metricsService.context.locale, 'es');
+            });
+          });
+        });
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      module('when the current domain extension is "fr"', function (hooks) {
+        hooks.beforeEach(function () {
+          currentDomainService.getExtension.returns('fr');
+        });
+
+        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'nl');
+          sinon.stub(cookiesService, 'write');
+
+          // when
+          localeService.setBestLocale({ queryParams: null });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-FR');
+        });
+      });
+
+      module('when the current domain extension is "org"', function (hooks) {
+        hooks.beforeEach(function () {
+          currentDomainService.getExtension.returns('org');
+        });
+
+        test('sets the default locale', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', '');
+          sinon.stub(cookiesService, 'write');
+
+          // when
+          localeService.setBestLocale({ queryParams: null });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+        });
+
+        module('when there is query param "lang"', function () {
+          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
             // given
-            currentDomainService.getExtension.returns('org');
-            const user = { lang: 'nl' };
-            const language = 'es';
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr');
 
             // when
-            localeService.detectBestLocale({ language, user });
+            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
 
             // then
-            sinon.assert.calledWith(intlService.setLocale, 'es');
-            sinon.assert.calledWith(dayjsService.setLocale, 'es');
-            assert.strictEqual(metricsService.context.locale, 'es');
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is query param "locale"', function () {
+          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr');
+
+            // when
+            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is a cookie', function () {
+          test('sets the locale with the "locale" cookie value', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr-BE');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is an unsupported cookie', function () {
+          test('sets the nearest supported base language', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'en-CA');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'en');
+          });
+        });
+
+        module('when the detected locale is fr-FR', function () {
+          test('always returns fr for not France domain', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr-FR');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr');
           });
         });
       });

--- a/admin/tests/unit/services/url-base-test.js
+++ b/admin/tests/unit/services/url-base-test.js
@@ -2,13 +2,14 @@
 // If you need a change, modify the original file and
 // propagate the changes in the copies in all the fronts.
 
-import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-admin/config/environment';
 import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'pix-admin/services/url-base';
 import setupIntl from 'pix-admin/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { setCurrentLocale } from '../../helpers/setup-intl.js';
 
 const { SUPPORTED_LOCALES } = ENV.APP;
 
@@ -20,13 +21,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the application home url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.homeUrl;
 
       // then
-      assert.strictEqual(homeUrl, '/?lang=en');
+      assert.strictEqual(homeUrl, '/?lang=fr');
     });
   });
 
@@ -34,13 +34,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the Pix server status url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.serverStatusUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=fr');
     });
   });
 
@@ -92,7 +91,7 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
     });
 
-    test('returns the Pix app forgotten password url for a locale', function (assert) {
+    test('returns the Pix app forgotten password url for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
@@ -100,7 +99,7 @@ module('Unit | Service | url-base', function (hooks) {
       const domainService = this.owner.lookup('service:current-domain');
       sinon.stub(domainService, 'getExtension').returns('fr');
 
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.pixAppForgottenPasswordUrl;
@@ -111,10 +110,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrl', function () {
-    test('returns the Pix website url for the current locale', function (assert) {
+    test('returns the Pix website url for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl();
@@ -123,10 +122,10 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://pix.org/en');
     });
 
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
@@ -137,10 +136,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrlFor', function () {
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrlFor('CGU');
@@ -150,12 +149,12 @@ module('Unit | Service | url-base', function (hooks) {
     });
 
     module('when the tld is fr', function () {
-      test('returns the Pix website url for the tld fr', function (assert) {
+      test('returns the Pix website url for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor();
@@ -164,12 +163,12 @@ module('Unit | Service | url-base', function (hooks) {
         assert.strictEqual(homeUrl, 'https://pix.fr');
       });
 
-      test('returns the Pix website url and path for the tld fr', function (assert) {
+      test('returns the Pix website url and path for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor('CGU');

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -7,6 +7,7 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import ENV from 'mon-pix/config/environment';
+
 const { DEFAULT_LOCALE, SUPPORTED_LOCALES, COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = ENV.APP;
 
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';


### PR DESCRIPTION
## 🔆 Problème

Actuellement, l'algorithme de détection de locale ne gère pas tous les cas que l'on souhaite lorsque l'utilisateur charge l'application. De plus, il n'y a pas de source de vérité pour la locale courante.

## ⛱️ Proposition

**Sous feature toggle `useLocale`**

- Modifier l'algorithme de détection des locales suivant ces priorités:
  - si domaine `.fr`, alors `locale='fr-FR'`
  - si cookie `locale` présent, alors `locale=<valeur du cookie>`
  - sinon `locale=<locale du navigateur>`

- Quand on détecte la locale on s'assure qu'elle est supportée par l'application, en déterminant la locale la plus proche supportée, exemple:
  - `fr` => `fr`
  - `fr-fr` => `fr-FR`
  - `fr-BE` => `fr-BE`, `nl-BE` => `nl-BE`
  - `fr-CA` => `fr`, `nl-NL` => `nl`
  - Non supporté => locale par défaut

- Dans le service `locale`
  - La fonction `currentLocale` retournera **toujours** la locale du cookie.
  - La fonction `currentLanguage` retournera la langue déduite de la locale courante.

**Normalement, quand le FT `useLocale` est activé, l'ensemble de l'application reste fonctionnel et inchangé. Seules la détection des locales et leur priorisation changent.**

## 🌊 Remarques

- Pour l'algorithme de détection des locales, nous utilisons la librairie `https://github.com/i18next/i18next-browser-languageDetector`
- À certains endroits, il est nécessaire d'utiliser `currentLanguage` au lieu de `currentLocale` pour conserver la rétro-compatibilité de certaines features.

## 🏄 Pour tester

⚠️ Il est conseillé de réaliser les tests en **navigation privée**.

**Non régression :**
Quand le feature toggle `useLocale` est désactivé, la détection des locales est la même qu'aujourd'hui.

**Quand le feature toggle `useLocale` est activé :**
Nouveaux comportement (sur `pix.fr`):
- https://admin-pr13104.review.pix.fr
- La locale est toujours stockée dans le cookie `locale`
- Sur pix.fr, la locale sera toujours `fr-FR` (comme précédemment)

Nouveaux comportement (sur `pix.org`):
- https://admin-pr13104.review.pix.org
- La locale est toujours stockée dans le cookie `locale`
- La détection des locales suit l'algorithme expliqué dans la proposition.
- La première fois où l'utilisateur arrive, on détermine la locale supportée la plus proche par rapport à la locale du navigateur.
- La locale ne peut pas être changée dans PixAdmin, car il n'y a pas de local switcher et le paramètre `lang` / `locale` n'est pas géré sur Pix Admin
- Quand un utilisateur revient on utilise le cookie `locale`, s'il est présent.

S'assurer qu'en changeant les locales, on accède aux contenus localisés.