### PR TITLE
[BUGFIX] Afficher la page d'analyse correctement même lorsqu'il n'y a pas de participation (PIX-19047).

### DIFF
--- a/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
+++ b/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js
@@ -7,8 +7,8 @@ class CompetenceResultForKnowledgeElementSnapshots {
   index;
   name;
   description;
-  meanLevel;
-  maxLevel;
+  meanLevel = 0;
+  maxLevel = 0;
 
   constructor({ competence } = {}) {
     this.#tubeResults = competence.tubes.map(

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -256,7 +256,7 @@ describe('Acceptance | API | Campaign Route', function () {
     });
 
     context('when there is no participation', function () {
-      it('should return 500', async function () {
+      it('should return 200', async function () {
         // given
         const campaignWithoutParticipation = databaseBuilder.factory.buildCampaign({
           name: 'Campagne de Test N°3',
@@ -271,7 +271,7 @@ describe('Acceptance | API | Campaign Route', function () {
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(500, response.payload);
+        expect(response.statusCode).to.equal(200, response.payload);
       });
     });
   });

--- a/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-route_test.js
@@ -189,7 +189,7 @@ describe('Acceptance | API | Campaign Route', function () {
   });
 
   describe('GET /api/campaigns/{campaignId}/level-per-tubes-and-competences', function () {
-    let campaign, userId;
+    let campaign, userId, organization, skillId;
     const options = {
       headers: { authorization: null },
       method: 'GET',
@@ -198,7 +198,7 @@ describe('Acceptance | API | Campaign Route', function () {
 
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
-      const organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildMembership({
         userId,
         organizationId: organization.id,
@@ -218,7 +218,7 @@ describe('Acceptance | API | Campaign Route', function () {
 
       const tubeId = databaseBuilder.factory.learningContent.buildTube({ competenceId }).id;
 
-      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId, status: 'actif' }).id;
+      skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId, status: 'actif' }).id;
 
       const user1 = databaseBuilder.factory.buildUser();
 
@@ -253,6 +253,26 @@ describe('Acceptance | API | Campaign Route', function () {
       // then
       expect(response.statusCode).to.equal(200, response.payload);
       expect(response.result.data.type).to.deep.equal('campaign-result-levels-per-tubes-and-competences');
+    });
+
+    context('when there is no participation', function () {
+      it('should return 500', async function () {
+        // given
+        const campaignWithoutParticipation = databaseBuilder.factory.buildCampaign({
+          name: 'Campagne de Test N°3',
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaignWithoutParticipation.id, skillId });
+        await databaseBuilder.commit();
+
+        options.url = `/api/campaigns/${campaignWithoutParticipation.id}/level-per-tubes-and-competences`;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(500, response.payload);
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Depuis la PR corrigeant l'accès à l'analyse sur les campagnes à gros volume #13071, nous avons cassé la page d'analyse lorsqu'il n'y a pas de participations. 
En effet, la serialization ne fonctionne plus quand il n'y a pas de participations : 
<img width="2202" height="604" alt="image" src="https://github.com/user-attachments/assets/7682b418-485b-4b0a-acac-0c16a51b7f97" />


L'explication vient du fait qu'avant, nous passions toujours par la méthode : `addKnowledgeElementSnapshots` dans le fichier `get-result-levels-per-tubes-and-competences.js` malgré que nous n'ayons pas de KEsnapshot : 

https://github.com/1024pix/pix/blob/8c0123c7168479d89c6c01aad2d7f7f729c627d9/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js#L10-L22

Ce qui avait pour conséquence de définir `maxLevel` et `meanLevel` : 

https://github.com/1024pix/pix/blob/ffa68669c145eedef0e2a2c4375f7e35c8e76636/api/src/prescription/campaign/domain/models/CompetenceResultForKnowledgeElementSnapshots.js#L24-L30

Et depuis la PR, nous avons qui fait que lorsqu'il n'y a pas de campaignParticipationIds nous ne rentrons pas dans la boucle : 

https://github.com/1024pix/pix/blob/ffa68669c145eedef0e2a2c4375f7e35c8e76636/api/src/prescription/campaign/domain/usecases/get-result-levels-per-tubes-and-competences.js#L22-L29


## ⛱️ Proposition

Ajouter des valeurs par défaut pour représenter ce que ça faisait avant, et 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter sur Pix Orga
- Créer une campagne 
- Aller dans l'onglet analyse et constater que nous n'avons pas d'erreurs