### PR TITLE
[TECH] Supprimer isCancelled pour CPF et LSU/ LSL (PIX-19003).

### DIFF
--- a/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -1,9 +1,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { AssessmentResult } from '../../../../shared/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../shared/domain/models/index.js';
 import { Certificate } from '../../domain/read-models/livret-scolaire/Certificate.js';
 
 const getCertificatesByOrganizationUAI = async function (uai) {
-  // isCancelled will be removed
   const result = await knex
     .select({
       id: 'certification-courses.id',
@@ -51,14 +50,13 @@ const getCertificatesByOrganizationUAI = async function (uai) {
     .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
     .whereNotExists(
+      // Y inclure le status cancelled ici
       knex
         .select(1)
         .from({ 'last-certification-courses': 'certification-courses' })
         .whereRaw('"last-certification-courses"."userId" = "certification-courses"."userId"')
-        .whereRaw('"last-certification-courses"."isCancelled"= false')
         .whereRaw('"certification-courses"."createdAt" < "last-certification-courses"."createdAt"'),
     )
-    .where({ 'certification-courses.isCancelled': false })
     .where({ 'view-active-organization-learners.isDisabled': false })
     .whereRaw('"assessment-results"."status" <> ?', AssessmentResult.status.CANCELLED)
     .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)

--- a/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/cpf-certification-result-repository.js
@@ -108,7 +108,6 @@ function _selectCpfCertificationResults(qb = knex) {
 function _filterQuery(qb = knex, startDate, endDate) {
   return qb
     .where('certification-courses.isPublished', true)
-    .where('certification-courses.isCancelled', false) // isCancelled will be removed
     .whereNotNull('certification-courses.sex')
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
     .where('sessions.publishedAt', '>=', startDate)

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -13,7 +13,7 @@ import {
   buildValidatedUnpublishedCertificationData,
 } from '../../../../../tooling/domain-builder/factory/build-certifications-results-for-livret-scolaire.js';
 
-describe('Integration | Repository | Certification-ls ', function () {
+describe('Integration | Repository | Certification-livret-scolaire ', function () {
   const pixScore = 400;
   const uai = '789567AA';
   const verificationCode = 'P-123498NN';
@@ -134,7 +134,6 @@ describe('Integration | Repository | Certification-ls ', function () {
 
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         userId: user.id,
-        isCancelled: false,
       });
 
       const assessment = databaseBuilder.factory.buildAssessment({
@@ -207,7 +206,7 @@ describe('Integration | Repository | Certification-ls ', function () {
       expect(certificationResults).to.deep.equal([expected]);
     });
 
-    it("should not return cancelled certification for a given uai by assessmentresults.status === 'cancelled'", async function () {
+    it('should not return cancelled certification for a given uai', async function () {
       // given
       const organizationId = buildOrganization(uai).id;
       const user = buildUser();
@@ -225,31 +224,6 @@ describe('Integration | Repository | Certification-ls ', function () {
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         status: 'cancelled',
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const certificationResults = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
-
-      // then
-      expect(certificationResults).to.deep.equal([]);
-    });
-
-    it('should not return cancelled certification for a given UAI by certificationCourses.isCancelled to true', async function () {
-      // given
-      const organizationId = buildOrganization(uai).id;
-      const user = buildUser();
-      const organizationLearner = buildOrganizationLearner({
-        userId: user.id,
-        organizationId,
-      });
-      buildCancelledCertificationData({
-        user,
-        organizationLearner,
-        verificationCode,
-        pixScore,
-        competenceMarks,
       });
 
       await databaseBuilder.commit();

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -59,7 +59,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         }).id;
         createCertificationCourseWithCompetenceMarks({
           sessionId: publishedSessionId,
-          certificationCourseCancelled: true,
+          assessmentResultStatus: AssessmentResult.status.CANCELLED,
         });
         await databaseBuilder.commit();
 
@@ -405,7 +405,6 @@ function createCertificationCourseWithCompetenceMarks({
   certificationCourseId = 145,
   sex = 'M',
   assessmentResultStatus = AssessmentResult.status.VALIDATED,
-  certificationCourseCancelled = false,
   isPublished = true,
   sessionId,
   firstName = 'Barack',
@@ -434,7 +433,6 @@ function createCertificationCourseWithCompetenceMarks({
     birthCountry,
     isPublished: isPublished,
     sessionId,
-    isCancelled: certificationCourseCancelled,
   });
 
   if (cpfFilename || cpfImportStatus) {

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-livret-scolaire.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-livret-scolaire.js
@@ -1,5 +1,5 @@
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
+import { Assessment } from '../../../../src/shared/domain/models/index.js';
 import { databaseBuilder } from '../../../test-helper.js';
 
 const assessmentCreatedDate = new Date('2020-04-19');
@@ -25,7 +25,6 @@ function _buildCertificationData({
   organizationLearner,
   certificationCreatedDate,
   isPublished,
-  isCancelled,
   verificationCode,
 }) {
   const { id: certificationCenterId, name: certificationCenter } = _createCertificationCenter();
@@ -54,7 +53,6 @@ function _buildCertificationData({
     isPublished,
     createdAt: certificationCreatedDate || new Date(),
     verificationCode,
-    isCancelled,
   });
 
   databaseBuilder.factory.buildCertificationCourse({
@@ -64,7 +62,6 @@ function _buildCertificationData({
     birthdate: organizationLearner.birthdate,
     sessionId: session.id,
     isPublished: false,
-    isCancelled,
   });
 
   const assessment = databaseBuilder.factory.buildAssessment({
@@ -112,23 +109,13 @@ function buildOrganization(uai) {
   return databaseBuilder.factory.buildOrganization({ externalId: uai });
 }
 
-function buildCancelledCertificationData({
-  user,
-  organizationLearner,
-  verificationCode,
-  pixScore,
-  competenceMarks,
-  certificationCreatedDate,
-}) {
-  return _buildValidatedCertificationData({
+function buildCancelledCertificationData({ user, organizationLearner, certificationCreatedDate }) {
+  return _buildCertificationResultsData({
     user,
     organizationLearner,
-    verificationCode,
-    pixScore,
     certificationCreatedDate,
-    competenceMarks,
     isPublished: false,
-    isCancelled: true,
+    assessmentResultStatus: status.CANCELLED,
   });
 }
 
@@ -140,7 +127,7 @@ function buildValidatedPublishedCertificationData({
   competenceMarks,
   certificationCreatedDate,
 }) {
-  return _buildValidatedCertificationData({
+  return _buildCertificationResultsData({
     user,
     organizationLearner,
     verificationCode,
@@ -159,7 +146,7 @@ function buildValidatedUnpublishedCertificationData({
   competenceMarks,
   certificationCreatedDate,
 }) {
-  return _buildValidatedCertificationData({
+  return _buildCertificationResultsData({
     user,
     organizationLearner,
     verificationCode,
@@ -170,7 +157,7 @@ function buildValidatedUnpublishedCertificationData({
   });
 }
 
-function _buildValidatedCertificationData({
+function _buildCertificationResultsData({
   user,
   organizationLearner,
   verificationCode,
@@ -178,9 +165,8 @@ function _buildValidatedCertificationData({
   competenceMarks,
   certificationCreatedDate,
   isPublished,
-  isCancelled = false,
+  assessmentResultStatus = status.VALIDATED,
 }) {
-  const certificationStatus = status.VALIDATED;
   const { session, certificationCourse, assessmentId } = _buildCertificationData({
     user,
     organizationLearner,
@@ -188,7 +174,6 @@ function _buildValidatedCertificationData({
     type,
     pixScore,
     isPublished,
-    isCancelled,
     certificationCreatedDate,
   });
 
@@ -196,7 +181,7 @@ function _buildValidatedCertificationData({
     assessmentId,
     certificationCourseId: certificationCourse.id,
     pixScore,
-    status: certificationStatus,
+    status: assessmentResultStatus,
     createdAt: assessmentCreatedDate,
     competenceMarks,
   });
@@ -210,14 +195,14 @@ function _buildValidatedCertificationData({
     assessmentId,
     certificationCourseId: certificationCourse.id,
     pixScore,
-    status: certificationStatus,
+    status: assessmentResultStatus,
     createdAt: assessmentBeforeCreatedDate,
   });
 
   databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore,
-    status: certificationStatus,
+    status: assessmentResultStatus,
     createdAt: assessmentBeforeBeforeCreatedDate,
   });
 


### PR DESCRIPTION
## 🔆 Problème
> [!IMPORTANT]
>  (je commence à découper le sujet `isCancelled` en plusieurs PR :) )

Le statut d’une certification est définit par l’assessment-result.
Ce dernier peut être `validated` si le candidat réussit sa certification ou bien `rejected` s'il échoue.
Et pour le cas d’une certification annulée, on ne se basait pas sur la même chose => On dépendait de `certification-courses.isCancelled`. Or ce statut doit être traité comme les autres et un chantier a été fait pour fixer ça 🥳 

Maintenant que toutes les certifications annulées se basent sur le statut de l'`assessment-result`, on peut supprimer tranquillement la présence du `isCancelled`.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

Le commit `FIXME` présente un soucis, pour moi la requête est incomplète (d’où le test qui pète).
Cas qu'on attend => Si la certification la plus récente est une certification annulée, alors il est censé prendre celle d'avant. 
Cas qu'on à ici => On ne récupère pas celle d'avant. Avec la ligne isCancelled retiré, ce n'est plus le cas.

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
