### PR TITLE
[BUGFIX] Ne pas afficher la page des CGU pour les utilisateurs non connectés (PIX-19062)

### DIFF
--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -7,6 +7,8 @@ export default class TermsOfServiceRoute extends Route {
   @service router;
 
   beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'authentication');
+
     if (this.session.isAuthenticatedByGar || !this.currentUser.user.mustValidateTermsOfService) {
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();
@@ -14,8 +16,6 @@ export default class TermsOfServiceRoute extends Route {
         this.router.replaceWith('');
       }
     }
-
-    this.session.requireAuthentication(transition, 'login');
   }
 
   model() {

--- a/mon-pix/tests/acceptance/terms-of-service-test.js
+++ b/mon-pix/tests/acceptance/terms-of-service-test.js
@@ -1,3 +1,4 @@
+import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
@@ -12,6 +13,17 @@ module('Acceptance | terms-of-service', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
+
+  module('when user is not authenticated', function () {
+    test('should redirect to login page', async function (assert) {
+      // given / when
+      const screen = await visit('/cgu');
+
+      // then
+      assert.ok(screen.findByRole('heading', { name: t('pages.sign-in.first-title') }));
+      assert.strictEqual(currentURL(), '/connexion');
+    });
+  });
 
   module('When user log in and must validate Pix latest terms of service', function () {
     test('should be redirected to terms-of-services page', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'un utilisateur non connecté tente d'accéder aux CGU, il voit une page d'erreur Oups

<img width="1271" height="617" alt="image" src="https://github.com/user-attachments/assets/94c78af7-b12d-4ae6-804f-bfbbcfa84a8d" />


## ⛱️ Proposition

Rediriger vers la page de connexion


## 🏄 Pour tester

- Sur pix-app:
  - Sans être connecté, tenter d'accéder à la page des cgu ( URL '/cgu')
  - Constater la redirection vers la page de login