### PR TITLE
[TECH] Supprimer le feature toggle d'inscription d'un utilisateur après parcours anonyme (PIX-18027)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -53,12 +53,6 @@ export default {
     defaultValue: false,
     tags: ['modulix', 'team-contenu', 'llm', 'embed', 'pix-app'],
   },
-  upgradeToRealUserEnabled: {
-    type: 'boolean',
-    description: 'Enable upgrade of anonymous accounts to true accounts after anonymous campaign participation.',
-    defaultValue: false,
-    tags: ['frontend', 'team-acces', 'pix-app'],
-  },
   isAutoShareEnabled: {
     type: 'boolean',
     description: 'Enable automatic campaign sharing.',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -27,7 +27,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
             'should-display-new-analysis-page': false,
-            'upgrade-to-real-user-enabled': false,
             'use-locale': false,
           },
         },

--- a/mon-pix/app/components/authentication/signup-form/index.gjs
+++ b/mon-pix/app/components/authentication/signup-form/index.gjs
@@ -32,7 +32,6 @@ export default class SignupForm extends Component {
   @service locale;
   @service url;
   @service errorMessages;
-  @service featureToggles;
   @service pixMetrics;
 
   @tracked isLoading = false;
@@ -91,7 +90,7 @@ export default class SignupForm extends Component {
       user.lang = this.locale.currentLanguage;
       const wasAnonymousBeforeSaving = user.isAnonymous;
       await user.save({ adapterOptions: { redirectionUrl: this.session.redirectionUrl } });
-      if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && wasAnonymousBeforeSaving) {
+      if (wasAnonymousBeforeSaving) {
         this.pixMetrics.trackEvent('SignUpFromAnonymousUserDone');
         this.session.set('skipRedirectAfterSessionInvalidation', true);
         await this.session.invalidate();

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -66,8 +66,8 @@ export default class EvaluationResultsHero extends Component {
     );
   }
 
-  get isUserAnonymousAndUpgradeToRealUserEnabled() {
-    return this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.currentUser.user.isAnonymous;
+  get isUserAnonymous() {
+    return this.currentUser?.user?.isAnonymous;
   }
 
   get hasQuestResults() {
@@ -245,7 +245,7 @@ export default class EvaluationResultsHero extends Component {
         <div class="evaluation-results-hero-details__actions">
           {{#if @isSharableCampaign}}
             {{#if @campaignParticipationResult.isShared}}
-              {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
+              {{#if this.isUserAnonymous}}
                 <p>{{t "pages.sign-up.save-progress-message"}}</p>
                 <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
                   {{t "pages.sign-up.actions.sign-up-on-pix"}}
@@ -256,7 +256,7 @@ export default class EvaluationResultsHero extends Component {
                   {{t "pages.skill-review.hero.see-trainings"}}
                 </PixButton>
               {{else}}
-                {{#unless (or @campaign.hasCustomResultPageButton this.isUserAnonymousAndUpgradeToRealUserEnabled)}}
+                {{#unless (or @campaign.hasCustomResultPageButton this.isUserAnonymous)}}
                   {{this.handleBackToHomepageDisplay}}
                   <PixButtonLink @route="authentication.login" @size="large" onclick={{this.handleBackToHomepageClick}}>
                     {{t "navigation.back-to-homepage"}}
@@ -290,7 +290,7 @@ export default class EvaluationResultsHero extends Component {
             {{/if}}
           {{else}}
             {{#unless @campaign.hasCustomResultPageButton}}
-              {{#if this.isUserAnonymousAndUpgradeToRealUserEnabled}}
+              {{#if this.isUserAnonymous}}
                 <p>{{t "pages.sign-up.save-progress-message"}}</p>
                 <PixButtonLink @route="inscription" @size="large" onclick={{this.handleSignUpClick}}>
                   {{t "pages.sign-up.actions.sign-up-on-pix"}}

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -3,7 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isQuestEnabled;
-  @attr('boolean') upgradeToRealUserEnabled;
   @attr('boolean') isAutoShareEnabled;
   @attr('boolean') useLocale;
 }

--- a/mon-pix/app/routes/inscription/inscription.js
+++ b/mon-pix/app/routes/inscription/inscription.js
@@ -13,7 +13,7 @@ export default class InscriptionRoute extends Route {
   }
 
   beforeModel() {
-    if (this.featureToggles.featureToggles?.upgradeToRealUserEnabled && this.isAnonymous) {
+    if (this.isAnonymous) {
       return;
     }
     this.session.prohibitAuthentication('authenticated.user-dashboard');

--- a/mon-pix/tests/acceptance/authentication/signup-test.js
+++ b/mon-pix/tests/acceptance/authentication/signup-test.js
@@ -63,122 +63,76 @@ module('Acceptance | authentication | Signup', function (hooks) {
     assert.dom(homepageHeading).exists();
   });
 
-  module('when feature toggle upgradeToRealUserEnabled is true', function (hooks) {
-    hooks.beforeEach(async function () {
-      server.create('feature-toggle', { id: '0', upgradeToRealUserEnabled: true });
-    });
+  module('when real user is authenticated', function () {
+    test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
+      // given
+      const firstName = 'John';
+      const lastName = 'Doe';
+      const email = 'john.doe@email.com';
 
-    module('when real user is authenticated', function () {
-      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
-        // given
-        const firstName = 'John';
-        const lastName = 'Doe';
-        const email = 'john.doe@email.com';
+      const user = server.create('user', { firstName, lastName, email, isAnonymous: false });
+      await authenticate(user);
 
-        const user = server.create('user', { firstName, lastName, email, isAnonymous: false });
-        await authenticate(user);
+      // when
+      const screen = await visit('/inscription');
 
-        // when
-        const screen = await visit('/inscription');
-
-        // then
-        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
-        assert.dom(homepageHeading).exists();
-      });
-    });
-
-    module('when anonymous user is authenticated', function (hooks) {
-      let user;
-      let screen;
-
-      hooks.beforeEach(async function () {
-        user = server.create('user', { isAnonymous: true });
-        await authenticate(user);
-      });
-
-      test('he can access the sign up page', async function (assert) {
-        // given/when
-        screen = await visit('/inscription');
-
-        // then
-        const signupHeading = screen.getByRole('heading', { name: t('pages.sign-up.first-title') });
-        assert.dom(signupHeading).exists();
-        const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
-        assert.dom(loginButton).doesNotExist();
-        const otherAuthenticationProvidersTitle = screen.queryByText(
-          t('components.authentication.other-authentication-providers.signup.heading'),
-        );
-        assert.dom(otherAuthenticationProvidersTitle).doesNotExist();
-      });
-
-      test('then he signs up and is redirected to dashboard', async function (assert) {
-        // given
-        server.patch('/users/:id', (schema, request) => {
-          const { id } = request.params;
-          const { data } = JSON.parse(request.requestBody);
-          user = schema.users.find(id);
-          return user.update(data.attributes);
-        });
-
-        // when
-        screen = await visit('/inscription');
-
-        await fillByLabel(t(I18N_KEYS.firstNameInput), 'Jane');
-        await fillByLabel(t(I18N_KEYS.lastNameInput), 'Doe');
-        await fillByLabel(t(I18N_KEYS.emailInput), 'jane.doe@example.net');
-        await fillByLabel(t(I18N_KEYS.passwordInput), 'p@ssW0rd');
-        await clickByName(t(I18N_KEYS.cguCheckbox));
-
-        await clickByName(t(I18N_KEYS.submitButton));
-
-        // then
-        const homepageHeading = screen.queryByRole('heading', { name: t('pages.dashboard.title') });
-        assert.dom(homepageHeading).exists();
-        assert.dom(screen.getByText('Jane')).exists();
-
-        const session = this.owner.lookup('service:session');
-        assert.strictEqual(session.data.authenticated.authenticator, 'authenticator:oauth2');
-      });
+      // then
+      const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
+      assert.dom(homepageHeading).exists();
     });
   });
 
-  module('when feature toggle upgradeToRealUserEnabled is false', function (hooks) {
+  module('when anonymous user is authenticated', function (hooks) {
+    let user;
+    let screen;
+
     hooks.beforeEach(async function () {
-      server.create('feature-toggle', { id: '0', upgradeToRealUserEnabled: false });
+      user = server.create('user', { isAnonymous: true });
+      await authenticate(user);
     });
 
-    module('when real user is authenticated', function () {
-      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
-        // given
-        const firstName = 'John';
-        const lastName = 'Doe';
-        const email = 'john.doe@email.com';
+    test('he can access the sign up page', async function (assert) {
+      // given/when
+      screen = await visit('/inscription');
 
-        const user = server.create('user', { firstName, lastName, email, isAnonymous: false });
-        await authenticate(user);
-
-        // when
-        const screen = await visit('/inscription');
-
-        // then
-        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
-        assert.dom(homepageHeading).exists();
-      });
+      // then
+      const signupHeading = screen.getByRole('heading', { name: t('pages.sign-up.first-title') });
+      assert.dom(signupHeading).exists();
+      const loginButton = screen.queryByRole('link', { name: t('pages.sign-up.actions.login') });
+      assert.dom(loginButton).doesNotExist();
+      const otherAuthenticationProvidersTitle = screen.queryByText(
+        t('components.authentication.other-authentication-providers.signup.heading'),
+      );
+      assert.dom(otherAuthenticationProvidersTitle).doesNotExist();
     });
 
-    module('when anonymous user is authenticated', function () {
-      test('he can not access to the sign up page and is redirected to his dashboard', async function (assert) {
-        // given
-        const user = server.create('user', { isAnonymous: true });
-        await authenticate(user);
-
-        // when
-        const screen = await visit('/inscription');
-
-        // then
-        const homepageHeading = screen.getByRole('heading', { name: t('pages.dashboard.title') });
-        assert.dom(homepageHeading).exists();
+    test('then he signs up and is redirected to dashboard', async function (assert) {
+      // given
+      server.patch('/users/:id', (schema, request) => {
+        const { id } = request.params;
+        const { data } = JSON.parse(request.requestBody);
+        user = schema.users.find(id);
+        return user.update(data.attributes);
       });
+
+      // when
+      screen = await visit('/inscription');
+
+      await fillByLabel(t(I18N_KEYS.firstNameInput), 'Jane');
+      await fillByLabel(t(I18N_KEYS.lastNameInput), 'Doe');
+      await fillByLabel(t(I18N_KEYS.emailInput), 'jane.doe@example.net');
+      await fillByLabel(t(I18N_KEYS.passwordInput), 'p@ssW0rd');
+      await clickByName(t(I18N_KEYS.cguCheckbox));
+
+      await clickByName(t(I18N_KEYS.submitButton));
+
+      // then
+      const homepageHeading = screen.queryByRole('heading', { name: t('pages.dashboard.title') });
+      assert.dom(homepageHeading).exists();
+      assert.dom(screen.getByText('Jane')).exists();
+
+      const session = this.owner.lookup('service:session');
+      assert.strictEqual(session.data.authenticated.authenticator, 'authenticator:oauth2');
     });
   });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/hero/evaluation-results-hero-test.js
@@ -275,41 +275,36 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
       });
 
       module('when user is anonymous', function () {
-        module('when feature toggle upgradeToRealUserEnabled is true', function () {
-          test('it should not display a sign in button', async function (assert) {
-            //given
-            const featureToggles = this.owner.lookup('service:featureToggles');
-            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
+        test('it should not display a sign in button', async function (assert) {
+          //given
+          stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione', isAnonymous: true });
+          this.set('campaign', {
+            customResultPageText: 'My custom result page text',
+            organizationId: 1,
+          });
 
-            stubCurrentUserService(this.owner, { id: 1, firstName: 'Hermione', isAnonymous: true });
-            this.set('campaign', {
-              customResultPageText: 'My custom result page text',
-              organizationId: 1,
-            });
+          this.set('campaignParticipationResult', {
+            campaignParticipationBadges: [],
+            isShared: false,
+            canImprove: false,
+            masteryRate: 0.75,
+            reachedStage: { acquired: 4, total: 5 },
+          });
 
-            this.set('campaignParticipationResult', {
-              campaignParticipationBadges: [],
-              isShared: false,
-              canImprove: false,
-              masteryRate: 0.75,
-              reachedStage: { acquired: 4, total: 5 },
-            });
-
-            // when
-            const screen = await render(
-              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+          // when
+          const screen = await render(
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @questResults={{this.questResults}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
   @isSharableCampaign={{true}}
 />`,
-            );
+          );
 
-            // then
-            assert.ok(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
-            assert.notOk(screen.queryByText(t('pages.sign-up.save-progress-message')));
-            assert.notOk(screen.queryByText(t('pages.sign-up.actions.sign-up-on-pix')));
-          });
+          // then
+          assert.ok(screen.getByRole('button', { name: t('pages.skill-review.actions.send') }));
+          assert.notOk(screen.queryByText(t('pages.sign-up.save-progress-message')));
+          assert.notOk(screen.queryByText(t('pages.sign-up.actions.sign-up-on-pix')));
         });
       });
 
@@ -567,52 +562,19 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
           });
         });
 
-        module('when feature toggle upgradeToRealUserEnabled is false', function () {
-          test('it should not display a sign in button', async function (assert) {
-            // given
-            const featureToggles = this.owner.lookup('service:featureToggles');
-            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: false });
-
-            // when
-            const screen = await render(
-              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+        test('it should display a sign in button', async function (assert) {
+          // when
+          const screen = await render(
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @questResults={{this.questResults}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
   @isSharableCampaign={{true}}
 />`,
-            );
-
-            // then
-            assert.ok(
-              screen.queryByText(
-                t('pages.skill-review.hero.shared-message', { date: sharedAtDate(now), time: sharedAtTime(now) }),
-              ),
-            );
-            assert.ok(screen.getByRole('link', { name: t('navigation.back-to-homepage') }));
-            assert.notOk(screen.queryByText(t('pages.sign-up.save-progress-message')));
-            assert.notOk(screen.queryByText(t('pages.sign-up.actions.sign-up-on-pix')));
-          });
-        });
-        module('when feature toggle upgradeToRealUserEnabled is true', function () {
-          test('it should display a sign in button', async function (assert) {
-            // given
-            const featureToggles = this.owner.lookup('service:featureToggles');
-            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
-
-            // when
-            const screen = await render(
-              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
-  @campaign={{this.campaign}}
-  @questResults={{this.questResults}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-  @isSharableCampaign={{true}}
-/>`,
-            );
-            // then
-            assert.ok(screen.queryByText(t('pages.sign-up.save-progress-message')));
-            assert.ok(screen.queryByText(t('pages.sign-up.actions.sign-up-on-pix')));
-          });
+          );
+          // then
+          assert.ok(screen.queryByText(t('pages.sign-up.save-progress-message')));
+          assert.ok(screen.queryByText(t('pages.sign-up.actions.sign-up-on-pix')));
         });
       });
     });
@@ -621,66 +583,28 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
   module('when campaign results should not be shared', function () {
     module('when there is no custom link', function () {
       module('when user is anonymous', function () {
-        module('when feature toggle upgradeToRealUserEnabled is true ', function () {
-          test('it should display only an inscription link', async function (assert) {
-            // given
-            const featureToggles = this.owner.lookup('service:featureToggles');
-            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: true });
+        test('it should display only an inscription link', async function (assert) {
+          // given
+          stubCurrentUserService(this.owner, { isAnonymous: true });
 
-            stubCurrentUserService(this.owner, { isAnonymous: true });
+          this.set('campaign', { hasCustomResultPageButton: false });
+          this.set('campaignParticipationResult', { masteryRate: 0.75 });
 
-            this.set('campaign', { hasCustomResultPageButton: false });
-            this.set('campaignParticipationResult', { masteryRate: 0.75 });
-
-            // when
-            const screen = await render(
-              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
+          // when
+          const screen = await render(
+            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
   @campaign={{this.campaign}}
   @campaignParticipationResult={{this.campaignParticipationResult}}
   @isSharableCampaign={{false}}
 />`,
-            );
+          );
 
-            // then
-            assert.dom(screen.queryByText(t('pages.sign-up.save-progress-message'))).exists();
-            assert.dom(screen.getByRole('link', { name: t('pages.sign-up.actions.sign-up-on-pix') })).exists();
-            assert
-              .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }))
-              .doesNotExist();
-            assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
-            assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
-          });
-        });
-        module('when feature toggle upgradeToRealUserEnabled is false', function () {
-          test('it should display only a connection link', async function (assert) {
-            // given
-            const featureToggles = this.owner.lookup('service:featureToggles');
-            sinon.stub(featureToggles, 'featureToggles').value({ upgradeToRealUserEnabled: false });
-
-            stubCurrentUserService(this.owner, { isAnonymous: true });
-
-            this.set('campaign', { hasCustomResultPageButton: false });
-            this.set('campaignParticipationResult', { masteryRate: 0.75 });
-
-            // when
-            const screen = await render(
-              hbs`<Campaigns::Assessment::Results::EvaluationResultsHero
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-  @isSharableCampaign={{false}}
-/>`,
-            );
-
-            // then
-            assert.dom(screen.getByRole('link', { name: t('navigation.back-to-homepage') })).exists();
-            assert
-              .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }))
-              .doesNotExist();
-            assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
-            assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
-            assert.dom(screen.queryByText(t('pages.sign-up.save-progress-message'))).doesNotExist();
-            assert.dom(screen.queryByRole('link', { name: t('pages.sign-up.actions.sign-up-on-pix') })).doesNotExist();
-          });
+          // then
+          assert.dom(screen.queryByText(t('pages.sign-up.save-progress-message'))).exists();
+          assert.dom(screen.getByRole('link', { name: t('pages.sign-up.actions.sign-up-on-pix') })).exists();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
+          assert.dom(screen.queryByText(t('pages.skill-review.hero.explanations.send-results'))).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.actions.send') })).doesNotExist();
         });
       });
 


### PR DESCRIPTION
## 🔆 Problème

Le FT upgradeToRealUserEnabled est désormais activé en PROD est n'est plus nécéssaire 

## ⛱️ Proposition

Retirer le FT upgradeToRealUserEnabled

## 🏄 Pour tester

- En tant qu'utilisateur anonyme:
  - Aller sur app/campagnes/AUTOCOUR1
  - Faire la campagne jusqu'au bout
  - Constater qu'il est ossible de s'inscrire à l'issue de la campagne et de conserver ses pix