### PR TITLE
[FEATURE] Passer l'url du combinix en cours lors du clic sur un item de type module (PIX-19061)

### DIFF
--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -1,7 +1,7 @@
 const getBySlug = async function (request, h, { moduleSerializer, usecases }) {
   const { slug } = request.params;
-  const redirectionHash = request.query.redirectionHash;
-  const module = await usecases.getModule({ slug, redirectionHash });
+  const encryptedRedirectionUrl = request.query.encryptedRedirectionUrl;
+  const module = await usecases.getModule({ slug, encryptedRedirectionUrl });
 
   return moduleSerializer.serialize(module);
 };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -14,7 +14,7 @@ const register = async function (server) {
         validate: {
           params: Joi.object({ slug: Joi.string().required() }),
           query: Joi.object({
-            redirectionHash: Joi.string(),
+            encryptedRedirectionUrl: Joi.string(),
           }),
         },
         notes: ['- Permet de récupérer un module grâce à son titre slugifié'],

--- a/api/src/devcomp/domain/usecases/get-module.js
+++ b/api/src/devcomp/domain/usecases/get-module.js
@@ -1,13 +1,13 @@
 import { config } from '../../../shared/config.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 
-async function getModule({ slug, redirectionHash, moduleRepository }) {
+async function getModule({ slug, encryptedRedirectionUrl, moduleRepository }) {
   const module = await moduleRepository.getBySlug({ slug });
 
-  if (redirectionHash) {
+  if (encryptedRedirectionUrl) {
     let redirectionUrl = null;
     try {
-      redirectionUrl = await cryptoService.decrypt(redirectionHash, config.module.secret);
+      redirectionUrl = await cryptoService.decrypt(encryptedRedirectionUrl, config.module.secret);
       if (redirectionUrl) {
         module.setRedirectionUrl(redirectionUrl);
       }

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,13 +1,16 @@
+import { config } from '../../shared/config.js';
 import { requestResponseUtils } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 
-const getByCode = async function (request, _, dependencies = { requestResponseUtils }) {
+const getByCode = async function (request, _, dependencies = { requestResponseUtils, combinedCourseSerializer }) {
   const { code } = request.query.filter;
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
-
-  const combinedCourse = await usecases.getCombinedCourseByCode({ userId, code });
-  return combinedCourseSerializer.serialize(combinedCourse);
+  const TLD = dependencies.requestResponseUtils.extractTLDFromRequest(request);
+  const appDomain = config.domain.pixApp;
+  const hostURL = TLD ? `${appDomain}.${TLD}` : appDomain;
+  const combinedCourse = await usecases.getCombinedCourseByCode({ userId, code, hostURL });
+  return dependencies.combinedCourseSerializer.serialize(combinedCourse);
 };
 
 const start = async function (request, h, dependencies = { requestResponseUtils }) {

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -43,7 +43,7 @@ export class CombinedCourseDetails extends CombinedCourse {
       .map(({ data }) => data.moduleId.data);
   }
 
-  generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = [], hashedCombinedCourseUrl) {
+  generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = [], encryptedCombinedCourseUrl) {
     this.items = [];
     for (const requirement of this.#quest.successRequirements) {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
@@ -78,7 +78,7 @@ export class CombinedCourseDetails extends CombinedCourse {
             reference: module.slug,
             title: module.title,
             type: ITEM_TYPE.MODULE,
-            redirection: hashedCombinedCourseUrl,
+            redirection: encryptedCombinedCourseUrl,
           }),
         );
       }

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -43,7 +43,7 @@ export class CombinedCourseDetails extends CombinedCourse {
       .map(({ data }) => data.moduleId.data);
   }
 
-  generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = []) {
+  generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = [], hashedCombinedCourseUrl) {
     this.items = [];
     for (const requirement of this.#quest.successRequirements) {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
@@ -78,6 +78,7 @@ export class CombinedCourseDetails extends CombinedCourse {
             reference: module.slug,
             title: module.title,
             type: ITEM_TYPE.MODULE,
+            redirection: hashedCombinedCourseUrl,
           }),
         );
       }

--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -4,10 +4,11 @@ export const ITEM_TYPE = {
 };
 
 export class CombinedCourseItem {
-  constructor({ id, title, reference, type }) {
+  constructor({ id, title, reference, type, redirection }) {
     this.id = id;
     this.title = title;
     this.reference = reference;
+    this.redirection = redirection;
     this.type = type;
   }
 }

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -67,12 +67,12 @@ export async function getCombinedCourseByCode({
   const modules = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds });
 
   const combinedCourseUrl = hostURL + '/parcours/' + combinedCourseDetails.code;
-  const hashedCombinedCourseUrl = await cryptoService.encrypt(combinedCourseUrl, config.module.secret);
+  const encryptedCombinedCourseUrl = await cryptoService.encrypt(combinedCourseUrl, config.module.secret);
   combinedCourseDetails.generateItems(
     [...campaigns, ...modules],
     recommendableModuleIds,
     recommendedModuleIdsForUser,
-    hashedCombinedCourseUrl,
+    encryptedCombinedCourseUrl,
   );
 
   return combinedCourseDetails;

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -1,10 +1,13 @@
+import { config } from '../../../shared/config.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { CombinedCourseDetails } from '../models/CombinedCourse.js';
 import { DataForQuest } from '../models/DataForQuest.js';
 
 export async function getCombinedCourseByCode({
   userId,
   code,
+  hostURL,
   combinedCourseParticipationRepository,
   combinedCourseRepository,
   campaignRepository,
@@ -63,7 +66,14 @@ export async function getCombinedCourseByCode({
 
   const modules = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds });
 
-  combinedCourseDetails.generateItems([...campaigns, ...modules], recommendableModuleIds, recommendedModuleIdsForUser);
+  const combinedCourseUrl = hostURL + '/parcours/' + combinedCourseDetails.code;
+  const hashedCombinedCourseUrl = await cryptoService.encrypt(combinedCourseUrl, config.module.secret);
+  combinedCourseDetails.generateItems(
+    [...campaigns, ...modules],
+    recommendableModuleIds,
+    recommendedModuleIdsForUser,
+    hashedCombinedCourseUrl,
+  );
 
   return combinedCourseDetails;
 }

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (combinedCourse) {
     items: {
       ref: 'id',
       included: true,
-      attributes: ['title', 'reference', 'type'],
+      attributes: ['title', 'reference', 'type', 'redirection'],
     },
     typeForAttribute: (attribute) => {
       if (attribute === 'items') return 'combined-course-items';

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -640,6 +640,10 @@ const configuration = (function () {
     config.v3Certification.latestCalibrationDate = '2020-01-01';
   }
 
+  if (process.env.NODE_ENV === 'development') {
+    config.domain.pixApp = 'http://localhost:4200';
+  }
+
   return config;
 })();
 

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -11,7 +11,15 @@ const requestResponseUtils = {
   extractUserIdFromRequest,
   extractLocaleFromRequest,
   extractTimestampFromRequest,
+  extractTLDFromRequest,
 };
+
+function extractTLDFromRequest(request) {
+  const forwardedHost = request.headers['x-forwarded-host'];
+  if (forwardedHost.includes('.fr')) return 'fr';
+  if (forwardedHost.includes('.org')) return 'org';
+  return null;
+}
 
 function escapeFileName(fileName) {
   return fileName
@@ -48,6 +56,7 @@ export {
   escapeFileName,
   extractLocaleFromRequest,
   extractTimestampFromRequest,
+  extractTLDFromRequest,
   extractUserIdFromRequest,
   requestResponseUtils,
 };

--- a/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
@@ -25,10 +25,10 @@ describe('Acceptance | Controller | modules-controller-getBySlug', function () {
 
       it('should return module with redirectionUrl', async function () {
         const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
-        const redirectionHash = await cryptoService.encrypt(expectedUrl, config.module.secret);
+        const encryptedRedirectionUrl = await cryptoService.encrypt(expectedUrl, config.module.secret);
         const options = {
           method: 'GET',
-          url: `/api/modules/bien-ecrire-son-adresse-mail?redirectionHash=${encodeURIComponent(redirectionHash)}`,
+          url: `/api/modules/bien-ecrire-son-adresse-mail?encryptedRedirectionUrl=${encodeURIComponent(encryptedRedirectionUrl)}`,
         };
 
         const response = await server.inject(options);

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -7,19 +7,19 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
   describe('#getBySlug', function () {
     it('should call getModule use-case and return serialized modules', async function () {
       const slug = 'slug';
-      const redirectionHash = 'redirectionHash';
+      const encryptedRedirectionUrl = 'encryptedRedirectionUrl';
       const serializedModule = Symbol('serialized modules');
       const module = Symbol('modules');
       const usecases = {
         getModule: sinon.stub(),
       };
-      usecases.getModule.withArgs({ slug, redirectionHash }).returns(module);
+      usecases.getModule.withArgs({ slug, encryptedRedirectionUrl }).returns(module);
       const moduleSerializer = {
         serialize: sinon.stub(),
       };
       moduleSerializer.serialize.withArgs(module).returns(serializedModule);
 
-      const result = await modulesController.getBySlug({ params: { slug }, query: { redirectionHash } }, null, {
+      const result = await modulesController.getBySlug({ params: { slug }, query: { encryptedRedirectionUrl } }, null, {
         moduleSerializer,
         usecases,
       });

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -38,10 +38,10 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
       };
       moduleRepository.getBySlug.withArgs({ slug }).resolves(expectedModule);
       const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
-      const redirectionHash = await cryptoService.encrypt(expectedUrl, config.module.secret);
+      const encryptedRedirectionUrl = await cryptoService.encrypt(expectedUrl, config.module.secret);
 
       // when
-      const module = await getModule({ slug, redirectionHash, moduleRepository });
+      const module = await getModule({ slug, encryptedRedirectionUrl, moduleRepository });
 
       // then
       expect(module.redirectionUrl).to.equal(expectedUrl);

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -15,7 +15,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
     combinedCourseUrl = hostURL + '/parcours/' + code;
 
     sinon.stub(cryptoService, 'encrypt');
-    cryptoService.encrypt.withArgs(combinedCourseUrl).resolves('hashedUrl');
+    cryptoService.encrypt.withArgs(combinedCourseUrl).resolves('encryptedUrl');
   });
 
   it('should return CombinedCourse for provided code', async function () {
@@ -87,14 +87,14 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         reference: 'bac-a-sable',
         title: 'Bac à sable',
         type: ITEM_TYPE.MODULE,
-        redirection: 'hashedUrl',
+        redirection: 'encryptedUrl',
       }),
       new CombinedCourseItem({
         id: moduleId2,
         reference: 'bases-clavier-1',
         title: 'Les bases du clavier sur ordinateur 1/2',
         type: ITEM_TYPE.MODULE,
-        redirection: 'hashedUrl',
+        redirection: 'encryptedUrl',
       }),
     ]);
     expect(result.id).to.equal(questId);

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -1,0 +1,46 @@
+import { combinedCourseController } from '../../../../src/quest/application/combined-course-controller.js';
+import { usecases } from '../../../../src/quest/domain/usecases/index.js';
+import { config } from '../../../../src/shared/config.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Application | Controller | Combined Course', function () {
+  describe('#getByCode', function () {
+    it('should call usecase with hostURL containing TLD when it is provided', async function () {
+      // given
+      const code = 'abc123';
+      const userId = 1;
+      const TLD = 'fr';
+      const hostURL = config.domain.pixApp + '.' + TLD;
+      const request = {
+        query: {
+          filter: {
+            code,
+          },
+        },
+      };
+      const dependencies = {
+        combinedCourseSerializer: {
+          serialize: sinon.stub(),
+        },
+        requestResponseUtils: {
+          extractUserIdFromRequest: sinon.stub(),
+          extractTLDFromRequest: sinon.stub(),
+        },
+      };
+      sinon.stub(usecases, 'getCombinedCourseByCode');
+
+      dependencies.requestResponseUtils.extractUserIdFromRequest.returns(userId);
+      dependencies.requestResponseUtils.extractTLDFromRequest.returns(TLD);
+      usecases.getCombinedCourseByCode.withArgs({ userId, code, hostURL }).resolves();
+      // when
+      await combinedCourseController.getByCode(request, hFake, dependencies);
+
+      // then
+      expect(usecases.getCombinedCourseByCode).to.have.been.calledWithExactly({
+        userId,
+        code,
+        hostURL,
+      });
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -133,12 +133,51 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           }),
         ]);
       });
+      it('should not take hashedCombinedCourseUrl if item type is campaign', function () {
+        // given
+        const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
+        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+        const quest = new Quest({
+          id: 1,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaign.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+
+        // when
+        combinedCourse.generateItems([campaign], [], [], hashedCombinedCourseUrl);
+
+        // then
+        expect(combinedCourse.items).to.deep.equal([
+          new CombinedCourseItem({
+            id: campaign.id,
+            reference: campaign.code,
+            title: campaign.name,
+            type: ITEM_TYPE.CAMPAIGN,
+            redirection: undefined,
+          }),
+        ]);
+      });
 
       describe('when items are type module', function () {
         it('should return module if it is in quest but not is not in target profile', function () {
           // given
           const recommendableModuleIds = [];
           const recommendedModuleIdsForUser = [];
+          const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
           const quest = new Quest({
             id: 1,
             rewardId: null,
@@ -161,7 +200,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           const module = new Module({ id: 7, title: 'module' });
 
           // when
-          combinedCourse.generateItems([module], recommendableModuleIds, recommendedModuleIdsForUser);
+          combinedCourse.generateItems(
+            [module],
+            recommendableModuleIds,
+            recommendedModuleIdsForUser,
+            hashedCombinedCourseUrl,
+          );
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -170,6 +214,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: module.slug,
               title: module.title,
               type: ITEM_TYPE.MODULE,
+              redirection: hashedCombinedCourseUrl,
             }),
           ]);
         });
@@ -224,6 +269,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         });
         it('should return module if it in quest, recommandable and recommended for user', function () {
           // given
+          const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
           const module = new Module({ id: 1, title: 'module' });
           const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
@@ -260,7 +306,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
 
           // when
-          combinedCourse.generateItems([campaign, module], recommendableModuleIds, recommendedModuleIdsForUser);
+          combinedCourse.generateItems(
+            [campaign, module],
+            recommendableModuleIds,
+            recommendedModuleIdsForUser,
+            hashedCombinedCourseUrl,
+          );
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -275,6 +326,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: module.slug,
               title: module.title,
               type: ITEM_TYPE.MODULE,
+              redirection: hashedCombinedCourseUrl,
             }),
           ]);
         });

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -133,9 +133,9 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           }),
         ]);
       });
-      it('should not take hashedCombinedCourseUrl if item type is campaign', function () {
+      it('should not take encryptedCombinedCourseUrl if item type is campaign', function () {
         // given
-        const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
+        const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
         const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
         const quest = new Quest({
           id: 1,
@@ -158,7 +158,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
 
         // when
-        combinedCourse.generateItems([campaign], [], [], hashedCombinedCourseUrl);
+        combinedCourse.generateItems([campaign], [], [], encryptedCombinedCourseUrl);
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -177,7 +177,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           // given
           const recommendableModuleIds = [];
           const recommendedModuleIdsForUser = [];
-          const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
+          const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const quest = new Quest({
             id: 1,
             rewardId: null,
@@ -204,7 +204,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             [module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
-            hashedCombinedCourseUrl,
+            encryptedCombinedCourseUrl,
           );
 
           // then
@@ -214,7 +214,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: module.slug,
               title: module.title,
               type: ITEM_TYPE.MODULE,
-              redirection: hashedCombinedCourseUrl,
+              redirection: encryptedCombinedCourseUrl,
             }),
           ]);
         });
@@ -269,7 +269,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         });
         it('should return module if it in quest, recommandable and recommended for user', function () {
           // given
-          const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
+          const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const module = new Module({ id: 1, title: 'module' });
           const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
@@ -310,7 +310,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             [campaign, module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
-            hashedCombinedCourseUrl,
+            encryptedCombinedCourseUrl,
           );
 
           // then
@@ -326,7 +326,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: module.slug,
               title: module.title,
               type: ITEM_TYPE.MODULE,
-              redirection: hashedCombinedCourseUrl,
+              redirection: encryptedCombinedCourseUrl,
             }),
           ]);
         });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -49,7 +49,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             title: 'title',
             reference: 'slug',
             type: ITEM_TYPE.MODULE,
-            redirection: 'hashedCombinedCourseUrl',
+            redirection: 'encryptedCombinedCourseUrl',
           },
         },
       ],

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -24,7 +24,10 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
         id: '1',
         relationships: {
           items: {
-            data: [{ id: '1', type: 'combined-course-items' }],
+            data: [
+              { id: '1', type: 'combined-course-items' },
+              { id: '7', type: 'combined-course-items' },
+            ],
           },
         },
       },
@@ -36,6 +39,17 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             title: 'diagnostique',
             reference: 'ABCDIAG1',
             type: ITEM_TYPE.CAMPAIGN,
+            redirection: undefined,
+          },
+        },
+        {
+          type: 'combined-course-items',
+          id: '7',
+          attributes: {
+            title: 'title',
+            reference: 'slug',
+            type: ITEM_TYPE.MODULE,
+            redirection: 'hashedCombinedCourseUrl',
           },
         },
       ],

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -7,6 +7,7 @@ import {
   escapeFileName,
   extractLocaleFromRequest,
   extractTimestampFromRequest,
+  extractTLDFromRequest,
   extractUserIdFromRequest,
 } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
@@ -34,6 +35,42 @@ describe('Unit | Utils | Request Utils', function () {
 
       // then
       expect(result).to.equal(null);
+    });
+  });
+
+  describe('#extractTLDFromRequest', function () {
+    it('should return fr when forwared host includes .fr', function () {
+      // given
+      const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ audience: 'https://app.pix.fr' }),
+      };
+      // when
+      const result = extractTLDFromRequest(request);
+
+      // then
+      expect(result).to.equal('fr');
+    });
+    it('should return org when forwared host includes .org', function () {
+      // given
+      const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ audience: 'https://app.pix.org' }),
+      };
+      // when
+      const result = extractTLDFromRequest(request);
+
+      // then
+      expect(result).to.equal('org');
+    });
+    it('should return null when forwared host includes something else', function () {
+      // given
+      const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ audience: 'http://localhost:4200' }),
+      };
+      // when
+      const result = extractTLDFromRequest(request);
+
+      // then
+      expect(result).to.be.null;
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -1,10 +1,19 @@
+import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import { CombinedCourse, CombinedCourseDetails } from '../../../../src/quest/domain/models/CombinedCourse.js';
 import { Quest } from '../../../../src/quest/domain/models/Quest.js';
 import { domainBuilder } from '../domain-builder.js';
 
 function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
   const campaign = domainBuilder.buildCampaign({ name: 'diagnostique', code: 'ABCDIAG1' });
-
+  const module = new Module({
+    id: 7,
+    slug: 'slug',
+    title: 'title',
+    isBeta: true,
+    grains: [],
+    details: '',
+    version: '',
+  });
   quest =
     quest ??
     new Quest({
@@ -23,14 +32,25 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
             },
           },
         },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: module.id,
+              comparison: 'equal',
+            },
+          },
+        },
       ],
     });
 
   combinedCourse =
     combinedCourse ?? new CombinedCourse({ id: 1, code: 'COMBINIX1', organizationId: 1, name: 'Mon parcours' });
 
+  const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest);
-  combinedCourseDetails.generateItems(items ?? [campaign]);
+  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], hashedCombinedCourseUrl);
 
   return combinedCourseDetails;
 }

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -48,9 +48,9 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
   combinedCourse =
     combinedCourse ?? new CombinedCourse({ id: 1, code: 'COMBINIX1', organizationId: 1, name: 'Mon parcours' });
 
-  const hashedCombinedCourseUrl = 'hashedCombinedCourseUrl';
+  const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest);
-  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], hashedCombinedCourseUrl);
+  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], encryptedCombinedCourseUrl);
 
   return combinedCourseDetails;
 }

--- a/mon-pix/app/adapters/module.js
+++ b/mon-pix/app/adapters/module.js
@@ -5,9 +5,9 @@ export default class Module extends ApplicationAdapter {
     if (query.slug) {
       let url = `${this.host}/${this.namespace}/modules/${query.slug}`;
 
-      if (query.redirectionHash) {
-        const redirectionHash = encodeURIComponent(query.redirectionHash);
-        url += `?redirectionHash=${redirectionHash}`;
+      if (query.encryptedRedirectionUrl) {
+        const encryptedRedirectionUrl = encodeURIComponent(query.encryptedRedirectionUrl);
+        url += `?encryptedRedirectionUrl=${encryptedRedirectionUrl}`;
       }
 
       return this.ajax(url, 'GET');

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -1,4 +1,5 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 
 const Content = <template>
@@ -14,7 +15,7 @@ const Content = <template>
   {{#if @isLocked}}
     <Content @title={{@item.title}} @isLocked={{true}} />
   {{else}}
-    <LinkTo @route={{@item.route}} @model={{@item.reference}} disabled>
+    <LinkTo @route={{@item.route}} @model={{@item.reference}} @query={{hash redirection=@item.redirection}} disabled>
       <Content @title={{@item.title}} />
     </LinkTo>
   {{/if}}

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -4,6 +4,7 @@ export default class CombinedCourseItem extends Model {
   @attr('string') title;
   @attr('string') reference;
   @attr('string') type;
+  @attr('string') redirection;
 
   get route() {
     return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';

--- a/mon-pix/app/routes/module.js
+++ b/mon-pix/app/routes/module.js
@@ -5,6 +5,6 @@ export default class ModuleRoute extends Route {
   @service store;
 
   model(params) {
-    return this.store.queryRecord('module', { slug: params.slug, redirectionHash: params.redirection });
+    return this.store.queryRecord('module', { slug: params.slug, encryptedRedirectionUrl: params.redirection });
   }
 }

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -151,7 +151,7 @@ module('Integration | Component | combined course', function (hooks) {
         title: 'mon module',
         reference: 'mon-module',
         type: 'MODULE',
-        redirection: 'une+url',
+        redirection: 'une+url+chiffree',
       });
 
       const combinedCourse = store.createRecord('combined-course', {

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -151,6 +151,7 @@ module('Integration | Component | combined course', function (hooks) {
         title: 'mon module',
         reference: 'mon-module',
         type: 'MODULE',
+        redirection: 'une+url',
       });
 
       const combinedCourse = store.createRecord('combined-course', {
@@ -171,7 +172,17 @@ module('Integration | Component | combined course', function (hooks) {
       assert.ok(screen.getByText('mon module'));
       assert.strictEqual(
         screen.getByRole('link', { name: 'mon module' }).getAttribute('href'),
-        router.urlFor('module', { slug: combinedCourseItem.reference }),
+        router.urlFor(
+          'module',
+          {
+            slug: combinedCourseItem.reference,
+          },
+          {
+            queryParams: {
+              redirection: combinedCourseItem.redirection,
+            },
+          },
+        ),
       );
     });
   });

--- a/mon-pix/tests/unit/routes/module/module-test.js
+++ b/mon-pix/tests/unit/routes/module/module-test.js
@@ -21,7 +21,7 @@ module('Unit | Route | modules | module', function (hooks) {
     const module = Symbol('the-module');
 
     store.queryRecord = sinon.stub();
-    store.queryRecord.withArgs('module', { slug: 'the-module', redirectionHash: 'somehash' }).resolves(module);
+    store.queryRecord.withArgs('module', { slug: 'the-module', encryptedRedirectionUrl: 'somehash' }).resolves(module);
 
     // when
     const model = await route.model({ slug: 'the-module', redirection: 'somehash' });


### PR DESCRIPTION
## 🔆 Problème
Suite de la PR #13127.
Maintenant que dans la partie modulix il est possible de passer une url afin d'être redirigé en fin de module, il manque le mécanisme pour générer cet url et l'envoyer en queryParam sur les différentes pages du module

## ⛱️ Proposition
Generer l'url chiffrée lors du clic sur un item de type module au sein d'un parcours combiné, et passer cet url dans un queryParam "redirection" sur les pages du module afin de pouvoir le récuperer et d'être redirigé en fin de module

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter à PixApp avec `attestation-blank@example.net`
- Aller sur le parcours combiné `COMBINIX1`
- Commencer le parcours
- Cliquer sur le module disponible
- Aller au bout de celui-ci
- Cliquer sur le bouton "Continuer"
- Constater que l'on est bien redirigé vers la page d'accueil du parcours combiné
- 🐈‍⬛ 