### PR TITLE
[FEATURE] Récupérer le bon référentiel cadre lors de la sélection de l'épreuve (PIX-17885).

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -8,7 +8,7 @@ function buildComplementaryCertification({
   createdAt = new Date('2020-01-01'),
   minimumReproducibilityRate = 70.0,
   minimumReproducibilityRateLowerLevel = 60.0,
-  hasComplementaryReferential = false,
+  hasComplementaryReferential = true,
   hasExternalJury = false,
   certificationExtraTime = 45,
 } = {}) {

--- a/api/src/certification/configuration/domain/services/get-version-number.js
+++ b/api/src/certification/configuration/domain/services/get-version-number.js
@@ -1,0 +1,11 @@
+export function getVersionNumber(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    date.getUTCFullYear().toString() +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getSeconds())
+  );
+}

--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -7,6 +7,7 @@
  */
 
 import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
+import { getVersionNumber } from '../services/get-version-number.js';
 
 /**
  * @param {Object} params
@@ -38,17 +39,3 @@ export const createConsolidatedFramework = async ({
     version: getVersionNumber(),
   });
 };
-
-function getVersionNumber() {
-  const date = new Date();
-
-  const pad = (n) => String(n).padStart(2, '0');
-  return (
-    date.getUTCFullYear().toString() +
-    pad(date.getUTCMonth() + 1) +
-    pad(date.getUTCDate()) +
-    pad(date.getUTCHours()) +
-    pad(date.getUTCMinutes()) +
-    pad(date.getSeconds())
-  );
-}

--- a/api/src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js
+++ b/api/src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js
@@ -1,0 +1,8 @@
+class ComplementaryCertificationCourse {
+  constructor({ complementaryCertificationKey, hasComplementaryReferential } = {}) {
+    this.complementaryCertificationKey = complementaryCertificationKey;
+    this.hasComplementaryReferential = hasComplementaryReferential;
+  }
+}
+
+export { ComplementaryCertificationCourse };

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -23,6 +23,7 @@ import * as userRepository from '../../../shared/infrastructure/repositories/use
 import * as certificationCandidateRepository from '../../infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCompanionAlertRepository from '../../infrastructure/repositories/certification-companion-alert-repository.js';
 import * as challengeCalibrationRepository from '../../infrastructure/repositories/challenge-calibration-repository.js';
+import * as complementaryCertificationCourseRepository from '../../infrastructure/repositories/complementary-certification-course-repository.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
 import * as evaluationSessionRepository from '../../infrastructure/repositories/session-repository.js';
 import * as flashAlgorithmService from '../services/algorithm-methods/flash.js';
@@ -34,6 +35,7 @@ import pickChallengeService from '../services/pick-challenge-service.js';
  * @typedef {evaluationSessionRepository} EvaluationSessionRepository
  * @typedef {certificationChallengeRepository} CertificationChallengeRepository
  * @typedef {certificationAssessmentRepository} CertificationAssessmentRepository
+ * @typedef {complementaryCertificationCourseRepository} ComplementaryCertificationCourseRepository
  * @typedef {complementaryCertificationScoringCriteriaRepository} ComplementaryCertificationScoringCriteriaRepository
  * @typedef {assessmentResultRepository} AssessmentResultRepository
  * @typedef {certificationCourseRepository} CertificationCourseRepository
@@ -66,6 +68,7 @@ const dependencies = {
   certificationCompanionAlertRepository,
   certificationCourseRepository,
   certificationAssessmentRepository,
+  complementaryCertificationCourseRepository,
   complementaryCertificationScoringCriteriaRepository,
   sharedFlashAlgorithmConfigurationRepository,
   services,

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-course-repository.js
@@ -1,0 +1,21 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { ComplementaryCertificationCourse } from '../../domain/models/ComplementaryCertificationCourse.js';
+
+export const findByCertificationCourseId = async function ({ certificationCourseId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const result = await knexConn('complementary-certification-courses')
+    .select({
+      complementaryCertificationKey: 'complementary-certifications.key',
+      hasComplementaryReferential: 'complementary-certifications.hasComplementaryReferential',
+    })
+    .where({ certificationCourseId })
+    .leftJoin(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'complementary-certification-courses.complementaryCertificationId',
+    )
+    .first();
+
+  return result ? new ComplementaryCertificationCourse(result) : null;
+};

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,7 +1,6 @@
-import dayjs from 'dayjs';
-
 import { knex } from '../../../../db/knex-database-connection.js';
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
+import { getVersionNumber } from '../../../certification/configuration/domain/services/get-version-number.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { config } from '../../config.js';
 import { NotFoundError } from '../../domain/errors.js';
@@ -118,7 +117,7 @@ export async function findActiveFlashCompatible({
   let challengeDtos;
 
   if (hasComplementaryReferential) {
-    const version = dayjs(date).format('YYYYMMDDHHmmss');
+    const version = getVersionNumber(date);
 
     challengeDtos = await _findChallengesForComplementaryCertification({
       complementaryCertificationKey,

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -118,10 +118,12 @@ export async function findActiveFlashCompatible({
   let challengeDtos;
 
   if (hasComplementaryReferential) {
+    const version = dayjs(date).format('YYYYMMDDHHmmss');
+
     challengeDtos = await _findChallengesForComplementaryCertification({
       complementaryCertificationKey,
       cacheKey,
-      date,
+      version,
     });
   } else {
     challengeDtos = await _findChallengesForCoreCertification({ locale, accessibilityAdjustmentNeeded, cacheKey });
@@ -132,12 +134,10 @@ export async function findActiveFlashCompatible({
   );
 }
 
-async function _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, date }) {
-  const formattedDate = dayjs(date).format('YYYYMMDDHHmmss');
-
+async function _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, version }) {
   const { closestVersion } = await knex('certification-frameworks-challenges')
     .where({ complementaryCertificationKey })
-    .andWhere('version', '<=', formattedDate)
+    .andWhere('version', '<=', version)
     .max('version as closestVersion')
     .first();
 

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -111,12 +111,13 @@ export async function findActiveFlashCompatible({
   successProbabilityThreshold = config.features.successProbabilityThreshold,
   accessibilityAdjustmentNeeded = false,
   complementaryCertificationKey,
+  hasComplementaryReferential,
 } = {}) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
   let challengeDtos;
 
-  if (complementaryCertificationKey) {
+  if (hasComplementaryReferential) {
     challengeDtos = await _findChallengesForComplementaryCertification({
       complementaryCertificationKey,
       cacheKey,

--- a/api/tests/certification/configuration/unit/domain/services/get-version-number_test.js
+++ b/api/tests/certification/configuration/unit/domain/services/get-version-number_test.js
@@ -1,0 +1,10 @@
+import { getVersionNumber } from '../../../../../../src/certification/configuration/domain/services/get-version-number.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Services | get-version-number', function () {
+  it('should return string from given date', async function () {
+    const fakeCurrentDate = new Date('2025-06-23T12:56:43Z');
+    const versionNumber = await getVersionNumber(fakeCurrentDate);
+    expect(versionNumber).to.deep.equal('20250623125643');
+  });
+});

--- a/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import { CertificationCompletedJobController } from '../../../../../../src/certification/evaluation/application/jobs/certification-completed-job-controller.js';
 import { CertificationCompletedJob } from '../../../../../../src/certification/evaluation/domain/events/CertificationCompleted.js';
 import { AlgorithmEngineVersion } from '../../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
@@ -525,9 +524,7 @@ describe('Certification | Evaluation | Integration | Application | Certification
           const limitDate = new Date('2020-01-01T00:00:00Z');
           certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-          const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-            key: ComplementaryCertificationKeys.CLEA,
-          });
+          const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification.clea({});
 
           const badgeId = databaseBuilder.factory.buildBadge({ isCertifiable: true }).id;
           complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
@@ -1,0 +1,49 @@
+import { ComplementaryCertificationCourse } from '../../../../../../src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js';
+import * as complementaryCertificationCourseRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/complementary-certification-course-repository.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Certification | Evaluation | Repository | Complementary-certification Course', function () {
+  describe('#findByCertificationCourseId', function () {
+    describe('when a complementary certification course exists', function () {
+      it('should return a complementary certification course entity', async function () {
+        // given
+        const complementaryCertification = await databaseBuilder.factory.buildComplementaryCertification.droit({});
+
+        const certificationCourse = await databaseBuilder.factory.buildCertificationCourse();
+
+        await databaseBuilder.factory.buildComplementaryCertificationCourse({
+          certificationCourseId: certificationCourse.id,
+          complementaryCertificationId: complementaryCertification.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await complementaryCertificationCourseRepository.findByCertificationCourseId({
+          certificationCourseId: certificationCourse.id,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(ComplementaryCertificationCourse);
+        expect(result.complementaryCertificationKey).to.equal(complementaryCertification.key);
+        expect(result.hasComplementaryReferential).to.equal(complementaryCertification.hasComplementaryReferential);
+      });
+    });
+
+    describe('when there is no complementary certification course for this course ID', function () {
+      it('should return null', async function () {
+        // given
+        const certificationCourse = await databaseBuilder.factory.buildCertificationCourse();
+        await databaseBuilder.commit();
+
+        // when
+        const result = await complementaryCertificationCourseRepository.findByCertificationCourseId({
+          certificationCourseId: certificationCourse.id,
+        });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -3,52 +3,54 @@ import { ComplementaryCertificationKeys } from '../../../../../../src/certificat
 import { FRENCH_FRANCE } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
-describe('#simulateFlashAssessmentScenario', function () {
-  describe('when a complementary certification scenario is required', function () {
-    it('should fetch the complementary framework challenges', async function () {
-      // given
-      const locale = FRENCH_FRANCE;
-      const accessibilityAdjustmentNeeded = false;
-      const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
-      const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', function () {
+  describe('#simulateFlashAssessmentScenario', function () {
+    describe('when a complementary certification scenario is required', function () {
+      it('should fetch the complementary framework challenges', async function () {
+        // given
+        const locale = FRENCH_FRANCE;
+        const accessibilityAdjustmentNeeded = false;
+        const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+        const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
 
-      // when
-      await catchErr(simulateFlashAssessmentScenario)({
-        locale,
-        accessibilityAdjustmentNeeded,
-        complementaryCertificationKey,
-        sharedChallengeRepository: challengeRepositoryStub,
-      });
+        // when
+        await catchErr(simulateFlashAssessmentScenario)({
+          locale,
+          accessibilityAdjustmentNeeded,
+          complementaryCertificationKey,
+          sharedChallengeRepository: challengeRepositoryStub,
+        });
 
-      // then
-      expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-        complementaryCertificationKey,
-        locale,
-        accessibilityAdjustmentNeeded: undefined,
+        // then
+        expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+          complementaryCertificationKey,
+          locale,
+          accessibilityAdjustmentNeeded: undefined,
+        });
       });
     });
-  });
 
-  describe('when a complementary certification scenario is not required', function () {
-    it('should fetch the core referential challenges', async function () {
-      // given
-      const locale = FRENCH_FRANCE;
-      const accessibilityAdjustmentNeeded = false;
-      const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+    describe('when a complementary certification scenario is not required', function () {
+      it('should fetch the core referential challenges', async function () {
+        // given
+        const locale = FRENCH_FRANCE;
+        const accessibilityAdjustmentNeeded = false;
+        const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
 
-      // when
-      await catchErr(simulateFlashAssessmentScenario)({
-        locale,
-        accessibilityAdjustmentNeeded,
-        complementaryCertificationKey: undefined,
-        sharedChallengeRepository: challengeRepositoryStub,
-      });
+        // when
+        await catchErr(simulateFlashAssessmentScenario)({
+          locale,
+          accessibilityAdjustmentNeeded,
+          complementaryCertificationKey: undefined,
+          sharedChallengeRepository: challengeRepositoryStub,
+        });
 
-      // then
-      expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-        locale,
-        accessibilityAdjustmentNeeded,
-        complementaryCertificationKey: undefined,
+        // then
+        expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+          locale,
+          accessibilityAdjustmentNeeded,
+          complementaryCertificationKey: undefined,
+        });
       });
     });
   });

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -3,7 +3,6 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { config } from '../../../../../src/shared/config.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
@@ -604,9 +603,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             // given
             const userId = databaseBuilder.factory.buildUser().id;
 
-            const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-              key: ComplementaryCertificationKeys.CLEA,
-            });
+            const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification.clea({});
 
             const badgeId = databaseBuilder.factory.buildBadge({ isCertifiable: true }).id;
             const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 
-import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { ValidatorQCM } from '../../../../../src/evaluation/domain/models/ValidatorQCM.js';
 import { ValidatorQCU } from '../../../../../src/evaluation/domain/models/ValidatorQCU.js';
 import { config } from '../../../../../src/shared/config.js';
@@ -1518,7 +1517,6 @@ describe('Integration | Repository | challenge-repository', function () {
       challengesLC.push(challengeData06_skill02_qcm_perime_notFlashCompatible_fren_noEmbedJson);
       challengesLC.push(challengeData07_skill03_qcm_valide_notFlashCompatible_frnl_noEmbedJson);
       challengesLC.push(challengeData08_skill03_qcu_archive_notFlashCompatible_fr_noEmbedJson);
-      challengesLC.push(domainBuilder.buildChallenge({ id: 'toto' }));
     });
 
     context('when complementary certification given', function () {
@@ -1530,6 +1528,8 @@ describe('Integration | Repository | challenge-repository', function () {
         const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification.pixEdu1erDegre(
           {},
         );
+
+        challengesLC.push(domainBuilder.buildChallenge({ id: 'toto' }));
 
         databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
@@ -1564,9 +1564,10 @@ describe('Integration | Repository | challenge-repository', function () {
 
         // when
         const flashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({
-          complementaryCertificationKey: complementaryCertification.key,
-          locale: 'fr',
           date: candidateReconciliationDate,
+          locale: 'fr',
+          complementaryCertificationKey: complementaryCertification.key,
+          hasComplementaryReferential: complementaryCertification.hasComplementaryReferential,
         });
 
         // then

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-complementary-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-complementary-certification-course.js
@@ -1,0 +1,13 @@
+import { ComplementaryCertificationCourse } from '../../../../../../src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js';
+
+const buildComplementaryCertificationCourse = function ({
+  complementaryCertificationKey,
+  hasComplementaryReferential,
+} = {}) {
+  return new ComplementaryCertificationCourse({
+    complementaryCertificationKey,
+    hasComplementaryReferential,
+  });
+};
+
+export { buildComplementaryCertificationCourse };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -187,6 +187,7 @@ import { buildUserEnrolment } from './certification/enrolment/build-user.js';
 import { buildUserCertificationEligibility } from './certification/enrolment/build-user-certification-eligibility.js';
 import { buildV3CertificationEligibility } from './certification/enrolment/build-v3-certification-eligibility.js';
 import { buildEvaluationCandidate } from './certification/evaluation/build-candidate.js';
+import { buildComplementaryCertificationCourse } from './certification/evaluation/build-complementary-certification-course.js';
 import { buildComplementaryCertificationScoringCriteria } from './certification/evaluation/build-complementary-certification-scoring-criteria.js';
 import { buildComplementaryCertificationScoringWithoutComplementaryReferential } from './certification/evaluation/build-complementary-certification-scoring-without-complementary-referential.js';
 import { buildDoubleCertificationScoring } from './certification/evaluation/build-double-certification-scoring.js';
@@ -265,6 +266,7 @@ const certification = {
   evaluation: {
     buildCandidate: buildEvaluationCandidate,
     buildResultsSession,
+    buildComplementaryCertificationCourse,
     buildComplementaryCertificationScoringCriteria,
     buildComplementaryCertificationScoringWithoutComplementaryReferential,
     buildComplementaryCertificationScoringWithComplementaryReferential,


### PR DESCRIPTION
## 🔆 Problème

Aujourd'hui, lors d'un passage d'une certif complémentaire, nous ne filtrons pas les épreuves d'un référentiel cadre spécifique selon sa version.

## ⛱️ Proposition

Utiliser la date de réconciliation du candidat pour utiliser la bonne version du référentiel cadre.

## 🏄 Pour tester

Dans **Admin**
- Habiliter un centre à la complémentaire DROIT
- Ajouter un nouveau référentiel cadre pour la complémentaire DROIT

Dans **Certif**
- Créer une nouvelle session et y inscrire un candidat pour cette complémentaire

Dans **PixApp**
- Passer quelques épreuves de cette épreuve
- Vérifier en BDD que l'ID des épreuves passées (dans la table `answers`) se trouve bien dans la bonne version du notre référentiel cadre (table `certification-frameworks-challenges`)

### Pour tester le simulateur : 

```
TOKEN=$(curl --insecure 'https://admin-pr13151.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13151.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "stopAtChallenge": 3, "complementaryCertificationKey": "DROIT", "locale": "fr-fr" }' | jq '.'
```