### PR TITLE
[TECH] Valeurs par défaut des features toggle en RA et tests

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -33,6 +33,7 @@ export default {
     type: 'boolean',
     description: 'Used to enable filtering recommended training by organizations',
     defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-devcomp', 'pix-admin'],
   },
   isSelfAccountDeletionEnabled: {

--- a/api/src/shared/infrastructure/feature-toggles/index.js
+++ b/api/src/shared/infrastructure/feature-toggles/index.js
@@ -4,6 +4,7 @@ import { InMemoryKeyValueStorage } from '../key-value-storages/InMemoryKeyValueS
 import { FeatureTogglesClient } from './feature-toggles-client.js';
 
 const isTestEnv = process.env.NODE_ENV === 'test';
+const isReviewAppEnv = process.env.REVIEW_APP === 'true';
 
 let _instance = null;
 
@@ -13,11 +14,19 @@ let _instance = null;
  */
 async function getInstance() {
   if (!_instance) {
+    const environment = getFeatureTogglesEnv();
     const storage = isTestEnv ? new InMemoryKeyValueStorage() : featureTogglesStorage;
-    _instance = new FeatureTogglesClient(storage);
+    _instance = new FeatureTogglesClient(storage, environment);
+
     await _instance.init(config);
   }
   return _instance;
+}
+
+function getFeatureTogglesEnv() {
+  if (isTestEnv) return 'test';
+  if (isReviewAppEnv) return 'reviewApp';
+  return;
 }
 
 /**

--- a/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
+++ b/api/tests/shared/unit/infrastructure/feature-toggles/feature-toggles-client.test.js
@@ -61,6 +61,50 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
       // when / then
       await expect(featureToggles.init(invalidConfig)).to.rejectedWith(Joi.ValidationError);
     });
+
+    context('when in test environement', function () {
+      it('adds feature toggles with provided devDefaultValues.test', async function () {
+        // given
+        const featureToggles = new FeatureTogglesClient(storage, 'test');
+
+        // when
+        await featureToggles.init({
+          myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
+          myToggle2: {
+            description: 'Description 2',
+            type: 'boolean',
+            defaultValue: false,
+            devDefaultValues: { test: true },
+          },
+        });
+
+        // then
+        const all = await featureToggles.all();
+        expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+      });
+    });
+
+    context('when in review app environement', function () {
+      it('adds feature toggles with provided devDefaultValues.reviewApp', async function () {
+        // given
+        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp');
+
+        // when
+        await featureToggles.init({
+          myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
+          myToggle2: {
+            description: 'Description 2',
+            type: 'boolean',
+            defaultValue: false,
+            devDefaultValues: { reviewApp: true },
+          },
+        });
+
+        // then
+        const all = await featureToggles.all();
+        expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+      });
+    });
   });
 
   describe('get', function () {
@@ -157,6 +201,56 @@ describe('Unit | Infrastructure | FeatureToggles | FeatureTogglesClient', functi
 
       // then
       expect(all).to.deep.equal({ myToggle1: false, myToggle2: true, myToggle3: 'foo' });
+    });
+
+    context('when in test environement', function () {
+      it('resets feature toggles with provided devDefaultValues.test', async function () {
+        // given
+        const featureToggles = new FeatureTogglesClient(storage, 'test');
+        await featureToggles.init({
+          myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
+          myToggle2: {
+            description: 'Description 2',
+            type: 'boolean',
+            defaultValue: false,
+            devDefaultValues: { test: true },
+          },
+        });
+        await featureToggles.set('myToggle1', true);
+        await featureToggles.set('myToggle2', false);
+
+        // when
+        await featureToggles.resetDefaults();
+
+        // then
+        const all = await featureToggles.all();
+        expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+      });
+    });
+
+    context('when in review app environement', function () {
+      it('resets feature toggles with provided devDefaultValues.reviewApp', async function () {
+        // given
+        const featureToggles = new FeatureTogglesClient(storage, 'reviewApp');
+        await featureToggles.init({
+          myToggle1: { description: 'Description 1', type: 'boolean', defaultValue: false },
+          myToggle2: {
+            description: 'Description 2',
+            type: 'boolean',
+            defaultValue: false,
+            devDefaultValues: { reviewApp: true },
+          },
+        });
+        await featureToggles.set('myToggle1', true);
+        await featureToggles.set('myToggle2', false);
+
+        // when
+        await featureToggles.resetDefaults();
+
+        // then
+        const all = await featureToggles.all();
+        expect(all).to.deep.equal({ myToggle1: false, myToggle2: true });
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, il n'est pas possible de définir des valeurs par défaut sur les feature toggles  les environnements de Review App et de test.

## ⛱️ Proposition

Ajout de la configuration suivante (optionnelle) dans la config des feature toggles :
```js
devDefaultValues: { test: 'value-in-tests', reviewApp: 'value-in-review-app' },
```

Exemple complet :
```js
  isFilteringRecommendedTrainingByOrganizationsEnabled: {
    type: 'boolean',
    description: 'Used to enable filtering recommended training by organizations',
    defaultValue: false,
    devDefaultValues: { test: false, reviewApp: true },
    tags: ['frontend', 'team-devcomp', 'pix-admin'],
  },
```

Pour `devDefaultValues.test`, c'est la valeur par défaut utilisée **pour les tests d'API** (unitaires, intégration, acceptance).

Pour `devDefaultValues.reviewApp`, c'est la valeur par défaut utilisée **quand la Review App de l'API est déployée.**


## 🌊 Remarques

Le feature toggle `isFilteringRecommendedTrainingByOrganizationsEnabled` a été activé par défaut dans les review app. (vu avec @yannbertrand)

## 🏄 Pour tester

Vérifier que `isFilteringRecommendedTrainingByOrganizationsEnabled` est bien activé dans la review app de cette PR.
