### PR TITLE
[TECH] Enregistrer l'assessmentId ou le passageId dans le Chat LLM persisté (PIX-19063)

### DIFF
--- a/api/src/devcomp/domain/usecases/start-embed-llm-chat.js
+++ b/api/src/devcomp/domain/usecases/start-embed-llm-chat.js
@@ -2,7 +2,7 @@ import { DomainError } from '../../../shared/domain/errors.js';
 
 export async function startEmbedLlmChat({ configId, userId, passageId, llmApi, passageRepository }) {
   await checkIfPassageBelongsToUser(passageId, userId, passageRepository);
-  return await llmApi.startChat({ configId, userId });
+  return await llmApi.startChat({ configId, userId, passageId });
 }
 
 async function checkIfPassageBelongsToUser(passageId, userId, passageRepository) {

--- a/api/src/evaluation/domain/usecases/start-embed-llm-chat.js
+++ b/api/src/evaluation/domain/usecases/start-embed-llm-chat.js
@@ -2,7 +2,7 @@ import { DomainError } from '../../../shared/domain/errors.js';
 
 export async function startEmbedLlmChat({ configId, userId, assessmentId, llmApi, assessmentRepository }) {
   await checkIfAssessmentBelongsToUser(assessmentId, userId, assessmentRepository);
-  return await llmApi.startChat({ configId, userId });
+  return await llmApi.startChat({ configId, userId, assessmentId });
 }
 
 async function checkIfAssessmentBelongsToUser(assessmentId, userId, assessmentRepository) {

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -5,6 +5,8 @@ export class Chat {
    * @param {Object} params
    * @param {string} params.id
    * @param {number=} params.userId
+   * @param {number=} params.assessmentId
+   * @param {number=} params.passageId
    * @param {string} params.configurationId
    * @param {Configuration} params.configuration
    * @param {boolean} params.hasAttachmentContextBeenAdded
@@ -15,6 +17,8 @@ export class Chat {
   constructor({
     id,
     userId,
+    assessmentId,
+    passageId,
     configurationId,
     configuration,
     hasAttachmentContextBeenAdded,
@@ -24,6 +28,8 @@ export class Chat {
   }) {
     this.id = id;
     this.userId = userId;
+    this.assessmentId = assessmentId;
+    this.passageId = passageId;
     this.configurationId = configurationId;
     this.configuration = configuration;
     this.hasAttachmentContextBeenAdded = hasAttachmentContextBeenAdded;
@@ -150,6 +156,8 @@ export class Chat {
     return {
       id: this.id,
       userId: this.userId,
+      assessmentId: this.assessmentId,
+      passageId: this.passageId,
       configurationId: this.configurationId,
       configuration: this.configuration.toDTO(),
       hasAttachmentContextBeenAdded: this.hasAttachmentContextBeenAdded,

--- a/api/src/llm/domain/usecases/start-chat.js
+++ b/api/src/llm/domain/usecases/start-chat.js
@@ -4,6 +4,8 @@ export async function startChat({
   configuration,
   configurationId,
   userId,
+  assessmentId,
+  passageId,
   chatRepository,
   configurationRepository,
   randomUUID,
@@ -15,6 +17,8 @@ export async function startChat({
   const newChat = new Chat({
     id: chatId,
     userId,
+    assessmentId,
+    passageId,
     configurationId,
     configuration,
     hasAttachmentContextBeenAdded: false,

--- a/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/start-embed-llm-chat_test.js
@@ -49,7 +49,7 @@ describe('Unit | Devcomp | Domain | UseCases | start-embed-llm-chat', function (
         }),
       );
       const someLLMChatDTO = Symbol('LLMCHATDTO');
-      llmApi.startChat.withArgs({ configId, userId }).resolves(someLLMChatDTO);
+      llmApi.startChat.withArgs({ configId, userId, passageId }).resolves(someLLMChatDTO);
 
       // when
       const chat = await startEmbedLlmChat({ configId, passageId, userId, llmApi, passageRepository });

--- a/api/tests/evaluation/unit/domain/usecases/start-embed-llm-chat_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/start-embed-llm-chat_test.js
@@ -49,7 +49,7 @@ describe('Unit | Eval | Domain | UseCases | start-embed-llm-chat', function () {
         }),
       );
       const someLLMChatDTO = Symbol('LLMCHATDTO');
-      llmApi.startChat.withArgs({ configId, userId }).resolves(someLLMChatDTO);
+      llmApi.startChat.withArgs({ configId, userId, assessmentId }).resolves(someLLMChatDTO);
 
       // when
       const chat = await startEmbedLlmChat({ configId, assessmentId, userId, llmApi, assessmentRepository });

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -99,13 +99,23 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
 
       it('should return the newly created chat', async function () {
         // when
-        const chat = await startChat({ configurationId, userId, randomUUID, chatRepository, configurationRepository });
+        const chat = await startChat({
+          configurationId,
+          userId,
+          assessmentId: 11,
+          passageId: 22,
+          randomUUID,
+          chatRepository,
+          configurationRepository,
+        });
 
         // then
         expect(chat).to.deepEqualInstance(
           new Chat({
             id: '123e4567-e89b-12d3-a456-426614174000',
             userId: 123456,
+            assessmentId: 11,
+            passageId: 22,
             configurationId: 'uneConfigQuiExist',
             configuration: new Configuration({}), // Configuration’s properties are not enumerable
             hasAttachmentContextBeenAdded: false,
@@ -117,6 +127,8 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
         expect(await chatTemporaryStorage.get('123e4567-e89b-12d3-a456-426614174000')).to.deep.equal({
           id: '123e4567-e89b-12d3-a456-426614174000',
           userId: 123456,
+          assessmentId: 11,
+          passageId: 22,
           configurationId: 'uneConfigQuiExist',
           configuration: {
             llm: {

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -1170,6 +1170,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         expect(chat.toDTO()).to.deep.equal({
           id: 'some-chat-id',
           userId: 123,
+          assessmentId: undefined,
+          passageId: undefined,
           configurationId: 'abc123',
           configuration: configurationDTO,
           hasAttachmentContextBeenAdded: false,
@@ -1242,6 +1244,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         expect(chat.toDTO()).to.deep.equal({
           id: 'some-chat-id',
           userId: 123,
+          assessmentId: undefined,
+          passageId: undefined,
           configurationId: 'abc123',
           configuration: configurationDTO,
           hasAttachmentContextBeenAdded: false,
@@ -1285,6 +1289,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       const chat = new Chat({
         id: 'some-chat-id',
         userId: 123,
+        assessmentId: 456,
         configurationId: 'abc123',
         configuration: new Configuration(configurationDTO),
         hasAttachmentContextBeenAdded: true,
@@ -1333,6 +1338,8 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       expect(dto).to.deep.equal({
         id: 'some-chat-id',
         userId: 123,
+        assessmentId: 456,
+        passageId: undefined,
         configurationId: 'abc123',
         configuration: configurationDTO,
         hasAttachmentContextBeenAdded: true,


### PR DESCRIPTION
## 🔆 Problème

Pour pouvoir traiter le mode debug et les signalements, il nous faut nous souvenir, pour un chat donné, à quel assessment ou passage il appartient le cas échéant.

## ⛱️ Proposition

Ajouter ces infos dans le modèle Chat

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
