### PR TITLE
[FEATURE] Ajouter les dates de création et mise à jour des lignes dans la table "combined_course_participations" (PIX-19073)

### DIFF
--- a/api/db/migrations/20250808075247_add-created-at-and-updated-at-on-combined-course-participations.js
+++ b/api/db/migrations/20250808075247_add-created-at-and-updated-at-on-combined-course-participations.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'combined_course_participations';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.timestamps(false, true, true);
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropTimestamps(true);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème
Lorsque nous avons crée la table `combined_course_participations` nous n'avons pas ajoutés les colonnes `createdAt` & `updatedAt`. Or nous en avons besoin afin de sauvegarder et utiliser les différentes dates de création et de mise a jour du statut de la participation au parcours combiné

## ⛱️ Proposition
Créer une migration qui ajoute les deux colonnes précedemment citées sur la table `combined_course_participations`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Se connecter avec le cli scalingo a la BDD de la RA.
`\d combined_course_participations`
Constater la présence des deux colonnes
🐈‍⬛ 