### PR TITLE
[FEATURE] Ajout d'une modale pour changer le nom des participants sur PixOrga (PIX-18971)

### DIFF
--- a/orga/app/adapters/organization-participant.js
+++ b/orga/app/adapters/organization-participant.js
@@ -22,4 +22,14 @@ export default class OrganizationParticipantAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners`;
     return this.ajax(url, 'DELETE', { data: { listLearners: ids } });
   }
+
+  updateParticipantName(organizationId, learnerId, firstName, lastName) {
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners/${learnerId}`;
+    return this.ajax(url, 'PATCH', {
+      data: {
+        firstName,
+        lastName,
+      },
+    });
+  }
 }

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -13,6 +13,7 @@ import { CONNECTION_TYPES } from '../../helpers/connection-types';
 import ImportInformationBanner from '../import-information-banner';
 import InElement from '../in-element';
 import SelectableList from '../selectable-list';
+import EditParticipantNameModal from '../ui/edit-participant-name-modal';
 import EmptyState from '../ui/empty-state';
 import GenerateUsernamePasswordModal from './generate-username-password-modal';
 import ListActionBar from './list-action-bar';
@@ -44,6 +45,8 @@ export default class ScoList extends Component {
   @tracked isShowingAuthenticationMethodModal = false;
   @tracked showResetPasswordModal = false;
   @tracked showGenerateUsernamePasswordModal = false;
+  @tracked showEditNameModal = false;
+  @tracked selectedStudentForNameModification = null;
   @tracked divisions;
 
   @tracked affectedStudents = [];
@@ -124,6 +127,19 @@ export default class ScoList extends Component {
   }
 
   @action
+  openEditNameModal(student, event) {
+    event.stopPropagation();
+    this.selectedStudentForNameModification = student;
+    this.showEditNameModal = true;
+  }
+
+  @action
+  closeEditNameModal() {
+    this.selectedStudentForNameModification = null;
+    this.showEditNameModal = false;
+  }
+
+  @action
   async generateUsernamePasswordForStudents(affectedStudents, resetSelectedStudents) {
     const affectedStudentsIds = affectedStudents.map((affectedStudents) => affectedStudents.id);
     try {
@@ -180,12 +196,6 @@ export default class ScoList extends Component {
     }
   }
 
-  @action
-  addStopPropagationOnFunction(toggleStudent, event) {
-    event.stopPropagation();
-    toggleStudent();
-  }
-
   <template>
     <ImportInformationBanner @importDetail={{@importDetail}} />
 
@@ -222,6 +232,8 @@ export default class ScoList extends Component {
               @student={{student}}
               @isStudentSelected={{isStudentSelected student}}
               @openAuthenticationMethodModal={{this.openAuthenticationMethodModal}}
+              @openEditNameModal={{this.openEditNameModal}}
+              @canEditLearnerName={{this.currentUser.canEditLearnerName}}
               @onToggleStudent={{fn withFunction (fn toggleStudent student) stopPropagation}}
               @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
             />
@@ -286,6 +298,12 @@ export default class ScoList extends Component {
         @student={{this.student}}
         @display={{this.isShowingAuthenticationMethodModal}}
         @onClose={{this.closeAuthenticationMethodModal}}
+      />
+
+      <EditParticipantNameModal
+        @participant={{this.selectedStudentForNameModification}}
+        @show={{this.showEditNameModal}}
+        @onClose={{this.closeEditNameModal}}
       />
     {{/let}}
   </template>

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -134,6 +134,11 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
           <Item @onClick={{fn @openAuthenticationMethodModal @student}}>
             {{t "pages.sco-organization-participants.actions.manage-account"}}
           </Item>
+          {{#if @canEditLearnerName}}
+            <Item @onClick={{fn @openEditNameModal @student}}>
+              {{t "components.ui.edit-participant-name-modal.label"}}
+            </Item>
+          {{/if}}
         </IconTrigger>
       {{/if}}</:cell>
   </PixTableColumn>

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -12,6 +12,7 @@ import ImportInformationBanner from '../import-information-banner';
 import InElement from '../in-element';
 import SelectableList from '../selectable-list';
 import DeletionModal from '../ui/deletion-modal';
+import EditParticipantNameModal from '../ui/edit-participant-name-modal';
 import EmptyState from '../ui/empty-state';
 import ActionBar from './action-bar';
 import EditStudentNumberModal from './modal/edit-student-number-modal';
@@ -24,6 +25,7 @@ export default class ListItems extends Component {
   @tracked selectedStudent = null;
   @tracked showDeletionModal = false;
   @tracked isShowingEditStudentNumberModal = false;
+  @tracked showEditNameModal = false;
   @tracked isLoadingGroups;
 
   constructor() {
@@ -92,6 +94,19 @@ export default class ListItems extends Component {
   }
 
   @action
+  openEditNameModal(student, event) {
+    event.stopPropagation();
+    this.selectedStudent = student;
+    this.showEditNameModal = true;
+  }
+
+  @action
+  closeEditNameModal() {
+    this.selectedStudent = null;
+    this.showEditNameModal = false;
+  }
+
+  @action
   async addResetOnFunction(wrappedFunction, resetParticipants, ...args) {
     await wrappedFunction(...args);
     resetParticipants();
@@ -126,6 +141,8 @@ export default class ListItems extends Component {
               @context={{context}}
               @isStudentSelected={{isStudentSelected student}}
               @openEditStudentNumberModal={{this.openEditStudentNumberModal}}
+              @openEditNameModal={{this.openEditNameModal}}
+              @canEditLearnerName={{this.currentUser.canEditLearnerName}}
               @isAdminInOrganization={{this.currentUser.isAdminInOrganization}}
               @onToggleStudent={{fn this.addStopPropagationOnFunction (fn toggleStudent student)}}
               @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
@@ -196,6 +213,12 @@ export default class ListItems extends Component {
         @onSubmit={{this.onSaveStudentNumber}}
       />
     {{/let}}
+
+    <EditParticipantNameModal
+      @participant={{this.selectedStudent}}
+      @show={{this.showEditNameModal}}
+      @onClose={{this.closeEditNameModal}}
+    />
   </template>
 }
 

--- a/orga/app/components/sup-organization-participant/table-row.gjs
+++ b/orga/app/components/sup-organization-participant/table-row.gjs
@@ -128,6 +128,11 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
           <Item @onClick={{fn @openEditStudentNumberModal @student}}>
             {{t "pages.sup-organization-participants.actions.edit-student-number"}}
           </Item>
+          {{#if @canEditLearnerName}}
+            <Item @onClick={{fn @openEditNameModal @student}}>
+              {{t "components.ui.edit-participant-name-modal.label"}}
+            </Item>
+          {{/if}}
         </IconTrigger>
       {{/if}}</:cell>
   </PixTableColumn>

--- a/orga/app/components/ui/edit-participant-name-modal.gjs
+++ b/orga/app/components/ui/edit-participant-name-modal.gjs
@@ -1,0 +1,138 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class EditParticipantNameModal extends Component {
+  @service notifications;
+  @service intl;
+  @service store;
+  @service currentUser;
+
+  @tracked firstName = '';
+  @tracked lastName = '';
+
+  @tracked isLoading = false;
+
+  constructor(...args) {
+    super(...args);
+
+    this.firstName = this.args.participant?.firstName || '';
+    this.lastName = this.args.participant?.lastName || '';
+  }
+
+  @action
+  updateFirstName(event) {
+    this.firstName = event.target.value;
+  }
+
+  @action
+  updateLastName(event) {
+    this.lastName = event.target.value;
+  }
+
+  get hasChanges() {
+    return this.firstName !== this.args.participant?.firstName || this.lastName !== this.args.participant?.lastName;
+  }
+
+  get areFieldsValid() {
+    return this.isFirstNameValid && this.isLastNameValid;
+  }
+
+  get isFirstNameValid() {
+    return Boolean(this.firstName.trim());
+  }
+  get isLastNameValid() {
+    return Boolean(this.lastName.trim());
+  }
+
+  @action
+  async updateParticipantName() {
+    if (!this.areFieldsValid) {
+      return;
+    }
+    if (!this.hasChanges) {
+      this.notifications.success(this.intl.t('components.ui.edit-participant-name-modal.success-message'));
+      return this.args.onClose();
+    }
+
+    this.isLoading = true;
+
+    try {
+      const adapter = this.store.adapterFor('organization-participant');
+
+      await adapter.updateParticipantName(
+        this.currentUser.organization.id,
+        this.args.participant.id,
+        this.firstName.trim(),
+        this.lastName.trim(),
+      );
+
+      this.args.participant.firstName = this.firstName.trim();
+      this.args.participant.lastName = this.lastName.trim();
+
+      this.notifications.success(this.intl.t('components.ui.edit-participant-name-modal.success-message'));
+      this.args.onClose();
+    } catch {
+      this.notifications.error(this.intl.t('api-error-messages.global'));
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <PixModal
+      @title={{t "components.ui.edit-participant-name-modal.label"}}
+      @showModal={{@show}}
+      @onCloseButtonClick={{@onClose}}
+    >
+      <:content>
+
+        <div class="name-edit-modal__content">
+
+          <div class="input-container">
+            <PixInput
+              @id="firstName"
+              @value={{this.firstName}}
+              {{on "input" this.updateFirstName}}
+              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @validationStatus={{if this.isFirstNameValid "default" "error"}}
+              @errorMessage={{t "components.ui.edit-participant-name-modal.error-messages.first-name"}}
+            >
+              <:label>{{t "components.ui.edit-participant-name-modal.fields.first-name"}}</:label>
+            </PixInput>
+          </div>
+
+          <div class="input-container">
+            <PixInput
+              @id="lastName"
+              @value={{this.lastName}}
+              {{on "input" this.updateLastName}}
+              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @validationStatus={{if this.isLastNameValid "default" "error"}}
+              @errorMessage={{t "components.ui.edit-participant-name-modal.error-messages.last-name"}}
+            >
+              <:label>{{t "components.ui.edit-participant-name-modal.fields.last-name"}}</:label>
+            </PixInput>
+          </div>
+
+        </div>
+
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{@onClose}} @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+
+        <PixButton @triggerAction={{this.updateParticipantName}}>
+          {{t "common.actions.save"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -56,6 +56,10 @@ export default class CurrentUserService extends Service {
     return this.isAdminInOrganization && this.prescriber.hasCoverRateFeature;
   }
 
+  get canEditLearnerName() {
+    return this.isAdminInOrganization && !this.hasLearnerImportFeature && !this.organization.isManagingStudents;
+  }
+
   async load() {
     if (this.session.isAuthenticated) {
       try {

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -629,4 +629,8 @@ function routes() {
     };
     return json;
   });
+
+  this.patch('/organizations/:organizationId/organization-learners/:learnerId', function () {
+    return new Response(204);
+  });
 }

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -62,6 +62,7 @@ function _addUserToOrganization(user, { externalId, organizationType } = {}) {
   const memberships = server.create('membership', {
     organizationId: organization.id,
     userId: user.id,
+    organizationRole: 'ADMIN',
   });
 
   user.userOrgaSettings = server.create('user-orga-setting', { user, organization });

--- a/orga/tests/integration/components/organization-participant/list-test.js
+++ b/orga/tests/integration/components/organization-participant/list-test.js
@@ -1091,6 +1091,147 @@ module('Integration | Component | OrganizationParticipant | List', function (hoo
     });
   });
 
+  module('edit modal functionality', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        canEditLearnerName = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      this.triggerFiltering = sinon.stub();
+      this.set('fullNameFilter', null);
+      this.set('certificabilityFilter', []);
+    });
+
+    test('it should display dropdown actions when user can edit learner name', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      // when
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('pages.sup-organization-participants.actions.show-actions') }));
+    });
+
+    test('it should open edit modal when clicking edit action', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`);
+
+      // when
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sup-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+
+      const editButton = screen.getByText(t('components.ui.edit-participant-name-modal.label'));
+      await click(editButton);
+
+      // then
+      assert.ok(screen.getByDisplayValue('Jean'));
+      assert.ok(screen.getByDisplayValue('Dupont'));
+    });
+
+    test('it should close edit modal when clicking close', async function (assert) {
+      // given
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`);
+
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sup-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+
+      const editButton = screen.getByText(t('components.ui.edit-participant-name-modal.label'));
+      await click(editButton);
+
+      // when
+      const closeButton = screen.getByRole('button', {
+        name: t('common.actions.close'),
+      });
+      await click(closeButton);
+
+      // thenm
+      assert.notOk(screen.queryByDisplayValue('Jean'));
+      assert.notOk(screen.queryByDisplayValue('Dupont'));
+    });
+
+    test('it should not display dropdown actions when user cannot edit learner name', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        canEditLearnerName = false;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const participants = [
+        {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          extraColumns: {},
+        },
+      ];
+      this.set('participants', participants);
+
+      // when
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`);
+
+      // then
+      assert.notOk(screen.queryByLabelText(t('pages.sup-organization-participants.actions.show-actions')));
+    });
+  });
+
   module('hide checkbox context', function () {
     test('when user is not admin of organisation', async function (assert) {
       //given

--- a/orga/tests/integration/components/sco-organization-participant/list-test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.js
@@ -1584,4 +1584,128 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       });
     });
   });
+
+  module('edit modal functionality', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentUserStub extends Service {
+        prescriber = {};
+        canEditLearnerName = true;
+        organization = store.createRecord('organization', {
+          id: '1',
+          divisions: [store.createRecord('division', { id: '3E', name: '3E' })],
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.set('divisions', []);
+      this.set('connectionTypes', []);
+      this.set('certificability', []);
+      this.set('search', null);
+    });
+
+    test('it should display dropdown actions when user can edit learner name', async function (assert) {
+      // given
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          username: 'jean.dupont0101',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+/>`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }));
+    });
+
+    test('it should open edit modal when clicking edit action', async function (assert) {
+      // given
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          username: 'jean.dupont0101',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+  @refreshValues={{this.noop}}
+/>`);
+
+      // when
+      const dropdownButton = screen.getByRole('button', {
+        name: t('pages.sco-organization-participants.actions.show-actions'),
+      });
+      await click(dropdownButton);
+      const editButton = screen.getByRole('button', { name: t('components.ui.edit-participant-name-modal.label') });
+
+      // then
+      assert.ok(editButton);
+      assert.dom(editButton).isNotDisabled();
+    });
+
+    test('it should not display dropdown actions when user cannot edit learner name', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        prescriber = {};
+        canEditLearnerName = false;
+        organization = store.createRecord('organization', {
+          id: '1',
+          divisions: [store.createRecord('division', { id: '3F', name: '3F' })],
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const students = [
+        store.createRecord('sco-organization-participant', {
+          id: '1',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          isAuthenticatedFromGar: false,
+        }),
+      ];
+      this.set('students', students);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+/>`);
+
+      // then
+      assert.notOk(
+        screen.queryByRole('button', { name: t('pages.sco-organization-participants.actions.show-actions') }),
+      );
+    });
+  });
 });

--- a/orga/tests/integration/components/ui/edit-participant-name-modal-test.gjs
+++ b/orga/tests/integration/components/ui/edit-participant-name-modal-test.gjs
@@ -1,0 +1,289 @@
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import EditParticipantNameModal from 'pix-orga/components/ui/edit-participant-name-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Ui::EditParticipantNameModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let notificationsStub;
+  let storeStub;
+  let currentUserStub;
+  let adapterStub;
+  let lastNameLabel;
+  let firstNameLabel;
+
+  hooks.beforeEach(function () {
+    notificationsStub = this.owner.lookup('service:notifications');
+    storeStub = this.owner.lookup('service:store');
+    currentUserStub = this.owner.lookup('service:current-user');
+
+    adapterStub = {
+      updateParticipantName: sinon.stub(),
+    };
+
+    sinon.stub(notificationsStub, 'success');
+    sinon.stub(notificationsStub, 'error');
+    sinon.stub(storeStub, 'adapterFor').returns(adapterStub);
+
+    firstNameLabel = t('components.ui.edit-participant-name-modal.fields.first-name') + ' *';
+    lastNameLabel = t('components.ui.edit-participant-name-modal.fields.last-name') + ' *';
+
+    currentUserStub.organization = { id: 'org-123' };
+  });
+
+  test('should render modal with participant data', async function (assert) {
+    const participant = {
+      id: '123',
+      firstName: 'Jean',
+      lastName: 'Dupont',
+    };
+    const closeStub = sinon.stub();
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    assert.ok(screen.getByDisplayValue('Jean'));
+    assert.ok(screen.getByDisplayValue('Dupont'));
+  });
+
+  test('should update firstName when typing in first name input', async function (assert) {
+    const participant = {
+      id: '123',
+      firstName: 'Jean',
+      lastName: 'Dupont',
+    };
+    const closeStub = sinon.stub();
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    await fillByLabel(firstNameLabel, 'Pierre');
+
+    assert.notOk(screen.queryByText('Jean'));
+  });
+
+  test('should update lastName when typing in last name input', async function (assert) {
+    const participant = {
+      id: '123',
+      firstName: 'Jean',
+      lastName: 'Dupont',
+    };
+    const closeStub = sinon.stub();
+    const screen = await render(
+      <template>
+        <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+      </template>,
+    );
+
+    await fillByLabel(lastNameLabel, 'Martin');
+
+    assert.notOk(screen.queryByText('Jean'));
+  });
+
+  module('validation', function () {
+    test('should show error message when first name is empty', async function (assert) {
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '');
+
+      assert.ok(screen.getByText(t('components.ui.edit-participant-name-modal.error-messages.first-name')));
+    });
+
+    test('should show error message when last name is empty', async function (assert) {
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      const screen = await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(lastNameLabel, '');
+
+      assert.ok(screen.getByText(t('components.ui.edit-participant-name-modal.error-messages.last-name')));
+    });
+  });
+
+  module('save', function () {
+    test('should not call API when no changes are made', async function (assert) {
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.notCalled(adapterStub.updateParticipantName);
+      sinon.assert.calledWith(notificationsStub.success, 'Nom mis à jour avec succès');
+      sinon.assert.calledOnce(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should call API when changes are made', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(adapterStub.updateParticipantName, 'org-123', '123', 'Pierre', 'Martin');
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should update participant data and show success notification on successful save', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await fillByLabel(lastNameLabel, 'Martin');
+      await clickByName(t('common.actions.save'));
+
+      assert.strictEqual(participant.firstName, 'Pierre');
+      assert.strictEqual(participant.lastName, 'Martin');
+      sinon.assert.calledWith(notificationsStub.success, 'Nom mis à jour avec succès');
+      sinon.assert.calledOnce(closeStub);
+    });
+
+    test('should show error notification on API failure', async function (assert) {
+      const error = new Error('API Error');
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      adapterStub.updateParticipantName.rejects(error);
+
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, 'Pierre');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(notificationsStub.error, t('api-error-messages.global'));
+      sinon.assert.notCalled(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should not call API when fields are invalid', async function (assert) {
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.notCalled(adapterStub.updateParticipantName);
+      sinon.assert.notCalled(notificationsStub.success);
+      sinon.assert.notCalled(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+
+    test('should trim whitespace from names before saving', async function (assert) {
+      adapterStub.updateParticipantName.resolves();
+
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await fillByLabel(firstNameLabel, '  Pierre  ');
+      await fillByLabel(lastNameLabel, '  Martin  ');
+      await clickByName(t('common.actions.save'));
+
+      sinon.assert.calledWith(adapterStub.updateParticipantName, 'org-123', '123', 'Pierre', 'Martin');
+      assert.strictEqual(participant.firstName, 'Pierre');
+      assert.strictEqual(participant.lastName, 'Martin');
+    });
+  });
+
+  module('close', function () {
+    test('should call onClose when cancel button is clicked', async function (assert) {
+      const participant = {
+        id: '123',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+      };
+      const closeStub = sinon.stub();
+      await render(
+        <template>
+          <EditParticipantNameModal @show={{true}} @onClose={{closeStub}} @participant={{participant}} />
+        </template>,
+      );
+
+      await clickByName(t('common.actions.cancel'));
+
+      sinon.assert.calledOnce(closeStub);
+      assert.ok(true); // QUnit assertion for test completion
+    });
+  });
+});

--- a/orga/tests/unit/adapters/organization-participant-test.js
+++ b/orga/tests/unit/adapters/organization-participant-test.js
@@ -71,4 +71,26 @@ module('Unit | Adapters | organization-participant', function (hooks) {
       assert.ok(ajaxStub.calledWithExactly(url, 'DELETE'));
     });
   });
+
+  module('#updateParticipantName', () => {
+    test('should PATCH organization-learner name', async function (assert) {
+      // given
+      const organizationId = 1;
+      const learnerId = 2;
+      const firstName = 'John';
+      const lastName = 'Doe';
+
+      // when
+      adapter.updateParticipantName(organizationId, learnerId, firstName, lastName);
+
+      // then
+      const url = `${ENV.APP.API_HOST}/api/organizations/${organizationId}/organization-learners/${learnerId}`;
+      const expectedData = {
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+
+      assert.ok(ajaxStub.calledWithExactly(url, 'PATCH', { data: expectedData }));
+    });
+  });
 });

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -510,6 +510,56 @@ module('Unit | Service | current-user', function (hooks) {
         assert.false(currentUserService.canAccessStatisticsPage);
       });
     });
+
+    module('#canEditLearnerName', function () {
+      test('should return true if user is admin, organisation has no import feature and organization is not managing students', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.true(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if user is not admin', function (assert) {
+        currentUserService.isAdminInOrganization = false;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if user has import feature', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: true,
+        };
+        currentUserService.organization = {
+          isManagingStudents: false,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+
+      test('should return false if organization is managing students', function (assert) {
+        currentUserService.isAdminInOrganization = true;
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+        currentUserService.organization = {
+          isManagingStudents: true,
+        };
+
+        assert.false(currentUserService.canEditLearnerName);
+      });
+    });
   });
 
   module('user is not authenticated', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -211,7 +211,8 @@
       "close": "Close",
       "confirm": "Confirm",
       "global": "Actions",
-      "link-to-participant": "See whole participant's activity"
+      "link-to-participant": "See whole participant's activity",
+      "save": "Save"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -406,6 +407,18 @@
       "deletion-modal": {
         "confirm-deletion": "Yes, I delete",
         "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions"
+      },
+      "edit-participant-name-modal": {
+        "error-messages":{
+          "first-name": "The user's first name cannot be empty.",
+          "last-name": "The user's name cannot be empty."
+        },
+        "fields": {
+          "first-name": "First name",
+          "last-name": "Last name"
+        },
+        "label": "Udate the participant's name",
+        "success-message": "The participant's name has been successfully updated."
       }
     }
   },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -211,7 +211,8 @@
       "close": "Fermer",
       "confirm": "Confirmer",
       "global": "Actions",
-      "link-to-participant": "Voir toute l'activité du participant"
+      "link-to-participant": "Voir toute l'activité du participant",
+      "save": "Enregistrer"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -406,6 +407,18 @@
       "deletion-modal": {
         "confirm-deletion": "Oui, je supprime",
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions"
+      },
+      "edit-participant-name-modal": {
+        "error-messages":{
+          "first-name": "Le prénom de l'utilisateur ne peut pas être vide.",
+          "last-name": "Le nom de l'utilisateur ne peut pas être vide."
+        },
+        "fields": {
+          "first-name": "Prénom",
+          "last-name": "Nom"
+        },
+        "label": "Modifier le nom de l'utilisateur",
+        "success-message": "Nom mis à jour avec succès"
       }
     }
   },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -211,7 +211,8 @@
       "close": "Sluiten",
       "confirm": "Bevestigen",
       "global": "Acties",
-      "link-to-participant": "Alle activiteiten van de deelnemer bekijken"
+      "link-to-participant": "Alle activiteiten van de deelnemer bekijken",
+      "save": "Opslaan"
     },
     "api-error-messages": {
       "bad-request-error": "De gegevens die je hebt opgegeven, hebben niet het juiste format.",
@@ -406,6 +407,18 @@
       "deletion-modal": {
         "confirm-deletion": "Ja, verwijderen",
         "confirmation-checkbox": "Ik kan bevestigen dat ik de gevolgen van de {count} schrappingen volledig begrijp. "
+      },
+      "edit-participant-name-modal": {
+        "error-messages":{
+          "first-name": "De voornaam van de gebruiker mag niet leeg zijn.",
+          "last-name": "De achternaam van de gebruiker mag niet leeg zijn."
+        },
+        "fields": {
+          "first-name": "Voornaam",
+          "last-name": "Achternaam"
+        },
+        "label": "Deelnemer naam wijzigen",
+        "success-message": "De naam van de deelnemer is bijgewerkt."
       }
     }
   },


### PR DESCRIPTION
## 🔆 Problème

Le support est fréquemment amené à renommer des comptes, par nécessité des usagers suite à un changement d'état civil ou suite à des erreurs ou volonté de pseudonymat. 

Renommer un compte ne modifie pas les informations du prescrit.
Une personne restera donc avec son deadname/pseudo/erreur dans les résultats affichés dans Pix Orga pour les prescripteurs. 
C’est problématique voire violent pour certain(e)s. 

## ⛱️ Proposition

Nous avons déjà ajouté la route dans une précédente PR.
Celle ci consiste à ajouter une modale dans la liste des participants pour exploiter la route.

## 🌊 Remarques

- Il n'y a aucune règle de validation sur les noms et prenoms, il n'y en a pas non plus à l'inscription.

## 🏄 Pour tester

- Connecte toi a [PixOrga](https://orga-pr13097.review.pix.fr/)
- Utilise Pro classic pour le premier test, la modale devrait apparaitre et tu dois pouvoir changer le nom. 
- Si tu es vraiment motivé(e) tu peux également modifier en base les autres organisations.
- La modale ne doit apparaître que si: l'organisation n'a pas la feature `LEARNER_IMPORT` et n'est pas `managingStudents`