### PR TITLE
[TECH] Isoler la gestion des URLs Pix dans l'API

### DIFF
--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -3,55 +3,66 @@ const FRENCH_FRANCE = 'fr-fr';
 const FRENCH_SPOKEN = 'fr';
 const DUTCH_SPOKEN = 'nl';
 const SPANISH_SPOKEN = 'es';
-
-const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
 const DEFAULT_CHALLENGE_LOCALE = 'fr-fr';
+const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
 
+const DEFAULT_LOCALE = 'fr';
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 const SUPPORTED_LANGUAGES = Array.from(new Set(SUPPORTED_LOCALES.map((locale) => new Intl.Locale(locale).language)));
 
-const DEFAULT_LOCALE = 'fr';
-
 /**
- * Returns all locales available in challenges of the Pix platform
+ * @returns {string[]} - all locales available in challenges of the Pix platform
  */
 function getChallengeLocales() {
   return CHALLENGE_LOCALES;
 }
 
+/**
+ * @returns {string} - the default locale for challenges
+ */
 function getDefaultChallengeLocale() {
   return DEFAULT_CHALLENGE_LOCALE;
 }
 
+/**
+ * @returns {string[]} - all supported locales by the Pix platform
+ */
 function getSupportedLocales() {
   return SUPPORTED_LOCALES;
 }
 
 /**
- * @deprecated use getSupportedLocales or getChallengeLocales instead whenever possible.
+ * @deprecated use getSupportedLocales or getChallengeLocales instead whenever possible
+ * @returns {string[]} - all supported languages by the Pix platform
  */
 function getSupportedLanguages() {
   return SUPPORTED_LANGUAGES;
 }
 
+/**
+ * @returns {string} - the default locale for the Pix platform
+ */
 function getDefaultLocale() {
   return DEFAULT_LOCALE;
 }
 
 /**
- * Returns the given language if the language is supported, otherwise returns the default locale.
  * @deprecated will soon be removed
+ * @returns {string} - the given language if the language is supported, otherwise returns the default locale
  */
 function coerceLanguage(language) {
   if (SUPPORTED_LANGUAGES.includes(language)) {
     return language;
   }
-
   return DEFAULT_LOCALE;
 }
 
+/**
+ * @returns {string} - the nearest supported locale by Pix platform according the given locale
+ */
 function getNearestSupportedLocale(locale) {
   if (!locale) return undefined;
   try {
@@ -70,17 +81,38 @@ function getNearestSupportedLocale(locale) {
   }
 }
 
+/**
+ * @returns {string} - the base locale (ex: 'fr', 'en'...) according the given locale (ex: 'fr-FR', 'en-GB')
+ */
+function getBaseLocale(locale) {
+  try {
+    return new Intl.Locale(locale).language;
+  } catch {
+    return new Intl.Locale(DEFAULT_LOCALE).language;
+  }
+}
+
+/**
+ * @returns {boolean} - returns true when locale from France (ex: fr-fr or fr-FR), otherwise false
+ */
+function isFranceLocale(locale) {
+  const supportedLocale = getNearestSupportedLocale(locale) || DEFAULT_LOCALE;
+  return supportedLocale === FRENCH_FRANCE_LOCALE;
+}
+
 export {
   coerceLanguage,
   DUTCH_SPOKEN,
   ENGLISH_SPOKEN,
   FRENCH_FRANCE,
   FRENCH_SPOKEN,
+  getBaseLocale,
   getChallengeLocales,
   getDefaultChallengeLocale,
   getDefaultLocale,
   getNearestSupportedLocale,
   getSupportedLanguages,
   getSupportedLocales,
+  isFranceLocale,
   SPANISH_SPOKEN,
 };

--- a/api/src/shared/domain/services/url-service.js
+++ b/api/src/shared/domain/services/url-service.js
@@ -1,0 +1,159 @@
+/**
+ * Build and manage all Pix application URLs according a locale.
+ */
+
+import { config } from '../../config.js';
+import { getBaseLocale, getDefaultLocale, getNearestSupportedLocale, isFranceLocale } from './locale-service.js';
+
+const PIX_WEBSITE_DOMAIN_FR = `${config.domain.pix}${config.domain.tldFr}`;
+const PIX_WEBSITE_DOMAIN_ORG = `${config.domain.pix}${config.domain.tldOrg}`;
+
+// Pix website URLs for each supported locales
+export const PIX_WEBSITE_ROOT_URLS = {
+  'fr-FR': PIX_WEBSITE_DOMAIN_FR,
+  'fr-BE': `${PIX_WEBSITE_DOMAIN_ORG}/fr-be`,
+  'nl-BE': `${PIX_WEBSITE_DOMAIN_ORG}/nl-be`,
+  nl: `${PIX_WEBSITE_DOMAIN_ORG}/nl-be`,
+  en: `${PIX_WEBSITE_DOMAIN_ORG}/en`,
+  es: `${PIX_WEBSITE_DOMAIN_ORG}/en`,
+  fr: `${PIX_WEBSITE_DOMAIN_ORG}/fr`,
+};
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @returns {string} - Pix Website URL according the locale
+ */
+export function getPixWebsiteUrl(locale) {
+  const supportedLocale = getNearestSupportedLocale(locale) || getDefaultLocale();
+  return PIX_WEBSITE_ROOT_URLS[supportedLocale];
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @returns {string} - Pix Website domain according the locale
+ */
+export function getPixWebsiteDomain(locale) {
+  const websiteUrl = getPixWebsiteUrl(locale);
+  const { hostname } = new URL(websiteUrl);
+
+  return hostname;
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @param {Object} options - options for building the URL
+ * @param {string} [options.pathname] - optional pathname to append to the URL
+ * @param {Object} [options.queryParams] - optional query parameters to append to the URL
+ * @param {string} [options.hash] - optional hash to append to the URL
+ * @returns {string} - Pix App URL according the locale
+ */
+export function getPixAppUrl(locale, { pathname, queryParams, hash } = {}) {
+  const rootUrl = isFranceLocale(locale)
+    ? `${config.domain.pixApp}${config.domain.tldFr}`
+    : `${config.domain.pixApp}${config.domain.tldOrg}`;
+
+  return _buildUrlWithLocale({ rootUrl, locale, pathname, queryParams, hash });
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @param {Object} options - options for building the URL
+ * @param {string} [options.pathname] - optional pathname to append to the URL
+ * @param {Object} [options.queryParams] - optional query parameters to append to the URL
+ * @param {string} [options.hash] - optional hash to append to the URL
+ * @returns {string} - Pix Orga URL according the locale
+ */
+export function getPixOrgaUrl(locale, { pathname, queryParams, hash } = {}) {
+  const rootUrl = isFranceLocale(locale)
+    ? `${config.domain.pixOrga}${config.domain.tldFr}`
+    : `${config.domain.pixOrga}${config.domain.tldOrg}`;
+
+  return _buildUrlWithLocale({ rootUrl, locale, pathname, queryParams, hash });
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @param {Object} options - options for building the URL
+ * @param {string} [options.pathname] - optional pathname to append to the URL
+ * @param {Object} [options.queryParams] - optional query parameters to append to the URL
+ * @param {string} [options.hash] - optional hash to append to the URL
+ * @returns {string} - Pix Certif URL according the locale
+ */
+export function getPixCertifUrl(locale, { pathname, queryParams, hash } = {}) {
+  const rootUrl = isFranceLocale(locale)
+    ? `${config.domain.pixCertif}${config.domain.tldFr}`
+    : `${config.domain.pixCertif}${config.domain.tldOrg}`;
+
+  return _buildUrlWithLocale({ rootUrl, locale, pathname, queryParams, hash });
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @returns {string} - Pix App URL according the locale
+ */
+export function getPixAppConnexionUrl(locale) {
+  return getPixAppUrl(locale, { pathname: '/connexion' });
+}
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @param {string} redirectUrl - URL to redirect the user to after email validation
+ * @param {string} token - Token used for email validation
+ * @returns {string} - generated URL to validate user account email
+ */
+export function getEmailValidationUrl({ locale, redirectUrl, token } = {}) {
+  if (!token) return redirectUrl;
+
+  const queryParams = { token };
+  if (redirectUrl) queryParams['redirect_url'] = redirectUrl;
+
+  return getPixAppUrl(locale, { pathname: '/api/users/validate-email', queryParams });
+}
+
+// Pix website paths for each supported locales
+export const PIX_WEBSITE_PATHS = {
+  SUPPORT: {
+    'fr-FR': 'support',
+    'fr-BE': 'support',
+    'nl-BE': 'support',
+    nl: 'support',
+    en: 'support',
+    es: 'support',
+    fr: 'support',
+  },
+};
+
+/**
+ * @param {string} locale - user locale or a challenge locale
+ * @returns {string} - Pix Support URL according the locale
+ */
+export function getSupportUrl(locale) {
+  const supportedLocale = getNearestSupportedLocale(locale) || getDefaultLocale();
+  const websiteRootUrl = getPixWebsiteUrl(supportedLocale);
+  return `${websiteRootUrl}/${PIX_WEBSITE_PATHS.SUPPORT[supportedLocale]}`;
+}
+
+function _buildUrlWithLocale({ rootUrl, pathname, queryParams, locale, hash } = {}) {
+  const url = new URL(rootUrl);
+
+  if (pathname) {
+    url.pathname = pathname;
+  }
+
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  if (hash) {
+    url.hash = hash;
+  }
+
+  if (!isFranceLocale(locale) && !queryParams?.lang) {
+    const supportedLocale = getNearestSupportedLocale(locale) || getDefaultLocale();
+    url.searchParams.set('lang', getBaseLocale(supportedLocale));
+  }
+
+  return url.toString();
+}

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -10,10 +10,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
   const userId = 123;
   const userEmail = 'test@example.net';
   const password = 'Password123';
-  const localeFromHeader = 'fr-FR';
+  const locale = 'fr-FR';
   const user = new User({ email: userEmail });
   const hashedPassword = 'ABCDEF1234';
-  const savedUser = new User({ id: userId, email: userEmail, locale: localeFromHeader });
+  const savedUser = new User({ id: userId, email: userEmail, locale });
 
   let campaignCode;
   let authenticationMethodRepository;
@@ -71,7 +71,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // when
       await createUser({
         user,
-        localeFromHeader,
+        locale,
         password,
         campaignCode,
         authenticationMethodRepository,
@@ -94,7 +94,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // when
       await createUser({
         user,
-        localeFromHeader,
+        locale,
         password,
         campaignCode,
         authenticationMethodRepository,
@@ -117,7 +117,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // when
       await createUser({
         user,
-        localeFromHeader,
+        locale,
         password,
         campaignCode,
         authenticationMethodRepository,
@@ -154,7 +154,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         const error = await catchErr(createUser)({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -196,7 +196,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         const error = await catchErr(createUser)({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -240,7 +240,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         const error = await catchErr(createUser)({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -272,7 +272,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         await createUser({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -303,7 +303,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         await createUser({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -332,7 +332,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // when
       await createUser({
         user,
-        localeFromHeader,
+        locale,
         password,
         campaignCode,
         authenticationMethodRepository,
@@ -357,7 +357,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         await createUser({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -383,7 +383,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         const error = await catchErr(createUser)({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -404,7 +404,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         await createUser({
           user,
-          localeFromHeader,
+          locale,
           password,
           campaignCode,
           authenticationMethodRepository,
@@ -431,7 +431,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
     });
 
     context('step send account creation email to user', function () {
-      const user = new User({ email: userEmail, locale: localeFromHeader });
+      const user = new User({ email: userEmail, locale });
       let redirectionUrl;
 
       beforeEach(function () {
@@ -444,7 +444,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         const expectedEmail = createAccountCreationEmail({
           email: userEmail,
           firstName: user.firstName,
-          locale: localeFromHeader,
+          locale,
           token,
           redirectionUrl,
         });
@@ -452,7 +452,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // when
         await createUser({
           user,
-          localeFromHeader,
+          locale,
           password,
           redirectionUrl,
           authenticationMethodRepository,
@@ -478,7 +478,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           const expectedEmail = createAccountCreationEmail({
             email: userEmail,
             firstName: user.firstName,
-            locale: localeFromHeader,
+            locale,
             token,
             redirectionUrl: null,
           });
@@ -486,7 +486,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           // when
           await createUser({
             user,
-            localeFromHeader,
+            locale,
             password,
             campaignCode,
             authenticationMethodRepository,
@@ -515,7 +515,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           const expectedEmail = createAccountCreationEmail({
             email: userEmail,
             firstName: user.firstName,
-            locale: localeFromHeader,
+            locale,
             token,
             redirectionUrl: null,
           });
@@ -523,7 +523,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           // when
           await createUser({
             user,
-            localeFromHeader,
+            locale,
             password,
             campaignCode,
             authenticationMethodRepository,
@@ -553,7 +553,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       const expectedEmail = createAccountCreationEmail({
         email: userEmail,
         firstName: user.firstName,
-        locale: localeFromHeader,
+        locale,
         token,
         redirectionUrl,
       });
@@ -561,7 +561,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // when
       const createdUser = await createUser({
         user,
-        localeFromHeader,
+        locale,
         password,
         redirectionUrl,
         authenticationMethodRepository,

--- a/api/tests/shared/unit/domain/services/locale-service.test.js
+++ b/api/tests/shared/unit/domain/services/locale-service.test.js
@@ -78,4 +78,62 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       });
     });
   });
+
+  describe('getBaseLocale', function () {
+    context('when locale is valid', function () {
+      [
+        { locale: 'fr-fr', expectedBaseLocale: 'fr' },
+        { locale: 'fr-FR', expectedBaseLocale: 'fr' },
+        { locale: 'en', expectedBaseLocale: 'en' },
+        { locale: 'en-GB', expectedBaseLocale: 'en' },
+      ].forEach(({ locale, expectedBaseLocale }) => {
+        it(`returns the corresponding base locale ${expectedBaseLocale} for ${locale}`, function () {
+          // given / when
+          const baseLocale = localeService.getBaseLocale(locale);
+
+          // then
+          expect(baseLocale).to.equal(expectedBaseLocale);
+        });
+      });
+    });
+
+    context('when locale is invalid', function () {
+      ['fr_FR', 'yo-yo-yo', null].forEach((invalidLocale) => {
+        it(`returns the default base locale for ${invalidLocale}`, function () {
+          // given / when
+          const baseLocale = localeService.getBaseLocale(invalidLocale);
+
+          // then
+          const defaultBaseLocale = new Intl.Locale(localeService.getDefaultLocale()).language;
+          expect(baseLocale).to.equal(defaultBaseLocale);
+        });
+      });
+    });
+  });
+
+  describe('isFranceLocale', function () {
+    context('when locale from France', function () {
+      ['fr-fr', 'fr-FR'].forEach((franceLocale) => {
+        it(`returns true for ${franceLocale}`, function () {
+          // given / when
+          const isFranceLocale = localeService.isFranceLocale(franceLocale);
+
+          // then
+          expect(isFranceLocale).to.be.true;
+        });
+      });
+    });
+
+    context('when locale is not from France', function () {
+      ['fr', 'en', 'en-GB', null].forEach((franceLocale) => {
+        it(`returns true for ${franceLocale}`, function () {
+          // given / when
+          const isFranceLocale = localeService.isFranceLocale(franceLocale);
+
+          // then
+          expect(isFranceLocale).to.be.false;
+        });
+      });
+    });
+  });
 });

--- a/api/tests/shared/unit/domain/services/url-service.test.js
+++ b/api/tests/shared/unit/domain/services/url-service.test.js
@@ -1,0 +1,445 @@
+import { getSupportedLocales } from '../../../../../src/shared/domain/services/locale-service.js';
+import {
+  getEmailValidationUrl,
+  getPixAppConnexionUrl,
+  getPixAppUrl,
+  getPixCertifUrl,
+  getPixOrgaUrl,
+  getPixWebsiteDomain,
+  getPixWebsiteUrl,
+  getSupportUrl,
+  PIX_WEBSITE_PATHS,
+  PIX_WEBSITE_ROOT_URLS,
+} from '../../../../../src/shared/domain/services/url-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Domain | Services | url-service', function () {
+  describe('getPixWebsiteUrl', function () {
+    context('all supported locales must have a Pix Website localized URL', function () {
+      getSupportedLocales().forEach((locale) => {
+        it(`returns the Pix Website localized URL for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixWebsiteUrl(locale);
+
+          // then
+          expect(url).to.equal(PIX_WEBSITE_ROOT_URLS[locale]);
+        });
+      });
+    });
+
+    context('when locale is not supported or not canonical', function () {
+      [
+        { locale: 'fr-fr', expected: 'https://pix.fr' },
+        { locale: 'nl-NL', expected: 'https://pix.org/nl-be' },
+        { locale: 'tlh', expected: 'https://pix.org/fr' },
+      ].forEach(({ locale, expected }) => {
+        it(`returns the best Pix Website localized URL for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixWebsiteUrl(locale);
+
+          // then
+          expect(url).to.equal(expected);
+        });
+      });
+    });
+  });
+
+  describe('getPixWebsiteDomain', function () {
+    it('returns the Pix Website domain according to the locale', function () {
+      // given
+      const locale = 'fr-FR';
+
+      // when
+      const domain = getPixWebsiteDomain(locale);
+
+      // then
+      expect(domain).to.equal('pix.fr');
+    });
+  });
+
+  describe('getPixAppUrl', function () {
+    context('when locale is fr-FR or fr-fr', function () {
+      ['fr-fr', 'fr-FR'].forEach((locale) => {
+        it(`returns the Pix App URL with France domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixAppUrl(locale);
+
+          // then
+          expect(url).to.equal('https://test.app.pix.fr/');
+        });
+      });
+    });
+
+    context('when locale is not fr-FR and supported or not', function () {
+      [
+        { locale: 'fr', expected: 'https://test.app.pix.org/?lang=fr' },
+        { locale: 'en', expected: 'https://test.app.pix.org/?lang=en' },
+        { locale: 'fr-BE', expected: 'https://test.app.pix.org/?lang=fr' },
+        { locale: 'tlh', expected: 'https://test.app.pix.org/?lang=fr' },
+        { locale: 'fr-CA', expected: 'https://test.app.pix.org/?lang=fr' },
+        { locale: 'fr_CA', expected: 'https://test.app.pix.org/?lang=fr' },
+        { locale: null, expected: 'https://test.app.pix.org/?lang=fr' },
+      ].forEach(({ locale, expected }) => {
+        it(`returns the Pix App URL with Org domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixAppUrl(locale);
+
+          // then
+          expect(url).to.equal(expected);
+        });
+      });
+    });
+
+    context('when pathname is provided', function () {
+      it('appends the pathname to the Pix App URL', function () {
+        // given
+        const locale = 'en';
+        const pathname = '/connexion';
+
+        // when
+        const url = getPixAppUrl(locale, { pathname });
+
+        // then
+        expect(url).to.equal('https://test.app.pix.org/connexion?lang=en');
+      });
+    });
+
+    context('when queryParams are provided', function () {
+      it('appends the query parameters to the Pix App URL', function () {
+        // given
+        const locale = 'en';
+        const queryParams = { code: '123+' };
+
+        // when
+        const url = getPixAppUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://test.app.pix.org/?code=123%2B&lang=en');
+      });
+
+      it('overrides the lang parameter if it is provided in queryParams', function () {
+        // given
+        const locale = 'fr';
+        const queryParams = { lang: 'en' };
+
+        // when
+        const url = getPixAppUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://test.app.pix.org/?lang=en');
+      });
+    });
+
+    context('when hash is provided', function () {
+      it('appends the hash to the Pix App URL', function () {
+        // given
+        const locale = 'en';
+        const hash = '#section';
+
+        // when
+        const url = getPixAppUrl(locale, { hash });
+
+        // then
+        expect(url).to.equal('https://test.app.pix.org/?lang=en#section');
+      });
+    });
+  });
+
+  describe('getPixOrgaUrl', function () {
+    context('when locale is fr-FR or fr-fr', function () {
+      ['fr-fr', 'fr-FR'].forEach((locale) => {
+        it(`returns the Pix Orga URL with France domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixOrgaUrl(locale);
+
+          // then
+          expect(url).to.equal('https://orga.pix.fr/');
+        });
+      });
+    });
+
+    context('when locale is not fr-FR and supported or not', function () {
+      [
+        { locale: 'fr', expected: 'https://orga.pix.org/?lang=fr' },
+        { locale: 'en', expected: 'https://orga.pix.org/?lang=en' },
+        { locale: 'fr-BE', expected: 'https://orga.pix.org/?lang=fr' },
+        { locale: 'tlh', expected: 'https://orga.pix.org/?lang=fr' },
+        { locale: 'fr-CA', expected: 'https://orga.pix.org/?lang=fr' },
+        { locale: 'fr_CA', expected: 'https://orga.pix.org/?lang=fr' },
+        { locale: null, expected: 'https://orga.pix.org/?lang=fr' },
+      ].forEach(({ locale, expected }) => {
+        it(`returns the Pix Orga URL with Org domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixOrgaUrl(locale);
+
+          // then
+          expect(url).to.equal(expected);
+        });
+      });
+    });
+
+    context('when pathname is provided', function () {
+      it('appends the pathname to the Pix Orga URL', function () {
+        // given
+        const locale = 'en';
+        const pathname = '/connexion';
+
+        // when
+        const url = getPixOrgaUrl(locale, { pathname });
+
+        // then
+        expect(url).to.equal('https://orga.pix.org/connexion?lang=en');
+      });
+    });
+
+    context('when queryParams are provided', function () {
+      it('appends the query parameters to the Pix Orga URL', function () {
+        // given
+        const locale = 'en';
+        const queryParams = { code: '123+' };
+
+        // when
+        const url = getPixOrgaUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://orga.pix.org/?code=123%2B&lang=en');
+      });
+
+      it('overrides the lang parameter if it is provided in queryParams', function () {
+        // given
+        const locale = 'fr';
+        const queryParams = { lang: 'en' };
+
+        // when
+        const url = getPixOrgaUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://orga.pix.org/?lang=en');
+      });
+    });
+
+    context('when hash is provided', function () {
+      it('appends the hash to the Pix Orga URL', function () {
+        // given
+        const locale = 'en';
+        const hash = '#section';
+
+        // when
+        const url = getPixOrgaUrl(locale, { hash });
+
+        // then
+        expect(url).to.equal('https://orga.pix.org/?lang=en#section');
+      });
+    });
+  });
+
+  describe('getPixCertifUrl', function () {
+    context('when locale is fr-FR or fr-fr', function () {
+      ['fr-fr', 'fr-FR'].forEach((locale) => {
+        it(`returns the Pix Certif URL with France domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixCertifUrl(locale);
+
+          // then
+          expect(url).to.equal('https://certif.pix.fr/');
+        });
+      });
+    });
+
+    context('when locale is not fr-FR and supported or not', function () {
+      [
+        { locale: 'fr', expected: 'https://certif.pix.org/?lang=fr' },
+        { locale: 'en', expected: 'https://certif.pix.org/?lang=en' },
+        { locale: 'fr-BE', expected: 'https://certif.pix.org/?lang=fr' },
+        { locale: 'tlh', expected: 'https://certif.pix.org/?lang=fr' },
+        { locale: 'fr-CA', expected: 'https://certif.pix.org/?lang=fr' },
+        { locale: 'fr_CA', expected: 'https://certif.pix.org/?lang=fr' },
+        { locale: null, expected: 'https://certif.pix.org/?lang=fr' },
+      ].forEach(({ locale, expected }) => {
+        it(`returns the Pix Certif URL with Org domain for locale "${locale}"`, function () {
+          // given / when
+          const url = getPixCertifUrl(locale);
+
+          // then
+          expect(url).to.equal(expected);
+        });
+      });
+    });
+
+    context('when pathname is provided', function () {
+      it('appends the pathname to the Pix Certif URL', function () {
+        // given
+        const locale = 'en';
+        const pathname = '/connexion';
+
+        // when
+        const url = getPixCertifUrl(locale, { pathname });
+
+        // then
+        expect(url).to.equal('https://certif.pix.org/connexion?lang=en');
+      });
+    });
+
+    context('when queryParams are provided', function () {
+      it('appends the query parameters to the Pix Certif URL', function () {
+        // given
+        const locale = 'en';
+        const queryParams = { code: '123+' };
+
+        // when
+        const url = getPixCertifUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://certif.pix.org/?code=123%2B&lang=en');
+      });
+
+      it('overrides the lang parameter if it is provided in queryParams', function () {
+        // given
+        const locale = 'fr';
+        const queryParams = { lang: 'en' };
+
+        // when
+        const url = getPixCertifUrl(locale, { queryParams });
+
+        // then
+        expect(url).to.equal('https://certif.pix.org/?lang=en');
+      });
+    });
+
+    context('when hash is provided', function () {
+      it('appends the hash to the Pix Certif URL', function () {
+        // given
+        const locale = 'en';
+        const hash = '#section';
+
+        // when
+        const url = getPixCertifUrl(locale, { hash });
+
+        // then
+        expect(url).to.equal('https://certif.pix.org/?lang=en#section');
+      });
+    });
+  });
+
+  describe('getEmailValidationUrl', function () {
+    context('when locale is fr-FR', function () {
+      it('returns the email validation URL on France domain with redirect url', function () {
+        // given
+        const locale = 'fr-FR';
+        const redirectUrl = 'https://test.app.pix.fr/redirect-here';
+
+        // when
+        const url = getEmailValidationUrl({ locale, token: 'ABC', redirectUrl });
+
+        // then
+        expect(url).to.equal(
+          `https://test.app.pix.fr/api/users/validate-email?token=ABC&redirect_url=${encodeURIComponent(redirectUrl)}`,
+        );
+      });
+    });
+
+    context('when locale is not fr-FR', function () {
+      it('returns the email validation URL on Org domain with redirect url', function () {
+        // given
+        const locale = 'en';
+        const redirectUrl = 'https://test.app.pix.fr/redirect-here';
+
+        // when
+        const url = getEmailValidationUrl({ locale, token: 'ABC', redirectUrl });
+
+        // then
+        expect(url).to.equal(
+          `https://test.app.pix.org/api/users/validate-email?token=ABC&redirect_url=${encodeURIComponent(redirectUrl)}&lang=en`,
+        );
+      });
+    });
+
+    context('when no validation token', function () {
+      it('returns the redirect URL', function () {
+        // given
+        const redirectUrl = 'https://test.app.pix.fr/redirect-here';
+
+        // given / when
+        const url = getEmailValidationUrl({ locale: 'fr', redirectUrl });
+
+        // then
+        expect(url).to.equal(redirectUrl);
+      });
+    });
+
+    context('when no redirect uri', function () {
+      it('returns the email validation URL without redirect', function () {
+        // given / when
+        const url = getEmailValidationUrl({ locale: 'fr', token: 'ABC' });
+
+        // then
+        expect(url).to.equal('https://test.app.pix.org/api/users/validate-email?token=ABC&lang=fr');
+      });
+    });
+  });
+
+  describe('getPixAppConnexionUrl', function () {
+    context('when locale is fr-FR or fr-fr', function () {
+      ['fr-fr', 'fr-FR'].forEach((locale) => {
+        it(`returns the Pix App connexion URL for locale "${locale}" without lang parameter`, function () {
+          // given / when
+          const url = getPixAppConnexionUrl(locale);
+
+          // then
+          expect(url).to.equal('https://test.app.pix.fr/connexion');
+        });
+      });
+
+      context('when locale is not fr-FR and supported or not', function () {
+        [
+          { locale: 'fr', nearestBaseLocale: 'fr' },
+          { locale: 'en', nearestBaseLocale: 'en' },
+          { locale: 'nl-BE', nearestBaseLocale: 'nl' },
+          { locale: 'fr-BE', nearestBaseLocale: 'fr' },
+          { locale: 'tlh', nearestBaseLocale: 'fr' },
+          { locale: 'fr-CA', nearestBaseLocale: 'fr' },
+          { locale: 'fr_CA', nearestBaseLocale: 'fr' },
+          { locale: null, nearestBaseLocale: 'fr' },
+        ].forEach(({ locale, nearestBaseLocale }) => {
+          it(`returns the Pix App connexion URL for locale "${locale}" with nearest base locale in lang parameter`, function () {
+            // given / when
+            const url = getPixAppConnexionUrl(locale);
+
+            // then
+            expect(url).to.equal(`https://test.app.pix.org/connexion?lang=${nearestBaseLocale}`);
+          });
+        });
+      });
+    });
+  });
+
+  describe('getSupportUrl', function () {
+    context('all supported locales must have a Pix Support localized URL', function () {
+      getSupportedLocales().forEach((locale) => {
+        it(`returns the Pix Support localized URL for locale "${locale}"`, function () {
+          // given / when
+          const url = getSupportUrl(locale);
+
+          // then
+          expect(url).to.equal(`${PIX_WEBSITE_ROOT_URLS[locale]}/${PIX_WEBSITE_PATHS.SUPPORT[locale]}`);
+        });
+      });
+    });
+
+    context('when locale is not supported or not canonical', function () {
+      [
+        { locale: 'fr-fr', expected: 'https://pix.fr/support' },
+        { locale: 'nl-NL', expected: 'https://pix.org/nl-be/support' },
+        { locale: 'tlh', expected: 'https://pix.org/fr/support' },
+      ].forEach(({ locale, expected }) => {
+        it(`returns the best Pix Support localized URL for locale "${locale}"`, function () {
+          // given / when
+          const url = getSupportUrl(locale);
+
+          // then
+          expect(url).to.equal(expected);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

La gestion des URLs Pix (PixSite, PixApp, PixOrga...) est dépendante des locales et actuellement gérée différemment dans toute la base de code l'API. Il y a plusieurs endroits où la génération des URLs est incorrect par rapport à la locale utilisateur ou du challenge.

## ⛱️ Proposition

- Créer un service unique gestion des URLs Pix dans le contexte partagé.
- Le fonctionnement doit être iso à l’actuel avec les locales actuelles (celles des challenges)
- Le fonctionnement doit être utilisable avec les locale canonique supportée dans la plateforme Pix

## 🌊 Remarques

Cette PR a été réaliser en amont de la PR https://github.com/1024pix/pix/pull/13165

