### PR TITLE
[BUGFIX] Permettre d'ignorer les valeurs par défaut de `modulix-editor` dans les arguments de POIs (PIX-18994)

### DIFF
--- a/api/src/devcomp/domain/models/element/CustomElement.js
+++ b/api/src/devcomp/domain/models/element/CustomElement.js
@@ -13,7 +13,81 @@ class CustomElement extends Element {
     assertNotNullOrUndefined(tagName, 'The tagName is required for a CustomElement element');
     assertNotNullOrUndefined(props, 'The props are required for a CustomElement element');
     this.tagName = tagName;
-    this.props = props;
+    this.props = this.#normalizeProps(props);
+  }
+
+  /**
+   * @param{object} props
+   */
+  #normalizeProps(props) {
+    switch (this.tagName) {
+      case 'pix-carousel':
+        return this.#normalizePixCarouselProps(props);
+      case 'image-quiz':
+      case 'qcu-image':
+        return this.#normalizeImageQuizProps(props);
+      case 'image-quizzes':
+        return this.#normalizeImageQuizzesProps(props);
+      default:
+        return props;
+    }
+  }
+
+  /**
+   * @param{object} props
+   */
+  #normalizePixCarouselProps(props) {
+    return {
+      ...props,
+      titleLevel: CustomElement.unsetNumber(props.titleLevel),
+      slides: props.slides.map((slide) => ({
+        ...slide,
+        displayWidth: CustomElement.unsetNumber(slide.displayWidth),
+        displayHeight: CustomElement.unsetNumber(slide.displayHeight),
+        license: CustomElement.unsetObject(slide.license),
+      })),
+    };
+  }
+
+  /**
+   * @param{object} props
+   */
+  #normalizeImageQuizProps(props) {
+    return {
+      ...props,
+      maxChoicesPerLine: CustomElement.unsetNumber(props.maxChoicesPerLine),
+      choices: props.choices.map((choice) => ({
+        ...choice,
+        image: CustomElement.unsetObject(choice.image),
+      })),
+    };
+  }
+
+  /**
+   * @param{object} props
+   */
+  #normalizeImageQuizzesProps(props) {
+    return {
+      quizzes: props.quizzes.map((quiz) => this.#normalizeImageQuizProps(quiz)),
+    };
+  }
+
+  /**
+   * @param{number|undefined} number
+   */
+  static unsetNumber(number) {
+    return number === 0 ? undefined : number;
+  }
+
+  /**
+   * @param{object} object
+   */
+  static unsetObject(object) {
+    if (!object) return undefined;
+    for (const value of Object.values(object)) {
+      if (value) return object;
+    }
+    return undefined;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -562,37 +562,57 @@
                 {
                   "title": "Situation A",
                   "description": "Super description!",
-                  "displayWidth": 624,
+                  "displayWidth": 0,
                   "image": {
                     "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
                     "alt": "une alternative A avec des \"double quotes\""
+                  },
+                  "license": {
+                    "name": "",
+                    "attribution": "",
+                    "url": ""
                   }
                 },
                 {
                   "title": "Situation B",
                   "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc at imperdiet libero, eget suscipit enim. Proin in nibh id ligula tempus suscipit eu at dolor. Fusce tincidunt gravida turpis, a sagittis ex bibendum nec. Morbi hendrerit lectus sed libero tristique, non luctus diam ultricies. Cras in quam consectetur, tempor quam id, euismod turpis. Duis faucibus erat lectus, blandit mattis lectus euismod quis. Duis imperdiet volutpat metus at varius. Nunc vitae mattis leo, ac vehicula urna. Mauris euismod eleifend lorem quis porta. Quisque ac diam sollicitudin nisl convallis ullamcorper. Donec ut suscipit arcu.",
-                  "displayWidth": 624,
+                  "displayWidth": 0,
                   "image": {
                     "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
                     "alt": "une alternative B"
+                  },
+                  "license": {
+                    "name": "",
+                    "attribution": "",
+                    "url": ""
                   }
                 },
                 {
                   "title": "Liste non ordonnée",
                   "description": "\n  <ul>\n<li>Ruben</li>\n       <li>Chase</li>\n         <li>Zooma</li>\n         <li>Stela</li>\n       </ul>\n     ",
-                  "displayWidth": 624,
+                  "displayWidth": 0,
                   "image": {
                     "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
                     "alt": "hehe je suis un alt"
+                  },
+                  "license": {
+                    "name": "",
+                    "attribution": "",
+                    "url": ""
                   }
                 },
                 {
                   "title": "Liste ordonnée",
                   "description": "<ol>\n   <li>Ruben</li>\n <li>Chase</li>\n  <li>Zooma</li>\n         <li>Stela</li>\n       </ol>\n",
-                  "displayWidth": 624,
+                  "displayWidth": 0,
                   "image": {
                     "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
                     "alt": "halte là !"
+                  },
+                  "license": {
+                    "name": "name",
+                    "attribution": "attri",
+                    "url": "url"
                   }
                 }
               ]

--- a/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
@@ -97,4 +97,203 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function 
       expect(error.message).to.equal('The props are required for a CustomElement element');
     });
   });
+
+  describe('Convert MODULIX-EDITOR default values to POI optional values', function () {
+    describe('static unsetObject', function () {
+      describe('when object has falsy values', function () {
+        it('should unset empty object', function () {
+          const result = CustomElement.unsetObject({});
+          expect(result).to.equal(undefined);
+        });
+
+        it('should unset object with falsy values', function () {
+          const result = CustomElement.unsetObject({
+            number: 0,
+            string: '',
+            boolean: false,
+            undefined: undefined,
+            null: null,
+          });
+          expect(result).to.equal(undefined);
+        });
+      });
+
+      describe('when object has truthy values', function () {
+        it('should return original object', function () {
+          const object = {
+            number: 1,
+            string: 'a',
+            boolean: true,
+            undefined: undefined,
+            null: null,
+          };
+          const result = CustomElement.unsetObject(object);
+          expect(result).to.equal(object);
+        });
+      });
+    });
+
+    describe('static unsetNumber', function () {
+      it('should unset 0 to undefined', function () {
+        const result = CustomElement.unsetNumber(0);
+        expect(result).to.equal(undefined);
+      });
+
+      const unmodifiedExamples = [1, '0', '123', -1, undefined, null];
+      unmodifiedExamples.forEach((value) => {
+        it('should return original value', function () {
+          const result = CustomElement.unsetNumber(value);
+          expect(result).to.equal(value);
+        });
+      });
+    });
+
+    describe('pix-carousel', function () {
+      it('should normalize props', function () {
+        const pixCarouselElement = new CustomElement({
+          id: 'adzadaz-azdzad-azdazddza-dzazad',
+          tagName: 'pix-carousel',
+          props: {
+            aspectRatio: 1.84,
+            titleLevel: 0,
+            type: 'image',
+            randomSlides: false,
+            disableAnimation: false,
+            slides: [
+              {
+                title: 'Situation A',
+                displayWidth: 0,
+                displayHeight: 0,
+                description: 'Super description!',
+                image: {
+                  src: 'https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg',
+                  alt: 'une alternative A avec des "double quotes"',
+                },
+                license: {
+                  name: '',
+                  attribution: '',
+                  url: '',
+                },
+              },
+            ],
+          },
+        });
+
+        expect(pixCarouselElement.props).to.be.deep.equal({
+          aspectRatio: 1.84,
+          titleLevel: undefined,
+          type: 'image',
+          randomSlides: false,
+          disableAnimation: false,
+          slides: [
+            {
+              title: 'Situation A',
+              displayWidth: undefined,
+              displayHeight: undefined,
+              description: 'Super description!',
+              image: {
+                src: 'https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg',
+                alt: 'une alternative A avec des "double quotes"',
+              },
+              license: undefined,
+            },
+          ],
+        });
+      });
+    });
+
+    describe('image-quizzes', function () {
+      const singleVariants = ['image-quiz', 'qcu-image'];
+
+      singleVariants.forEach((variant) => {
+        it(`should normalize ${variant} props`, function () {
+          const imageQuizElement = new CustomElement({
+            id: 'adzadaz-azdzad-azdazddza-dzazad',
+            tagName: variant,
+            props: {
+              name: 'test',
+              maxChoicesPerLine: 0,
+              imageChoicesSize: 'large',
+              choices: [
+                {
+                  name: 'Test : J’utilise un test unitaire. J’utilise ce type de test uniquement pour atteindre mes objectifs annuels.',
+                  image: {
+                    src: '',
+                    width: 0,
+                    height: 0,
+                  },
+                  response: 'different',
+                },
+              ],
+              hideChoicesName: true,
+              orderChoices: false,
+            },
+          });
+
+          expect(imageQuizElement.props).to.be.deep.equal({
+            name: 'test',
+            maxChoicesPerLine: undefined,
+            imageChoicesSize: 'large',
+            choices: [
+              {
+                name: 'Test : J’utilise un test unitaire. J’utilise ce type de test uniquement pour atteindre mes objectifs annuels.',
+                image: undefined,
+                response: 'different',
+              },
+            ],
+            hideChoicesName: true,
+            orderChoices: false,
+          });
+        });
+      });
+
+      it('should normalize props', function () {
+        const imageQuizElement = new CustomElement({
+          id: 'adzadaz-azdzad-azdazddza-dzazad',
+          tagName: 'image-quizzes',
+          props: {
+            quizzes: [
+              {
+                name: 'test',
+                maxChoicesPerLine: 0,
+                imageChoicesSize: 'large',
+                choices: [
+                  {
+                    name: 'Test : J’utilise un test unitaire. J’utilise ce type de test uniquement pour atteindre mes objectifs annuels.',
+                    image: {
+                      src: '',
+                      width: 0,
+                      height: 0,
+                    },
+                    response: 'different',
+                  },
+                ],
+                hideChoicesName: true,
+                orderChoices: false,
+              },
+            ],
+          },
+        });
+
+        expect(imageQuizElement.props).to.be.deep.equal({
+          quizzes: [
+            {
+              name: 'test',
+              maxChoicesPerLine: undefined,
+              imageChoicesSize: 'large',
+              choices: [
+                {
+                  name: 'Test : J’utilise un test unitaire. J’utilise ce type de test uniquement pour atteindre mes objectifs annuels.',
+                  image: undefined,
+                  response: 'different',
+                },
+              ],
+              hideChoicesName: true,
+              orderChoices: false,
+            },
+          ],
+        });
+      });
+    });
+  });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -160,7 +160,7 @@ const customElementSchema = Joi.object({
   props: Joi.alternatives()
     .conditional('tagName', {
       switch: [
-        { is: 'image-quizz', then: imageQuizPropsSchema },
+        { is: 'image-quiz', then: imageQuizPropsSchema },
         { is: 'image-quizzes', then: imageQuizzesPropsSchema },
         { is: 'llm-compare-messages', then: llmCompareMessagesPropsSchema },
         { is: 'llm-prompt-select', then: llmPromptSelectPropsSchema },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -55,6 +55,7 @@ const llmCompareMessagesPropsSchema = Joi.object({
 }).required();
 
 const llmPromptSelectPropsSchema = Joi.object({
+  speed: Joi.number().default(20).min(0).optional(),
   messages: Joi.array()
     .items(
       Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -87,15 +87,15 @@ const messageConversationPropsSchema = Joi.object({
 }).required();
 
 const licenseSchema = Joi.object({
-  name: Joi.string().required(),
-  attribution: Joi.string().required(),
-  url: Joi.string().required(),
+  name: Joi.string().allow('').required(),
+  attribution: Joi.string().allow('').required(),
+  url: Joi.string().allow('').required(),
 });
 
 const slideImageSchema = Joi.object({
   title: Joi.string().required(),
   description: Joi.string().allow('').required(),
-  displayWidth: Joi.number().min(0).required(),
+  displayWidth: Joi.number().min(0).optional(),
   image: Joi.object({
     src: Joi.string().required(),
     alt: Joi.string().required(),
@@ -112,7 +112,7 @@ const slideTextSchema = Joi.object({
 const slideImageTextSchema = Joi.object({
   title: Joi.string().required(),
   description: Joi.string().allow('').required(),
-  displayHeight: Joi.number().min(0).required(),
+  displayHeight: Joi.number().min(0).optional(),
   text: Joi.string().required(),
   image: Joi.object({
     src: Joi.string().required(),
@@ -123,7 +123,7 @@ const slideImageTextSchema = Joi.object({
 const commonFields = {
   aspectRatio: Joi.number().min(0).required(),
   randomSlides: Joi.boolean().required(),
-  titleLevel: Joi.number().integer().min(0).max(6).required(),
+  titleLevel: Joi.number().integer().min(0).max(6).optional(),
   disableAnimation: Joi.boolean().required(),
 };
 


### PR DESCRIPTION
## 🔆 Problème

Lors de la configuration d'éléments `custom` (POIs) sur `modulix-editor`, l'éditeur remplit automatiquement les champs avec des valeurs par défaut.
Dans certains cas, nous préférons utiliser `undefined` à la place de ces valeurs (`0`, objet vide, etc...).

## ⛱️ Proposition

Au moment de la construction du modèle d'un module, transformer les valeurs non désirées en `undefined`.

## 🌊 Remarques

- Régularisation des schémas de propriétés : 
  - passage de `required()` à `optional()` pour les valeurs concernées.
  - correction d'une erreur typographique dans le schéma de `image-quiz`.
  - ajout (oubli) de la propriété optionnelle `speed` dans le schéma de `llm-prompt-select`.

## 🏄 Pour tester

- Se rendre sur le [module d'exposition des POIs](https://app-pr13115.review.pix.fr/modules/demo-epreuves-components/passage).
- Arriver à l'exemple de `pix-carousel`, à la fin du module.
- Constater que les images sont visibles, alors qu'elles ont une propriété `displayWidth` égale à `0` dans le [fichier de configuration du module](https://github.com/1024pix/pix/pull/13115/files#diff-f0e71bf23eeb702abd7541aea80e12622cca59db56fdf263fa783000baf8996fR565).
- Constater qu'aucune license ne s'affiche sur les 3 premières images, alors qu'elles ont une propriété `license` contenant des valeurs falsy dans le [fichier de configuration du module](https://github.com/1024pix/pix/pull/13115/files#diff-f0e71bf23eeb702abd7541aea80e12622cca59db56fdf263fa783000baf8996fR569-R573).
