### PR TITLE
[FEATURE] Suppression du feature-toggle  shouldDisplayNewAnalysisPage (PIX-17682)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -41,12 +41,6 @@ export default {
     defaultValue: true,
     tags: ['frontend', 'team-acces'],
   },
-  shouldDisplayNewAnalysisPage: {
-    description: 'Display the new page for campaign analysis',
-    type: 'boolean',
-    defaultValue: false,
-    tags: ['frontend', 'pix-orga', 'team-prescription'],
-  },
   showExperimentalMissions: {
     type: 'boolean',
     description: 'Consider experimental missions as active',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -27,7 +27,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
-            'should-display-new-analysis-page': false,
             'use-locale': false,
           },
         },


### PR DESCRIPTION
## 🔆 Problème

Le développement est en prod avec le feature-toggle à true depuis un petit moment, on a des bons retours et pas de soucis tech.
Le code de l'ancienne page a été supprimé

## ⛱️ Proposition

Supprimer le feature-toggle associé

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- aller voir la liste des features toggles de l'api et remarquer qu'il n'en fait plus parti
- CI verte