### PR TITLE
[FEATURE] Créer deux modules de démo quasiment vide à des fins de tests (PIX-19080)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -41,15 +41,15 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
   databaseBuilder.factory.buildTraining({
     id: firstTrainingId,
     type: 'modulix',
-    title: 'Bac à sable',
-    link: '/modules/bac-a-sable',
+    title: 'Demo combinix 1',
+    link: '/modules/demo-combinix-1',
     locale: 'fr-fr',
   });
   databaseBuilder.factory.buildTraining({
     id: secondTrainingId,
     type: 'modulix',
-    title: 'Choisir un jeu vidéo adapté à son enfant',
-    link: '/modules/jeux-video-enfant',
+    title: 'Demo combinix 2',
+    link: '/modules/demo-combinix-2',
     locale: 'fr-fr',
   });
 
@@ -76,7 +76,7 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
         comparison: 'all',
         data: {
           moduleId: {
-            data: '6282925d-4775-4bca-b513-4c3009ec5886',
+            data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
             comparison: 'equal',
           },
         },
@@ -86,7 +86,7 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
         comparison: 'all',
         data: {
           moduleId: {
-            data: '875df1ff-27c1-4b41-a0a8-5ff46013f35e',
+            data: 'f32a2238-4f65-4698-b486-15d51935d335',
             comparison: 'equal',
           },
         },
@@ -96,7 +96,7 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
         comparison: 'all',
         data: {
           moduleId: {
-            data: '65b761ab-3ebd-44a9-84b7-8b5e151aee76',
+            data: 'ab82925d-4775-4bca-b513-4c3009ec5886',
             comparison: 'equal',
           },
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
@@ -1,0 +1,32 @@
+{
+  "id": "eeeb4951-6f38-4467-a4ba-0c85ed71321a",
+  "slug": "demo-combinix-1",
+  "title": "Demo combinix 1",
+  "isBeta": true,
+  "details": {
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
+    "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet d'avoir le scénario d'un module en arrivant rapidement à la fin</p>",
+    "duration": 1,
+    "level": "Débutant",
+    "tabletSupport": "inconvenient",
+    "objectives": ["Test parcours combiné"]
+  },
+  "grains": [
+    {
+      "id": "6728cc2c-7fef-48aa-8586-9c98f010d3be",
+      "type": "activity",
+      "title": "Grain de démo",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "760ed7fc-cad2-4771-86ff-00f856d557ec",
+            "type": "text",
+            "content": "<p>Bravo, le module 1 est terminé</p>"
+          }
+        }
+      ]
+    }
+
+  ]
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
@@ -1,0 +1,32 @@
+{
+  "id": "f32a2238-4f65-4698-b486-15d51935d335",
+  "slug": "demo-combinix-2",
+  "title": "Demo combinix 2",
+  "isBeta": true,
+  "details": {
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
+    "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet d'avoir le scénario d'un module en arrivant rapidement à la fin</p>",
+    "duration": 1,
+    "level": "Débutant",
+    "tabletSupport": "inconvenient",
+    "objectives": ["Test parcours combiné 2"]
+  },
+  "grains": [
+    {
+      "id": "f585adba-3a6a-4a60-acef-e35b1c79b1e5",
+      "type": "activity",
+      "title": "Grain de démo",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "0692109f-2ea3-4cf2-ad4f-9e05ec5e60d2",
+            "type": "text",
+            "content": "<p>Bravo, le module 2 est terminé</p>"
+          }
+        }
+      ]
+    }
+
+  ]
+}


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre du développement des parcours combinés, nous avons besoin de jouer des campagnes ainsi que des modules pour tester principalement le début et la fin de ceux-ci, notamment pour les redirections.
Il n'existe pas (hors demo-llm) de modulix très court permettant juste de simuler l'affichage de celui ci ainsi que sa fin. 

## ⛱️ Proposition
Créer deux modulix contenant juste du texte pour afficher qu'ils sont terminés et juste la bouton de fin. 
On ajoute ces deux modulix dans les seeds du parcours combiné de test

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Aller sur [Premier Modulix Démo](https://app-pr13145.review.pix.fr/modules/demo-combinix-1)
Vérifier le fonctionnement de celui-ci ainsi que l'affichage de la fin du module

Aller sur [Second Modulix Démo](https://app-pr13145.review.pix.fr/modules/demo-combinix-2)
Vérifier le fonctionnement de celui-ci ainsi que l'affichage de la fin du module

🐈‍⬛ 