### PR TITLE
[FEATURE] Ajout d'une route pour obtenir des statistiques de participation (PIX-18955)

### DIFF
--- a/api/src/prescription/organization-learner/application/organization-learners-controller.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-controller.js
@@ -2,6 +2,7 @@ import { NoProfileRewardsFoundError } from '../../../profile/domain/errors.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as analysisByTubesSerializer from '../infrastructure/serializers/jsonapi/analysis-by-tubes-serializer.js';
 import * as attestationParticipantStatusSerializer from '../infrastructure/serializers/jsonapi/attestation-participants-status-serializer.js';
+import * as organizationParticipationsStatisticsSerializer from '../infrastructure/serializers/jsonapi/organization-participation-statistics-serializer.js';
 
 const getAttestationZipForDivisions = async function (request, h) {
   const organizationId = request.params.organizationId;
@@ -42,8 +43,21 @@ const getAttestationParticipantsStatus = async function (
   return h.response(dependencies.attestationParticipantStatusSerializer.serialize(result)).code(200);
 };
 
+const getParticipationStatistics = async function (
+  request,
+  h,
+  dependencies = { organizationParticipationsStatisticsSerializer },
+) {
+  const ownerId = request.auth.credentials.userId;
+  const { organizationId } = request.params;
+  const result = await usecases.getOrganizationLearnerStatistics({ organizationId, ownerId });
+
+  return h.response(dependencies.organizationParticipationsStatisticsSerializer.serialize(result)).code(200);
+};
+
 const organizationLearnersController = {
   getAnalysisByTubes,
+  getParticipationStatistics,
   getAttestationZipForDivisions,
   getAttestationParticipantsStatus,
 };

--- a/api/src/prescription/organization-learner/application/organization-learners-route.js
+++ b/api/src/prescription/organization-learner/application/organization-learners-route.js
@@ -38,6 +38,29 @@ const register = async function (server) {
     },
     {
       method: 'GET',
+      path: '/api/organizations/{organizationId}/participation-statistics',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganization,
+            assign: 'checkUserBelongsToOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationLearnersController.getParticipationStatistics,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Cette route retourne les statistiques des participations toute campagne active confondu ',
+        ],
+        tags: ['api', 'prescription', 'organization', 'participations', 'statistics'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/organizations/{organizationId}/attestations/{attestationKey}',
       config: {
         pre: [

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-statistics.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-learner-statistics.js
@@ -1,0 +1,7 @@
+const getOrganizationLearnerStatistics = async ({ organizationId, ownerId, organizationLearnerStatisticsRepository }) =>
+  await organizationLearnerStatisticsRepository.getParticipationStatistics({
+    organizationId,
+    ownerId,
+  });
+
+export { getOrganizationLearnerStatistics };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -40,6 +40,7 @@ import * as analysisRepository from '../../infrastructure/repositories/analysis-
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as organizationLearnerActivityRepository from '../../infrastructure/repositories/organization-learner-activity-repository.js';
 import * as organizationLearnerFeatureRepository from '../../infrastructure/repositories/organization-learner-feature-repository.js';
+import * as organizationLearnerStatisticsRepository from '../../infrastructure/repositories/organization-learner-statistics-repository.js';
 import * as organizationParticipantRepository from '../../infrastructure/repositories/organization-participant-repository.js';
 import * as registrationOrganizationLearnerRepository from '../../infrastructure/repositories/registration-organization-learner-repository.js';
 import * as scoOrganizationParticipantRepository from '../../infrastructure/repositories/sco-organization-participant-repository.js';
@@ -85,6 +86,7 @@ const dependencies = {
   tokenService,
   passwordValidator,
   writeCsvUtils,
+  organizationLearnerStatisticsRepository,
 };
 
 import { createAndReconcileUserToOrganizationLearner } from './create-and-reconcile-user-to-organization-learner.js';
@@ -106,6 +108,7 @@ import { getAnalysisByTubes } from './get-analysis-by-tubes.js';
 import { getAttestationZipForDivisions } from './get-attestation-zip-for-divisions.js';
 import { getOrganizationLearner } from './get-organization-learner.js';
 import { getOrganizationLearnerActivity } from './get-organization-learner-activity.js';
+import { getOrganizationLearnerStatistics } from './get-organization-learner-statistics.js';
 import { getOrganizationLearnerWithParticipations } from './get-organization-learner-with-participations.js';
 import { getOrganizationToJoin } from './get-organization-to-join.js';
 import { updateOrganizationLearnerDependentUserPassword } from './update-organization-learner-dependent-user-password.js';
@@ -124,13 +127,14 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedOrganizationLearners,
   generateOrganizationLearnersUsernameAndTemporaryPassword,
   generateResetOrganizationLearnersPasswordCsvContent,
-  generateUsernameWithTemporaryPassword,
   generateUsername,
+  generateUsernameWithTemporaryPassword,
   getAnalysisByTubes,
   getAttestationZipForDivisions,
-  getOrganizationLearnerActivity,
-  getOrganizationLearnerWithParticipations,
   getOrganizationLearner,
+  getOrganizationLearnerActivity,
+  getOrganizationLearnerStatistics,
+  getOrganizationLearnerWithParticipations,
   getOrganizationToJoin,
   updateOrganizationLearnerDependentUserPassword,
 };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-statistics-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-statistics-repository.js
@@ -1,0 +1,25 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+
+const getParticipationStatistics = async function ({ organizationId, ownerId }) {
+  const knexConnection = DomainTransaction.getConnection();
+
+  return knexConnection('campaign-participations')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .select(
+      knexConnection.raw('count(*) as "totalParticipationCount"'),
+      knexConnection.raw(
+        `count(*) filter (where "status" = ?) as "completedParticipationCount"`,
+        CampaignParticipationStatuses.SHARED,
+      ),
+    )
+    .whereNull('campaigns.deletedAt')
+    .whereNull('campaigns.archivedAt')
+    .where({
+      'campaigns.organizationId': organizationId,
+      'campaigns.ownerId': ownerId,
+    })
+    .first();
+};
+
+export { getParticipationStatistics };

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participation-statistics-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-participation-statistics-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (statistics) {
+  return new Serializer('organization-participation-statistics', {
+    attributes: ['totalParticipationCount', 'completedParticipationCount'],
+  }).serialize(statistics);
+};
+
+export { serialize };

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-statistics-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-statistics-repository_test.js
@@ -1,0 +1,230 @@
+import * as organizationLearnerStatisticsRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-statistics-repository.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Repository | Organization Learner Statistics', function () {
+  describe('#getParticipationStatistics', function () {
+    let organizationId, ownerId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      ownerId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+    });
+
+    context('when there are no campaigns', function () {
+      it('should return zero counts', async function () {
+        // when
+        const statistics = await organizationLearnerStatisticsRepository.getParticipationStatistics({
+          organizationId,
+          ownerId,
+        });
+
+        // then
+        expect(statistics).to.deep.equal({
+          totalParticipationCount: 0,
+          completedParticipationCount: 0,
+        });
+      });
+    });
+
+    context('when there are campaigns with participations', function () {
+      it('should return correct statistics', async function () {
+        // given
+        const campaignId1 = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+        }).id;
+
+        const campaignId2 = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+
+        // Create participations: 2 shared, 1 started, 1 to_share
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId1,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId1,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId2,
+          status: CampaignParticipationStatuses.STARTED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId2,
+          status: CampaignParticipationStatuses.TO_SHARE,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const statistics = await organizationLearnerStatisticsRepository.getParticipationStatistics({
+          organizationId,
+          ownerId,
+        });
+
+        // then
+        expect(statistics).to.deep.equal({
+          totalParticipationCount: 4,
+          completedParticipationCount: 2,
+        });
+      });
+    });
+
+    context('when there are campaigns from other organizations or owners', function () {
+      it('should not include them in statistics', async function () {
+        // given
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const otherOwnerId = databaseBuilder.factory.buildUser().id;
+
+        // Campaign from target organization but different owner
+        const campaignId1 = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId: otherOwnerId,
+        }).id;
+
+        // Campaign from different organization but same owner
+        const campaignId2 = databaseBuilder.factory.buildCampaign({
+          organizationId: otherOrganizationId,
+          ownerId,
+        }).id;
+
+        // Target campaign
+        const campaignId3 = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId1,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId2,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId3,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const statistics = await organizationLearnerStatisticsRepository.getParticipationStatistics({
+          organizationId,
+          ownerId,
+        });
+
+        // then
+        expect(statistics).to.deep.equal({
+          totalParticipationCount: 1,
+          completedParticipationCount: 1,
+        });
+      });
+    });
+
+    context('when campaigns are deleted or archived', function () {
+      it('should not include them in statistics', async function () {
+        // given
+        const deletedCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+
+          deletedAt: new Date('2023-01-01'),
+        }).id;
+
+        const archivedCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+
+          archivedAt: new Date('2023-01-01'),
+        }).id;
+
+        const activeCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: deletedCampaignId,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: archivedCampaignId,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: activeCampaignId,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const statistics = await organizationLearnerStatisticsRepository.getParticipationStatistics({
+          organizationId,
+          ownerId,
+        });
+
+        // then
+        expect(statistics).to.deep.equal({
+          totalParticipationCount: 1,
+          completedParticipationCount: 1,
+        });
+      });
+    });
+
+    context('when there are participations with all possible statuses', function () {
+      it('should only count SHARED status as completed', async function () {
+        // given
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          ownerId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+
+        // Create participations with all possible statuses
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          status: CampaignParticipationStatuses.STARTED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          status: CampaignParticipationStatuses.TO_SHARE,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          status: CampaignParticipationStatuses.SHARED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const statistics = await organizationLearnerStatisticsRepository.getParticipationStatistics({
+          organizationId,
+          ownerId,
+        });
+
+        // then
+        expect(statistics).to.deep.equal({
+          totalParticipationCount: 4,
+          completedParticipationCount: 2,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/organization-learners-route_test.js
@@ -129,4 +129,54 @@ describe('Prescription | Unit | Router | organization-learner-router', function 
       );
     });
   });
+
+  describe('GET /api/organizations/{organizationId}/participation-statistics', function () {
+    const method = 'GET';
+
+    it('should throw 403 if user is not admin in organization', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) =>
+        h
+          .response({ errors: new Error('forbidden') })
+          .code(403)
+          .takeover(),
+      );
+
+      const organizationPlacesStatisticsStub = sinon.stub(organizationLearnersController, 'getParticipationStatistics');
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/organizations/1/participation-statistics';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(organizationPlacesStatisticsStub.called).to.be.false;
+    });
+
+    it('should call prehandlers before calling controller method', async function () {
+      // given
+      sinon
+        .stub(organizationLearnersController, 'getParticipationStatistics')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/organizations/1/participation-statistics';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(securityPreHandlers.checkUserBelongsToOrganization).to.have.been.calledBefore(
+        organizationLearnersController.getParticipationStatistics,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème
Nous voulons renvoyer des statistiques à nos prescripteurs dans notre nouvelle page d'accueil flambant neuve.
## ⛱️ Proposition
Créer une route qui retourne le nombre total de participations ainsi que le nombre de participations qui ont le statut `SHARED`  
## 🏄 Pour tester
``` shell
ORGANISATION_ID=1001
REVIEW_URL="https://api-pr13174.review.pix.fr/api/"
ACCESS_TOKEN=$( \
  curl "$REVIEW_URL/token" \
    --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' \
  | jq -r .access_token \
)
curl "$REVIEW_URL/organizations/$ORGANISATION_ID/participation-statistics" \
  -X  GET\
  -H 'content-type: application/vnd.api+json'\
  -H "Authorization: Bearer $ACCESS_TOKEN"
```
