### PR TITLE
[FEATURE] Permettre de prévisualiser un module existant (PIX-19112)

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -92,6 +92,10 @@ export default class ModulixPreview extends Component {
   }
 
   get formattedModule() {
+    if (this.args.module) {
+      return this.args.module;
+    }
+
     if (!this.module || this.module === '') {
       return { grains: [] };
     }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -104,6 +104,7 @@ Router.map(function () {
   });
   this.route('combined-courses', { path: '/parcours/:code' });
 
+  this.route('module-preview-existing', { path: '/modules/preview/:slug' });
   this.route('module-preview', { path: '/modules/preview' });
   this.route('module', { path: '/modules/:slug' }, function () {
     this.route('details');

--- a/mon-pix/app/routes/module-preview-existing.js
+++ b/mon-pix/app/routes/module-preview-existing.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModulePreviewExistingRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const queryRecord = await this.store.queryRecord('module', { slug: params.slug });
+    return queryRecord;
+  }
+}

--- a/mon-pix/app/services/passage-events.js
+++ b/mon-pix/app/services/passage-events.js
@@ -4,6 +4,7 @@ import ENV from 'mon-pix/config/environment';
 export default class PassageEvents extends Service {
   @service store;
   @service requestManager;
+  @service modulixPreviewMode;
 
   passageId = null;
   sequenceNumber = 1;
@@ -16,6 +17,10 @@ export default class PassageEvents extends Service {
   async record({ type, data }) {
     this.sequenceNumber++;
 
+    if (this.modulixPreviewMode.isEnabled) {
+      return;
+    }
+
     const events = [
       {
         type,
@@ -25,6 +30,7 @@ export default class PassageEvents extends Service {
         ...data,
       },
     ];
+
     return this.requestManager.request({
       url: `${ENV.APP.API_HOST}/api/passage-events`,
       method: 'POST',

--- a/mon-pix/app/templates/module-preview-existing.gjs
+++ b/mon-pix/app/templates/module-preview-existing.gjs
@@ -1,0 +1,2 @@
+import Preview from 'mon-pix/components/module/preview';
+<template><Preview @module={{@model}} /></template>

--- a/mon-pix/tests/acceptance/module/preview-existing-module_test.js
+++ b/mon-pix/tests/acceptance/module/preview-existing-module_test.js
@@ -1,0 +1,32 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Module | Routes | Preview Existing Module', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test('should allow to preview existing module', async function (assert) {
+    // given
+    server.create('module', {
+      id: 'existing-module',
+      slug: 'existing-module',
+      title: 'Existing Module',
+      isBeta: true,
+      grains: [],
+      details: {},
+    });
+
+    // when
+    const screen = await visit('/modules/preview/existing-module');
+
+    // then
+    assert.strictEqual(currentURL(), '/modules/preview/existing-module');
+    assert.dom(screen.getByRole('heading', { name: 'Existing Module' })).exists();
+  });
+});

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -41,4 +41,15 @@ module('Integration | Component | Module | Preview', function (hooks) {
     // then
     assert.dom(screen.queryByRole('textbox', { name: 'Contenu du Module' })).exists();
   });
+
+  module('when previewing an existing module passed as argument', function () {
+    test('should display the module title', async function (assert) {
+      // given
+      const moduleData = { title: 'Existing module' };
+      const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Existing module' })).exists();
+    });
+  });
 });

--- a/mon-pix/tests/unit/services/passage-events-test.js
+++ b/mon-pix/tests/unit/services/passage-events-test.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -50,6 +51,11 @@ module('Unit | Services | PassageEvents', function (hooks) {
       const requestStub = sinon.stub(requestManager, 'request');
       passageEventService.initialize({ passageId: 1 });
 
+      class PreviewModeServiceStub extends Service {
+        isEnabled = false;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
       // when
       await passageEventService.record({
         type: 'FlashcardsStartedEvent',
@@ -87,6 +93,11 @@ module('Unit | Services | PassageEvents', function (hooks) {
       const requestManager = this.owner.lookup('service:request-manager');
       const requestStub = sinon.stub(requestManager, 'request');
       passageEventService.initialize({ passageId: 1 });
+
+      class PreviewModeServiceStub extends Service {
+        isEnabled = false;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
       // when
       await passageEventService.record({
@@ -142,6 +153,34 @@ module('Unit | Services | PassageEvents', function (hooks) {
         }),
       });
       assert.ok(true);
+    });
+
+    module('when preview mode is enabled', function () {
+      test('should not record a passageEvent', async function (assert) {
+        // given
+        const passageEventService = this.owner.lookup('service:passageEvents');
+        const requestManager = this.owner.lookup('service:request-manager');
+        const requestStub = sinon.stub(requestManager, 'request');
+        passageEventService.initialize({ passageId: 1 });
+
+        class PreviewModeServiceStub extends Service {
+          isEnabled = true;
+        }
+        this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+        // when
+        await passageEventService.record({
+          type: 'FlashcardsRectoSeenEvent',
+          passageId: 1,
+          data: {
+            elementId: '04287d5b-285e-4a67-9fb1-3adbf95deb2f',
+          },
+        });
+
+        // then
+        sinon.assert.notCalled(requestStub);
+        assert.ok(true);
+      });
     });
   });
 });


### PR DESCRIPTION
## 🍦 Contexte

Aujourd’hui, l'équipe Contenu Modulix utilise principalement Google Docs pour collaborer sur la création d’un module, notamment pour faire de la revue et échanger des commentaires. Mais il serait beaucoup plus pratique de pouvoir le faire directement sur les modules dans leur navigateur.

## 🔆 Problème

L’extension de navigateur [Hypothes.is](https://web.hypothes.is/) permet de faire des commentaires sur n’importe quel page web et a des fonctionnalités intéressantes comme la restriction de la visibilité des commentaires à un groupe privé.

L’extension ne peut pas être utilisée sur une page interactive de module, car tous les éléments se sont pas affichés au chargement de la page, et l’extension ne sait pas où placer les commentaires les concernant.

La preview Modulix qui affiche tout le contenu du module dès le chargement de la page permettrait de résoudre ce problème, mais elle est généré dynamiquement par Modulix Editor en passant un JSON à une page avec une url générique (/modules/preview). Or, [Hypothes.is](http://hypothes.is/) a besoin d’une url unique pour s’y retrouver.

## ⛱️ Proposition

Pouvoir prévisualiser un module existant (donc d’après le fichier JSON inclus dans l’API) en ajoutant son slug à la fin de l’url (ex : /modules/preview/bac-a-sable).

## 🌊 Remarques

- J'ai corrigé la configuration mirage qui attendait toujours que les slugs soient identiques aux id. Sans ça le test d'acceptance échouait si le module n'avait pas pour `id` la même chaine de caractère que le `slug`. Par souci de cohérence, il faudrait aussi corriger les autres tests d'acceptance.
- Tous les éléments ne sont pas complètement "dépliés" aujourd'hui, notamment le QAB, les feedbacks…

## 🏄 Pour tester

Vérifier le bon affichage du module déplié :
https://app-pr13171.review.pix.fr/modules/preview/galerie
