### PR TITLE
[BUGFIX] Réparer le démarrage de l'API Maddo (PIX-19085).

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,8 @@
 import { OidcAuthenticationServiceRegistry } from '../../../src/identity-access-management/domain/services/oidc-authentication-service-registry.js';
 import * as oidcProviderRepository from '../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
+// userRepo should be import to avoid circular dependency
+//eslint-disable-next-line no-unused-vars
+import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
 
 const oidcAuthenticationServiceRegistry = new OidcAuthenticationServiceRegistry({ oidcProviderRepository });
 


### PR DESCRIPTION
## 🔆 Problème

Depuis la PR https://github.com/1024pix/pix/pull/13135, l'API Maddo ne fonctionne plus.

```
2025-08-08 14:25:50.921859722 +0200 CEST[web-1] campaignToJoinRepository: campaignRepositories.campaignToJoinRepository,
2025-08-08 14:25:50.921861278 +0200 CEST[web-1] at file:///app/src/prescription/campaign/domain/usecases/index.js:65:29
2025-08-08 14:25:50.921855428 +0200 CEST[web-1] file:///app/src/prescription/campaign/domain/usecases/index.js:65
2025-08-08 14:25:50.921860915 +0200 CEST[web-1] ReferenceError: Cannot access 'campaignRepositories' before initialization 
```

## ⛱️ Proposition

En remettant, l'import userRepo cela refonctionne, nous faisons ça en patch temporaire. Désolé.

## 🌊 Remarques

Le mauvais déploiement en intégration ne bloque pas la création de version, c'est triste. 

Nous avons essayé de comprendre un peu avec des debugs : `NODE_DEBUG=module` et `NODE_DEBUG=esm`, mais nous n'avons pas trop fouillé. 

## 🏄 Pour tester

- Lancer la RA Maddo est constaté que le déploiement se fait 