### PR TITLE
[FEATURE] Rediriger l'utilisateur à la page de parcours combiné lors de la fin de la campagne de diagnostique (PIX-18124)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -5,6 +5,7 @@ import {
   REQUIREMENT_COMPARISONS,
   REQUIREMENT_TYPES,
 } from '../../../../src/quest/domain/models/Quest.js';
+import { config } from '../../../../src/shared/config.js';
 import { Assessment, CampaignParticipationStatuses, Membership } from '../../../../src/shared/domain/models/index.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
 import {
@@ -21,12 +22,15 @@ const firstTrainingId = QUEST_OFFSET + 1;
 const secondTrainingId = QUEST_OFFSET + 2;
 
 function buildCombinedCourseQuest(databaseBuilder, organizationId) {
+  const tldFr = config.environment === 'development' ? '' : config.domain.tldFr;
   const targetProfile = buildTargetProfile(databaseBuilder, { id: organizationId }, 0, TARGET_PROFILE_TUBES[0]);
   const campaign = databaseBuilder.factory.buildCampaign({
     name: 'Je teste mes compétences',
     organizationId,
     code: 'CODE123',
     targetProfileId: targetProfile.id,
+    customResultPageButtonText: 'Continuer',
+    customResultPageButtonUrl: `${config.domain.pixApp}${tldFr}/parcours/COMBINIX1`,
   });
   CAMPAIGN_SKILLS[0].map((skillId) =>
     databaseBuilder.factory.buildCampaignSkill({


### PR DESCRIPTION
## 🔆 Problème
A la fin de la campagne de diagnostique on aimerait avoir un bouton de redirection vers la page de récap du parcours combiné.

## ⛱️ Proposition
On réutilise la feature de customisation de bouton de fin de parcours existant côté prescription (😎). On ajoute l'url de la page de parcours combiné dans la propriété `customResultPageButtonUrl` ainsi que le texte 'Continuer' dans `customResultPageButtonText` afin d'avoir la redirection.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter a PixApp avec `attestation-blank@example.net`
- Acceder au parcours `COMBINIX1`
- Faire la campagne de diagnostique
- Vérifier à la fin que le bouton "Continuer" est présent et qu'il redirige vers la page de parcours combiné
- 🐈‍⬛ 
