### PR TITLE
[FEATURE] Permettre l'utilisation de `pix-cursor` et `llm-messages` dans les modules (PIX-18962)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -489,6 +489,61 @@
       ]
     },
     {
+      "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef8",
+      "type": "lesson",
+      "title": "llm-messages",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "a1f5e147-ea8c-4046-8020-f21c28529388",
+            "type": "text",
+            "content": "<p>llm-messages</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "03bacda5-2b76-49fd-a266-3a9bb16c20c9",
+            "type": "custom",
+            "tagName": "llm-messages",
+            "props": {
+              "messages": [
+                {
+                  "direction": "outbound",
+                  "content": "Bonjour"
+                },
+                {
+                  "direction": "inbound",
+                  "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?<br>Avez-vous, par pur hasard, besoin d’une recette de cookie géant ?"
+                },
+                {
+                  "direction": "outbound",
+                  "content": "Pourquoi pas..."
+                },
+                {
+                  "direction": "inbound",
+                  "content": "Pour faire un cookie géant, prenez une recette de cookie, et multipliez toutes les doses par 10.<br>Ensuite, au lieu de faire des petits tas de pate, faites un gros tas de pate sur votre plaque de cuisson.<br><strong>Bon appétit ! 🍪✨</strong>"
+                },
+                {
+                  "direction": "outbound",
+                  "content": "Elle est bizarre ta recette."
+                },
+                {
+                  "direction": "inbound",
+                  "content": "Désolé si ma recette ne vous plaît pas, souhaitez-vous une recette différente ?"
+                },
+                {
+                  "direction": "outbound",
+                  "content": "Non, je m'en vais."
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "id": "662434d8-5d88-4be6-a339-a81916933229",
       "type": "lesson",
       "title": "llm-prompt-select",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -675,6 +675,49 @@
           }
         }
       ]
+    },
+    {
+      "id": "fc38e052-ed9f-4d68-b09f-515b7069ad00",
+      "type": "lesson",
+      "title": "pix-cursor",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "7c2efda7-1839-4b58-8673-ab32294cc799",
+            "type": "text",
+            "content": "<p>pix-cursor</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "b04ef581-48f2-4543-9bf4-e1e8784fa396",
+            "type": "custom",
+            "tagName": "pix-cursor",
+            "props": {
+              "options": [
+                {
+                  "label": "Bon",
+                  "feedback": { "type": "good", "text": "OUI, ÇA SENT LA PATATE ! 🎉" }
+                },
+                {
+                  "label": "Presque",
+                  "feedback": { "type": "close", "text": "PATATE 🥔" }
+                },
+                {
+                  "label": "Neutre",
+                  "feedback": { "type": "neutral", "text": "Ça souffle dis donc 💨" }
+                },
+                {
+                  "label": "Incorrect",
+                  "feedback": { "type": "bad", "text": "❌ C'EST NON! Et voici pourquoi : <br>Quis elit cupidatat commodo adipisicing aliqua qui commodo proident ipsum dolore culpa in. Mollit eiusmod elit sint in aute nulla enim. Sit sint in sunt esse excepteur cupidatat et adipisicing nulla excepteur consectetur reprehenderit est ipsum. Cupidatat proident est pariatur minim labore excepteur culpa aliqua consectetur laboris voluptate consectetur enim nulla laboris. Aliquip occaecat irure sunt. Laboris eiusmod eu dolor veniam minim proident. Elit consequat est occaecat." }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -54,16 +54,18 @@ const llmCompareMessagesPropsSchema = Joi.object({
     .required(),
 }).required();
 
+const llmMessageSchema = Joi.object({
+  direction: Joi.string().valid('inbound', 'outbound').required(),
+  content: Joi.string().required(),
+});
+
+const llmMessagesPropsSchema = Joi.object({
+  messages: Joi.array().items(llmMessageSchema.required()).required(),
+}).required();
+
 const llmPromptSelectPropsSchema = Joi.object({
   speed: Joi.number().default(20).min(0).optional(),
-  messages: Joi.array()
-    .items(
-      Joi.object({
-        direction: Joi.string().valid('inbound', 'outbound').required(),
-        content: Joi.string().required(),
-      }).required(),
-    )
-    .required(),
+  messages: Joi.array().items(llmMessageSchema).required(),
   prompts: Joi.array()
     .items(
       Joi.object({
@@ -152,6 +154,7 @@ const customElementSchema = Joi.object({
       'image-quiz',
       'image-quizzes',
       'llm-compare-messages',
+      'llm-messages',
       'llm-prompt-select',
       'message-conversation',
       'pix-carousel',
@@ -164,6 +167,7 @@ const customElementSchema = Joi.object({
         { is: 'image-quiz', then: imageQuizPropsSchema },
         { is: 'image-quizzes', then: imageQuizzesPropsSchema },
         { is: 'llm-compare-messages', then: llmCompareMessagesPropsSchema },
+        { is: 'llm-messages', then: llmMessagesPropsSchema },
         { is: 'llm-prompt-select', then: llmPromptSelectPropsSchema },
         { is: 'message-conversation', then: messageConversationPropsSchema },
         { is: 'pix-carousel', then: pixCarouselPropsSchema },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -146,6 +146,18 @@ const pixCarouselPropsSchema = Joi.object({
   .meta({ title: 'pix-carousel' })
   .required();
 
+const pixCursorOptions = Joi.object({
+  label: Joi.string().required(),
+  feedback: Joi.object({
+    type: Joi.string().valid('bad', 'neutral', 'close', 'good').required(),
+    text: Joi.string().required(),
+  }).required(),
+});
+
+const pixCursorPropsSchema = Joi.object({
+  options: Joi.array().items(pixCursorOptions.required()).required(),
+});
+
 const customElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
@@ -158,6 +170,7 @@ const customElementSchema = Joi.object({
       'llm-prompt-select',
       'message-conversation',
       'pix-carousel',
+      'pix-cursor',
       'qcu-image',
     )
     .required(),
@@ -171,6 +184,7 @@ const customElementSchema = Joi.object({
         { is: 'llm-prompt-select', then: llmPromptSelectPropsSchema },
         { is: 'message-conversation', then: messageConversationPropsSchema },
         { is: 'pix-carousel', then: pixCarouselPropsSchema },
+        { is: 'pix-cursor', then: pixCursorPropsSchema },
         { is: 'qcu-image', then: imageQuizPropsSchema },
       ],
       otherwise: Joi.object().required(),

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.8.1",
+        "@1024pix/epreuves-components": "^0.9.3",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.8.1.tgz",
-      "integrity": "sha512-fF0jZsYDc0MJP0ASAIymftTZ8dgiy95QUQLbu5/ey+0DLEgcoXLXAHtc8ArizNbo2ZxD8Px8Jrd99aA5rqQ3Zg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.3.tgz",
+      "integrity": "sha512-Z/Wed94U8AzimIHah+s6ztw1BUY50s0DxT4JiwDDBjhvc+XRqM6ej1d815fMge9tWzXumDsBT9+l2js9RLy4wA==",
       "dev": true,
       "license": "MIT"
     },

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.8.1",
+    "@1024pix/epreuves-components": "^0.9.3",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.8.1",
+        "@1024pix/epreuves-components": "^0.9.3",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.8.1.tgz",
-      "integrity": "sha512-fF0jZsYDc0MJP0ASAIymftTZ8dgiy95QUQLbu5/ey+0DLEgcoXLXAHtc8ArizNbo2ZxD8Px8Jrd99aA5rqQ3Zg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.3.tgz",
+      "integrity": "sha512-Z/Wed94U8AzimIHah+s6ztw1BUY50s0DxT4JiwDDBjhvc+XRqM6ej1d815fMge9tWzXumDsBT9+l2js9RLy4wA==",
       "dev": true,
       "license": "MIT"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.8.1",
+    "@1024pix/epreuves-components": "^0.9.3",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",


### PR DESCRIPTION
## 🔆 Problème

Les composants `pix-cursor` et `llm-messages` ont été mis à disposition dans la version 9 de `@1024pix/epreuves-components`.

## ⛱️ Proposition

Ajouter le schéma Joi des props de ces composants.
Mettre à jour le package.
Mettre à jour le module d'exposition des POIs.

## 🌊 Remarques

Suppression d'un `required()` un peu trop sévère sur le schéma de `llm-prompt-select`.

## 🏄 Pour tester

- [Ouvrir le module `demo-epreuves-components`](https://app-pr13120.review.pix.fr/modules/demo-epreuves-components/passage).
- Descendre jusqu'à la leçon `llm-messages`.
- Constater qu'une conversation non interactive avec un LLM est affichée. 
- Descendre jusqu'à la leçon `pix-cursor`.
- Constater qu'un slider interactif s'affiche.