### PR TITLE
[BUGFIX] Corriger la restriction du dépassement de place lors du changement d'organisation (PIX-18991).

### DIFF
--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -33,5 +33,6 @@ export default class AuthenticatedRoute extends Route {
   @action
   refreshAuthenticatedModel() {
     this.refresh();
+    this.store.unloadAll('organization-place-statistic');
   }
 }

--- a/orga/tests/unit/routes/authenticated-test.js
+++ b/orga/tests/unit/routes/authenticated-test.js
@@ -136,6 +136,7 @@ module('Unit | Route | authenticated', function (hooks) {
     test('should call refresh', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated');
+      const unloadAllStub = sinon.stub(route.store, 'unloadAll');
       route.refresh = sinon.stub();
 
       // when
@@ -143,6 +144,7 @@ module('Unit | Route | authenticated', function (hooks) {
 
       // then
       assert.ok(route.refresh.called);
+      assert.ok(unloadAllStub.calledWithExactly('organization-place-statistic'));
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Au changement d'organisation, si nous étions sur une organisation ayant dépasser son quotat de place, l'utilisateur ne pouvais pas consulter les resultats de campagne de la nouvelle organisation à moins de recharger la page.

## ⛱️ Proposition

Nettoyer le store appartenant à l'ancienne organisation afin de ne pas bloquer inutilement les autres organisations.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Supprimer des lots de place dans PixAdmin et activer le blocage sur l'organisation Pro Classic
aller sur PixOrga
Se mettre sur Pro Classic et constater la présence du bandeau.
Changer d'orga et constater la disparition dudit bandeau ainsi que l'accès à toutes les fonctionalités de PixOrga