### PR TITLE
[TECH] Copier la configuration des tables de config certif vers la nouvelle table (PIX-19064).

### DIFF
--- a/api/db/migrations/20250807134527_copy-flash-configurations-to-new-table.js
+++ b/api/db/migrations/20250807134527_copy-flash-configurations-to-new-table.js
@@ -1,0 +1,92 @@
+const TABLE_NAME = 'certification-configurations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  // First step: copy the flash config for challenge selection
+  const stepOneOriginalConfigs = await knex('flash-algorithm-configurations')
+    .select(
+      'maximumAssessmentLength',
+      'challengesBetweenSameCompetence',
+      'limitToOneQuestionPerTube',
+      'enablePassageByAllCompetences',
+      'variationPercent',
+      'createdAt',
+    )
+    .orderBy('createdAt', 'asc'); // to insert from oldest to newest in the new table
+
+  for (const config of stepOneOriginalConfigs) {
+    await knex(TABLE_NAME).insert({
+      startingDate: config.createdAt,
+      maximumAssessmentLength: config.maximumAssessmentLength,
+      challengesBetweenSameCompetence: config.challengesBetweenSameCompetence,
+      limitToOneQuestionPerTube: config.limitToOneQuestionPerTube,
+      enablePassageByAllCompetences: config.enablePassageByAllCompetences,
+      variationPercent: config.variationPercent,
+    });
+  }
+
+  // Second step : for every new config except the last one (the one considered active), set the expiration date
+  const stepTwoNewlyCreatedConfigs = await knex(TABLE_NAME)
+    .select('id', 'startingDate')
+    .orderBy('startingDate', 'desc');
+
+  while (stepTwoNewlyCreatedConfigs.length > 1) {
+    const topConfig = stepTwoNewlyCreatedConfigs.shift();
+    const lastCreatedAtBecomesNextConfigExpirationDate = topConfig.startingDate;
+    const previousConfigId = stepTwoNewlyCreatedConfigs[0].id;
+
+    // The N-1 config expiration date is set to the Nth createdAt
+    await knex(TABLE_NAME).where({ id: previousConfigId }).update({
+      expirationDate: lastCreatedAtBecomesNextConfigExpirationDate,
+    });
+  }
+
+  // Third step : now for each config, identify the related config configuration
+  const stepThreeConfigToPopulateWithScoring = await knex(TABLE_NAME)
+    .select('id', 'startingDate')
+    .orderBy('startingDate', 'asc');
+
+  for (const currentFlashConfig of stepThreeConfigToPopulateWithScoring) {
+    const startingDate = currentFlashConfig.startingDate;
+
+    const certificationScoringConfiguration = await knex('certification-scoring-configurations')
+      .select('configuration')
+      .where('createdAt', '>=', startingDate)
+      .orderBy('createdAt', 'asc') // taking the oldest one
+      .first();
+
+    const competenceScoringConfiguration = await knex('competence-scoring-configurations')
+      .select('configuration')
+      .where('createdAt', '>=', startingDate)
+      .orderBy('createdAt', 'asc') // taking the oldest one
+      .first();
+
+    let newGlobalScoringConfiguration = null; // To secure migration, in case of no related scoring
+    if (certificationScoringConfiguration?.configuration) {
+      newGlobalScoringConfiguration = JSON.stringify(certificationScoringConfiguration.configuration);
+    }
+
+    let newCompetencesScoringConfiguration = null; // To secure migration, in case of no related scoring
+    if (competenceScoringConfiguration?.configuration) {
+      newCompetencesScoringConfiguration = JSON.stringify(competenceScoringConfiguration?.configuration);
+    }
+
+    await knex(TABLE_NAME).where({ id: currentFlashConfig.id }).update({
+      'global-scoring-configuration': newGlobalScoringConfiguration,
+      'competences-scoring-configuration': newCompetencesScoringConfiguration,
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex(TABLE_NAME).truncate();
+};
+
+export { down, up };

--- a/api/tests/integration/migration/20250807134527_copy-flash-configurations-to-new-table_test.js
+++ b/api/tests/integration/migration/20250807134527_copy-flash-configurations-to-new-table_test.js
@@ -1,0 +1,129 @@
+import { up } from '../../../db/migrations/20250807134527_copy-flash-configurations-to-new-table.js';
+import { _ } from '../../../src/shared/infrastructure/utils/lodash-utils.js';
+import { databaseBuilder, expect, knex } from '../../test-helper.js';
+
+describe('Integration | Migration | 20250807134527_copy-flash-configurations-to-new-table', function () {
+  it('should transfer flash-algorithm-configurations from farthest to latest', async function () {
+    // given
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+      maximumAssessmentLength: 30,
+      challengesBetweenSameCompetence: 1,
+      limitToOneQuestionPerTube: false,
+      enablePassageByAllCompetences: false,
+      variationPercent: 0.3,
+      createdAt: new Date('2020-10-19'),
+    });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+      maximumAssessmentLength: 32,
+      challengesBetweenSameCompetence: null,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+      variationPercent: 0.5,
+      createdAt: new Date('2025-01-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await up(knex);
+
+    // then
+    const certifConfigurations = await knex('certification-configurations').select().orderBy('id');
+    const expected = certifConfigurations.map((config) => _.omit(config, ['id']));
+    expect(expected).to.deep.equal([
+      {
+        startingDate: new Date('2020-10-19'),
+        expirationDate: new Date('2025-01-01'),
+        maximumAssessmentLength: 30,
+        challengesBetweenSameCompetence: 1,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: false,
+        variationPercent: 0.3,
+        'global-scoring-configuration': null,
+        'competences-scoring-configuration': null,
+      },
+      {
+        startingDate: new Date('2025-01-01'),
+        expirationDate: null,
+        maximumAssessmentLength: 32,
+        challengesBetweenSameCompetence: null,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: true,
+        variationPercent: 0.5,
+        'global-scoring-configuration': null,
+        'competences-scoring-configuration': null,
+      },
+    ]);
+  });
+
+  it('should assign the right certification-scoring-configurations', async function () {
+    // given
+    const createdByUserId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildScoringConfiguration({
+      createdAt: new Date('2020-10-19'),
+      createdByUserId,
+    });
+    const theRigthScoring = [{ a: 'b' }];
+    databaseBuilder.factory.buildScoringConfiguration({
+      createdAt: new Date('2025-01-02'),
+      createdByUserId,
+      configuration: theRigthScoring,
+    });
+    databaseBuilder.factory.buildScoringConfiguration({
+      createdAt: new Date('2025-09-12'),
+      createdByUserId,
+    });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+      maximumAssessmentLength: 32,
+      challengesBetweenSameCompetence: null,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+      variationPercent: 0.5,
+      createdAt: new Date('2025-01-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await up(knex);
+
+    // then
+    const certifConfiguration = await knex('certification-configurations').select().orderBy('id').first();
+    expect(certifConfiguration['global-scoring-configuration']).to.deep.equal(theRigthScoring);
+  });
+
+  it('should assign the right competence-scoring-configurations', async function () {
+    // given
+    const createdByUserId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdAt: new Date('2020-10-19'),
+      createdByUserId,
+      configuration: [],
+    });
+    const theRigthScoring = [{ comp: 'a' }];
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdAt: new Date('2025-01-02'),
+      createdByUserId,
+      configuration: theRigthScoring,
+    });
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdAt: new Date('2025-09-12'),
+      createdByUserId,
+      configuration: [],
+    });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+      maximumAssessmentLength: 32,
+      challengesBetweenSameCompetence: null,
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+      variationPercent: 0.5,
+      createdAt: new Date('2025-01-01'),
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await up(knex);
+
+    // then
+    const certifConfiguration = await knex('certification-configurations').select().orderBy('id').first();
+    expect(certifConfiguration['competences-scoring-configuration']).to.deep.equal(theRigthScoring);
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

On a cree une nouvelle table pour deplacer les configs dans une table a plat. Faut migrer en prenant en compte la subtilite du mode actuel.

Il faut prendre en compte que en PROD il y a plusieurs flash-config pour un seule scoring partage.

## ⛱️ Proposition

Une migration pour permettre la version a plat. C’est a dire

* Creer deux “millesime“, 2 lignes, une par algo de deroule (old flash-config)
  * La expiration date des millesime N-1 = starting du millesime N
  * Seul le millesime de + haut niveau du coup n'a pas de expirationDate (= latest)
* Copier dans chaque millesime les config d’algo (une actuellement pour 2 millesime)
  * Le premier resultat de scoring qui est >= au starting date du millesime est celui qui a ete utilise en PROD 

## 🌊 Remarques

* ~PR inheritance avec https://github.com/1024pix/pix/pull/13134 mais vous pouvez relire, me pas merger celle-ci en premier cependant~ 

merge OK

## 🏄 Pour tester

⚠️ Soyez super attentif sur la copie car un KO serait critique en PROD 🙏🏻 (j'ai fais moi meme des tests) 

J'ai prepare la RA comme la PROD en terme de config dans les 3 tbles, pour eviter des suprises (car en mode seeds on a qu'une seule ligne de config)

* Derouler le ` npm run db:rollback:latest`
* Derouler le `npm run db:migrate`
* Verifier de maniere tres minutieuse le resultat (y compris le contenu des JSONB)

<img width="1022" height="724" alt="Capture d’écran 2025-08-08 à 14 43 08" src="https://github.com/user-attachments/assets/e5ebfe1d-fe5c-41cc-bbf0-f28cc542d4af" />
