### PR TITLE
[TECH] Supprimer les anciennes erreurs de locales sur PixApp

### DIFF
--- a/mon-pix/app/services/error-messages.js
+++ b/mon-pix/app/services/error-messages.js
@@ -16,14 +16,6 @@ const AUTHENTICATION_ERROR_CODES_MAPPING = {
   EXPIRED_AUTHENTICATION_KEY: {
     i18nKey: 'pages.login-or-register-oidc.error.expired-authentication-key',
   },
-  INVALID_LOCALE_FORMAT: {
-    i18nKey: 'pages.sign-up.errors.invalid-locale-format',
-    getOptions: (error) => ({ invalidLocale: error.meta.locale }),
-  },
-  LOCALE_NOT_SUPPORTED: {
-    i18nKey: 'pages.sign-up.errors.locale-not-supported',
-    getOptions: (error) => ({ localeNotSupported: error.meta.locale }),
-  },
   USER_IS_TEMPORARY_BLOCKED: {
     getI18nKey: (error) => {
       if (error.meta?.isLoginFailureWithUsername) {

--- a/mon-pix/tests/integration/components/authentication/login-form-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/login-form-test.gjs
@@ -96,34 +96,6 @@ module('Integration | Component | Authentication | LoginForm', function (hooks) 
       await fillByLabel(t(I18N_KEYS.passwordInput), 'JeMeLoggue1024');
     });
 
-    test('it displays error message for invalid local', async function (assert) {
-      // given
-      sessionService.authenticateUser.rejects(
-        _buildApiResponseError({ errorCode: 'INVALID_LOCALE_FORMAT', meta: { locale: 'foo' } }),
-      );
-
-      // when
-      await clickByName(t(I18N_KEYS.submitButton));
-
-      // then
-      const errorMessage = t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: 'foo' });
-      assert.dom(screen.getByText(errorMessage)).exists();
-    });
-
-    test('it displays error message for local not supported', async function (assert) {
-      // given
-      sessionService.authenticateUser.rejects(
-        _buildApiResponseError({ errorCode: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'foo' } }),
-      );
-
-      // when
-      await clickByName(t(I18N_KEYS.submitButton));
-
-      // then
-      const errorMessage = t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: 'foo' });
-      assert.dom(screen.getByText(errorMessage)).exists();
-    });
-
     test('it displays error message for a user with a temporary password', async function (assert) {
       // given
       sinon.stub(storeService, 'createRecord');

--- a/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/signup-form/index-test.gjs
@@ -176,52 +176,6 @@ module('Integration | Component | Authentication | SignupForm | index', function
     });
   });
 
-  module('When a business error occurred', function (hooks) {
-    let screen;
-
-    hooks.beforeEach(async function () {
-      const userModel = { save: sinon.stub() };
-      screen = await render(<template><SignupForm @user={{userModel}} /></template>);
-      await fillByLabel(t(I18N_KEYS.firstNameInput), 'John');
-      await fillByLabel(t(I18N_KEYS.lastNameInput), 'Doe');
-      await fillByLabel(t(I18N_KEYS.emailInput), 'john.doe@email.com');
-      await fillByLabel(t(I18N_KEYS.passwordInput), 'JeMeLoggue1024');
-      await clickByName(t(I18N_KEYS.cguCheckbox));
-    });
-
-    test('it displays an error message for invalid locale', async function (assert) {
-      // given
-      sessionService.authenticateUser.rejects(
-        _buildApiReponseError({ errorCode: 'INVALID_LOCALE_FORMAT', meta: { locale: 'foo' } }),
-      );
-
-      // when
-      await clickByName(t(I18N_KEYS.submitButton));
-
-      // then
-      const errorMessage = t('pages.sign-up.errors.invalid-locale-format', {
-        invalidLocale: 'foo',
-      });
-      assert.dom(screen.getByText(errorMessage)).exists();
-    });
-
-    test('it displays an error message for not supported locale', async function (assert) {
-      // given
-      sessionService.authenticateUser.rejects(
-        _buildApiReponseError({ errorCode: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'foo' } }),
-      );
-
-      // when
-      await clickByName(t(I18N_KEYS.submitButton));
-
-      // then
-      const errorMessage = t('pages.sign-up.errors.locale-not-supported', {
-        localeNotSupported: 'foo',
-      });
-      assert.dom(screen.getByText(errorMessage)).exists();
-    });
-  });
-
   module('When a http error occurred', function (hooks) {
     let screen;
 

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc-test.js
@@ -74,58 +74,6 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         });
       });
 
-      module('locale errors', function () {
-        module('when invalid locale', function () {
-          test('it displays the invalid locale error message', async function (assert) {
-            // given
-            const component = createGlimmerComponent('authentication/login-or-register-oidc');
-
-            const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
-            sessionService.authenticate.rejects({
-              errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }],
-            });
-
-            component.args.identityProviderSlug = 'super-idp';
-            component.args.authenticationKey = 'super-key';
-            component.isTermsOfServiceValidated = true;
-
-            // when
-            await component.register();
-
-            // then
-            assert.strictEqual(
-              component.registerErrorMessage,
-              `${t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: 'zzzz' })}`,
-            );
-          });
-        });
-
-        module('when locale is not supported', function () {
-          test('it displays the unsupported locale error message', async function (assert) {
-            // given
-            const component = createGlimmerComponent('authentication/login-or-register-oidc');
-
-            const sessionService = stubSessionService(this.owner, { isAuthenticated: false });
-            sessionService.authenticate.rejects({
-              errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }],
-            });
-
-            component.args.identityProviderSlug = 'super-idp';
-            component.args.authenticationKey = 'super-key';
-            component.isTermsOfServiceValidated = true;
-
-            // when
-            await component.register();
-
-            // then
-            assert.strictEqual(
-              component.registerErrorMessage,
-              `${t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: 'jp' })}`,
-            );
-          });
-        });
-      });
-
       test('displays an error message but not with the details', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');

--- a/mon-pix/tests/unit/services/error-messages-test.js
+++ b/mon-pix/tests/unit/services/error-messages-test.js
@@ -65,36 +65,6 @@ module('Unit | Service | errorMessages', function (hooks) {
         assert.deepEqual(message, t('pages.login-or-register-oidc.error.expired-authentication-key'));
       });
 
-      test('INVALID_LOCALE_FORMAT', function (assert) {
-        // given
-        const error = { code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'fr' } };
-
-        // when
-        const errorMessages = this.owner.lookup('service:errorMessages');
-        const message = errorMessages.getAuthenticationErrorMessage(error);
-
-        // then
-        assert.deepEqual(
-          message,
-          t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: error.meta.locale }),
-        );
-      });
-
-      test('LOCALE_NOT_SUPPORTED', function (assert) {
-        // given
-        const error = { code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'fr' } };
-
-        // when
-        const errorMessages = this.owner.lookup('service:errorMessages');
-        const message = errorMessages.getAuthenticationErrorMessage(error);
-
-        // then
-        assert.deepEqual(
-          message,
-          t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: error.meta.locale }),
-        );
-      });
-
       module('USER_IS_TEMPORARY_BLOCKED', function () {
         test('When isLoginFailureWithUsername is false', function (assert) {
           // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1929,10 +1929,6 @@
         "sign-up-on-pix": "Sign up for Pix",
         "submit": "Sign up"
       },
-      "errors": {
-        "invalid-locale-format": "Provided locale \"{invalidLocale}\" has an invalid format.",
-        "locale-not-supported": "Provided locale \"{localeNotSupported}\" isn't currently supported."
-      },
       "fields": {
         "email": {
           "help": "(e.g. name@example.org)"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1915,10 +1915,6 @@
         "submit": "Crear cuenta",
         "sign-up-on-pix": "Crear cuenta en Pix"
       },
-      "errors": {
-        "invalid-locale-format": "Tu configuración local «{invalidLocale}» tiene un formato incorrecto.",
-        "locale-not-supported": "Tu configuración local «{localeNotSupported}» no es compatible actualmente."
-      },
       "fields": {
         "email": {
           "help": "(ej. nombre@ejemplo.fr)"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1929,10 +1929,6 @@
         "sign-up-on-pix": "S'inscrire sur Pix",
         "submit": "Je m'inscris"
       },
-      "errors": {
-        "invalid-locale-format": "Votre locale \"{invalidLocale}\" n'est pas dans le bon format.",
-        "locale-not-supported": "Votre locale \"{localeNotSupported}\" n'est actuellement pas supportée."
-      },
       "fields": {
         "email": {
           "help": "(ex: nom@exemple.fr)"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1918,10 +1918,6 @@
         "submit": "Registreren",
         "sign-up-on-pix": "Inschrijven bij Pix"
       },
-      "errors": {
-        "invalid-locale-format": "Uw locale \"{invalidLocale}\" heeft de verkeerde indeling.",
-        "locale-not-supported": "Uw \"{localeNotSupported}\" locale wordt momenteel niet ondersteund."
-      },
       "fields": {
         "email": {
           "help": "(voorbeeld: naam.voornaam@voorbeeld.org)"


### PR DESCRIPTION
## 🔆 Problème

Suite aux commit https://github.com/1024pix/pix/pull/13053/commits/056599238e728166100b83712d69c7da8eb25103 et https://github.com/1024pix/pix/pull/13053/commits/159e246139fd659389246c9447d4652811c044cc de la PR https://github.com/1024pix/pix/pull/13053, l'api ne retourne plus les codes d'erreurs `INVALID_LOCALE_FORMAT` et `LOCALE_NOT_SUPPORTED`

## ⛱️ Proposition

Enlever également la gestion de ces erreurs dans les fronts. Actuellement, uniquement PixApp gérait ces erreurs.

## 🏄 Pour tester

Pas de test particulier (suppression de code non utilisé).
