### PR TITLE
[FEATURE] Ajouter les bannières des typologies SCO / SCO-1D dans la page de presentation de l'organisation (PIX-18950).

### DIFF
--- a/orga/app/components/banner/mission-banner.gjs
+++ b/orga/app/components/banner/mission-banner.gjs
@@ -1,0 +1,66 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { LinkTo } from '@ember/routing';
+import t from 'ember-intl/helpers/t';
+import CopyPasteButton from 'pix-orga/components/copy-paste-button';
+import htmlUnsafe from 'pix-orga/helpers/html-unsafe';
+
+<template>
+  <PixNotificationAlert class="mission-list-banner" @type="communication-orga" @withIcon={{true}}>
+    {{t "pages.missions.list.banner.welcome"}}
+    <br />
+    <ul>
+      <li>
+        {{#if @isAdmin}}
+          <span>{{htmlUnsafe (t "pages.missions.list.banner.step1.admin.head")}}
+            <LinkTo @route="authenticated.import-organization-participants">
+              <b>{{t "pages.missions.list.banner.step1.admin.link"}}</b>
+            </LinkTo>
+            {{htmlUnsafe (t "pages.missions.list.banner.step1.admin.tail")}}
+          </span>
+        {{else}}
+          <span>{{htmlUnsafe (t "pages.missions.list.banner.step1.non-admin")}}</span>
+        {{/if}}
+      </li>
+      <li>
+        <ul>
+          {{t "pages.missions.list.banner.step2.title"}}
+          <li>
+            <div class="mission-list-banner__copypaste-container">
+              <span>{{htmlUnsafe (t "pages.missions.list.banner.step2.option1" pixJuniorUrl=@pixJuniorUrl)}}
+              </span>
+              <div class="mission-list-banner__school-code">
+                Code :&nbsp;<b>{{@schoolCode}}</b>
+                <div class="copy-paste-button-container">
+                  <CopyPasteButton
+                    @clipBoardtext={{@schoolCode}}
+                    @successMessage="{{t 'pages.missions.list.banner.copypaste-container.button.success'}}"
+                    @defaultMessage="{{t 'pages.missions.list.banner.copypaste-container.button.tooltip'}}"
+                  />
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="mission-list-banner__copypaste-container">
+              <span>
+                {{htmlUnsafe
+                  (t "pages.missions.list.banner.step2.option2.body" pixJuniorUrl=@pixJuniorSchoolUrl code=@schoolCode)
+                }}
+                <a href={{@pixJuniorSchoolUrl}} target="_blank" rel="noopener noreferrer" id="external-link-icon">
+                  <PixIcon @name="openNew" />
+                </a>
+              </span>
+              <span>
+                {{htmlUnsafe (t "pages.missions.list.banner.step2.option2.hint")}}
+              </span>
+            </div>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <span>{{htmlUnsafe (t "pages.missions.list.banner.step3")}}</span>
+      </li>
+    </ul>
+  </PixNotificationAlert>
+</template>

--- a/orga/app/components/banner/sco-banner.gjs
+++ b/orga/app/components/banner/sco-banner.gjs
@@ -1,0 +1,23 @@
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
+
+<template>
+  <PixNotificationAlert @type="communication-orga" @withIcon={{true}}>
+    {{t "banners.import.message"}}
+    <ol class="banner-list">
+      <li>
+        {{t "banners.import.step1a" htmlSafe=true}}
+        <LinkTo
+          @route="authenticated.import-organization-participants"
+          class="link link--banner link--bold link--underlined"
+        >
+          {{t "banners.import.step1b"}}
+        </LinkTo>
+        {{t "banners.import.step1c"}}
+      </li>
+      <li>{{t "banners.import.step2" htmlSafe=true}}</li>
+      <li>{{t "banners.import.step3" htmlSafe=true}}</li>
+    </ol>
+  </PixNotificationAlert>
+</template>

--- a/orga/app/components/banner/sco-communication.gjs
+++ b/orga/app/components/banner/sco-communication.gjs
@@ -1,8 +1,6 @@
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { t } from 'ember-intl';
+import ScoBanner from 'pix-orga/components/banner/sco-banner';
 
 export default class ScommunicationBanner extends Component {
   @service currentUser;
@@ -24,23 +22,7 @@ export default class ScommunicationBanner extends Component {
 
   <template>
     {{#if this.shouldDisplayBanner}}
-      <PixNotificationAlert @type="communication-orga" @withIcon={{true}}>
-        {{t "banners.import.message"}}
-        <ol class="banner-list">
-          <li>
-            {{t "banners.import.step1a" htmlSafe=true}}
-            <LinkTo
-              @route="authenticated.import-organization-participants"
-              class="link link--banner link--bold link--underlined"
-            >
-              {{t "banners.import.step1b"}}
-            </LinkTo>
-            {{t "banners.import.step1c"}}
-          </li>
-          <li>{{t "banners.import.step2" htmlSafe=true}}</li>
-          <li>{{t "banners.import.step3" htmlSafe=true}}</li>
-        </ol>
-      </PixNotificationAlert>
+      <ScoBanner />
     {{/if}}
   </template>
 }

--- a/orga/app/components/index/classic.gjs
+++ b/orga/app/components/index/classic.gjs
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import ScoBanner from 'pix-orga/components/banner/sco-banner';
 import OrganizationInfo from 'pix-orga/components/index/organization-information';
 import Welcome from 'pix-orga/components/index/welcome';
 
@@ -13,6 +14,9 @@ export default class IndexClassic extends Component {
 
   <template>
     <Welcome @firstName={{this.currentUser.prescriber.firstName}} @description={{this.description}} />
+    {{#if this.currentUser.isSCOManagingStudents}}
+      <ScoBanner />
+    {{/if}}
     <OrganizationInfo @organizationName={{this.currentUser.organization.name}} />
   </template>
 }

--- a/orga/app/components/index/missions.gjs
+++ b/orga/app/components/index/missions.gjs
@@ -1,11 +1,13 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import MissionBanner from 'pix-orga/components/banner/mission-banner';
 import OrganizationInfo from 'pix-orga/components/index/organization-information';
 import Welcome from 'pix-orga/components/index/welcome';
 
 export default class IndexMissions extends Component {
   @service currentUser;
   @service intl;
+  @service url;
 
   get description() {
     return this.intl.t('components.index.welcome.description.missions');
@@ -13,6 +15,12 @@ export default class IndexMissions extends Component {
 
   <template>
     <Welcome @firstName={{this.currentUser.prescriber.firstName}} @description={{this.description}} />
+    <MissionBanner
+      @isAdmin={{this.currentUser.isAdminInOrganization}}
+      @pixJuniorSchoolUrl={{this.url.pixJuniorSchoolUrl}}
+      @pixJuniorUrl={{this.url.pixJuniorUrl}}
+      @schoolCode={{this.currentUser.organization.schoolCode}}
+    />
     <OrganizationInfo @organizationName={{this.currentUser.organization.name}} />
   </template>
 }

--- a/orga/app/controllers/authenticated/index.js
+++ b/orga/app/controllers/authenticated/index.js
@@ -5,6 +5,6 @@ export default class IndexController extends Controller {
   @service currentUser;
 
   get canAccessMissionsPage() {
-    return this.currentUser.prescriber.canAccessMissionsPage;
+    return this.currentUser.canAccessMissionsPage;
   }
 }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -35,6 +35,10 @@ export default class Url extends UrlBaseService {
     return `${this.currentDomain.getJuniorBaseUrl()}/schools/${schoolCode}`;
   }
 
+  get pixJuniorUrl() {
+    return this.currentDomain.getJuniorBaseUrl();
+  }
+
   getLegalDocumentUrl(path) {
     return this.getPixWebsiteUrl(path);
   }

--- a/orga/app/templates/authenticated/missions/list.gjs
+++ b/orga/app/templates/authenticated/missions/list.gjs
@@ -1,79 +1,21 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import eq from 'ember-truth-helpers/helpers/eq';
-import CopyPasteButton from 'pix-orga/components/copy-paste-button';
+import MissionBanner from 'pix-orga/components/banner/mission-banner';
 import PageTitle from 'pix-orga/components/ui/page-title';
-import htmlUnsafe from 'pix-orga/helpers/html-unsafe';
+
 <template>
   {{pageTitle (t "pages.missions.title")}}
 
-  <PixNotificationAlert class="mission-list-banner" @type="communication-orga" @withIcon={{true}}>
-    {{t "pages.missions.list.banner.welcome"}}
-    <br />
-    <ul>
-      <li>
-        {{#if @model.isAdminOfTheCurrentOrganization}}
-          <span>{{htmlUnsafe (t "pages.missions.list.banner.step1.admin.head")}}
-            <LinkTo @route="authenticated.import-organization-participants">
-              <b>{{t "pages.missions.list.banner.step1.admin.link"}}</b>
-            </LinkTo>
-            {{htmlUnsafe (t "pages.missions.list.banner.step1.admin.tail")}}
-          </span>
-        {{else}}
-          <span>{{htmlUnsafe (t "pages.missions.list.banner.step1.non-admin")}}</span>
-        {{/if}}
-      </li>
-      <li>
-        <ul>
-          {{t "pages.missions.list.banner.step2.title"}}
-          <li>
-            <div class="mission-list-banner__copypaste-container">
-              <span>{{htmlUnsafe (t "pages.missions.list.banner.step2.option1" pixJuniorUrl=@controller.juniorUrl)}}
-              </span>
-              <div class="mission-list-banner__school-code">
-                Code :&nbsp;<b>{{@controller.schoolCode}}</b>
-                <div class="copy-paste-button-container">
-                  <CopyPasteButton
-                    @clipBoardtext={{@controller.schoolCode}}
-                    @successMessage="{{t 'pages.missions.list.banner.copypaste-container.button.success'}}"
-                    @defaultMessage="{{t 'pages.missions.list.banner.copypaste-container.button.tooltip'}}"
-                  />
-                </div>
-              </div>
-            </div>
-          </li>
-          <li>
-            <div class="mission-list-banner__copypaste-container">
-              <span>
-                {{htmlUnsafe
-                  (t
-                    "pages.missions.list.banner.step2.option2.body"
-                    pixJuniorUrl=@model.pixJuniorSchoolUrl
-                    code=@controller.schoolCode
-                  )
-                }}
-                <a href={{@model.pixJuniorSchoolUrl}} target="_blank" rel="noopener noreferrer" id="external-link-icon">
-                  <PixIcon @name="openNew" />
-                </a>
-              </span>
-              <span>
-                {{htmlUnsafe (t "pages.missions.list.banner.step2.option2.hint")}}
-              </span>
-            </div>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <span>{{htmlUnsafe (t "pages.missions.list.banner.step3")}}</span>
-      </li>
-    </ul>
-  </PixNotificationAlert>
+  <MissionBanner
+    @isAdmin={{@model.isAdminOfTheCurrentOrganization}}
+    @pixJuniorSchoolUrl={{@model.pixJuniorSchoolUrl}}
+    @pixJuniorUrl={{@controller.juniorUrl}}
+    @schoolCode={{@controller.schoolCode}}
+  />
 
   <PageTitle>
     <:title>{{t "pages.missions.title"}}</:title>

--- a/orga/tests/integration/components/index/classic_test.gjs
+++ b/orga/tests/integration/components/index/classic_test.gjs
@@ -41,4 +41,36 @@ module('Integration | Component | Index::Classic', function (hooks) {
     assert.ok(screen.getByText(t('components.index.organization-information.label')));
     assert.ok(screen.getByText('Ma super organization'));
   });
+
+  module('when organisation is SCO and managingStudents', function () {
+    test('should display sco banner', async function (assert) {
+      class CurrentUserStub extends Service {
+        isSCOManagingStudents = true;
+        prescriber = {
+          firstName: 'Jean',
+        };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const screen = await render(<template><IndexClassic /></template>);
+
+      // then
+      assert.ok(screen.getByText(t('banners.import.message')));
+    });
+  });
+
+  module('when organisation is not SCO and managingStudents', function () {
+    test('should display sco banner', async function (assert) {
+      class CurrentUserStub extends Service {
+        isSCOManagingStudents = false;
+        prescriber = {
+          firstName: 'Jean',
+        };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const screen = await render(<template><IndexClassic /></template>);
+
+      // then
+      assert.notOk(screen.queryByText(t('banners.import.message')));
+    });
+  });
 });

--- a/orga/tests/integration/components/index/missions_test.gjs
+++ b/orga/tests/integration/components/index/missions_test.gjs
@@ -14,6 +14,9 @@ module('Integration | Component | Index::Missions', function (hooks) {
       prescriber = {
         firstName: 'Jean',
       };
+      organization = {
+        schoolCode: 'MISSION',
+      };
     }
     this.owner.register('service:current-user', CurrentUserStub);
     const screen = await render(<template><IndexMissions /></template>);
@@ -21,6 +24,22 @@ module('Integration | Component | Index::Missions', function (hooks) {
     // then
     assert.ok(screen.getByRole('heading', { name: t('components.index.welcome.title', { name: 'Jean' }) }));
     assert.ok(screen.getByText(t('components.index.welcome.description.missions')));
+  });
+
+  test('should display mission banner', async function (assert) {
+    class CurrentUserStub extends Service {
+      prescriber = {
+        firstName: 'Jean',
+      };
+      organization = {
+        schoolCode: 'MISSION',
+      };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+    const screen = await render(<template><IndexMissions /></template>);
+
+    // then
+    assert.ok(screen.getByText(t('pages.missions.list.banner.welcome')));
   });
 
   test('should display organization information', async function (assert) {
@@ -31,6 +50,7 @@ module('Integration | Component | Index::Missions', function (hooks) {
 
       organization = {
         name: 'Ma super organization',
+        schoolCode: 'MISSION',
       };
     }
     this.owner.register('service:current-user', CurrentUserStub);

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -144,7 +144,7 @@ module('Unit | Service | url', function (hooks) {
   module('#pixJuniorSchoolUrl', function () {
     test('returns pix junior url for current organization', function (assert) {
       const service = this.owner.lookup('service:url');
-      service.pixJuniorUrl = 'https://junior.pix.fr';
+
       service.currentUser = { organization: { schoolCode: 'MINIPIXOU' } };
       service.currentDomain = { getJuniorBaseUrl: () => 'https://junior.pix.fr' };
 
@@ -154,12 +154,21 @@ module('Unit | Service | url', function (hooks) {
     });
     test('returns empty string if the current organization has not any school code', function (assert) {
       const service = this.owner.lookup('service:url');
-      service.pixJuniorUrl = 'https://junior.pix.fr';
       service.currentUser = { organization: {} };
+      service.currentDomain = { getJuniorBaseUrl: () => 'https://junior.pix.fr' };
 
       const pixJuniorSchoolUrl = service.pixJuniorSchoolUrl;
 
       assert.strictEqual(pixJuniorSchoolUrl, '');
+    });
+  });
+
+  module('#pixJuniorUrl', function () {
+    test('returns pix junior url for current organization', function (assert) {
+      const service = this.owner.lookup('service:url');
+      service.currentDomain = { getJuniorBaseUrl: () => 'https://junior.pix.fr' };
+
+      assert.strictEqual(service.pixJuniorUrl, 'https://junior.pix.fr');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

On a des bandeaux affichés un peu partout parceque nous n'avons pas moyen de les centraliser quelque part

## ⛱️ Proposition

Avec la nouvelle page d'accueil. il est possible maintenant de les centraliser à cet endroit. 


## 🌊 Remarques

Pour le moment on garde l'affichage actuel. on pourra les supprimer lorsque la page d'accueil sera LIVE

## 🏄 Pour tester

Aller sur PixOrga 

SCO Managing => visibilité du bandeau SCO
SCO-1D => visiblitité du bandeau SCO 1D

les autres => bandeau non visible