### PR TITLE
[FEATURE] Ajouter la possibilité de passer une url de redirection en fin de modulix (PIX-19046)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -544,6 +544,15 @@ LOG_FOR_HUMANS=true
 # default: none
 AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 
+# Secret salt value used in module redirection url generation & verification
+#
+# If not present, the application will crash during combined course.
+#
+# presence: required
+# type: String
+# default: none
+REDIRECTION_URL_SECRET=moduleSecret
+
 # SCO account recovery - token lifetime (minutes)
 # Mind to update in the following template BREVO_ACCOUNT_RECOVERY_TEMPLATE_ID
 #
@@ -1120,3 +1129,4 @@ DD/MM/YYYY [-] HH:mm:ss [[].SSS]
 # type: String - Date format (YYYY-MM-DDTHH:mm:ssZ[ZZ])
 # default: 2025-02-01T12:00:00Z+0200
 LATEST_CERTIFICATION_CALIBRATION_DATE=
+

--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -1,6 +1,7 @@
 const getBySlug = async function (request, h, { moduleSerializer, usecases }) {
   const { slug } = request.params;
-  const module = await usecases.getModule({ slug });
+  const redirectionHash = request.query.redirectionHash;
+  const module = await usecases.getModule({ slug, redirectionHash });
 
   return moduleSerializer.serialize(module);
 };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -13,6 +13,9 @@ const register = async function (server) {
         handler: handlerWithDependencies(modulesController.getBySlug),
         validate: {
           params: Joi.object({ slug: Joi.string().required() }),
+          query: Joi.object({
+            redirectionHash: Joi.string(),
+          }),
         },
         notes: ['- Permet de récupérer un module grâce à son titre slugifié'],
         tags: ['api', 'modules'],

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -25,6 +25,13 @@ class Module {
       throw new ModuleInstantiationError('A module should have a list of grains');
     }
   }
+
+  setRedirectionUrl(url) {
+    const parsedUrl = URL.parse(url);
+    if (parsedUrl) {
+      this.redirectionUrl = parsedUrl.toString();
+    }
+  }
 }
 
 export { Module };

--- a/api/src/devcomp/domain/usecases/get-module.js
+++ b/api/src/devcomp/domain/usecases/get-module.js
@@ -1,5 +1,21 @@
-async function getModule({ slug, moduleRepository }) {
-  return moduleRepository.getBySlug({ slug });
+import { config } from '../../../shared/config.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
+
+async function getModule({ slug, redirectionHash, moduleRepository }) {
+  const module = await moduleRepository.getBySlug({ slug });
+
+  if (redirectionHash) {
+    let redirectionUrl = null;
+    try {
+      redirectionUrl = await cryptoService.decrypt(redirectionHash, config.module.secret);
+      if (redirectionUrl) {
+        module.setRedirectionUrl(redirectionUrl);
+      }
+    } catch {
+      return module;
+    }
+  }
+  return module;
 }
 
 export { getModule };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -5,7 +5,7 @@ const { Serializer } = jsonapiSerializer;
 function serialize(module) {
   return new Serializer('module', {
     transform(module) {
-      return {
+      const transformedModule = {
         id: module.id,
         slug: module.slug,
         title: module.title,
@@ -21,8 +21,14 @@ function serialize(module) {
           };
         }),
       };
+
+      if (module.redirectionUrl) {
+        transformedModule.redirectionUrl = module.redirectionUrl;
+      }
+
+      return transformedModule;
     },
-    attributes: ['slug', 'title', 'isBeta', 'version', 'grains', 'details'],
+    attributes: ['slug', 'title', 'isBeta', 'version', 'grains', 'details', 'redirectionUrl'],
     grains: {
       ref: 'id',
       includes: true,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -399,6 +399,7 @@ const configuration = (function () {
       isDirectMetricsEnabled: toBoolean(process.env.FT_ENABLE_DIRECT_METRICS),
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
     },
+    module: { secret: process.env.REDIRECTION_URL_SECRET },
     partner: {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
@@ -560,7 +561,7 @@ const configuration = (function () {
     config.mailing.brevo.templates.targetProfileNotCertifiableTemplateId =
       'test-target-profile-no-certifiable-template-id';
     config.mailing.brevo.templates.warningConnectionTemplateId = 'test-warning-connection-template-id';
-
+    config.module.secret = 'moduleUrlSecret';
     config.bcryptNumberOfSaltRounds = 1;
 
     config.authentication.secret = 'the-password-must-be-at-least-32-characters-long';

--- a/api/src/shared/domain/services/crypto-service.js
+++ b/api/src/shared/domain/services/crypto-service.js
@@ -13,7 +13,7 @@ const scrypt = util.promisify(crypto.scrypt);
 const phcRegexp =
   /^\$(?<algoDesc>[\w+-]+)\$N=(?<N>\d+)\$r=(?<r>\d+)\$p=(?<p>\d+)\$(?<initializationVector>[\w/+=-]+)\$(?<encryptedText>[\w/+=-]+)$/;
 
-const key = config.authentication.secret;
+const authenticationKey = config.authentication.secret;
 const { bcryptNumberOfSaltRounds } = config;
 
 const N = Math.pow(2, 13);
@@ -44,10 +44,11 @@ const checkPassword = async function ({ password, passwordHash }) {
 
 /**
  * @param {string} text
+ * @param {string} key
  * @returns {Promise<string>} an output in PHC format.
  *   Example: $scrypt+aes-256-ctr$N=8192$r=8$p=10$bsKRpytT0ocFpxmIlk/COw==$L0kaiHkLjrbD3C
  */
-const encrypt = async function (text) {
+const encrypt = async function (text, key = authenticationKey) {
   const initializationVector = await randomBytes(AES_256_CTR_CIPHER_IV_LENGTH);
 
   const derivedKey = await scrypt(key, initializationVector, AES_256_CTR_KEY_LENGTH, { N, r, p });
@@ -64,9 +65,10 @@ const encrypt = async function (text) {
 
 /**
  * @param {string} phcText
+ * @param {string} key
  * @returns {Promise<string>} a decrypted text
  */
-const decrypt = async function (phcText) {
+const decrypt = async function (phcText, key = authenticationKey) {
   const matched = phcRegexp.exec(phcText);
   const N = Number(matched.groups.N);
   const r = Number(matched.groups.r);

--- a/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
@@ -1,3 +1,5 @@
+import { config } from '../../../../../src/shared/config.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { createServer, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | modules-controller-getBySlug', function () {
@@ -19,6 +21,20 @@ describe('Acceptance | Controller | modules-controller-getBySlug', function () {
 
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.type).to.equal('modules');
+      });
+
+      it('should return module with redirectionUrl', async function () {
+        const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+        const redirectionHash = await cryptoService.encrypt(expectedUrl, config.module.secret);
+        const options = {
+          method: 'GET',
+          url: `/api/modules/bien-ecrire-son-adresse-mail?redirectionHash=${encodeURIComponent(redirectionHash)}`,
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes['redirection-url']).to.equal(expectedUrl);
       });
     });
 

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -7,18 +7,22 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
   describe('#getBySlug', function () {
     it('should call getModule use-case and return serialized modules', async function () {
       const slug = 'slug';
+      const redirectionHash = 'redirectionHash';
       const serializedModule = Symbol('serialized modules');
       const module = Symbol('modules');
       const usecases = {
         getModule: sinon.stub(),
       };
-      usecases.getModule.withArgs({ slug }).returns(module);
+      usecases.getModule.withArgs({ slug, redirectionHash }).returns(module);
       const moduleSerializer = {
         serialize: sinon.stub(),
       };
       moduleSerializer.serialize.withArgs(module).returns(serializedModule);
 
-      const result = await modulesController.getBySlug({ params: { slug } }, null, { moduleSerializer, usecases });
+      const result = await modulesController.getBySlug({ params: { slug }, query: { redirectionHash } }, null, {
+        moduleSerializer,
+        usecases,
+      });
 
       expect(result).to.equal(serializedModule);
     });

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -138,4 +138,40 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       });
     });
   });
+
+  describe('#setRedirectionUrl', function () {
+    let module;
+
+    beforeEach(function () {
+      const id = 1;
+      const slug = 'les-adresses-email';
+      const title = 'Les adresses email';
+      const isBeta = false;
+      const grains = [Symbol('text')];
+      const details = Symbol('details');
+      const version = Symbol('version');
+
+      module = new Module({ id, slug, title, isBeta, grains, details, version });
+    });
+    it('should set redirectionUrl when url is valid', function () {
+      // given
+      const url = 'https://app.pix.fr/parcours/COMBINIX1';
+
+      // when
+      module.setRedirectionUrl(url);
+
+      // then
+      expect(module.redirectionUrl).to.equal(url);
+    });
+    it('should not set redirectionUrl when url is invalid', function () {
+      // given
+      const url = 'wrong';
+
+      // when
+      module.setRedirectionUrl(url);
+
+      // then
+      expect(module.redirectionUrl).to.be.undefined;
+    });
+  });
 });

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -1,4 +1,7 @@
+import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
 import { getModule } from '../../../../../src/devcomp/domain/usecases/get-module.js';
+import { config } from '../../../../../src/shared/config.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
@@ -17,6 +20,31 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
 
       // then
       expect(module).to.equal(expectedModule);
+    });
+
+    it('should get and return a Module with a redirection url', async function () {
+      // given
+      const id = 1;
+      const slug = 'les-adresses-email';
+      const title = 'Les adresses email';
+      const isBeta = false;
+      const grains = [Symbol('text')];
+      const details = Symbol('details');
+      const version = Symbol('version');
+
+      const expectedModule = new Module({ id, slug, title, isBeta, grains, details, version });
+      const moduleRepository = {
+        getBySlug: sinon.stub(),
+      };
+      moduleRepository.getBySlug.withArgs({ slug }).resolves(expectedModule);
+      const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+      const redirectionHash = await cryptoService.encrypt(expectedUrl, config.module.secret);
+
+      // when
+      const module = await getModule({ slug, redirectionHash, moduleRepository });
+
+      // then
+      expect(module.redirectionUrl).to.equal(expectedUrl);
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -22,6 +22,55 @@ import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerializer', function () {
   describe('#serialize', function () {
+    it('should serialize with redirectionUrl', function () {
+      // given
+      const id = 'id';
+      const slug = 'bien-ecrire-son-adresse-mail';
+      const title = 'Bien écrire son adresse mail';
+      const redirectionUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+      const isBeta = true;
+      const version = Symbol('version');
+      const details = {
+        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        description:
+          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+        duration: 12,
+        level: 'Débutant',
+        objectives: [
+          'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+          'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+          'Comprendre les fonctions des parties d’une adresse mail',
+        ],
+      };
+      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta, version });
+      moduleFromDomain.setRedirectionUrl(redirectionUrl);
+      const expectedJson = {
+        data: {
+          type: 'modules',
+          id,
+          attributes: {
+            'redirection-url': redirectionUrl,
+            slug,
+            title,
+            'is-beta': isBeta,
+            details,
+            version,
+          },
+          relationships: {
+            grains: {
+              data: [],
+            },
+          },
+        },
+      };
+
+      // when
+      const json = moduleSerializer.serialize(moduleFromDomain);
+
+      // then
+      expect(json).to.deep.equal(expectedJson);
+    });
+
     it('should serialize with empty grains list', function () {
       // given
       const id = 'id';

--- a/mon-pix/app/adapters/module.js
+++ b/mon-pix/app/adapters/module.js
@@ -3,7 +3,13 @@ import ApplicationAdapter from './application';
 export default class Module extends ApplicationAdapter {
   queryRecord(store, type, query) {
     if (query.slug) {
-      const url = `${this.host}/${this.namespace}/modules/${query.slug}`;
+      let url = `${this.host}/${this.namespace}/modules/${query.slug}`;
+
+      if (query.redirectionHash) {
+        const redirectionHash = encodeURIComponent(query.redirectionHash);
+        url += `?redirectionHash=${redirectionHash}`;
+      }
+
       return this.ajax(url, 'GET');
     }
 

--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -31,9 +31,16 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
     </div>
 
     <div class="module-recap__link-details">
-      <PixButtonLink @size="large" @route="authenticated.user-dashboard" @variant="primary">
-        {{t "pages.modulix.recap.goToHomepage"}}
-      </PixButtonLink>
+      {{#if @module.redirectionUrl}}
+        <PixButtonLink @size="large" @href={{@module.redirectionUrl}} @variant="primary">
+          {{t "pages.modulix.recap.goToHomepage"}}
+        </PixButtonLink>
+      {{else}}
+        <PixButtonLink @size="large" @route="authenticated.user-dashboard" @variant="primary">
+          {{t "pages.modulix.recap.goToHomepage"}}
+        </PixButtonLink>
+      {{/if}}
+
     </div>
 
     {{#if @module.isBeta}}

--- a/mon-pix/app/controllers/module.js
+++ b/mon-pix/app/controllers/module.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class Module extends Controller {
+  queryParams = ['redirection'];
+}

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -6,5 +6,6 @@ export default class Module extends Model {
   @attr('boolean') isBeta;
   @attr() details;
   @attr('string') version;
+  @attr('string') redirectionUrl;
   @hasMany('grain', { async: false, inverse: 'module' }) grains;
 }

--- a/mon-pix/app/routes/module.js
+++ b/mon-pix/app/routes/module.js
@@ -5,6 +5,6 @@ export default class ModuleRoute extends Route {
   @service store;
 
   model(params) {
-    return this.store.queryRecord('module', { slug: params.slug });
+    return this.store.queryRecord('module', { slug: params.slug, redirectionHash: params.redirection });
   }
 }

--- a/mon-pix/app/templates/module/details.gjs
+++ b/mon-pix/app/templates/module/details.gjs
@@ -7,7 +7,6 @@ import BetaBanner from 'mon-pix/components/module/layout/beta-banner';
       <BetaBanner />
     </div>
   {{/if}}
-
   <div class="modulix">
     <Details @module={{@model}} />
   </div>

--- a/mon-pix/tests/unit/routes/module/module-test.js
+++ b/mon-pix/tests/unit/routes/module/module-test.js
@@ -21,10 +21,10 @@ module('Unit | Route | modules | module', function (hooks) {
     const module = Symbol('the-module');
 
     store.queryRecord = sinon.stub();
-    store.queryRecord.withArgs('module', { slug: 'the-module' }).resolves(module);
+    store.queryRecord.withArgs('module', { slug: 'the-module', redirectionHash: 'somehash' }).resolves(module);
 
     // when
-    const model = await route.model({ slug: 'the-module' });
+    const model = await route.model({ slug: 'the-module', redirection: 'somehash' });
 
     // then
     assert.strictEqual(model, module);


### PR DESCRIPTION
## 🔆 Problème
A la fin d'un modulix, il n'existe aucun moyen de pouvoir être redirigé vers une url personnalisable comme c'est le cas en fin de campagne par exemple.
Dans le cadre des combinix, nous aimerions pouvoir rediriger l'utilisateur a la page d'accueil du combinix en fin de module inclus dans celui ci.

## ⛱️ Proposition
Pouvoir passer un paramètre dans l'url du modulix afin d'utiliser celui ci comme url de redirection en fin de modulix. On ajoute la condition sur le bouton continuer en fin de module pour être rediriger vers celui-ci si il est présent.

## 🌊 Remarques
On a créé une nouvelle clé de chiffrement afin de pouvoir chiffrer/dechiffrer côté api l'url qu'on passe en paramètre, afin d'éviter tout potentiel soucis de sécurité
Ajout donc d'une nouvelle var d'env `MODULE_SECRET`

## 🏄 Pour tester
Aller sur [Page Module avec Url](https://app-pr13127.review.pix.fr/modules/demo-llm?redirection=%24scrypt%2Baes-256-ctr%24N%3D8192%24r%3D8%24p%3D10%241fbYLVhPpCt76aJLkzfX5Q%3D%3D%242gNqKvxczJI47e1uZMvfvnHV9K116gplin281E94j7otDp4NXXRds1Aqqw%3D%3D)
Aller a la fin de module
Cliquer sur le bouton "Continuer"
Vérifier qu'on est bien redirigé vers la page surprise 
🎉 
