### PR TITLE
[TECH] Preparer la future structure pour stocker les configuration de l'algo flash de certif (PIX-19042).

### DIFF
--- a/api/db/migrations/20250807115444_new-certif-flash-config-table.js
+++ b/api/db/migrations/20250807115444_new-certif-flash-config-table.js
@@ -1,0 +1,60 @@
+const TABLE_NAME = 'certification-configurations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    const comment =
+      'This table holds the certification flash configurations ' +
+      'It drives the certification assessments challenge selections and ' +
+      'how a certification assessment challenges are translated into a scoring';
+    table.comment(comment);
+
+    table.increments('id').primary().comment('Technical identifier');
+
+    table
+      .dateTime('startingDate')
+      .notNullable()
+      .defaultTo(knex.fn.now())
+      .comment('Inclusive. This algorithm version is applicable starting this date.');
+
+    table.dateTime('expirationDate').comment('Exclusive. This algorithm version is applicable until this date.');
+
+    table.integer('maximumAssessmentLength').comment('Maximum number of challenges for an assessment');
+    table
+      .integer('challengesBetweenSameCompetence')
+      .comment('Number of challenges before presenting again a challenge from the same competences');
+
+    table.boolean('limitToOneQuestionPerTube').comment('Whether or not we allow multiple challenges for one tube');
+
+    table
+      .boolean('enablePassageByAllCompetences')
+      .comment('Force to present at least one challenge from every competence');
+
+    table
+      .float('variationPercent')
+      .comment('The allowed peak-to-peak amplitude in the variation of the difficulty between two challenges');
+
+    table
+      .jsonb('global-scoring-configuration')
+      .nullable()
+      .comment("Defines the mesh levels and boundaries of the assessment's global scoring");
+
+    table
+      .jsonb('competences-scoring-configuration')
+      .nullable()
+      .comment("Defines the mesh levels and boundaries of the assessment's competences scoring");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

La config de l’algo flash (algo de deroule + de scoring global et de competences) est repartie dans diverses tables qui n’ont pas la meme structure de nom et au final sont aussi intimement liees (meme si pas livrees en meme temps).

Ensemble elles representent un tout, un millesime d'une calibration de l'algo.

On prepare l'historisation des calibrations (aujourd'hui il y en a 2, bientot 3,et bientot X).

## ⛱️ Proposition

A la base on partait sur une table associative. Mais a l'execution + reflexion + discussion ce matin a ete etabli que on pouvait se passer d'avoir 4 tables, pour n'avoir plus que UNE table 🤩 

* Que cela serait un rajout de complexite
* Que tout chose consideree, on peut aller a la simplification, c'est a dire regrouper les configurations
  * Rendre les colonnes de scoring nullable va permettre de garder l'option de livrer les scoring apres le deroule
    * Le scoring n'est qu'un UPDATE et non plus un INSERT 
  * Une nouvelle calibration = un nouveau millesime = une nouvelle ligne dans cette nouvelle table
* Une expirationDate a ete ajoute, cela va permettre de faire une mecanique que l'on connait : la meme que pour le detachedAt de l'historisation des complementaires (qui marche correctement comme mecanique)
  * Note aux techs : j'ai vraiment hesite a aussi appele cela detachedAt  
* La nouvelle table se separe aussi des champs suivants
  * createdAt devient la nouvelle startingDate, j'ai trouve cela + explicite
  * createdByUserId disparait, aucun usage a notre connaissance,  et aussi aucun interet car si on voulait vraiment historiser la liste des modifications (INSERT, UPDATE) sur la configuration, la solution en vrai c'est `audit-logger` (sinon on a que le userId qui a modifie en dernier, ce qui me semble un peu inutile)

## 🌊 Remarques

* La migration de la config actuelle dans cette nouvelle table sera faite dans une autre migration
* Est volontairement laisse de cote le futur autour des ref cadre, on reste et on simplifie deja l'algo flash ou la config est commune a tous pour l'instant
* A ete discute et valide, mais pas dans cette premiere PR, que toutes les colonnes actuellement de la table `flash-algorithm-configurations` pourront devenir un JSONB aussi dans une future migration

## 🏄 Pour tester

* Tester le db migrate UP and DOWN

<img width="1422" height="724" alt="Capture d’écran 2025-08-08 à 14 43 08" src="https://github.com/user-attachments/assets/e7beece1-1b16-4660-9730-ebe46fdcf887" />

