### PR TITLE
[BUGFIX] Invitation Centre de Certif: si un utilisateur a une invitation en attente, le code n'est pas envoyé dans l'URL (PIX-18961)

### DIFF
--- a/api/src/team/domain/usecases/cancel-certification-center-invitation.js
+++ b/api/src/team/domain/usecases/cancel-certification-center-invitation.js
@@ -8,7 +8,6 @@ import { UncancellableCertificationCenterInvitationError } from '../errors.js';
  *
  * @param {string} certificationCenterInvitationId
  * @param {CertificationCenterInvitationRepository} certificationCenterInvitationRepository
- * @returns {Promise<CertificationCenterInvitation>}
  * @throws {UncancellableCertificationCenterInvitationError}
  */
 const cancelCertificationCenterInvitation = async function ({
@@ -21,7 +20,7 @@ const cancelCertificationCenterInvitation = async function ({
   if (!foundCertificationCenterInvitation.isPending) {
     throw new UncancellableCertificationCenterInvitationError();
   }
-  return await certificationCenterInvitationRepository.markAsCancelled({ id: foundCertificationCenterInvitation.id });
+  await certificationCenterInvitationRepository.markAsCancelled({ id: foundCertificationCenterInvitation.id });
 };
 
 export { cancelCertificationCenterInvitation };

--- a/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
@@ -83,7 +83,6 @@ const get = async function (id) {
  */
 const findOnePendingByEmailAndCertificationCenterId = async function ({ email, certificationCenterId }) {
   const existingPendingInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS)
-    .select('id')
     .where({ email, certificationCenterId, status: CertificationCenterInvitation.StatusType.PENDING })
     .first();
 

--- a/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
@@ -145,7 +145,6 @@ const markAsCancelled = async function ({ id }) {
   if (!certificationCenterInvitation) {
     throw new NotFoundError(`Certification center invitation of id ${id} is not found.`);
   }
-  return _toDomain(certificationCenterInvitation);
 };
 
 /**

--- a/api/tests/team/integration/domain/usecases/cancel-certification-center-invitation_test.js
+++ b/api/tests/team/integration/domain/usecases/cancel-certification-center-invitation_test.js
@@ -2,7 +2,7 @@ import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { UncancellableCertificationCenterInvitationError } from '../../../../../src/team/domain/errors.js';
 import { CertificationCenterInvitation } from '../../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
-import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Team | Domain | UseCase | cancel-certification-center-invitation', function () {
   describe('when the invitation exists', function () {
@@ -39,12 +39,15 @@ describe('Integration | Team | Domain | UseCase | cancel-certification-center-in
         await databaseBuilder.commit();
 
         // when
-        const result = await usecases.cancelCertificationCenterInvitation({
+        await usecases.cancelCertificationCenterInvitation({
           certificationCenterInvitationId: certificationCenterInvitation.id,
         });
 
         // then
-        expect(result).to.be.instanceOf(CertificationCenterInvitation);
+        const result = await knex('certification-center-invitations')
+          .where({ id: certificationCenterInvitation.id })
+          .first();
+
         expect(result).to.deep.include({
           id: certificationCenterInvitation.id,
           email: 'ploup.user@example.net',

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-invitation.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-invitation.js
@@ -7,6 +7,7 @@ const buildCertificationCenterInvitation = function ({
   status = CertificationCenterInvitation.StatusType.PENDING,
   role = 'MEMBER',
   code = 'ABCDE12345',
+  locale = 'fr',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
 } = {}) {
@@ -17,6 +18,7 @@ const buildCertificationCenterInvitation = function ({
     status,
     role,
     code,
+    locale,
     createdAt,
     updatedAt,
   });


### PR DESCRIPTION
## 🔆 Problème

Invitation Centre de Certif: Si un utilisateur a déjà une invitation en attente, le code n'est pas envoyé dans l'URL du lien (undefined).

## ⛱️ Proposition

S’assurer de récupérer le code de l’ancienne invitation de l’utilisateur.

## 🌊 Remarques

- Ajout de tests manquants dans api/src/team/infrastructure/repositories/certification-center-invitation-repository.js
- Suppression du retour inutile des invitations annulées dans le usecase ( jamais renvoyées par la route ) 


## 🏄 Pour tester

- Dans Pix-Certif
  - envoyer une inviation à une membre
  - Renvoyer une invitation à ce même membre
  - constater que dans les deux cas le code est bien présent dans la `redirectionUrl`
  
  
<img width="1088" height="297" alt="image" src="https://github.com/user-attachments/assets/3b4ff2c1-ade4-46f4-a90a-906df344351e" />
