### PR TITLE
[TECH] Suppression de la colonne isCancelled dans la table "certification-courses" (PIX-16049).

### DIFF
--- a/api/db/migrations/20250808074506_remove-is-cancelled-column-from-certification-courses-table.js
+++ b/api/db/migrations/20250808074506_remove-is-cancelled-column-from-certification-courses-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'isCancelled';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

isCancelled a disparu du code, il est temps de supprimer la colonne

## ⛱️ Proposition

Bye isCancelled

## 🏄 Pour tester

Constater que la colonne n'existe plus dans la table "certification-courses"
