### PR TITLE
[FEATURE] Aligner le bouton "Passer l'activité" à gauche (PIX-19103)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -1,7 +1,6 @@
 @use '../passage';
 @use 'pix-design-tokens/typography';
 
-
 $grain-card-border-radius: var(--pix-spacing-4x);
 
 .grain {
@@ -64,11 +63,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     padding: var(--pix-spacing-2x) 0;
     border-top: 0 solid var(--pix-neutral-100);
     border-radius: 0 0 $grain-card-border-radius $grain-card-border-radius;
-
-    &__with-skip-button {
-      display: flex;
-      justify-content: flex-end;
-    }
   }
 
   &--summary {
@@ -89,7 +83,7 @@ $grain-card-border-radius: var(--pix-spacing-4x);
 }
 
 .grain-card-icon {
- margin-right: var(--pix-spacing-1x);
+  margin-right: var(--pix-spacing-1x);
 }
 
 .grain-card-title {

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -293,7 +293,7 @@ export default class ModuleGrain extends Component {
         </div>
 
         {{#if this.shouldDisplaySkipButton}}
-          <footer class="grain-card__footer grain-card__footer__with-skip-button">
+          <footer class="grain-card__footer">
             <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
               {{this.skipButtonLabel}}
             </PixButton>


### PR DESCRIPTION
## 🔆 Problème

Le bouton "Passer" est sensé être aligné à gauche mais il ne l'est pas.

## ⛱️ Proposition

Aligner le bouton à gauche.

## 🌊 Remarques

RAS

## 🏄 Pour tester

https://app-pr13163.review.pix.fr/modules/bac-a-sable/passage
