### PR TITLE
[FEATURE] Limiter la hauteur des custom element à 550px (PIX-18960)

### DIFF
--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -6,13 +6,13 @@ message-conversation::part(conversation) {
 }
 
 .element-custom {
-  fieldset {
+  &__container {
     padding: var(--pix-spacing-2x);
     border: 2px dashed var(--pix-primary-700);
     border-radius: var(--pix-spacing-2x);
   }
 
-  legend {
+  &__legend {
     @extend %pix-body-s;
 
     display: inline-flex;

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -12,6 +12,11 @@ message-conversation::part(conversation) {
     border-radius: var(--pix-spacing-2x);
   }
 
+  &__container.element-custom__component {
+      max-height: 550px;
+      overflow: scroll;
+  }
+
   &__legend {
     @extend %pix-body-s;
 

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -25,15 +25,15 @@ export default class ModulixCustomElement extends ModuleElement {
   <template>
     <div class="element-custom">
       {{#if this.isInteractive}}
-        <fieldset>
-          <legend>
+        <fieldset class="element-custom__container">
+          <legend class="element-custom__legend">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
             <span>{{t "pages.modulix.interactiveElement.label"}}</span>
           </legend>
-          <div {{didInsert this.mountCustomElement}} />
+          <div class="element-custom__component" {{didInsert this.mountCustomElement}} />
         </fieldset>
       {{else}}
-        <div {{didInsert this.mountCustomElement}} />
+        <div class="element-custom__component" {{didInsert this.mountCustomElement}} />
       {{/if}}
     </div>
   </template>


### PR DESCRIPTION
## 🔆 Problème

Afin que tous les éléments custom soient visible entièrement sur un écran d'un utilisateur, nous souhaitons la hauteur de ces éléments à  max 550px.

## ⛱️ Proposition
Le faire en ajoutant une barre de scroll si ça dépasse.

## 🌊 Remarques

- Le scroll automatique dans l'élément message-conversation ne se fait plus. A voir comment corriger ça.
- Doit-on aussi le faire sur les élements custom non interactifs ? La barre de scroll rend l'affichage bizarre car pas de bordure dessus. 

## 🏄 Pour tester

- Aller sur le module [demo-epreuves-components](https://app-pr13124.review.pix.fr/modules/demo-epreuves-components)
- Vérifier que pour les POI ayant une hauteur > 550px, une barre de scroll s'affiche bien !
