### PR TITLE
[FEATURE] Changer l'algo de détection de local avec cookie dans PixOrga (PIX-18978)

### DIFF
--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -117,6 +117,6 @@ export default class AttestationList extends Component {
       </:columns>
     </PixTable>
 
-    <PixPagination @pagination={{@participantStatuses.meta}} @locale={{this.locale.currentLocale}} />
+    <PixPagination @pagination={{@participantStatuses.meta}} @locale={{this.locale.currentLanguage}} />
   </template>
 }

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -30,9 +30,7 @@ export default class LoginForm extends Component {
   @tracked emailValidationMessage = null;
 
   get displayRecoveryLink() {
-    if (this.locale.currentLocale === 'en' || !this.currentDomain.isFranceDomain) {
-      return false;
-    }
+    if (!this.currentDomain.isFranceDomain) return false;
     return !this.args.isWithInvitation;
   }
 

--- a/orga/app/components/auth/register-form.gjs
+++ b/orga/app/components/auth/register-form.gjs
@@ -103,7 +103,7 @@ export default class RegisterForm extends Component {
         email: this.email,
         password: this.password,
         cgu: true,
-        lang: this.locale.currentLocale,
+        lang: this.locale.currentLanguage,
       });
       await user.save();
 

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -24,10 +24,6 @@ export default class ParticipantsList extends Component {
   @tracked isModalOpen = false;
   @tracked participationToDelete;
 
-  get currentLocale() {
-    return this.locale.currentLocale;
-  }
-
   get canDeleteParticipation() {
     return this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber?.id;
   }
@@ -165,7 +161,7 @@ export default class ParticipantsList extends Component {
     {{/unless}}
 
     {{#if @participations}}
-      <PixPagination @pagination={{@participations.meta}} @locale={{this.currentLocale}} />
+      <PixPagination @pagination={{@participations.meta}} @locale={{this.locale.currentLanguage}} />
     {{/if}}
 
     <DeleteParticipationModal

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -197,7 +197,7 @@ export default class List extends Component {
           @destinationId={{paginationId}}
           @onChange={{reset}}
           @pagination={{@campaigns.meta}}
-          @locale={{this.locale.currentLocale}}
+          @locale={{this.locale.currentLanguage}}
         />
         <Filters
           @destinationId={{filtersId}}

--- a/orga/app/components/campaign/results/assessment-list.gjs
+++ b/orga/app/components/campaign/results/assessment-list.gjs
@@ -133,7 +133,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
 
     {{#if @participations}}
       {{#let (getService "service:locale") as |locale|}}
-        <PixPagination @pagination={{@participations.meta}} @locale={{locale.currentLocale}} />
+        <PixPagination @pagination={{@participations.meta}} @locale={{locale.currentLanguage}} />
       {{/let}}
     {{/if}}
   </section>

--- a/orga/app/components/campaign/results/profile-list.gjs
+++ b/orga/app/components/campaign/results/profile-list.gjs
@@ -151,7 +151,7 @@ import ParticipationEvolutionIcon from './participation-evolution-icon';
 
     {{#if (gt @profiles.length 0)}}
       {{#let (getService "service:locale") as |locale|}}
-        <PixPagination @pagination={{@profiles.meta}} @locale={{locale.currentLocale}} />
+        <PixPagination @pagination={{@profiles.meta}} @locale={{locale.currentLanguage}} />
       {{/let}}
     {{/if}}
   </section>

--- a/orga/app/components/import/download-import-template-link.gjs
+++ b/orga/app/components/import/download-import-template-link.gjs
@@ -10,7 +10,7 @@ export default class DownloadImportTemplateLink extends Component {
   @service session;
 
   get urlToDownloadCsvTemplate() {
-    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/organization-learners/csv-template?accessToken=${this.session.data.authenticated.access_token}&lang=${this.locale.currentLocale}`;
+    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/organization-learners/csv-template?accessToken=${this.session.data.authenticated.access_token}&lang=${this.locale.currentLanguage}`;
   }
 
   get showLink() {

--- a/orga/app/components/locale-switcher.gjs
+++ b/orga/app/components/locale-switcher.gjs
@@ -17,7 +17,7 @@ export default class LocaleSwitcher extends Component {
 
   constructor() {
     super(...arguments);
-    this.selectedLocale = this.args.defaultValue || this.locale.currentLocale;
+    this.selectedLocale = this.args.defaultValue || this.locale.currentLanguage;
   }
 
   @action

--- a/orga/app/components/mission/activity-table.gjs
+++ b/orga/app/components/mission/activity-table.gjs
@@ -49,7 +49,7 @@ function statusColor(status) {
     </PixTable>
 
     {{#let (getService "service:locale") as |locale|}}
-      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLocale}} />
+      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLanguage}} />
     {{/let}}
 
   {{else}}

--- a/orga/app/components/mission/result-table.gjs
+++ b/orga/app/components/mission/result-table.gjs
@@ -105,7 +105,7 @@ function getMissionResultColor(result) {
     </PixTable>
 
     {{#let (getService "service:locale") as |locale|}}
-      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLocale}} />
+      <PixPagination @pagination={{@missionLearners.meta}} @locale={{locale.currentLanguage}} />
     {{/let}}
   {{else}}
     <div class="table__empty content-text">

--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -403,7 +403,7 @@ export default class List extends Component {
           @destinationId={{paginationId}}
           @onChange={{reset}}
           @pagination={{@participants.meta}}
-          @locale={{this.locale.currentLocale}}
+          @locale={{this.locale.currentLanguage}}
         />
       </SelectableList>
 

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -260,7 +260,7 @@ export default class ScoList extends Component {
           @destinationId={{paginationId}}
           @onChange={{reset}}
           @pagination={{@students.meta}}
-          @locale={{this.locale.currentLocale}}
+          @locale={{this.locale.currentLanguage}}
         />
 
         <Filters

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -20,10 +20,6 @@ export default class Statistics extends Component {
 
   @tracked currentDomainFilter = null;
 
-  get currentLocale() {
-    return this.locale.currentLocale;
-  }
-
   get analysisByTubes() {
     return this.args.model.data.sort(
       (a, b) => a.competence_code.localeCompare(b.competence_code) || a.sujet?.localeCompare(b.sujet),
@@ -169,7 +165,7 @@ export default class Statistics extends Component {
         </:columns>
       </PixTable>
 
-      <PixPagination @pagination={{this.pagination}} @locale={{this.currentLocale}} />
+      <PixPagination @pagination={{this.pagination}} @locale={{this.locale.currentLanguage}} />
     {{else}}
       <PixBlock class="empty-state" @variant="orga">
         <div class="empty-state__text">

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -169,7 +169,7 @@ export default class ListItems extends Component {
           @destinationId={{paginationId}}
           @onChange={{reset}}
           @pagination={{@students.meta}}
-          @locale={{this.locale.currentLocale}}
+          @locale={{this.locale.currentLanguage}}
         />
 
         <Filters

--- a/orga/app/components/team/members-list.gjs
+++ b/orga/app/components/team/members-list.gjs
@@ -20,10 +20,6 @@ export default class MembersList extends Component {
     });
   }
 
-  get currentLocale() {
-    return this.locale.currentLocale;
-  }
-
   get displayManagingColumn() {
     return this.currentUser.isAdminInOrganization;
   }
@@ -51,7 +47,7 @@ export default class MembersList extends Component {
     {{/unless}}
 
     {{#if @members}}
-      <PixPagination @pagination={{@members.meta}} @locale={{this.currentLocale}} />
+      <PixPagination @pagination={{@members.meta}} @locale={{this.locale.currentLanguage}} />
     {{/if}}
   </template>
 }

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -37,7 +37,7 @@ export default class AuthenticatedCertificationsController extends Controller {
       const organizationId = this.currentUser.organization.id;
       const url = `/api/organizations/${organizationId}/certification-results?division=${encodeURIComponent(
         this.selectedDivision,
-      )}&lang=${this.locale.currentLocale}`;
+      )}&lang=${this.locale.currentLanguage}`;
 
       let token = '';
 
@@ -67,7 +67,7 @@ export default class AuthenticatedCertificationsController extends Controller {
         );
       }
 
-      const lang = this.locale.currentLocale;
+      const lang = this.locale.currentLanguage;
       const organizationId = this.currentUser.organization.id;
       const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}&isFrenchDomainExtension=${this.currentDomain.isFranceDomain}&lang=${lang}`;
       let token = '';

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -1,18 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
-
-const DUTCH_LOCALE = 'nl';
-const ENGLISH_LOCALE = 'en';
 
 export default class TermOfServiceController extends Controller {
   @service currentUser;
-  @service locale;
   @service router;
-
-  @tracked isDutchLocale = this.locale.currentLocale === DUTCH_LOCALE;
-  @tracked isEnglishLocale = this.locale.currentLocale === ENGLISH_LOCALE;
 
   @action
   async submit() {

--- a/orga/app/helpers/text-with-multiple-lang.js
+++ b/orga/app/helpers/text-with-multiple-lang.js
@@ -10,7 +10,7 @@ export default class textWithMultipleLang extends Helper {
     if (isHTMLSafe(text)) {
       text = text.toString();
     }
-    const lang = this.locale.currentLocale;
+    const lang = this.locale.currentLanguage;
     const listOfLocales = this.locale.supportedLocales;
     let outputText = _clean(text, listOfLocales);
 

--- a/orga/app/services/current-domain.js
+++ b/orga/app/services/current-domain.js
@@ -1,17 +1,29 @@
-import Service from '@ember/service';
+import Service, { service } from '@ember/service';
 import last from 'lodash/last';
 
 const FRANCE_TLD = 'fr';
 
 export default class CurrentDomainService extends Service {
+  @service location;
+
   get isFranceDomain() {
     return this.getExtension() === FRANCE_TLD;
   }
 
   getExtension() {
-    return last(location.hostname.split('.'));
+    const { hostname } = new URL(this.location.href);
+    return last(hostname.split('.'));
   }
 
+  get domain() {
+    const { host, hostname } = new URL(this.location.href);
+
+    if (hostname === 'localhost') return hostname;
+
+    return host.split('.').slice(-2).join('.');
+  }
+
+  // TODO: should be moved in url service
   getJuniorBaseUrl(stringUrl = window.location) {
     return `${stringUrl.protocol}//${stringUrl.hostname.replace('orga', 'junior')}`;
   }

--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -74,7 +74,7 @@ export default class ErrorMessagesService extends Service {
     if (!i18nKey) return;
     // TODO : Remove this when all import will be on generic import
     if (code === 'FIELD_DATE_FORMAT' && !meta.acceptedFormat) {
-      meta.acceptedFormat = this.locale.currentLocale === 'fr' ? 'jj/mm/aaaa' : 'dd/mm/yyyy';
+      meta.acceptedFormat = this.locale.currentLanguage === 'fr' ? 'jj/mm/aaaa' : 'dd/mm/yyyy';
     }
 
     return this.intl.t(i18nKey, this._formatMeta(meta));

--- a/orga/app/services/feature-toggles.js
+++ b/orga/app/services/feature-toggles.js
@@ -3,7 +3,13 @@ import Service, { service } from '@ember/service';
 export default class FeatureTogglesService extends Service {
   @service store;
 
+  _featureToggles = undefined;
+
+  get featureToggles() {
+    return this._featureToggles;
+  }
+
   async load() {
-    this.featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+    this._featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
   }
 }

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -15,7 +15,8 @@ export default class FileSaverService extends Service {
     downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
     noContentMessageNotification = this.intl.t('common.no-content'),
   }) {
-    const response = await fetcher({ url, token, locale: this.locale.currentLocale });
+    const acceptLanguage = this.locale.acceptLanguageHeader;
+    const response = await fetcher({ url, token, acceptLanguage });
 
     if (response.status === 204) {
       this.notifications.sendWarning(noContentMessageNotification);
@@ -38,15 +39,12 @@ export default class FileSaverService extends Service {
   }
 }
 
-function _fetchData({ url, token, locale }) {
+function _fetchData({ url, token, acceptLanguage }) {
   const reqHeaders = new Headers();
-
   reqHeaders.set('Authorization', `Bearer ${token}`);
-  reqHeaders.set('Accept-Language', locale);
+  reqHeaders.set('Accept-Language', acceptLanguage);
 
-  return fetch(url, {
-    headers: reqHeaders,
-  });
+  return fetch(url, { headers: reqHeaders });
 }
 
 function _getFileNameFromHeader(headers) {

--- a/orga/app/services/location.js
+++ b/orga/app/services/location.js
@@ -1,0 +1,7 @@
+import Service from '@ember/service';
+
+export default class LocationService extends Service {
+  get href() {
+    return window.location.href;
+  }
+}

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -5,6 +5,7 @@ import SessionService from 'ember-simple-auth/services/session';
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
   @service locale;
+  @service featureToggles;
   @service url;
 
   routeAfterAuthentication = 'authenticated';
@@ -18,10 +19,13 @@ export default class CurrentSessionService extends SessionService {
   async loadCurrentUserAndSetLocale(transition) {
     await this.currentUser.load();
 
-    const language = transition?.to?.queryParams?.lang;
-    this.locale.detectBestLocale({ language, user: this.currentUser.prescriber });
+    const queryParams = transition?.to?.queryParams;
+    this.locale.setBestLocale({ user: this.currentUser.prescriber, queryParams });
 
-    this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.prescriber?.lang);
+    if (!this.featureToggles.featureToggles?.useLocale) {
+      // should not happen with new locale system because we dont rely on user lang anymore.
+      this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.prescriber?.lang);
+    }
   }
 
   handleInvalidation() {

--- a/orga/app/services/url-base.js
+++ b/orga/app/services/url-base.js
@@ -18,8 +18,7 @@ export default class UrlBaseService extends Service {
   }
 
   get serverStatusUrl() {
-    const currentLocale = this.locale.currentLocale;
-    return `https://status.pix.org/?locale=${currentLocale}`;
+    return `https://status.pix.org/?locale=${this.locale.currentLanguage}`;
   }
 
   get pixAppUrl() {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -33,7 +33,7 @@ module.exports = function (environment) {
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-orga-local',
       DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
-      SUPPORTED_LOCALES: ['en', 'fr', 'nl'],
+      SUPPORTED_LOCALES: ['en', 'fr', 'nl', 'fr-FR', 'fr-BE', 'nl-BE'],
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       CERTIFICATION_BANNER_DISPLAY_DATES: process.env.CERTIFICATION_BANNER_DISPLAY_DATES || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-qunit": "^8.1.2",
         "globals": "^16.0.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
         "npm-run-all2": "^8.0.0",
@@ -27111,6 +27112,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-prettier": "^5.4.0",
     "eslint-plugin-qunit": "^8.1.2",
     "globals": "^16.0.0",
+    "i18next-browser-languagedetector": "^8.2.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "npm-run-all2": "^8.0.0",

--- a/orga/tests/helpers/setup-intl.js
+++ b/orga/tests/helpers/setup-intl.js
@@ -1,11 +1,19 @@
+import { getContext, settled } from '@ember/test-helpers';
 import { setupIntl as setupIntlFromEmberIntl } from 'ember-intl/test-support';
+
+export async function setCurrentLocale(locale) {
+  const { owner } = getContext();
+
+  const localeService = owner.lookup('service:locale');
+  localeService.setCurrentLocale(locale);
+
+  await settled();
+}
 
 export default function setupIntl(hooks, locale = 'fr') {
   setupIntlFromEmberIntl(hooks, locale);
 
-  hooks.beforeEach(function () {
-    this.localeService = this.owner.lookup('service:locale');
-    this.dayjs = this.owner.lookup('service:dayjs');
-    this.localeService.setCurrentLocale(locale);
+  hooks.beforeEach(async function () {
+    await setCurrentLocale(locale);
   });
 }

--- a/orga/tests/integration/components/auth/login-form-test.js
+++ b/orga/tests/integration/components/auth/login-form-test.js
@@ -1,5 +1,4 @@
 import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -278,18 +277,6 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   module('when domain is pix.org', function () {
     test('should not display recovery link', async function (assert) {
-      // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-
-        getExtension() {
-          return '.org';
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
       // when
       await renderScreen(hbs`<Auth::LoginForm />`);
 
@@ -301,16 +288,8 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
   module('when domain is pix.fr', function () {
     test('should display recovery link', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-
-        getExtension() {
-          return '.fr';
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
       // when
       await renderScreen(hbs`<Auth::LoginForm />`);

--- a/orga/tests/integration/components/auth/login-or-register-test.js
+++ b/orga/tests/integration/components/auth/login-or-register-test.js
@@ -1,5 +1,4 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
@@ -62,15 +61,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   module('when domain is not .fr', function () {
     test('displays the locale switcher and translate to selected locale', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       const routerService = this.owner.lookup('service:router');
-
       sinon.stub(routerService, 'replaceWith').returns(false);
 
       // when
@@ -85,13 +76,6 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
     test('saves selected locale and remove lang from query params', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return false;
-        }
-      }
-
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       const routerService = this.owner.lookup('service:router');
       const localeService = this.owner.lookup('service:locale');
 
@@ -113,12 +97,8 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   module('when domain is .fr', function () {
     test('does not display the locale switcher', async function (assert) {
       // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
 
       // when
       const screen = await render(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);

--- a/orga/tests/integration/components/banner/survey_test.gjs
+++ b/orga/tests/integration/components/banner/survey_test.gjs
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import Survey from 'pix-orga/components/banner/survey';
 import ENV from 'pix-orga/config/environment';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -19,14 +20,10 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         class RouterStub extends Service {
           currentRouteName = 'authenticated.campaigns.list.my-campaigns';
         }
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
-
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
 
         // when
         const screen = await render(<template><Survey /></template>);
@@ -45,15 +42,10 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         class RouterStub extends Service {
           currentRouteName = 'authenticated.campaigns.list.my-campaigns';
         }
-
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return true;
-          }
-        }
-
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
 
         // when
         const screen = await render(<template><Survey /></template>);
@@ -74,15 +66,7 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         class RouterStub extends Service {
           currentRouteName = 'authenticated.sco-organization-participants.list';
         }
-
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return false;
-          }
-        }
-
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
         // when
         const screen = await render(<template><Survey /></template>);
@@ -99,15 +83,7 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         class RouterStub extends Service {
           currentRouteName = 'authenticated.campaigns.list.my-campaigns';
         }
-
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return false;
-          }
-        }
-
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
         // when
         const screen = await render(<template><Survey /></template>);
@@ -124,15 +100,7 @@ module('Integration | Component | Banner::Survey', function (hooks) {
         class RouterStub extends Service {
           currentRouteName = 'authenticated.campaigns.list.my-campaigns';
         }
-
-        class CurrentDomainServiceStub extends Service {
-          get isFranceDomain() {
-            return false;
-          }
-        }
-
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
         // when
         const screen = await render(<template><Survey /></template>);

--- a/orga/tests/integration/components/layout/sidebar-test.js
+++ b/orga/tests/integration/components/layout/sidebar-test.js
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -10,14 +11,9 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('when the user is authenticated on orga.pix.fr', function (hooks) {
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return true;
-      }
-    }
-
     hooks.beforeEach(function () {
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('fr');
     });
 
     test('it should display documentation url given by current organization', async function (assert) {

--- a/orga/tests/test-helper.js
+++ b/orga/tests/test-helper.js
@@ -1,5 +1,6 @@
 import NotificationMessageService from '@1024pix/ember-cli-notifications/services/notifications';
 import { setApplication } from '@ember/test-helpers';
+import { clearAllCookies } from 'ember-cookies/test-support';
 import start from 'ember-exam/test-support/start';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
@@ -16,6 +17,16 @@ NotificationMessageService.reopen({
     notification.set('dismiss', true);
     this.content.removeObject(notification);
   },
+});
+
+// Set default browser locale
+const BROWSER_LOCALE = 'fr';
+Object.defineProperty(window.navigator, 'language', { value: BROWSER_LOCALE, configurable: true });
+Object.defineProperty(window.navigator, 'languages', { value: [BROWSER_LOCALE], configurable: true });
+
+// Reset all cookies before each test to avoid side-effects
+QUnit.hooks.beforeEach(function () {
+  clearAllCookies();
 });
 
 setApplication(Application.create(config.APP));

--- a/orga/tests/unit/controllers/authenticated/certifications-test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications-test.js
@@ -182,7 +182,7 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
         };
 
         controller.locale = {
-          currentLocale: 'fr',
+          currentLanguage: 'fr',
         };
 
         controller.model = {
@@ -245,7 +245,7 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
           };
 
           controller.locale = {
-            currentLocale: 'en',
+            currentLanguage: 'en',
           };
 
           controller.model = {

--- a/orga/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/orga/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -25,7 +25,7 @@ module('Unit | Helper | TextWithMultipleLang', function (hooks) {
   ].forEach((expected) => {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
       // given
-      helper.locale.currentLocale = expected.lang;
+      helper.locale.currentLanguage = expected.lang;
 
       // when
       const computedText = helper.compute([expected.text]).toString();

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -7,12 +7,8 @@ module('Unit | Route | application', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    class currentDomainStub extends Service {
-      get isFranceDomain() {
-        return true;
-      }
-    }
-    this.owner.register('service:currentDomain', currentDomainStub);
+    const domainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(domainService, 'getExtension').returns('fr');
 
     class CurrentUserStub extends Service {
       load = sinon.stub();

--- a/orga/tests/unit/services/current-domain-test.js
+++ b/orga/tests/unit/services/current-domain-test.js
@@ -2,35 +2,102 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-const FRANCE_TLD = 'fr';
-const INTERNATIONAL_TLD = 'org';
-
 module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
 
-  module('#isFranceDomain', function () {
-    test('returns true when TLD is the France domain (.fr)', function (assert) {
-      // given
-      const service = this.owner.lookup('service:currentDomain');
-      service.getExtension = sinon.stub().returns(FRANCE_TLD);
+  module('#getExtension', function () {
+    module('when location is FR TLD', function () {
+      test(`returns fr`, function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
 
-      // when
-      const isFranceDomain = service.isFranceDomain;
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const extension = service.getExtension();
 
-      // then
-      assert.true(isFranceDomain);
+        // then
+        assert.strictEqual(extension, 'fr');
+      });
     });
 
-    test('returns false when TLD is the international domain (.org)', function (assert) {
-      // given
-      const service = this.owner.lookup('service:currentDomain');
-      service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+    module('when location is ORG TLD', function () {
+      test(`returns org`, function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.org/foo?bar=baz');
 
-      // when
-      const isFranceDomain = service.isFranceDomain;
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const extension = service.getExtension();
 
-      // then
-      assert.false(isFranceDomain);
+        // then
+        assert.strictEqual(extension, 'org');
+      });
+    });
+  });
+
+  module('#isFranceDomain', function () {
+    module('when location is FR TLD', function () {
+      test('returns true', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const isFranceDomain = service.isFranceDomain;
+
+        // then
+        assert.true(isFranceDomain);
+      });
+    });
+
+    module('when location is ORG TLD', function () {
+      test('returns false', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.org/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const isFranceDomain = service.isFranceDomain;
+
+        // then
+        assert.false(isFranceDomain);
+      });
+    });
+  });
+
+  module('#domain', function () {
+    module('when location is localhost', function () {
+      test('returns locahost as domain', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('http://localhost:4200/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const domain = service.domain;
+
+        // then
+        assert.strictEqual(domain, 'localhost');
+      });
+    });
+
+    module('when location is not localhost', function () {
+      test('returns the last 2-parts segment', function (assert) {
+        // given
+        const locationService = this.owner.lookup('service:location');
+        sinon.stub(locationService, 'href').value('https://pix.fr/foo?bar=baz');
+
+        // when
+        const service = this.owner.lookup('service:currentDomain');
+        const domain = service.domain;
+
+        // then
+        assert.strictEqual(domain, 'pix.fr');
+      });
     });
   });
 

--- a/orga/tests/unit/services/error-messages-test.js
+++ b/orga/tests/unit/services/error-messages-test.js
@@ -1,8 +1,8 @@
-import { setLocale, t } from 'ember-intl/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupIntl from '../../helpers/setup-intl';
+import setupIntl, { setCurrentLocale } from '../../helpers/setup-intl';
 
 module('Unit | Service | Error messages', function (hooks) {
   setupTest(hooks);
@@ -165,9 +165,9 @@ module('Unit | Service | Error messages', function (hooks) {
         );
       });
 
-      test('should return the en message when error code is found without acceptedFormat', function (assert) {
+      test('should return the en message when error code is found without acceptedFormat', async function (assert) {
         // Given
-        setLocale(['en']);
+        await setCurrentLocale('en');
         const errorMessages = this.owner.lookup('service:errorMessages');
 
         // When

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -8,35 +8,24 @@ import ENV from 'pix-orga/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntl, { setCurrentLocale } from '../../helpers/setup-intl.js';
+
 const { DEFAULT_LOCALE } = ENV.APP;
 
 module('Unit | Services | locale', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks, 'fr');
 
   let localeService;
-  let cookiesService;
   let currentDomainService;
-  let dayjsService;
-  let intlService;
   let metricsService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
-    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl']);
-
-    cookiesService = this.owner.lookup('service:cookies');
-    sinon.stub(cookiesService, 'write');
-    sinon.stub(cookiesService, 'exists');
+    sinon.stub(localeService, 'supportedLocales').value(['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
-
-    dayjsService = this.owner.lookup('service:dayjs');
-    sinon.stub(dayjsService, 'setLocale');
-
-    intlService = this.owner.lookup('service:intl');
-    sinon.stub(intlService, 'primaryLocale');
-    sinon.stub(intlService, 'setLocale');
 
     class metricsServiceStub extends Service {
       context = {};
@@ -45,13 +34,59 @@ module('Unit | Services | locale', function (hooks) {
     metricsService = this.owner.lookup('service:metrics');
   });
 
+  module('currentLocale', function () {
+    module('when useLocale feature toggle is disabled', function () {
+      test('returns the intl locale', function (assert) {
+        // given
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr-BE');
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      module('when current locale is not set', function () {
+        test('returns the default locale', function (assert) {
+          // when
+          const currentLocale = localeService.currentLocale;
+
+          // then
+          assert.strictEqual(currentLocale, 'fr');
+        });
+      });
+
+      module('when current locale is set', function () {
+        test('returns the current locale', function (assert) {
+          // given
+          localeService.setCurrentLocale('fr-BE');
+
+          // when
+          const currentLocale = localeService.currentLocale;
+
+          // then
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+    });
+  });
+
   module('pixLocales', function () {
     test('returns the locales available in the Pix Platform', function (assert) {
       // when
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 
@@ -67,10 +102,10 @@ module('Unit | Services | locale', function (hooks) {
 
   module('acceptLanguageHeader', function () {
     module('when the domain is pix.fr', function () {
-      test('always returns fr-FR', function (assert) {
+      test('always returns fr-FR', async function (assert) {
         // given
         currentDomainService.getExtension.returns('fr');
-        sinon.stub(intlService, 'primaryLocale').value('en');
+        await setCurrentLocale('en');
 
         // when
         const acceptLanguageHeader = localeService.acceptLanguageHeader;
@@ -81,16 +116,16 @@ module('Unit | Services | locale', function (hooks) {
     });
 
     module('when the domain is pix.org', function () {
-      test('always returns the current locale', function (assert) {
+      test('always returns the current locale', async function (assert) {
         // given
         currentDomainService.getExtension.returns('org');
-        sinon.stub(intlService, 'primaryLocale').value('nl-BE');
+        await setCurrentLocale('nl');
 
         // when
         const acceptLanguageHeader = localeService.acceptLanguageHeader;
 
         // then
-        assert.strictEqual(acceptLanguageHeader, 'nl-BE');
+        assert.strictEqual(acceptLanguageHeader, 'nl');
       });
     });
   });
@@ -150,30 +185,71 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    test('set app locale', function (assert) {
-      // given
-      const locale = DEFAULT_LOCALE;
+    module('when useLocale feature toggle is disabled', function () {
+      test('set app locale', function (assert) {
+        // given
+        const dayjsService = this.owner.lookup('service:dayjs');
+        sinon.stub(dayjsService, 'setLocale');
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'setLocale');
+        const locale = DEFAULT_LOCALE;
 
-      // when
-      localeService.setCurrentLocale(locale);
+        // when
+        localeService.setCurrentLocale(locale);
 
-      // then
-      sinon.assert.calledWith(intlService.setLocale, locale);
-      sinon.assert.calledWith(dayjsService.setLocale, locale);
-      assert.strictEqual(metricsService.context.locale, locale);
+        // then
+        sinon.assert.calledWith(intlService.setLocale, locale);
+        sinon.assert.calledWith(dayjsService.setLocale, locale);
+        assert.strictEqual(metricsService.context.locale, locale);
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      test('set app locale in the cookies', function (assert) {
+        // given
+        const dayjsService = this.owner.lookup('service:dayjs');
+        sinon.stub(dayjsService, 'setLocale');
+        const intlService = this.owner.lookup('service:intl');
+        sinon.stub(intlService, 'setLocale');
+        const cookiesService = this.owner.lookup('service:cookies');
+        sinon.stub(cookiesService, 'write');
+        const locale = 'nl-BE';
+
+        // when
+        localeService.setCurrentLocale(locale);
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'nl-BE');
+        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+        sinon.assert.calledWith(intlService.setLocale, 'nl');
+        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+        assert.strictEqual(metricsService.context.locale, 'nl-BE');
+      });
     });
   });
 
-  module('detectBestLocale', function () {
-    module('when the current domain is "fr"', function () {
-      module('when there is no cookie locale', function () {
+  module('setBestLocale', function () {
+    module('when useLocale feature toggle is disabled', function () {
+      module('when the current domain is "fr"', function () {
         test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
           // given
-          cookiesService.exists.returns(false);
+          const dayjsService = this.owner.lookup('service:dayjs');
+          sinon.stub(dayjsService, 'setLocale');
+          const intlService = this.owner.lookup('service:intl');
+          sinon.stub(intlService, 'setLocale');
+          const cookiesService = this.owner.lookup('service:cookies');
+          sinon.stub(cookiesService, 'write');
+          sinon.stub(cookiesService, 'exists').returns(false);
           currentDomainService.getExtension.returns('fr');
 
           // when
-          localeService.detectBestLocale({ language: null, user: null });
+          localeService.setBestLocale({ queryParams: null, user: null });
 
           // then
           sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
@@ -183,100 +259,59 @@ module('Unit | Services | locale', function (hooks) {
         });
       });
 
-      module('when there is already a cookie locale', function () {
-        test('sets the locale with "fr" and does not update cookie locale', function (assert) {
-          // given
-          cookiesService.exists.returns(true);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.detectBestLocale({ language: null, user: null });
-
-          // then
-          sinon.assert.notCalled(cookiesService.write);
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
-      });
-    });
-
-    module('when the current domain extension is "org"', function () {
-      module('when no current user', function () {
-        module('when there is no overriding language', function () {
-          test('sets the the default locale', async function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-
-            // when
-            localeService.detectBestLocale({ language: null, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-            sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-            assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-          });
-        });
-
-        module('when the overriding language is supported', function () {
-          test('sets the locale with the overriding language', function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-            const language = 'es';
-
-            // when
-            localeService.detectBestLocale({ language, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, 'es');
-            sinon.assert.calledWith(dayjsService.setLocale, 'es');
-            assert.strictEqual(metricsService.context.locale, 'es');
-          });
-        });
-
-        module('when the overriding language is not supported', function () {
-          test('sets the default locale', function (assert) {
-            // given
-            currentDomainService.getExtension.returns('org');
-            const badLanguage = 'xxx';
-
-            // when
-            localeService.detectBestLocale({ language: badLanguage, user: null });
-
-            // then
-            sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-            sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-            assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-          });
-        });
-      });
-
-      module('when user is loaded', function () {
-        module('when there is no overriding language', function () {
-          module('when the user language is supported', function () {
-            test('sets the locale with the user language', async function (assert) {
+      module('when the current domain extension is "org"', function () {
+        module('when no current user', function () {
+          module('when there is no overriding language', function () {
+            test('sets the the default locale', async function (assert) {
               // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
               currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
 
               // when
-              localeService.detectBestLocale({ language: null, user });
+              localeService.setBestLocale({ queryParams: null, user: null });
 
               // then
-              sinon.assert.calledWith(intlService.setLocale, 'nl');
-              sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-              assert.strictEqual(metricsService.context.locale, 'nl');
+              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
+              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
+              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
             });
           });
 
-          module('when the user language is not supported', function () {
-            test('sets the default locale', async function (assert) {
+          module('when the overriding language is supported', function () {
+            test('sets the locale with the overriding language', function (assert) {
               // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
               currentDomainService.getExtension.returns('org');
-              const user = { lang: 'tlh' }; // tlh: Klingon locale
+              const queryParams = { lang: 'es' };
 
               // when
-              localeService.detectBestLocale({ language: null, user });
+              localeService.setBestLocale({ queryParams, user: null });
+
+              // then
+              sinon.assert.calledWith(intlService.setLocale, 'es');
+              sinon.assert.calledWith(dayjsService.setLocale, 'es');
+              assert.strictEqual(metricsService.context.locale, 'es');
+            });
+          });
+
+          module('when the overriding language is not supported', function () {
+            test('sets the default locale', function (assert) {
+              // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
+              currentDomainService.getExtension.returns('org');
+              const queryParams = { lang: 'xxx' };
+
+              // when
+              localeService.setBestLocale({ queryParams, user: null });
 
               // then
               sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
@@ -286,20 +321,190 @@ module('Unit | Services | locale', function (hooks) {
           });
         });
 
-        module('when the overriding language is given', function () {
-          test('sets the locale with the overriding language', function (assert) {
+        module('when user is loaded', function () {
+          module('when there is no overriding language', function () {
+            module('when the user language is supported', function () {
+              test('sets the locale with the user language', async function (assert) {
+                // given
+                const dayjsService = this.owner.lookup('service:dayjs');
+                sinon.stub(dayjsService, 'setLocale');
+                const intlService = this.owner.lookup('service:intl');
+                sinon.stub(intlService, 'setLocale');
+                currentDomainService.getExtension.returns('org');
+                const user = { lang: 'nl' };
+
+                // when
+                localeService.setBestLocale({ queryParams: null, user });
+
+                // then
+                sinon.assert.calledWith(intlService.setLocale, 'nl');
+                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+                assert.strictEqual(metricsService.context.locale, 'nl');
+              });
+            });
+
+            module('when the user language is not supported', function () {
+              test('sets the default locale', async function (assert) {
+                // given
+                const dayjsService = this.owner.lookup('service:dayjs');
+                sinon.stub(dayjsService, 'setLocale');
+                const intlService = this.owner.lookup('service:intl');
+                sinon.stub(intlService, 'setLocale');
+                currentDomainService.getExtension.returns('org');
+                const user = { lang: 'tlh' }; // tlh: Klingon locale
+
+                // when
+                localeService.setBestLocale({ queryParams: null, user });
+
+                // then
+                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
+                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
+                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
+              });
+            });
+          });
+
+          module('when the overriding language is given', function () {
+            test('sets the locale with the overriding language', function (assert) {
+              // given
+              const dayjsService = this.owner.lookup('service:dayjs');
+              sinon.stub(dayjsService, 'setLocale');
+              const intlService = this.owner.lookup('service:intl');
+              sinon.stub(intlService, 'setLocale');
+              currentDomainService.getExtension.returns('org');
+              const user = { lang: 'nl' };
+              const queryParams = { lang: 'es' };
+
+              // when
+              localeService.setBestLocale({ queryParams, user });
+
+              // then
+              sinon.assert.calledWith(intlService.setLocale, 'es');
+              sinon.assert.calledWith(dayjsService.setLocale, 'es');
+              assert.strictEqual(metricsService.context.locale, 'es');
+            });
+          });
+        });
+      });
+    });
+
+    module('when useLocale feature toggle is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+      });
+
+      module('when the current domain extension is "fr"', function (hooks) {
+        hooks.beforeEach(function () {
+          currentDomainService.getExtension.returns('fr');
+        });
+
+        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'nl');
+          sinon.stub(cookiesService, 'write');
+
+          // when
+          localeService.setBestLocale({ queryParams: null });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-FR');
+        });
+      });
+
+      module('when the current domain extension is "org"', function (hooks) {
+        hooks.beforeEach(function () {
+          currentDomainService.getExtension.returns('org');
+        });
+
+        test('sets the default locale', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', '');
+          sinon.stub(cookiesService, 'write');
+
+          // when
+          localeService.setBestLocale({ queryParams: null });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+        });
+
+        module('when there is query param "lang"', function () {
+          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
             // given
-            currentDomainService.getExtension.returns('org');
-            const user = { lang: 'nl' };
-            const language = 'es';
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr');
 
             // when
-            localeService.detectBestLocale({ language, user });
+            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
 
             // then
-            sinon.assert.calledWith(intlService.setLocale, 'es');
-            sinon.assert.calledWith(dayjsService.setLocale, 'es');
-            assert.strictEqual(metricsService.context.locale, 'es');
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is query param "locale"', function () {
+          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr');
+
+            // when
+            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is a cookie', function () {
+          test('sets the locale with the "locale" cookie value', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr-BE');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr-BE');
+          });
+        });
+
+        module('when there is an unsupported cookie', function () {
+          test('sets the nearest supported base language', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'en-CA');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'en');
+          });
+        });
+
+        module('when the detected locale is fr-FR', function () {
+          test('always returns fr for not France domain', async function (assert) {
+            // given
+            const cookiesService = this.owner.lookup('service:cookies');
+            cookiesService.write('locale', 'fr-FR');
+
+            // when
+            localeService.setBestLocale({ queryParams: null });
+
+            // then
+            const currentLocale = localeService.currentLocale;
+            assert.strictEqual(currentLocale, 'fr');
           });
         });
       });

--- a/orga/tests/unit/services/session-test.js
+++ b/orga/tests/unit/services/session-test.js
@@ -17,7 +17,7 @@ module('Unit | Service | session', function (hooks) {
 
     service = this.owner.lookup('service:session');
     service.currentUser = { load: sinon.stub(), prescriber: user };
-    service.locale = { detectBestLocale: sinon.stub(), isSupportedLocale: sinon.stub().returns(true) };
+    service.locale = { setBestLocale: sinon.stub(), isSupportedLocale: sinon.stub().returns(true) };
   });
 
   module('#handleAuthentication', function () {
@@ -27,7 +27,7 @@ module('Unit | Service | session', function (hooks) {
 
       // then
       sinon.assert.calledOnce(service.currentUser.load);
-      sinon.assert.calledWith(service.locale.detectBestLocale, { user, language: undefined });
+      sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams: undefined });
       assert.ok(true);
     });
   });
@@ -54,14 +54,14 @@ module('Unit | Service | session', function (hooks) {
     module('when locale is supported', function () {
       test('loads the current user, sets locale sets data.localeNotSupported to false', async function (assert) {
         // given
-        const transition = { to: { queryParams: { lang: 'es' } } };
+        const queryParams = { lang: 'es' };
 
         // when
-        await service.loadCurrentUserAndSetLocale(transition);
+        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.detectBestLocale, { language: 'es', user });
+        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
         assert.false(service.data.localeNotSupported);
       });
     });
@@ -69,15 +69,15 @@ module('Unit | Service | session', function (hooks) {
     module('when locale is not supported', function () {
       test('loads the current user, sets locale sets data.localeNotSupported to true', async function (assert) {
         // given
-        const transition = { to: { queryParams: { lang: 'es' } } };
+        const queryParams = { lang: 'es' };
         service.locale.isSupportedLocale = sinon.stub().returns(false);
 
         // when
-        await service.loadCurrentUserAndSetLocale(transition);
+        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.detectBestLocale, { language: 'es', user });
+        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
         assert.true(service.data.localeNotSupported);
       });
     });

--- a/orga/tests/unit/services/url-base-test.js
+++ b/orga/tests/unit/services/url-base-test.js
@@ -2,13 +2,14 @@
 // If you need a change, modify the original file and
 // propagate the changes in the copies in all the fronts.
 
-import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-orga/config/environment';
 import { PIX_WEBSITE_PATHS, PIX_WEBSITE_ROOT_URLS } from 'pix-orga/services/url-base';
 import setupIntl from 'pix-orga/tests/helpers/setup-intl';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+
+import { setCurrentLocale } from '../../helpers/setup-intl.js';
 
 const { SUPPORTED_LOCALES } = ENV.APP;
 
@@ -20,13 +21,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the application home url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.homeUrl;
 
       // then
-      assert.strictEqual(homeUrl, '/?lang=en');
+      assert.strictEqual(homeUrl, '/?lang=fr');
     });
   });
 
@@ -34,13 +34,12 @@ module('Unit | Service | url-base', function (hooks) {
     test('returns the Pix server status url', function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
 
       // when
       const homeUrl = service.serverStatusUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=en');
+      assert.strictEqual(homeUrl, 'https://status.pix.org/?locale=fr');
     });
   });
 
@@ -92,7 +91,7 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie');
     });
 
-    test('returns the Pix app forgotten password url for a locale', function (assert) {
+    test('returns the Pix app forgotten password url for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
@@ -100,7 +99,7 @@ module('Unit | Service | url-base', function (hooks) {
       const domainService = this.owner.lookup('service:current-domain');
       sinon.stub(domainService, 'getExtension').returns('fr');
 
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.pixAppForgottenPasswordUrl;
@@ -111,10 +110,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrl', function () {
-    test('returns the Pix website url for the current locale', function (assert) {
+    test('returns the Pix website url for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl();
@@ -123,10 +122,10 @@ module('Unit | Service | url-base', function (hooks) {
       assert.strictEqual(homeUrl, 'https://pix.org/en');
     });
 
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrl('this-is-my-document');
@@ -137,10 +136,10 @@ module('Unit | Service | url-base', function (hooks) {
   });
 
   module('getPixWebsiteUrlFor', function () {
-    test('returns the Pix website url and path for the current locale', function (assert) {
+    test('returns the Pix website url and path for the current locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url-base');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const homeUrl = service.getPixWebsiteUrlFor('CGU');
@@ -150,12 +149,12 @@ module('Unit | Service | url-base', function (hooks) {
     });
 
     module('when the tld is fr', function () {
-      test('returns the Pix website url for the tld fr', function (assert) {
+      test('returns the Pix website url for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor();
@@ -164,12 +163,12 @@ module('Unit | Service | url-base', function (hooks) {
         assert.strictEqual(homeUrl, 'https://pix.fr');
       });
 
-      test('returns the Pix website url and path for the tld fr', function (assert) {
+      test('returns the Pix website url and path for the tld fr', async function (assert) {
         // given
         const service = this.owner.lookup('service:url-base');
         const domainService = this.owner.lookup('service:current-domain');
         sinon.stub(domainService, 'getExtension').returns('fr');
-        setLocale('en');
+        await setCurrentLocale('en');
 
         // when
         const homeUrl = service.getPixWebsiteUrlFor('CGU');

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -1,10 +1,10 @@
-import { setLocale } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-orga/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntl from '../../helpers/setup-intl';
+import { setCurrentLocale } from '../../helpers/setup-intl.js';
 
 module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
@@ -22,10 +22,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
     });
 
-    test('returns the Pix website legal notice URL for a locale', function (assert) {
+    test('returns the Pix website legal notice URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const legalNoticeUrl = service.legalNoticeUrl;
@@ -47,10 +47,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, 'https://pix.org/fr/conditions-generales-d-utilisation');
     });
 
-    test('returns the Pix website CGU URL for a locale', function (assert) {
+    test('returns the Pix website CGU URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const cguUrl = service.cguUrl;
@@ -72,10 +72,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(dataProtectionPolicyUrl, 'https://pix.org/fr/politique-protection-donnees-personnelles-app');
     });
 
-    test('returns the Pix website data protection policy URL for a locale', function (assert) {
+    test('returns the Pix website data protection policy URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -97,10 +97,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite-pix-orga');
     });
 
-    test('returns the Pix website accessibility URL for a locale', function (assert) {
+    test('returns the Pix website accessibility URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const accessibilityUrl = service.accessibilityUrl;
@@ -175,10 +175,10 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/my-legal-document-path');
     });
 
-    test('returns the Pix legal document URL for a locale', function (assert) {
+    test('returns the Pix legal document URL for a locale', async function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      setLocale('en');
+      await setCurrentLocale('en');
 
       // when
       const accessibilityUrl = service.getLegalDocumentUrl('my-legal-document-path');


### PR DESCRIPTION
> [!WARNING]
> La majorité des changements est dû à la copie des services `locale` et `url-base`, qui sont copier de `mon-pix` pour conserver une cohérence des services entre les apps. Dans le futur, nous souhaiterions avoir un addon commun aux fronts contenant ces service.
> **Le commit important pour @1024pix/team-prescription est celui-ci: https://github.com/1024pix/pix/pull/13119/commits/743d3de78b21f679968e4dc8fcf78f585ebe128d**

## 🔆 Problème

Actuellement, l'algorithme de détection de locale ne gère pas tous les cas que l'on souhaite lorsque l'utilisateur charge l'application. De plus, il n'y a pas de source de vérité pour la locale courante.

## ⛱️ Proposition

**Sous feature toggle `useLocale`**

- Modifier l'algorithme de détection des locales suivant ces priorités:
  - si domaine `.fr`, alors `locale='fr-FR'`
  - si query parameter `locale`, alors `locale=locale`
  - si query parameter `lang`, alors `locale=lang`
  - si cookie `locale` présent, alors `locale=<valeur du cookie>`
  - sinon `locale=<locale du navigateur>`

- Quand on détecte la locale on s'assure qu'elle est supportée par l'application, en déterminant la locale la plus proche supportée, exemple:
  - `fr` => `fr`
  - `fr-fr` => `fr-FR`
  - `fr-BE` => `fr-BE`, `nl-BE` => `nl-BE`
  - `fr-CA` => `fr`, `nl-NL` => `nl`
  - Non supporté => locale par défaut

- Quand on détecte la locale, ou qu'elle est changée (ex: LocaleSwitcher), elle est stockée  dans un cookie `locale` qui sera la source de vérité de la locale courante pour le domaine.

- Dans le service `locale`
  - La fonction `currentLocale` retournera **toujours** la locale du cookie.
  - La fonction `currentLanguage` retournera la langue déduite de la locale courante.

**Normalement, quand le FT `useLocale` est activé, l'ensemble de l'application reste fonctionnel et inchangé. Seules la détection des locales et leur priorisation changent.**

## 🌊 Remarques

- Pour l'algorithme de détection des locales, nous utilisons la librairie `https://github.com/i18next/i18next-browser-languageDetector`
- À certains endroits, il est nécessaire d'utiliser `currentLanguage` au lieu de `currentLocale` pour conserver la rétro-compatibilité de certaines features.

## 🏄 Pour tester

⚠️ Il est conseillé de réaliser les tests en **navigation privée**.

**Non régression :**
Quand le feature toggle `useLocale` est désactivé, la détection des locales est la même qu'aujourd'hui.
- Tester les scénarios de `FileSaver`:
  - télécharger les attestations PDF par classe
  - télécharger les résultats par classe en CSV
  - génération en masse de mot de passe pour les élèves du sco
  - export des résultats d'une campagne

**Quand le feature toggle `useLocale` est activé :**
Nouveaux comportement (sur `pix.fr`):
- La locale est toujours stockée dans le cookie `locale`
- Sur pix.fr, la locale sera toujours `fr-FR` (comme précédement)
- Tester les scénarios de `FileSaver`:
  - télécharger les attestations PDF par classe
  - télécharger les résultats par classe en CSV
  - génération en masse de mot de passe pour les élèves du sco
  - export des résultats d'une campagne

Nouveaux comportement (sur `pix.org`):
- La locale est toujours stockée dans le cookie `locale`
- La détection des locales suit l'algorithme expliqué dans la proposition.
- La première fois où l'utilisateur arrive, on détermine la locale supportée la plus proche par rapport à la locale du navigateur.
- La locale peut être changée via : 
  - les locale switchers
  - les paramètres de requêtes `lang` ou `locale`
- Quand un utilisateur revient on utilise le cookie `locale`, s'il est présent.

S'assurer qu'en changeant les locales, on accède aux contenus localisés.