### PR TITLE
[TECH] Inclure les données de surcharge de prompt de modération et de validation en preview lors des échanges avec POC-LLM (PIX-19040)

### DIFF
--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -35,6 +35,12 @@ export async function register(server) {
               })
                 .optional()
                 .unknown(true),
+              preview: Joi.object({
+                moderationPrompt: Joi.string().min(1).optional(),
+                validationPrompt: Joi.string().min(1).optional(),
+              })
+                .optional()
+                .unknown(true),
             })
               .required()
               .unknown(true),

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -68,6 +68,9 @@ export class Configuration {
  * @property {object} challenge.victoryConditions FIXME add victoryConditions properties
  * @property {string=} challenge.context
  * @property {Attachment=} attachment
+ * @property {object=} preview
+ * @property {string=} preview.moderationPrompt
+ * @property {string=} preview.validationPrompt
  */
 
 /**

--- a/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/message-object-to-event-stream-transform.js
@@ -27,8 +27,8 @@ export function getTransform(streamCapture) {
       }
 
       if (usage) {
-        streamCapture.inputTokens = usage?.inputTokens ?? streamCapture.inputTokens;
-        streamCapture.outputTokens = usage?.outputTokens ?? streamCapture.outputTokens;
+        streamCapture.inputTokens = usage?.input_tokens ?? streamCapture.inputTokens;
+        streamCapture.outputTokens = usage?.output_tokens ?? streamCapture.outputTokens;
       }
 
       if (data) callback(null, data);

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -122,7 +122,7 @@ describe('Acceptance | Route | llm-preview', function () {
       });
     });
 
-    it('should throw a 201', async function () {
+    it('should return a 201', async function () {
       // given
       const token = generateValidRequestAuthorizationHeaderForApplication('pix-llm', 'Pix LLM', 'llm-preview');
 
@@ -142,6 +142,10 @@ describe('Acceptance | Route | llm-preview', function () {
             challenge: {
               inputMaxChars: 1024,
               inputMaxPrompts: 5,
+            },
+            preview: {
+              moderationPrompt: 'Un nouveau prompt de modération à transmettre à poc-llm',
+              validationPrompt: 'Un nouveau prompt de validation à transmettre à poc-llm',
             },
           },
         },
@@ -164,6 +168,10 @@ describe('Acceptance | Route | llm-preview', function () {
           challenge: {
             inputMaxChars: 1024,
             inputMaxPrompts: 5,
+          },
+          preview: {
+            moderationPrompt: 'Un nouveau prompt de modération à transmettre à poc-llm',
+            validationPrompt: 'Un nouveau prompt de validation à transmettre à poc-llm',
           },
         },
         hasAttachmentContextBeenAdded: false,

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -1824,7 +1824,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
               '60:{"ceci":"nest pas important","message":"coucou c\'est super"}',
               '40:{"message":"\\nle couscous c plutot bon"}47:{"message":" mais la paella c pas mal aussi\\n"}',
               '16:{"isValid":true}',
-              '78:{"jecrois":{"que":"jaifini"},"usage":{"inputTokens":3000,"outputTokens":5000}}',
+              '80:{"jecrois":{"que":"jaifini"},"usage":{"input_tokens":3000,"output_tokens":5000}}',
             ]),
           );
 

--- a/api/tests/llm/unit/infrastructure/streaming/transforms/message-object-to-event-stream-transform_test.js
+++ b/api/tests/llm/unit/infrastructure/streaming/transforms/message-object-to-event-stream-transform_test.js
@@ -184,7 +184,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | MessageObjectTo
           { pasMessage: 'Ca va super' },
           { message: 'Et toi ?' },
           {
-            usage: { superKey: 'wowouuo', inputTokens: 2_000, outputTokens: 5_000 },
+            usage: { superKey: 'wowouuo', input_tokens: 2_000, output_tokens: 5_000 },
           },
         ];
         const readable = Readable.from(input);


### PR DESCRIPTION
## 🔆 Problème

On souhaiterait permettre au métier d'éditer les prompts de modération et de validation à des fins de tests, uniquement en preview.

## ⛱️ Proposition

Il faut que l'API relaye les champs dédiés aux surcharges de prompt. Ajout des champs dans le modèle Configuration et dans le schéma de validation JOI d'une configuration en preview.

## 🌊 Remarques

j'ai inclus un piti piti fix sur le comptage de la consommation de tokens

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
