### PR TITLE
[FEATURE] Ajouter un bouton de réinitialisation de custom element (PIX-18931)

### DIFF
--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -5,13 +5,13 @@ message-conversation::part(conversation) {
 }
 
 .element-custom {
-  fieldset {
+  &__container {
     padding: var(--pix-spacing-2x);
     border: 2px dashed var(--pix-primary-700);
     border-radius: var(--pix-spacing-2x);
   }
 
-  legend {
+  &__legend {
     @extend %pix-body-s;
 
     display: inline-flex;

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -1,6 +1,5 @@
 @use 'pix-design-tokens/typography';
 
-
 message-conversation::part(conversation) {
   background-color: var(--pix-primary-10);
 }
@@ -20,5 +19,10 @@ message-conversation::part(conversation) {
     align-items: center;
     padding: 0 var(--pix-spacing-2x);
     color: var(--pix-primary-700);
+  }
+
+  &__reset {
+    display: flex;
+    justify-content: flex-end;
   }
 }

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -51,8 +51,8 @@ export default class ModulixCustomDraft extends ModuleElement {
           @iconBefore="refresh"
           @variant="tertiary"
           @triggerAction={{this.resetEmbed}}
-          aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
-        >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+          aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
+        >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
       </div>
     </div>
   </template>

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -59,8 +59,8 @@ export default class ModulixCustomElement extends ModuleElement {
             @iconBefore="refresh"
             @variant="tertiary"
             @triggerAction={{this.resetCustomElement}}
-            aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
-          >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+            aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
+          >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -1,17 +1,34 @@
 import { metadata } from '@1024pix/epreuves-components/metadata';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 import ModuleElement from './module-element';
 
 export default class ModulixCustomElement extends ModuleElement {
+  @tracked
+  customElement;
+
+  @tracked
+  resetButtonDisplayed = false;
+
   @action
   mountCustomElement(container) {
-    const customElement = document.createElement(this.args.component.tagName);
-    Object.assign(customElement, this.args.component.props);
-    container.append(customElement);
+    this.customElement = document.createElement(this.args.component.tagName);
+    Object.assign(this.customElement, this.args.component.props);
+    container.append(this.customElement);
+
+    if (this.customElement.reset !== undefined) {
+      this.resetButtonDisplayed = true;
+    }
+  }
+
+  @action
+  resetCustomElement() {
+    this.customElement.reset();
   }
 
   get isInteractive() {
@@ -34,6 +51,17 @@ export default class ModulixCustomElement extends ModuleElement {
         </fieldset>
       {{else}}
         <div {{didInsert this.mountCustomElement}} />
+      {{/if}}
+
+      {{#if this.resetButtonDisplayed}}
+        <div class="element-custom__reset">
+          <PixButton
+            @iconBefore="refresh"
+            @variant="tertiary"
+            @triggerAction={{this.resetCustomElement}}
+            aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
+          >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+        </div>
       {{/if}}
     </div>
   </template>

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -42,8 +42,8 @@ export default class ModulixCustomElement extends ModuleElement {
   <template>
     <div class="element-custom">
       {{#if this.isInteractive}}
-        <fieldset>
-          <legend>
+        <fieldset class="element-custom__container">
+          <legend class="element-custom__legend">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
             <span>{{t "pages.modulix.interactiveElement.label"}}</span>
           </legend>

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -176,8 +176,8 @@ export default class ModulixEmbed extends ModuleElement {
             @iconBefore="refresh"
             @variant="tertiary"
             @triggerAction={{this.resetEmbed}}
-            aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
-          >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+            aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
+          >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/app/components/module/element/text.gjs
+++ b/mon-pix/app/components/module/element/text.gjs
@@ -1,29 +1,11 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 import ModuleElement from './module-element';
 
 export default class ModulixText extends ModuleElement {
-  get contentWithIframe() {
-    const expression = /^<iframe/;
-    const regExp = new RegExp(expression);
-    return regExp.test(this.args.text.content);
-  }
-
   <template>
     <div class="element-text">
-      {{#if this.contentWithIframe}}
-        <fieldset>
-          <legend>
-            <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
-            <span>{{t "pages.modulix.interactiveElement.label"}}</span>
-          </legend>
-          {{htmlUnsafe @text.content}}
-        </fieldset>
-      {{else}}
-        {{htmlUnsafe @text.content}}
-      {{/if}}
+      {{htmlUnsafe @text.content}}
     </div>
   </template>
 }

--- a/mon-pix/tests/integration/components/module/custom-draft_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-draft_test.gjs
@@ -28,7 +28,9 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
     const expectedIframe = screen.getByTitle(customDraft.title);
     assert.strictEqual(expectedIframe.getAttribute('src'), customDraft.url);
     assert.strictEqual(window.getComputedStyle(expectedIframe).getPropertyValue('height'), `${customDraft.height}px`);
-    assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') })).exists();
+    assert
+      .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.interactive-element.reset.ariaLabel') }))
+      .exists();
     assert.dom(screen.getByText('Instruction du POIC')).exists();
   });
 
@@ -62,7 +64,7 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
       const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
 
       // when
-      await clickByName(t('pages.modulix.buttons.embed.reset.ariaLabel'));
+      await clickByName(t('pages.modulix.buttons.interactive-element.reset.ariaLabel'));
 
       // then
       const iframe = screen.getByTitle(customDraft.title);

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -44,7 +44,9 @@ module('Integration | Component | Module | Embed', function (hooks) {
     assert.strictEqual(expectedIframe.getAttribute('src'), embed.url);
     assert.strictEqual(expectedIframe.style.getPropertyValue('height'), '800px');
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.embed.start.ariaLabel') })).exists();
-    assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') })).doesNotExist();
+    assert
+      .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.interactive-element.reset.ariaLabel') }))
+      .doesNotExist();
     assert.dom(screen.getByText("Instruction de l'embed")).exists();
   });
 
@@ -83,7 +85,9 @@ module('Integration | Component | Module | Embed', function (hooks) {
       const startButtonName = t('pages.modulix.buttons.embed.start.ariaLabel');
       await clickByName(startButtonName);
       assert.dom(screen.queryByRole('button', { name: startButtonName })).doesNotExist();
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') })).exists();
+      assert
+        .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.interactive-element.reset.ariaLabel') }))
+        .exists();
     });
 
     test('should focus on the iframe', async function (assert) {
@@ -361,7 +365,9 @@ module('Integration | Component | Module | Embed', function (hooks) {
 
             // then
             assert
-              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.embed.reset.ariaLabel') }))
+              .dom(
+                screen.queryByRole('button', { name: t('pages.modulix.buttons.interactive-element.reset.ariaLabel') }),
+              )
               .doesNotExist();
           });
         });
@@ -536,7 +542,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
 
       // when
       await clickByName(t('pages.modulix.buttons.embed.start.ariaLabel'));
-      await clickByName(t('pages.modulix.buttons.embed.reset.ariaLabel'));
+      await clickByName(t('pages.modulix.buttons.interactive-element.reset.ariaLabel'));
 
       // then
       const iframe = screen.getByTitle(embed.title);

--- a/mon-pix/tests/integration/components/module/text_test.gjs
+++ b/mon-pix/tests/integration/components/module/text_test.gjs
@@ -1,6 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
 import { findAll } from '@ember/test-helpers';
-import { t } from 'ember-intl/test-support';
 import ModuleElementText from 'mon-pix/components/module/element/text';
 import { module, test } from 'qunit';
 
@@ -20,22 +19,5 @@ module('Integration | Component | Module | Text', function (hooks) {
     assert.ok(screen);
     assert.strictEqual(findAll('.element-text').length, 1);
     assert.ok(screen.getByText('toto'));
-  });
-
-  module('when text content contains an iframe tag', function () {
-    test('should display a legend above', async function (assert) {
-      // given
-      const textElement = {
-        content: '<iframe src="https://my-source.org" height="400"></iframe>',
-        type: 'text',
-      };
-
-      //  when
-      const screen = await render(<template><ModuleElementText @text={{textElement}} /></template>);
-
-      // then
-      assert.ok(screen);
-      assert.dom(screen.getByRole('group', { name: t('pages.modulix.interactiveElement.label') })).exists();
-    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1646,10 +1646,6 @@
           "transcription": "Show transcription"
         },
         "embed": {
-          "reset": {
-            "ariaLabel": "Reset the simulator",
-            "name": "Reset"
-          },
           "start": {
             "ariaLabel": "Start the simulator",
             "name": "Start"
@@ -1672,6 +1668,12 @@
           "skip": "Skip",
           "skipActivity": "Skip activity",
           "terminate": "Terminate"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "Reset the simulator",
+            "name": "Reset"
+          }
         },
         "stepper": {
           "next": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1632,10 +1632,6 @@
           "transcription": "Ver transcripción"
         },
         "embed": {
-          "reset": {
-            "ariaLabel": "Reiniciar simulación",
-            "name": "Restablecer"
-          },
           "start": {
             "ariaLabel": "Empezar simulación",
             "name": "Empezar"
@@ -1658,6 +1654,12 @@
           "skip": "Ir a",
           "skipActivity": "Ir a la actividad",
           "terminate": "Finalizar"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "Reiniciar simulación",
+            "name": "Restablecer"
+          }
         },
         "stepper": {
           "next": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1646,10 +1646,6 @@
           "transcription": "Afficher la transcription"
         },
         "embed": {
-          "reset": {
-            "ariaLabel": "Réinitialiser le simulateur",
-            "name": "Réinitialiser"
-          },
           "start": {
             "ariaLabel": "Commencer le simulateur",
             "name": "Commencer"
@@ -1672,6 +1668,12 @@
           "skip": "Passer",
           "skipActivity": "Passer l‘activité",
           "terminate": "Terminer"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "Réinitialiser le simulateur",
+            "name": "Réinitialiser"
+          }
         },
         "stepper": {
           "next": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1635,10 +1635,6 @@
           "transcription": "Transcriptie weergeven"
         },
         "embed": {
-          "reset": {
-            "ariaLabel": "De simulator resetten",
-            "name": "Reset"
-          },
           "start": {
             "ariaLabel": "De simulator starten",
             "name": "Start"
@@ -1661,6 +1657,12 @@
           "skip": "Overslaan",
           "skipActivity": "Overslaan activiteit",
           "terminate": "Afwerking"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "De simulator resetten",
+            "name": "Reset"
+          }
         },
         "stepper": {
           "next": {


### PR DESCRIPTION
## 🔆 Problème

Certains web components de `@1024pix/epreuves-components` mettent à disposition une méthode `reset` permettant de remettre à zéro le composant. On ne l'utilise pour l'instant pas.

## ⛱️ Proposition

Afficher le bouton "Reset" si il est disponible.

## 🌊 Remarques

Petit nettoyage au passage

## 🏄 Pour tester

Sur https://app-pr13125.review.pix.fr/modules/demo-epreuves-components/passage aller jusqu'au `llm-prompt-select` et voir qu'il y a un bouton "Réinitialiser" qui fonctionne (même style que pour les embeds).
