### PR TITLE
[FEATURE] Ajouter le support de l'événement `STEPPER_NEXT_STEP` (PIX-18365)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -17,6 +17,7 @@ import {
 import { GrainContinuedEvent, GrainSkippedEvent } from '../models/passage-events/grain-events.js';
 import { PassageStartedEvent, PassageTerminatedEvent } from '../models/passage-events/passage-events.js';
 import { QABCardAnsweredEvent, QABCardRetriedEvent } from '../models/passage-events/qab-events.js';
+import { StepperNextStepEvent } from '../models/passage-events/stepper-events.js';
 
 class PassageEventFactory {
   static build(eventData) {
@@ -37,6 +38,8 @@ class PassageEventFactory {
         return new GrainContinuedEvent(eventData);
       case 'GRAIN_SKIPPED':
         return new GrainSkippedEvent(eventData);
+      case 'STEPPER_NEXT_STEP':
+        return new StepperNextStepEvent(eventData);
       case 'PASSAGE_STARTED':
         return new PassageStartedEvent(eventData);
       case 'PASSAGE_TERMINATED':

--- a/api/src/devcomp/domain/models/passage-events/stepper-events.js
+++ b/api/src/devcomp/domain/models/passage-events/stepper-events.js
@@ -1,0 +1,27 @@
+import {
+  assertHasUuidLength,
+  assertNotNullOrUndefined,
+  assertPositiveInteger,
+} from '../../../../shared/domain/models/asserts.js';
+import { PassageEvent } from './PassageEvent.js';
+
+class StepperNextStepEvent extends PassageEvent {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, grainId, stepNumber }) {
+    super({
+      type: 'STEPPER_NEXT_STEP',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      data: { grainId, stepNumber },
+    });
+
+    assertNotNullOrUndefined(grainId, 'The grainId property is required for a StepperNextStepEvent');
+    assertHasUuidLength(grainId, 'The grainId property should be exactly 36 characters long');
+    assertNotNullOrUndefined(stepNumber, 'The stepNumber property is required for a StepperNextStepEvent');
+    assertPositiveInteger(stepNumber, 'The stepNumber property must be a positive integer');
+  }
+}
+
+export { StepperNextStepEvent };

--- a/api/src/shared/domain/models/asserts.js
+++ b/api/src/shared/domain/models/asserts.js
@@ -24,3 +24,9 @@ export function assertHasUuidLength(value, errorMessage = 'Uuid value must be ex
     throw new DomainError(errorMessage);
   }
 }
+
+export function assertPositiveInteger(value, errorMessage = 'value must be a positive integer') {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new DomainError(errorMessage);
+  }
+}

--- a/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/grain-events_test.js
@@ -5,7 +5,7 @@ import {
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
-describe('Integration | Devcomp | Domain | Models | passage-events | qab-events', function () {
+describe('Integration | Devcomp | Domain | Models | passage-events | grain-events', function () {
   describe('#GrainContinuedEvent', function () {
     it('should init and keep attributes', function () {
       // given

--- a/api/tests/devcomp/integration/domain/models/passage-events/stepper-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/stepper-events_test.js
@@ -1,0 +1,158 @@
+import { StepperNextStepEvent } from '../../../../../../src/devcomp/domain/models/passage-events/stepper-events.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | stepper-events', function () {
+  describe('#StepperNextStepEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = new Date();
+      const passageId = 2;
+      const sequenceNumber = 3;
+      const grainId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+      const stepNumber = 1;
+
+      // when
+      const stepperNextStepEvent = new StepperNextStepEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        grainId,
+        stepNumber,
+      });
+
+      // then
+      expect(stepperNextStepEvent.id).to.equal(id);
+      expect(stepperNextStepEvent.type).to.equal('STEPPER_NEXT_STEP');
+      expect(stepperNextStepEvent.occurredAt).to.equal(occurredAt);
+      expect(stepperNextStepEvent.createdAt).to.equal(createdAt);
+      expect(stepperNextStepEvent.passageId).to.equal(passageId);
+      expect(stepperNextStepEvent.sequenceNumber).to.equal(sequenceNumber);
+      expect(stepperNextStepEvent.data).to.deep.equal({ grainId, stepNumber });
+    });
+
+    describe('when grainId is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const stepNumber = 0;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new StepperNextStepEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              stepNumber,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property is required for a StepperNextStepEvent');
+      });
+    });
+
+    describe('when grainId is invalid', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const grainId = 'invalidGrainId';
+        const stepNumber = 0;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new StepperNextStepEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              grainId,
+              stepNumber,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The grainId property should be exactly 36 characters long');
+      });
+    });
+
+    describe('when stepNumber is not given', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const grainId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new StepperNextStepEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              grainId,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The stepNumber property is required for a StepperNextStepEvent');
+      });
+    });
+
+    describe('when stepNumber is invalid', function () {
+      it('should throw an error', function () {
+        // given
+        const id = Symbol('id');
+        const occurredAt = new Date();
+        const createdAt = new Date();
+        const passageId = 2;
+        const sequenceNumber = 3;
+        const grainId = '05112f63-0b47-4774-b638-6669c4e3a26d';
+        const stepNumber = 0;
+
+        // when
+        const error = catchErrSync(
+          () =>
+            new StepperNextStepEvent({
+              id,
+              occurredAt,
+              createdAt,
+              passageId,
+              sequenceNumber,
+              grainId,
+              stepNumber,
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The stepNumber property must be a positive integer');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -28,6 +28,7 @@ import {
   QABCardAnsweredEvent,
   QABCardRetriedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/qab-events.js';
+import { StepperNextStepEvent } from '../../../../../src/devcomp/domain/models/passage-events/stepper-events.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErrSync } from '../../../../test-helper.js';
 
@@ -202,6 +203,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(GrainSkippedEvent);
+      });
+    });
+
+    describe('when given a STEPPER_NEXT_STEP event', function () {
+      it('should return a StepperNextStepEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          grainId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
+          stepNumber: 1,
+          type: 'STEPPER_NEXT_STEP',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(StepperNextStepEvent);
       });
     });
 

--- a/api/tests/shared/unit/domain/models/asserts_test.js
+++ b/api/tests/shared/unit/domain/models/asserts_test.js
@@ -4,6 +4,7 @@ import {
   assertHasUuidLength,
   assertInstanceOf,
   assertNotNullOrUndefined,
+  assertPositiveInteger,
 } from '../../../../../src/shared/domain/models/asserts.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
 
@@ -121,6 +122,102 @@ describe('Unit | Shared | Models | asserts', function () {
 
         // when/then
         expect(() => assertHasUuidLength(value)).not.to.throw();
+      });
+    });
+  });
+
+  describe('#assertPositiveInteger', function () {
+    describe('given invalid value', function () {
+      it('should throw', function () {
+        // given
+        const value = 0;
+
+        // when
+        const error = catchErrSync(() => assertPositiveInteger(value))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('value must be a positive integer');
+      });
+
+      describe('given undefined', function () {
+        it('should throw', function () {
+          // given
+          const value = undefined;
+
+          // when
+          const error = catchErrSync(() => assertPositiveInteger(value))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('value must be a positive integer');
+        });
+      });
+
+      describe('given negative number', function () {
+        it('should throw', function () {
+          // given
+          const value = -1;
+
+          // when
+          const error = catchErrSync(() => assertPositiveInteger(value))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('value must be a positive integer');
+        });
+      });
+
+      describe('given zero', function () {
+        it('should throw', function () {
+          // given
+          const value = 0;
+
+          // when
+          const error = catchErrSync(() => assertPositiveInteger(value))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('value must be a positive integer');
+        });
+      });
+
+      describe('given positive floating number', function () {
+        it('should throw', function () {
+          // given
+          const value = 1.5;
+
+          // when
+          const error = catchErrSync(() => assertPositiveInteger(value))();
+
+          // then
+          expect(error).to.be.instanceOf(DomainError);
+          expect(error.message).to.equal('value must be a positive integer');
+        });
+      });
+    });
+
+    describe('given invalid value and a custom error message', function () {
+      it('should throw with the custom error message', function () {
+        // given
+        const value = 0;
+
+        // when
+        const error = catchErrSync(() => assertPositiveInteger(value, 'NOPE'))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('NOPE');
+      });
+    });
+
+    describe('given valid value', function () {
+      it('should not throw', function () {
+        // given
+        const value = 5;
+
+        // when/then
+        expect(() => assertPositiveInteger(value)).not.to.throw();
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -73,6 +73,14 @@ export default class ModulePassage extends Component {
   onStepperNextStep(currentStepPosition) {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
+    this.passageEvents.record({
+      type: 'STEPPER_NEXT_STEP',
+      data: {
+        grainId: currentGrain.id,
+        stepNumber: currentStepPosition,
+      },
+    });
+
     this.pixMetrics.trackEvent(
       `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
       {


### PR DESCRIPTION
## ⛱️ Proposition

Ajouter le support de l'événement `STEPPER_NEXT_STEP`

## 🏄 Pour tester

Vérifier [en RA](https://app-pr13156.review.pix.fr/modules/distinguer-vrai-faux-sur-internet/passage) que dans un stepper, l'événement est bien enregistré avec les bons paramètres.