### PR TITLE
[FEATURE] Ajouter un feature toggle pour pouvoir filtrer la recommandation de contenu formatif par organisations (PIX-19057)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
+  @attr('boolean') isFilteringRecommendedTrainingByOrganizationsEnabled;
   @attr('boolean') useLocale;
 }

--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -29,6 +29,12 @@ export default {
     defaultValue: false,
     tags: ['team-prescription', 'pix-api', 'backend'],
   },
+  isFilteringRecommendedTrainingByOrganizationsEnabled: {
+    type: 'boolean',
+    description: 'Used to enable filtering recommended training by organizations',
+    defaultValue: false,
+    tags: ['frontend', 'team-devcomp', 'pix-admin'],
+  },
   isSelfAccountDeletionEnabled: {
     description: 'Toggle self account deletion feature',
     type: 'boolean',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -23,6 +23,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'dynamic-feature-toggle-system': false,
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-auto-share-enabled': false,
+            'is-filtering-recommended-training-by-organizations-enabled': false,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,


### PR DESCRIPTION
## 🔆 Problème

On souhaite pouvoir recommander les contenus formatifs uniquement à certaines organisations d'un profil cible.

## ⛱️ Proposition

Ajouter un feature toggle pour activer cette fonctionnalité lorsqu'elle sera prête.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- En local ou RA, lancer la commande `npm run toggles -- --key=isFilteringRecommendedTrainingByOrganizationsEnabled --value=true` sur l'API
- Aller sur la [RA](https://admin-pr13130.review.pix.fr/) de Pix Admin
- Ouvrir l'onglet network
- Constater que la réponse de l'appel /feature-toggles contient bien le nouveau champ à true 😄 
