### PR TITLE
[BUGFIX] Renommer le bouton "commencer" affiché au début d'une épreuve timée (PIX-19105)

### DIFF
--- a/mon-pix/tests/acceptance/challenge-item-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-test.js
@@ -686,7 +686,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
           .exists();
 
         // when
-        await click(screen.getByRole('button', { name: `Commencer l'épreuve` }));
+        await click(screen.getByRole('button', { name: `Commencer` }));
 
         // then
         assert.dom(screen.getByRole('heading', { name: 'Mode Focus', level: 3 })).exists();

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2083,7 +2083,7 @@
       "title": "Terms and conditions of use"
     },
     "timed-challenge-instructions": {
-      "action": "Start the challenge",
+      "action": "Start",
       "primary": "You have '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' to complete the next question.",
       "secondary": "You can continue answering after this, but the question will not be marked as correct.",
       "time": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2069,7 +2069,7 @@
       "title": "Condiciones de uso"
     },
     "timed-challenge-instructions": {
-      "action": "Empezar la prueba",
+      "action": "Empezar",
       "primary": "Dispondrás de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' para superar la siguiente pregunta.",
       "secondary": "Podrás seguir respondiendo después, pero la pregunta no se considerará acertada.",
       "time": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2083,7 +2083,7 @@
       "title": "Conditions d'utilisation"
     },
     "timed-challenge-instructions": {
-      "action": "Commencer l'épreuve",
+      "action": "Commencer",
       "primary": "Vous disposerez de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' pour réussir la question suivante.",
       "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie.",
       "time": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2073,7 +2073,7 @@
       "title": "Gebruiksvoorwaarden"
     },
     "timed-challenge-instructions": {
-      "action": "De test beginnen",
+      "action": "Beginnen",
       "primary": "Je hebt '<span class=\"timed-challenge-instructies__time\">'{time}'</span>' om de volgende vraag te beantwoorden.",
       "secondary": "Als je doorgaat wordt de opdracht niet als voltooid beschouwd.",
       "time": {


### PR DESCRIPTION
## 🔆 Problème

Dans l'écran qui précède une épreuve chronométrée, le bouton indique "Commencer l'épreuve" (capture ci-dessous). Le texte qui précède parle simplement d'une "question". Les termes ne sont donc pas harmonisés. 

## ⛱️ Proposition

Renommer le bouton en "commencer"

## 🌊 Remarques

--

## 🏄 Pour tester

Afficher une épreuve timée et vérifier qu'il y a bien uniquement mentionné "commencer" dans les 4 langues
