### PR TITLE
[FEATURE] Script de reprise des locales des utilisateurs (PIX-18985)

### DIFF
--- a/api/src/identity-access-management/scripts/fill-users-locale-from-csv.script.js
+++ b/api/src/identity-access-management/scripts/fill-users-locale-from-csv.script.js
@@ -1,0 +1,122 @@
+import joi from 'joi';
+
+import { knex } from '../../../db/knex-database-connection.js';
+import { csvFileStreamer } from '../../shared/application/scripts/parsers.js';
+import { Script } from '../../shared/application/scripts/script.js';
+import { ScriptRunner } from '../../shared/application/scripts/script-runner.js';
+
+const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_DELAY_MS = 1000;
+
+const columnSchemas = [
+  { name: 'userId', schema: joi.number().required() },
+  { name: 'locale', schema: joi.string().required() },
+];
+
+export class FillUsersLocaleFromCsvScript extends Script {
+  constructor() {
+    super({
+      description: 'Update users.locale from a CSV (userId, locale) if locale is null.',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe: 'CSV file path to process',
+          demandOption: true,
+          coerce: csvFileStreamer(columnSchemas),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'If present, does not modify the database',
+          default: false,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Number of users to process per batch',
+          default: DEFAULT_BATCH_SIZE,
+        },
+        delayInMilliseconds: {
+          type: 'number',
+          describe: 'Delay between each batch in ms',
+          default: DEFAULT_DELAY_MS,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { file: streamFile, dryRun, batchSize, delayInMilliseconds } = options;
+    let totalUsersProcessed = 0;
+    let totalUsersUpdated = 0;
+    let totalUsersSkipped = 0;
+    let batchIndex = 0;
+
+    await streamFile(async (userRows) => {
+      batchIndex++;
+      logger.info(`Batch ${batchIndex}: ${userRows.length} users`);
+      await _delay(delayInMilliseconds);
+
+      const usersToUpdate = await _getUsersToUpdateFromBatch(userRows);
+
+      const batchSkipped = userRows.length - usersToUpdate.length;
+
+      const userUpdatedCount = await _updateUsersByLocale({ usersToUpdate, dryRun });
+      totalUsersUpdated += userUpdatedCount;
+      totalUsersProcessed += userRows.length;
+      totalUsersSkipped += batchSkipped;
+
+      logger.info(`${userUpdatedCount} users updated in this batch.`);
+      if (batchSkipped > 0) {
+        logger.info(`${batchSkipped} users already have a locale and will not be processed in this batch.`);
+      }
+    }, batchSize);
+
+    logger.info(`${totalUsersProcessed} users processed. ${totalUsersUpdated} updated.`);
+    if (totalUsersSkipped > 0) {
+      logger.info(`${totalUsersSkipped} users already had a locale and were not processed.`);
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FillUsersLocaleFromCsvScript);
+
+async function _delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function _fetchUseridsWithoutLocale(userIds) {
+  const rows = await knex('users').select('id').whereIn('id', userIds).whereNull('locale');
+  return rows.map((row) => row.id);
+}
+
+async function _getUsersToUpdateFromBatch(userRows) {
+  const normalizedRows = userRows.map((row) => ({ ...row, userId: Number(row.userId) }));
+  const userIds = normalizedRows.map((row) => row.userId);
+  const userIdsWithoutLocale = await _fetchUseridsWithoutLocale(userIds);
+  return normalizedRows.filter((row) => userIdsWithoutLocale.includes(row.userId));
+}
+
+function _groupUserIdsByLocale(users) {
+  const userIdsByLocale = {};
+  for (const user of users) {
+    const { locale, userId } = user;
+    if (!userIdsByLocale[locale]) {
+      userIdsByLocale[locale] = [];
+    }
+    userIdsByLocale[locale].push(userId);
+  }
+  return userIdsByLocale;
+}
+
+async function _updateUsersByLocale({ usersToUpdate, dryRun }) {
+  const userIdsByLocale = _groupUserIdsByLocale(usersToUpdate);
+
+  let totalUpdated = 0;
+  for (const [locale, userIds] of Object.entries(userIdsByLocale)) {
+    if (!dryRun) {
+      await knex('users').whereIn('id', userIds).update({ locale });
+    }
+    totalUpdated += userIds.length;
+  }
+  return totalUpdated;
+}

--- a/api/tests/identity-access-management/integration/scripts/files/fill-users-locale.csv
+++ b/api/tests/identity-access-management/integration/scripts/files/fill-users-locale.csv
@@ -1,0 +1,4 @@
+userId,locale
+1,fr-FR
+2,en
+3,nl

--- a/api/tests/identity-access-management/integration/scripts/fill-users-locale-from-csv.script.test.js
+++ b/api/tests/identity-access-management/integration/scripts/fill-users-locale-from-csv.script.test.js
@@ -1,0 +1,64 @@
+import * as url from 'node:url';
+
+import Joi from 'joi';
+
+import { FillUsersLocaleFromCsvScript } from '../../../../src/identity-access-management/scripts/fill-users-locale-from-csv.script.js';
+import { csvFileStreamer } from '../../../../src/shared/application/scripts/parsers.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+describe('Integration | Identity Access Management | Scripts | fill-users-locale-from-csv', function () {
+  describe('#handle', function () {
+    let userIdWithoutLocale1, userIdWithoutLocale2, userIdWithLocale, streamFile;
+    beforeEach(async function () {
+      userIdWithoutLocale1 = databaseBuilder.factory.buildUser({ id: 1, locale: null }).id;
+      userIdWithoutLocale2 = databaseBuilder.factory.buildUser({ id: 2, locale: null }).id;
+      userIdWithLocale = databaseBuilder.factory.buildUser({ id: 3, locale: 'es' }).id;
+      await databaseBuilder.commit();
+      const csvPath = `${currentDirectory}files/fill-users-locale.csv`;
+      const columnSchemas = [
+        { name: 'userId', schema: Joi.number().required() },
+        { name: 'locale', schema: Joi.string().required() },
+      ];
+      const streamer = await csvFileStreamer(columnSchemas);
+      streamFile = async (cb, batchSize) => {
+        const fileStream = await streamer(csvPath);
+        return fileStream(cb, batchSize);
+      };
+    });
+
+    it('updates only users without a locale from CSV', async function () {
+      // when
+      const script = new FillUsersLocaleFromCsvScript();
+      await script.handle({
+        options: { file: streamFile, dryRun: false, batchSize: 10, delayInMilliseconds: 0 },
+        logger,
+      });
+
+      // then
+      const user1 = await knex('users').where({ id: userIdWithoutLocale1 }).first();
+      const user2 = await knex('users').where({ id: userIdWithoutLocale2 }).first();
+      const user3 = await knex('users').where({ id: userIdWithLocale }).first();
+      expect(user1.locale).to.equal('fr-FR');
+      expect(user2.locale).to.equal('en');
+      expect(user3.locale).to.equal('es');
+    });
+
+    it('does nothing in dryRun mode', async function () {
+      // when
+      const script = new FillUsersLocaleFromCsvScript();
+      await script.handle({
+        options: { file: streamFile, dryRun: true, batchSize: 10, delayInMilliseconds: 0 },
+        logger,
+      });
+
+      // then
+      const user1 = await knex('users').where({ id: userIdWithoutLocale1 }).first();
+      const user2 = await knex('users').where({ id: userIdWithoutLocale2 }).first();
+      expect(user1.locale).to.be.null;
+      expect(user2.locale).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Nous avons des utilisateurs sans locale et on doit définir une locale sur ces utilisateurs.

## ⛱️ Proposition

Écrire un script de reprise de données pour remplir ou mettre à jour `users.locale` avec la locale fournie dans un fichier CSV.

## 🏄 Pour tester

exemple de fichier:

```
userId,locale
1,fr-FR
2,en
3,es
```


- Lancer le script avec : `node api/src/identity-access-management/scripts/fill-users-locale-from-csv.script.js --file=CHEMIN_CSV.csv`

- Constater qu'il n'y a plus de users sans locale