### PR TITLE
[TECH] Seeds pour peupler la nouvelle table de configurations certif (PIX-19072).

### DIFF
--- a/api/db/database-builder/factory/build-certification-configuration.js
+++ b/api/db/database-builder/factory/build-certification-configuration.js
@@ -1,0 +1,28 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export const buildCertificationConfiguration = function ({
+  startingDate = new Date('2018-01-01'),
+  expirationDate = null,
+  maximumAssessmentLength = 20,
+  challengesBetweenSameCompetence = null,
+  limitToOneQuestionPerTube = false,
+  enablePassageByAllCompetences = false,
+  variationPercent = 0.5,
+  globalScoringConfiguration = null,
+  competencesScoringConfiguration = null,
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-configurations',
+    values: {
+      startingDate,
+      expirationDate,
+      maximumAssessmentLength,
+      challengesBetweenSameCompetence,
+      limitToOneQuestionPerTube,
+      enablePassageByAllCompetences,
+      variationPercent,
+      'global-scoring-configuration': JSON.stringify(globalScoringConfiguration),
+      'competences-scoring-configuration': JSON.stringify(competencesScoringConfiguration),
+    },
+  });
+};

--- a/api/db/seeds/data/team-certification/shared/setup-configuration.js
+++ b/api/db/seeds/data/team-certification/shared/setup-configuration.js
@@ -1,3 +1,4 @@
+import { createCertificationConfiguration } from '../tools/algorithm-configuration/create-certification-configuration.js';
 import { createCompetenceScoringConfiguration } from '../tools/algorithm-configuration/create-competence-scoring-configuration.js';
 import { createV3CertificationConfiguration } from '../tools/algorithm-configuration/create-flash-configuration.js';
 import { createIssueReportCategories } from '../tools/algorithm-configuration/create-issue-report-categories.js';
@@ -7,6 +8,9 @@ export async function setupConfigurations({ databaseBuilder }) {
   await createV3CertificationConfiguration({ databaseBuilder });
   await createCompetenceScoringConfiguration({ databaseBuilder });
   await createScoringConfiguration({ databaseBuilder });
+
+  await createCertificationConfiguration({ databaseBuilder });
+
   await createIssueReportCategories({ databaseBuilder });
 
   await databaseBuilder.commit();

--- a/api/db/seeds/data/team-certification/tools/algorithm-configuration/create-certification-configuration.js
+++ b/api/db/seeds/data/team-certification/tools/algorithm-configuration/create-certification-configuration.js
@@ -1,0 +1,1069 @@
+export const createCertificationConfiguration = ({ databaseBuilder }) => {
+  _createExpiredConfiguration({ databaseBuilder });
+  _createActiveConfiguration({ databaseBuilder });
+};
+
+const _createActiveConfiguration = ({ databaseBuilder }) => {
+  databaseBuilder.factory.buildCertificationConfiguration({
+    startingDate: new Date('1977-10-19'),
+    expirationDate: null,
+    maximumAssessmentLength: 32,
+    challengesBetweenSameCompetence: null,
+    limitToOneQuestionPerTube: true,
+    enablePassageByAllCompetences: true,
+    variationPercent: 0.5,
+    globalScoringConfiguration,
+    competencesScoringConfiguration,
+  });
+};
+const _createExpiredConfiguration = ({ databaseBuilder }) => {
+  databaseBuilder.factory.buildCertificationConfiguration({
+    startingDate: new Date('1912-10-19'),
+    expirationDate: new Date('1977-10-19'),
+    maximumAssessmentLength: 3,
+    challengesBetweenSameCompetence: null,
+    limitToOneQuestionPerTube: false,
+    enablePassageByAllCompetences: false,
+    variationPercent: 0.3,
+    globalScoringConfiguration: null,
+    competencesScoringConfiguration: null,
+  });
+};
+
+const globalScoringConfiguration = [
+  {
+    meshLevel: 0,
+    bounds: {
+      min: -8,
+      max: -1.4,
+    },
+  },
+  {
+    meshLevel: 1,
+    bounds: {
+      min: -1.4,
+      max: -0.519,
+    },
+  },
+  {
+    meshLevel: 2,
+    bounds: {
+      min: -0.519,
+      max: 0.6,
+    },
+  },
+  {
+    meshLevel: 3,
+    bounds: {
+      min: 0.6,
+      max: 1.5,
+    },
+  },
+  {
+    meshLevel: 4,
+    bounds: {
+      min: 1.5,
+      max: 2.25,
+    },
+  },
+  {
+    meshLevel: 5,
+    bounds: {
+      min: 2.25,
+      max: 3.1,
+    },
+  },
+  {
+    meshLevel: 6,
+    bounds: {
+      min: 3.1,
+      max: 4,
+    },
+  },
+  {
+    meshLevel: 7,
+    bounds: {
+      min: 4,
+      max: 8,
+    },
+  },
+];
+
+const competencesScoringConfiguration = [
+  {
+    competence: '1.1',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '1.2',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '1.3',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '2.1',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '2.2',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '2.3',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '2.4',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '3.1',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '3.2',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '3.3',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '3.4',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '4.1',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '4.2',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '4.3',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '5.1',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+  {
+    competence: '5.2',
+    values: [
+      {
+        bounds: {
+          max: -2,
+          min: Number.MIN_SAFE_INTEGER,
+        },
+        competenceLevel: 0,
+      },
+      {
+        bounds: {
+          max: -1,
+          min: -2,
+        },
+        competenceLevel: 1,
+      },
+      {
+        bounds: {
+          max: 0.5,
+          min: -1,
+        },
+        competenceLevel: 2,
+      },
+      {
+        bounds: {
+          max: 1,
+          min: 0.5,
+        },
+        competenceLevel: 3,
+      },
+      {
+        bounds: {
+          max: 2,
+          min: 1,
+        },
+        competenceLevel: 4,
+      },
+      {
+        bounds: {
+          max: 3,
+          min: 2,
+        },
+        competenceLevel: 5,
+      },
+      {
+        bounds: {
+          max: 4,
+          min: 3,
+        },
+        competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## 🔆 Problème

Pour pouvoir basculer le code sur la nouvelle table de configuration, il faut qu'elle soit peuplee avec des seeds pour une experience de test a venir + agreable.

## ⛱️ Proposition

* Peupler la nouvelle table comme les 3 autres tables
* Ajouter une "vieille" configuration, je trouve que maintenant que on a plusieurs caibrations, cela va representer + la realite (avec nos getLatestByDate & co)

## 🌊 Remarques

## 🏄 Pour tester

* Comparer les donnes des tables de configurations avec celles dans la table `certification-configurations`, elles seront pareil sur la "derniere"
* Eventuellement : tester un `npm run db:seed` si vous voulez verifier un reseeding
