### PR TITLE
[TECH] Repasser les imports dynamiques en imports statiques

### DIFF
--- a/api/src/banner/domain/usecases/index.js
+++ b/api/src/banner/domain/usecases/index.js
@@ -1,9 +1,4 @@
-// eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as informationBannerRepository from '../../infrastructure/repositories/information-banner-repository.js';
 
 /**
@@ -16,13 +11,10 @@ const dependencies = {
   informationBannerRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { getInformationBanner } from './get-information-banner.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: 'index.js',
-  })),
+  getInformationBanner,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/complementary-certification/domain/usecases/index.js
+++ b/api/src/certification/complementary-certification/domain/usecases/index.js
@@ -1,9 +1,5 @@
 // eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as complementaryCertificationForTargetProfileAttachmentRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js';
 import * as organizationRepository from '../../../complementary-certification/infrastructure/repositories/organization-repository.js';
 import { mailService } from '../../../shared/domain/services/mail-service.js';
@@ -31,13 +27,20 @@ const dependencies = {
   mailService,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { attachBadges } from './attach-badges.js';
+import { getById } from './get-by-id.js';
+import { getByLabel } from './get-by-label.js';
+import { getComplementaryCertificationForTargetProfileAttachmentRepository } from './get-complementary-certification-for-target-profile-attachment.js';
+import { getComplementaryCertificationTargetProfileHistory } from './get-complementary-certification-target-profile-history.js';
+import { sendTargetProfileNotifications } from './send-target-profile-notifications.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: 'index.js',
-  })),
+  attachBadges,
+  getById,
+  getByLabel,
+  getComplementaryCertificationForTargetProfileAttachmentRepository,
+  getComplementaryCertificationTargetProfileHistory,
+  sendTargetProfileNotifications,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -1,11 +1,7 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as complementaryCertificationRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../../configuration/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as sharedFlashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
@@ -48,13 +44,28 @@ const dependencies = {
   sharedFlashAlgorithmConfigurationRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { calibrateConsolidatedFramework } from './calibrate-consolidated-framework.js';
+import { catchingUpCandidateReconciliation } from './catching-up-candidate-reconciliation.js';
+import { createConsolidatedFramework } from './create-consolidated-framework.js';
+import { createFlashAssessmentConfiguration } from './create-flash-assessment-configuration.js';
+import { exportScoWhitelist } from './export-sco-whitelist.js';
+import { findComplementaryCertifications } from './find-complementary-certifications.js';
+import { getActiveFlashAssessmentConfiguration } from './get-active-flash-assessment-configuration.js';
+import { getCurrentConsolidatedFramework } from './get-current-consolidated-framework.js';
+import { importScoWhitelist } from './import-sco-whitelist.js';
+import { searchAttachableTargetProfiles } from './search-attachable-target-profiles.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: 'index.js',
-  })),
+  calibrateConsolidatedFramework,
+  catchingUpCandidateReconciliation,
+  createConsolidatedFramework,
+  createFlashAssessmentConfiguration,
+  exportScoWhitelist,
+  findComplementaryCertifications,
+  getActiveFlashAssessmentConfiguration,
+  getCurrentConsolidatedFramework,
+  importScoWhitelist,
+  searchAttachableTargetProfiles,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/enrolment/application/services/index.js
+++ b/api/src/certification/enrolment/application/services/index.js
@@ -1,9 +1,4 @@
-// eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 /**
  * @typedef {import('../../infrastructure/repositories/index.js').EnrolledCandidateRepository} EnrolledCandidateRepository
  **/
@@ -18,13 +13,12 @@ const dependencies = {
   ...enrolmentRepositories,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { registerCandidateParticipation } from './register-candidate-participation-service.js';
+
 const servicesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  registerCandidateParticipation,
 };
+
 const services = injectDependencies(servicesWithoutInjectedDependencies, dependencies);
 
 export { services };

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -1,13 +1,9 @@
 // eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as divisionRepository from '../../../../prescription/campaign/infrastructure/repositories/division-repository.js';
 import * as organizationLearnerRepository from '../../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as attendanceSheetPdfUtils from '../../../enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js';
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
@@ -99,18 +95,64 @@ const dependencies = {
   certificationAssessmentRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { addCandidateToSession } from './add-candidate-to-session.js';
+import { candidateHasSeenCertificationInstructions } from './candidate-has-seen-certification-instructions.js';
+import { createSession } from './create-session.js';
+import { createSessions } from './create-sessions.js';
+import { deleteSession } from './delete-session.js';
+import { deleteUnlinkedCertificationCandidate } from './delete-unlinked-certification-candidate.js';
+import { enrolStudentsToSession } from './enrol-students-to-session.js';
+import { findCountries } from './find-countries.js';
+import { findDivisionsByCertificationCenter } from './find-divisions-by-certification-center.js';
+import { findStudentsForEnrolment } from './find-students-for-enrolment.js';
+import { getAttendanceSheet } from './get-attendance-sheet.js';
+import { getCandidate } from './get-candidate.js';
+import { getCandidateImportSheetData } from './get-candidate-import-sheet-data.js';
+import { getCandidateTimeline } from './get-candidate-timeline.js';
+import { getCenter } from './get-center.js';
+import { getCertificationCandidateSubscription } from './get-certification-candidate-subscription.js';
+import { getEnrolledCandidatesInSession } from './get-enrolled-candidates-in-session.js';
+import { getMassImportTemplateInformation } from './get-mass-import-template-information.js';
+import { getSession } from './get-session.js';
+import { getUserCertificationEligibility } from './get-user-certification-eligibility.js';
+import { hasBeenCandidate } from './has-been-candidate.js';
+import { importCertificationCandidatesFromCandidatesImportSheet } from './import-certification-candidates-from-candidates-import-sheet.js';
+import { reconcileCandidate } from './reconcile-candidate.js';
+import { updateEnrolledCandidate } from './update-enrolled-candidate.js';
+import { updateSession } from './update-session.js';
+import { validateSessions } from './validate-sessions.js';
+import { verifyCandidateCertificability } from './verify-candidate-certificability.js';
+import { verifyCandidateIdentity } from './verify-candidate-identity.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  addCandidateToSession,
+  candidateHasSeenCertificationInstructions,
+  createSession,
+  createSessions,
+  deleteSession,
+  deleteUnlinkedCertificationCandidate,
+  enrolStudentsToSession,
+  findCountries,
+  findDivisionsByCertificationCenter,
+  findStudentsForEnrolment,
+  getAttendanceSheet,
+  getCandidateImportSheetData,
+  getCandidateTimeline,
+  getCandidate,
+  getCenter,
+  getCertificationCandidateSubscription,
+  getEnrolledCandidatesInSession,
+  getMassImportTemplateInformation,
+  getSession,
+  getUserCertificationEligibility,
+  hasBeenCandidate,
+  importCertificationCandidatesFromCandidatesImportSheet,
+  reconcileCandidate,
+  updateEnrolledCandidate,
+  updateSession,
+  validateSessions,
+  verifyCandidateCertificability,
+  verifyCandidateIdentity,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/evaluation/domain/services/index.js
+++ b/api/src/certification/evaluation/domain/services/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 // TODO: cross-bounded context violation
 import * as scoringDegradationService from '../../../../certification/scoring/domain/services/scoring-degradation-service.js';
 import * as certificationChallengeLiveAlertRepository from '../../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
@@ -12,7 +9,6 @@ import * as areaRepository from '../../../../shared/infrastructure/repositories/
 import * as assessmentResultRepository from '../../../../shared/infrastructure/repositories/assessment-result-repository.js';
 import * as sharedChallengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as challengeRepository from '../../../evaluation/infrastructure/repositories/challenge-repository.js';
 import * as certificationAssessmentRepository from '../../../shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
@@ -76,18 +72,19 @@ const dependencies = {
   sharedChallengeRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { findByCertificationCourseIdAndAssessmentId } from './scoring/calibrated-challenge-service.js';
+import { scoreComplementaryCertificationV2 } from './scoring/score-complementary-certification-v2.js';
+import { scoreDoubleCertificationV3 } from './scoring/score-double-certification-v3.js';
+import { calculateCertificationAssessmentScore, handleV2CertificationScoring } from './scoring/scoring-v2.js';
+import { handleV3CertificationScoring } from './scoring/scoring-v3.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './scoring/'),
-    ignoredFileNames: ['index.js'],
-  })),
+  findByCertificationCourseIdAndAssessmentId,
+  scoreComplementaryCertificationV2,
+  scoreDoubleCertificationV3,
+  calculateCertificationAssessmentScore,
+  handleV2CertificationScoring,
+  handleV3CertificationScoring,
 };
 
 const services = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -1,9 +1,5 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as verifyCertificateCodeService from '../../../evaluation/domain/services/verify-certificate-code-service.js';
 import {
   answerRepository,
@@ -75,20 +71,31 @@ const dependencies = {
   services,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { createCompanionAlert } from './create-companion-alert.js';
+import { deneutralizeChallenge } from './deneutralize-challenge.js';
+import { getNextChallenge } from './get-next-challenge.js';
+import { getNextChallengeForV2Certification } from './get-next-challenge-for-v2-certification.js';
+import { neutralizeChallenge } from './neutralize-challenge.js';
+import { rescoreV2Certification } from './rescore-v2-certification.js';
+import { rescoreV3Certification } from './rescore-v3-certification.js';
+import { retrieveLastOrCreateCertificationCourse } from './retrieve-last-or-create-certification-course.js';
+import { scoreCompletedV2Certification } from './score-completed-v2-certification.js';
+import { scoreCompletedV3Certification } from './score-completed-v3-certification.js';
+import { simulateFlashAssessmentScenario } from './simulate-flash-assessment-scenario.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  createCompanionAlert,
+  deneutralizeChallenge,
+  getNextChallengeForV2Certification,
+  getNextChallenge,
+  neutralizeChallenge,
+  rescoreV2Certification,
+  rescoreV3Certification,
+  retrieveLastOrCreateCertificationCourse,
+  scoreCompletedV2Certification,
+  scoreCompletedV3Certification,
+  simulateFlashAssessmentScenario,
 };
-
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
 export { usecases };

--- a/api/src/certification/results/domain/usecases/index.js
+++ b/api/src/certification/results/domain/usecases/index.js
@@ -1,9 +1,4 @@
-// eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as sessionEnrolmentRepository from '../../../enrolment/infrastructure/repositories/session-repository.js';
 import * as resultsCertificationCourseRepository from '../../../results/infrastructure/repositories/certification-course-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
@@ -48,18 +43,40 @@ const dependencies = {
   certificationLivretScolaireRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { findCertificatesForDivision } from './find-certificates-for-division.js';
+import { findCertificationAttestationsForDivision } from './find-certification-attestations-for-division.js';
+import { findUserCertificationCourses } from './find-user-certification-courses.js';
+import { findUserPrivateCertificates } from './find-user-private-certificates.js';
+import { getCertificate } from './get-certificate.js';
+import { getCertificatesForSession } from './get-certificates-for-session.js';
+import { getCertificationCourseByVerificationCode } from './get-certification-course-by-verification-code.js';
+import { getCertificationResultForParcoursup } from './get-certification-result-for-parcoursup.js';
+import { getCertificationsResultsForLivretScolaire } from './get-certifications-results-for-livret-scolaire.js';
+import { getCleaCertifiedCandidateBySession } from './get-clea-certified-candidate-by-session.js';
+import { getPrivateCertificate } from './get-private-certificate.js';
+import { getScoCertificationResultsByDivision } from './get-sco-certification-results-by-division.js';
+import { getSessionCertificationReports } from './get-session-certification-reports.js';
+import { getSessionResults } from './get-session-results.js';
+import { getSessionResultsByResultRecipientEmail } from './get-session-results-by-result-recipient-email.js';
+import { getShareableCertificate } from './get-shareable-certificate.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  findCertificatesForDivision,
+  findCertificationAttestationsForDivision,
+  findUserCertificationCourses,
+  findUserPrivateCertificates,
+  getCertificate,
+  getCertificatesForSession,
+  getCertificationCourseByVerificationCode,
+  getCertificationResultForParcoursup,
+  getCertificationsResultsForLivretScolaire,
+  getCleaCertifiedCandidateBySession,
+  getPrivateCertificate,
+  getScoCertificationResultsByDivision,
+  getSessionCertificationReports,
+  getSessionResultsByResultRecipientEmail,
+  getSessionResults,
+  getShareableCertificate,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/scoring/domain/usecases/index.js
+++ b/api/src/certification/scoring/domain/usecases/index.js
@@ -1,9 +1,4 @@
-// eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as scoringConfigurationRepository from '../../../shared/infrastructure/repositories/scoring-configuration-repository.js';
 
 /**
@@ -12,13 +7,16 @@ import * as scoringConfigurationRepository from '../../../shared/infrastructure/
  **/
 const dependencies = { scoringConfigurationRepository };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { saveCertificationScoringConfiguration } from './save-certification-scoring-configuration.js';
+import { saveCompetenceForScoringConfiguration } from './save-competence-for-scoring-configuration.js';
+import { simulateCapacityFromScore } from './simulate-capacity-from-score.js';
+import { simulateScoreFromCapacity } from './simulate-score-from-capacity.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  saveCertificationScoringConfiguration,
+  saveCompetenceForScoringConfiguration,
+  simulateCapacityFromScore,
+  simulateScoreFromCapacity,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -1,11 +1,6 @@
-// eslint-disable import/no-restricted-paths
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as userRepository from '../../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as flashAlgorithmService from '../../../evaluation/domain/services/algorithm-methods/flash.js';
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationCpfService from '../../../shared/domain/services/certification-cpf-service.js';
@@ -143,18 +138,92 @@ const dependencies = {
   userRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { abortCertificationCourse } from './abort-certification-course.js';
+import { assignCertificationOfficerToJurySession } from './assign-certification-officer-to-jury-session.js';
+import { authorizeCertificationCandidateToResume } from './authorize-certification-candidate-to-resume.js';
+import { authorizeCertificationCandidateToStart } from './authorize-certification-candidate-to-start.js';
+import { cancel } from './cancel.js';
+import { clearCompanionAlert } from './clear-companion-alert.js';
+import { commentSessionAsJury } from './comment-session-as-jury.js';
+import { correctCandidateIdentityInCertificationCourse } from './correct-candidate-identity-in-certification-course.js';
+import { createCertificationChallengeLiveAlert } from './create-certification-challenge-live-alert.js';
+import { deleteCertificationIssueReport } from './delete-certification-issue-report.js';
+import { deleteSessionJuryComment } from './delete-session-jury-comment.js';
+import { dismissLiveAlert } from './dismiss-live-alert.js';
+import { endAssessmentBySupervisor } from './end-assessment-by-supervisor.js';
+import { finalizeSession } from './finalize-session.js';
+import { findFinalizedSessionsToPublish } from './find-finalized-sessions-to-publish.js';
+import { findFinalizedSessionsWithRequiredAction } from './find-finalized-sessions-with-required-action.js';
+import { findPaginatedCertificationCenterSessionSummaries } from './find-paginated-certification-center-session-summaries.js';
+import { getCertificationDetails } from './get-certification-details.js';
+import { getPreSignedUrls } from './get-cpf-presigned-urls.js';
+import { getInvigilatorKitSessionInfo } from './get-invigilator-kit-session-info.js';
+import { getJuryCertification } from './get-jury-certification.js';
+import { getJurySession } from './get-jury-session.js';
+import { getSession } from './get-session.js';
+import { getSessionForSupervising } from './get-session-for-supervising.js';
+import { getV3CertificationCourseDetailsForAdministration } from './get-v3-certification-course-details-for-administration.js';
+import { integrateCpfProccessingReceipts } from './integrate-cpf-processing-receipts.js';
+import { manuallyResolveCertificationIssueReport } from './manually-resolve-certification-issue-report.js';
+import { processAutoJury } from './process-auto-jury.js';
+import { publishSession } from './publish-session.js';
+import { publishSessionsInBatch } from './publish-sessions-in-batch.js';
+import { registerPublishableSession } from './register-publishable-session.js';
+import { rejectCertificationCourse } from './reject-certification-course.js';
+import { saveCertificationIssueReport } from './save-certification-issue-report.js';
+import { saveJuryComplementaryCertificationCourseResult } from './save-jury-complementary-certification-course-result.js';
+import { superviseSession } from './supervise-session.js';
+import { uncancel } from './uncancel.js';
+import { unfinalizeSession } from './unfinalize-session.js';
+import { unpublishSession } from './unpublish-session.js';
+import { unrejectCertificationCourse } from './unreject-certification-course.js';
+import { updateJuryComment } from './update-jury-comment.js';
+import { uploadCpfFiles } from './upload-cpf-files.js';
+import { validateLiveAlert } from './validate-live-alert.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  abortCertificationCourse,
+  assignCertificationOfficerToJurySession,
+  authorizeCertificationCandidateToResume,
+  authorizeCertificationCandidateToStart,
+  cancel,
+  clearCompanionAlert,
+  commentSessionAsJury,
+  correctCandidateIdentityInCertificationCourse,
+  createCertificationChallengeLiveAlert,
+  deleteCertificationIssueReport,
+  deleteSessionJuryComment,
+  dismissLiveAlert,
+  endAssessmentBySupervisor,
+  finalizeSession,
+  findFinalizedSessionsToPublish,
+  findFinalizedSessionsWithRequiredAction,
+  findPaginatedCertificationCenterSessionSummaries,
+  getCertificationDetails,
+  getPreSignedUrls,
+  getInvigilatorKitSessionInfo,
+  getJuryCertification,
+  getJurySession,
+  getSessionForSupervising,
+  getSession,
+  getV3CertificationCourseDetailsForAdministration,
+  integrateCpfProccessingReceipts,
+  manuallyResolveCertificationIssueReport,
+  processAutoJury,
+  publishSession,
+  publishSessionsInBatch,
+  registerPublishableSession,
+  rejectCertificationCourse,
+  saveCertificationIssueReport,
+  saveJuryComplementaryCertificationCourseResult,
+  superviseSession,
+  uncancel,
+  unfinalizeSession,
+  unpublishSession,
+  unrejectCertificationCourse,
+  updateJuryComment,
+  uploadCpfFiles,
+  validateLiveAlert,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -1,26 +1,14 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 
 const dependencies = {
   certificationCourseRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { getCertificationCourse } from './get-certification-course.js';
 
-/**
- * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
- * This is in progress, because they should be injected in this file and not by shared sub-domain
- * The only remaining file ignored should be index.js
- */
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  getCertificationCourse,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import * as llmApi from '../../../llm/application/api/llm-api.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
@@ -11,11 +8,8 @@ import * as knowledgeElementRepository from '../../../shared/infrastructure/repo
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const dependencies = {
   ...repositories,
@@ -31,8 +25,64 @@ const dependencies = {
   llmApi,
 };
 
+import { addTutorialEvaluation } from './add-tutorial-evaluation.js';
+import { addTutorialToUser } from './add-tutorial-to-user.js';
+import { attachTargetProfilesToTraining } from './attach-target-profiles-to-training.js';
+import { createOrUpdateTrainingTrigger } from './create-or-update-training-trigger.js';
+import { createPassage } from './create-passage.js';
+import { createTraining } from './create-training.js';
+import { detachTargetProfilesFromTraining } from './detach-target-profiles-from-training.js';
+import { duplicateTraining } from './duplicate-training.js';
+import { findCampaignParticipationTrainings } from './find-campaign-participation-trainings.js';
+import { findPaginatedFilteredTutorials } from './find-paginated-filtered-tutorials.js';
+import { findPaginatedTargetProfileTrainingSummaries } from './find-paginated-target-profile-training-summaries.js';
+import { findPaginatedTrainingSummaries } from './find-paginated-training-summaries.js';
+import { findPaginatedUserRecommendedTrainings } from './find-paginated-user-recommended-trainings.js';
+import { findRecommendedModulesByCampaignParticipationIds } from './find-recommended-modules-by-campaign-participation-ids.js';
+import { findRecommendedModulesByTargetProfileIds } from './find-recommended-modules-by-target-profile-ids.js';
+import { findTargetProfileSummariesForTraining } from './find-target-profile-summaries-for-training.js';
+import { findTutorials } from './find-tutorials.js';
+import { getModule } from './get-module.js';
+import { getModuleMetadataList } from './get-module-metadata-list.js';
+import { getTraining } from './get-training.js';
+import { getUserModuleStatuses } from './get-user-module-statuses.js';
+import { handleTrainingRecommendation } from './handle-training-recommendation.js';
+import { promptToLLMChat } from './prompt-to-llm-chat.js';
+import { recordPassageEvents } from './record-passage-events.js';
+import { startEmbedLlmChat } from './start-embed-llm-chat.js';
+import { terminatePassage } from './terminate-passage.js';
+import { updateTraining } from './update-training.js';
+import { verifyAndSaveAnswer } from './verify-and-save-answer.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  addTutorialEvaluation,
+  addTutorialToUser,
+  attachTargetProfilesToTraining,
+  createOrUpdateTrainingTrigger,
+  createPassage,
+  createTraining,
+  detachTargetProfilesFromTraining,
+  duplicateTraining,
+  findCampaignParticipationTrainings,
+  findPaginatedFilteredTutorials,
+  findPaginatedTargetProfileTrainingSummaries,
+  findPaginatedTrainingSummaries,
+  findPaginatedUserRecommendedTrainings,
+  findRecommendedModulesByCampaignParticipationIds,
+  findRecommendedModulesByTargetProfileIds,
+  findTargetProfileSummariesForTraining,
+  findTutorials,
+  getModuleMetadataList,
+  getModule,
+  getTraining,
+  getUserModuleStatuses,
+  handleTrainingRecommendation,
+  promptToLLMChat,
+  recordPassageEvents,
+  startEmbedLlmChat,
+  terminatePassage,
+  updateTraining,
+  verifyAndSaveAnswer,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as certificationEvaluationCandidateRepository from '../../../certification/evaluation/infrastructure/repositories/certification-candidate-repository.js';
 import { certificationCompletedJobRepository } from '../../../certification/evaluation/infrastructure/repositories/jobs/certification-completed-job-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
@@ -21,7 +18,6 @@ import * as courseRepository from '../../../shared/infrastructure/repositories/c
 import { repositories as injectedSharedRepositories } from '../../../shared/infrastructure/repositories/index.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { answerJobRepository } from '../../infrastructure/repositories/answer-job-repository.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeCriteriaRepository from '../../infrastructure/repositories/badge-criteria-repository.js';
@@ -42,12 +38,6 @@ import { pickChallengeService } from '../services/pick-challenge-service.js';
 import * as scorecardService from '../services/scorecard-service.js';
 import * as convertLevelStagesIntoThresholdsService from '../services/stages/convert-level-stages-into-thresholds-service.js';
 import * as getNewAcquiredStagesService from '../services/stages/get-new-acquired-stages-service.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
-
-const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
-};
 
 const dependencies = {
   algorithmDataFetcherService,
@@ -92,6 +82,93 @@ const dependencies = {
   convertLevelStagesIntoThresholdsService,
   getMasteryPercentageService,
   participationCompletedJobRepository,
+};
+
+import { completeAssessment } from './complete-assessment.js';
+import { copyTargetProfileBadges } from './copy-target-profile-badges.js';
+import { copyTargetProfileStages } from './copy-target-profile-stages.js';
+import { createBadge } from './create-badge.js';
+import { createOrUpdateStageCollection } from './create-or-update-stage-collection.js';
+import { findAllPaginatedAutonomousCourses } from './find-all-paginated-autonomous-courses.js';
+import { findAnswerByAssessment } from './find-answer-by-assessment.js';
+import { findAnswerByChallengeAndAssessment } from './find-answer-by-challenge-and-assessment.js';
+import { findCompetenceEvaluationsByAssessment } from './find-competence-evaluations-by-assessment.js';
+import { findFilteredMostRecentKnowledgeElementsByUser } from './find-filtered-most-recent-knowledge-elements-by-user.js';
+import { getAnswer } from './get-answer.js';
+import { getAutonomousCourse } from './get-autonomous-course.js';
+import { getAutonomousCourseTargetProfiles } from './get-autonomous-course-target-profiles.js';
+import { getCampaignParametersForSimulator } from './get-campaign-parameters-for-simulator.js';
+import { getCorrectionForAnswer } from './get-correction-for-answer.js';
+import { getNextChallengeForCampaignAssessment } from './get-next-challenge-for-campaign-assessment.js';
+import { getNextChallengeForCompetenceEvaluation } from './get-next-challenge-for-competence-evaluation.js';
+import { getNextChallengeForDemo } from './get-next-challenge-for-demo.js';
+import { getNextChallengeForPreview } from './get-next-challenge-for-preview.js';
+import { getNextChallengeForSimulator } from './get-next-challenge-for-simulator.js';
+import { getProgression } from './get-progression.js';
+import { getScorecard } from './get-scorecard.js';
+import { handleBadgeAcquisition } from './handle-badge-acquisition.js';
+import { handleStageAcquisition } from './handle-stage-acquisition.js';
+import { improveCompetenceEvaluation } from './improve-competence-evaluation.js';
+import { promptToLLMChat } from './prompt-to-llm-chat.js';
+import { rememberUserHasSeenAssessmentInstructions } from './remember-user-has-seen-assessment-instructions.js';
+import { rememberUserHasSeenNewDashboardInfo } from './remember-user-has-seen-new-dashboard-info.js';
+import { resetScorecard } from './reset-scorecard.js';
+import { saveAndCorrectAnswerForCampaign } from './save-and-correct-answer-for-campaign.js';
+import { saveAndCorrectAnswerForCertification } from './save-and-correct-answer-for-certification.js';
+import { saveAndCorrectAnswerForCompetenceEvaluation } from './save-and-correct-answer-for-competence-evaluation.js';
+import { saveAndCorrectAnswerForDemoAndPreview } from './save-and-correct-answer-for-demo-and-preview.js';
+import { saveAutonomousCourse } from './save-autonomous-course.js';
+import { saveFeedback } from './save-feedback.js';
+import { startEmbedLlmChat } from './start-embed-llm-chat.js';
+import { startOrResumeCompetenceEvaluation } from './start-or-resume-competence-evaluation.js';
+import { updateAutonomousCourse } from './update-autonomous-course.js';
+import { updateBadge } from './update-badge.js';
+import { updateBadgeCriterion } from './update-badge-criterion.js';
+import { isStageNotUpdatable, updateStage } from './update-stage.js';
+
+const usecasesWithoutInjectedDependencies = {
+  completeAssessment,
+  copyTargetProfileBadges,
+  copyTargetProfileStages,
+  createBadge,
+  createOrUpdateStageCollection,
+  findAllPaginatedAutonomousCourses,
+  findAnswerByAssessment,
+  findAnswerByChallengeAndAssessment,
+  findCompetenceEvaluationsByAssessment,
+  findFilteredMostRecentKnowledgeElementsByUser,
+  getAnswer,
+  getAutonomousCourseTargetProfiles,
+  getAutonomousCourse,
+  getCampaignParametersForSimulator,
+  getCorrectionForAnswer,
+  getNextChallengeForCampaignAssessment,
+  getNextChallengeForCompetenceEvaluation,
+  getNextChallengeForDemo,
+  getNextChallengeForPreview,
+  getNextChallengeForSimulator,
+  getProgression,
+  getScorecard,
+  handleBadgeAcquisition,
+  handleStageAcquisition,
+  improveCompetenceEvaluation,
+  promptToLLMChat,
+  rememberUserHasSeenAssessmentInstructions,
+  rememberUserHasSeenNewDashboardInfo,
+  resetScorecard,
+  saveAndCorrectAnswerForCampaign,
+  saveAndCorrectAnswerForCertification,
+  saveAndCorrectAnswerForCompetenceEvaluation,
+  saveAndCorrectAnswerForDemoAndPreview,
+  saveAutonomousCourse,
+  saveFeedback,
+  startEmbedLlmChat,
+  startOrResumeCompetenceEvaluation,
+  updateAutonomousCourse,
+  updateBadgeCriterion,
+  updateBadge,
+  isStageNotUpdatable,
+  updateStage,
 };
 
 const evaluationUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { oidcAuthenticationServiceRegistry } from '../../../../lib/domain/usecases/index.js';
 import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as userRecommendedTrainingRepository from '../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
@@ -25,7 +22,6 @@ import * as organizationRepository from '../../../shared/infrastructure/reposito
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import * as codeUtils from '../../../shared/infrastructure/utils/code-utils.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as emailRepository from '../../../shared/mail/infrastructure/repositories/email.repository.js';
 import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../team/infrastructure/repositories/membership.repository.js';
@@ -52,8 +48,6 @@ import { pixAuthenticationService } from '../services/pix-authentication-service
 import { resetPasswordService } from '../services/reset-password.service.js';
 import { scoAccountRecoveryService } from '../services/sco-account-recovery.service.js';
 import { addOidcProviderValidator } from '../validators/add-oidc-provider.validator.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const repositories = {
   accountRecoveryDemandRepository,
@@ -113,8 +107,122 @@ const utils = {
 
 const dependencies = Object.assign({ config, codeUtils }, repositories, services, validators, utils);
 
+import { acceptPixCertifTermsOfService } from './accept-pix-certif-terms-of-service.usecase.js';
+import { acceptPixLastTermsOfService } from './accept-pix-last-terms-of-service.usecase.js';
+import { acceptPixOrgaTermsOfService } from './accept-pix-orga-terms-of-service.usecase.js';
+import { addOidcProvider } from './add-oidc-provider.js';
+import { addPixAuthenticationMethod } from './add-pix-authentication-method.usecase.js';
+import { anonymizeGarAuthenticationMethods } from './anonymize-gar-authentication-methods.usecase.js';
+import { anonymizeUser } from './anonymize-user.usecase.js';
+import { authenticateAnonymousUser } from './authenticate-anonymous-user.usecase.js';
+import { authenticateApplication } from './authenticate-application.js';
+import { authenticateForSaml } from './authenticate-for-saml.usecase.js';
+import { authenticateOidcUser } from './authenticate-oidc-user.usecase.js';
+import { authenticateUser } from './authenticate-user.js';
+import { changeUserLanguage } from './change-user-language.usecase.js';
+import { checkScoAccountRecovery } from './check-sco-account-recovery.usecase.js';
+import { createAccessTokenFromRefreshToken } from './create-access-token-from-refresh-token.usecase.js';
+import { createOidcUser } from './create-oidc-user.usecase.js';
+import { createResetPasswordDemand } from './create-reset-password-demand.usecase.js';
+import { createUser } from './create-user.usecase.js';
+import { findPaginatedFilteredUsers } from './find-paginated-filtered-users.usecase.js';
+import { findUserAuthenticationMethods } from './find-user-authentication-methods.usecase.js';
+import { findUserForOidcReconciliation } from './find-user-for-oidc-reconciliation.usecase.js';
+import { getAccountRecoveryDetails } from './get-account-recovery-details.usecase.js';
+import { getActiveByUserIds } from './get-active-by-user-ids.usecase.js';
+import { getAllIdentityProviders } from './get-all-identity-providers.usecase.js';
+import { getAuthorizationUrl } from './get-authorization-url.usecase.js';
+import { getCertificationPointOfContact } from './get-certification-point-of-contact.usecase.js';
+import { getCurrentUser } from './get-current-user.usecase.js';
+import { getReadyIdentityProviders } from './get-ready-identity-providers.usecase.js';
+import { getRedirectLogoutUrl } from './get-redirect-logout-url.usecase.js';
+import { getSamlAuthenticationRedirectionUrl } from './get-saml-authentication-redirection-url.js';
+import { getUserAccountInfo } from './get-user-account-info.usecase.js';
+import { getUserByResetPasswordDemand } from './get-user-by-reset-password-demand.usecase.js';
+import { getUserDetailsForAdmin } from './get-user-details-for-admin.usecase.js';
+import { importUserLastLoggedAt } from './import-user-last-logged-at.usecase.js';
+import { listLtiPublicKeys } from './list-lti-public-keys.usecase.js';
+import { markAssessmentInstructionsInfoAsSeen } from './mark-assessment-instructions-info-as-seen.usecase.js';
+import { markUserHasSeenNewDashboardInfo } from './mark-user-has-seen-new-dashboard-info.usecase.js';
+import { reassignAuthenticationMethodToAnotherUser } from './reassign-authentication-method-to-another-user.usecase.js';
+import { reconcileOidcUser } from './reconcile-oidc-user.usecase.js';
+import { reconcileOidcUserForAdmin } from './reconcile-oidc-user-for-admin.usecase.js';
+import { registerLtiPlatform } from './register-lti-platform.js';
+import { rememberUserHasSeenChallengeTooltip } from './remember-user-has-seen-challenge-tooltip.usecase.js';
+import { rememberUserHasSeenLastDataProtectionPolicyInformation } from './remember-user-has-seen-last-data-protection-policy-information.usecase.js';
+import { removeAuthenticationMethod } from './remove-authentication-method.usecase.js';
+import { revokeAccessForUsers } from './revoke-access-for-users.usecase.js';
+import { revokeRefreshToken } from './revoke-refresh-token.usecase.js';
+import { selfDeleteUserAccount } from './self-delete-user-account.usecase.js';
+import { sendEmailForAccountRecovery } from './send-email-for-account-recovery.usecase.js';
+import { sendVerificationCode } from './send-verification-code.usecase.js';
+import { unblockUserAccount } from './unblock-user-account.js';
+import { updateExpiredPassword } from './update-expired-password.usecase.js';
+import { updateUserDetailsByAdmin } from './update-user-details-by-admin.usecase.js';
+import { updateUserEmailWithValidation } from './update-user-email-with-validation.usecase.js';
+import { updateUserForAccountRecovery } from './update-user-for-account-recovery.usecase.js';
+import { updateUserPassword } from './update-user-password.usecase.js';
+import { upgradeToRealUser } from './upgrade-to-real-user.usecase.js';
+import { validateUserAccountEmail } from './validate-user-account-email.usecase.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  acceptPixCertifTermsOfService,
+  acceptPixLastTermsOfService,
+  acceptPixOrgaTermsOfService,
+  addOidcProvider,
+  addPixAuthenticationMethod,
+  anonymizeGarAuthenticationMethods,
+  anonymizeUser,
+  authenticateAnonymousUser,
+  authenticateApplication,
+  authenticateForSaml,
+  authenticateOidcUser,
+  authenticateUser,
+  changeUserLanguage,
+  checkScoAccountRecovery,
+  createAccessTokenFromRefreshToken,
+  createOidcUser,
+  createResetPasswordDemand,
+  createUser,
+  findPaginatedFilteredUsers,
+  findUserAuthenticationMethods,
+  findUserForOidcReconciliation,
+  getAccountRecoveryDetails,
+  getActiveByUserIds,
+  getAllIdentityProviders,
+  getAuthorizationUrl,
+  getCertificationPointOfContact,
+  getCurrentUser,
+  getReadyIdentityProviders,
+  getRedirectLogoutUrl,
+  getSamlAuthenticationRedirectionUrl,
+  getUserAccountInfo,
+  getUserByResetPasswordDemand,
+  getUserDetailsForAdmin,
+  importUserLastLoggedAt,
+  listLtiPublicKeys,
+  markAssessmentInstructionsInfoAsSeen,
+  markUserHasSeenNewDashboardInfo,
+  reassignAuthenticationMethodToAnotherUser,
+  reconcileOidcUserForAdmin,
+  reconcileOidcUser,
+  registerLtiPlatform,
+  rememberUserHasSeenChallengeTooltip,
+  rememberUserHasSeenLastDataProtectionPolicyInformation,
+  removeAuthenticationMethod,
+  revokeAccessForUsers,
+  revokeRefreshToken,
+  selfDeleteUserAccount,
+  sendEmailForAccountRecovery,
+  sendVerificationCode,
+  unblockUserAccount,
+  updateExpiredPassword,
+  updateUserDetailsByAdmin,
+  updateUserEmailWithValidation,
+  updateUserForAccountRecovery,
+  updateUserPassword,
+  upgradeToRealUser,
+  validateUserAccountEmail,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/learning-content/domain/usecases/index.js
+++ b/api/src/learning-content/domain/usecases/index.js
@@ -1,17 +1,23 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { createLearningContentRelease } from './create-learning-content-release.js';
 import { dependencies } from './dependencies.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
+import { findSkillsByIds } from './find-skills-by-ids.js';
+import { getFrameworkAreas } from './get-framework-areas.js';
+import { getFrameworks } from './get-frameworks.js';
+import { patchLearningContentCacheEntry } from './patch-learning-content-cache-entry.js';
+import { refreshLearningContentCache } from './refresh-learning-content-cache.js';
+import { scheduleCreateLearningContentReleaseJob } from './schedule-create-learning-content-release-job.js';
+import { scheduleRefreshLearningContentCacheJob } from './schedule-refresh-learning-content-cache-job.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js', 'dependencies.js'],
-  })),
+  createLearningContentRelease,
+  findSkillsByIds,
+  getFrameworkAreas,
+  getFrameworks,
+  patchLearningContentCacheEntry,
+  refreshLearningContentCache,
+  scheduleCreateLearningContentReleaseJob,
+  scheduleRefreshLearningContentCacheJob,
 };
 
 export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/legal-documents/domain/usecases/index.js
+++ b/api/src/legal-documents/domain/usecases/index.js
@@ -1,13 +1,7 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import * as legalDocumentRepository from '../../infrastructure/repositories/legal-document.repository.js';
 import * as userAcceptanceRepository from '../../infrastructure/repositories/user-acceptance.repository.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const repositories = {
   legalDocumentRepository,
@@ -16,8 +10,14 @@ const repositories = {
 
 const dependencies = Object.assign({ logger }, repositories);
 
+import { acceptLegalDocumentByUserId } from './accept-legal-document-by-user-id.usecase.js';
+import { createLegalDocument } from './create-legal-document.usecase.js';
+import { getLegalDocumentStatusByUserId } from './get-legal-document-status-by-user-id.usecase.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  acceptLegalDocumentByUserId,
+  createLegalDocument,
+  getLegalDocumentStatusByUserId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/llm/domain/usecases/index.js
+++ b/api/src/llm/domain/usecases/index.js
@@ -1,13 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as repositories from '../../infrastructure/repositories/index.js';
 import * as toEventStream from '../../infrastructure/streaming/to-event-stream.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const dependencies = {
   ...repositories,
@@ -15,8 +10,12 @@ const dependencies = {
   randomUUID,
 };
 
+import { promptChat } from './prompt-chat.js';
+import { startChat } from './start-chat.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  promptChat,
+  startChat,
 };
 
 export const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as centerRepository from '../../../certification/enrolment/infrastructure/repositories/center-repository.js';
 import * as learnersApi from '../../../prescription/learner-management/application/api/learners-api.js';
 import * as schoolRepository from '../../../school/infrastructure/repositories/school-repository.js';
@@ -8,7 +5,6 @@ import * as codeGenerator from '../../../shared/domain/services/code-generator.j
 import { adminMemberRepository } from '../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCenterRepository from '../../infrastructure/repositories/certification-center.repository.js';
 import { certificationCenterApiRepository } from '../../infrastructure/repositories/certification-center-api.repository.js';
 import * as certificationCenterForAdminRepository from '../../infrastructure/repositories/certification-center-for-admin.repository.js';
@@ -21,8 +17,6 @@ import { tagRepository } from '../../infrastructure/repositories/tag.repository.
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
 import * as organizationCreationValidator from '../validators/organization-creation-validator.js';
 import * as organizationValidator from '../validators/organization-with-tags-and-target-profiles.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 /**
  * @typedef {import ('../../../prescription/learner-management/application/api/learners-api.js')} learnersApi
@@ -66,10 +60,57 @@ const repositories = {
 
 const dependencies = Object.assign({}, repositories);
 
-const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
-};
+import { addOrganizationFeatureInBatch } from './add-organization-feature-in-batch.js';
+import { addTagsToOrganizations } from './add-tags-to-organizations.usecase.js';
+import { archiveCertificationCenter } from './archive-certification-center.usecase.js';
+import { archiveCertificationCentersInBatch } from './archive-certification-centers-in-batch.usecase.js';
+import { archiveOrganization } from './archive-organization.usecase.js';
+import { archiveOrganizationsInBatch } from './archive-organizations-in-batch.usecase.js';
+import { attachChildOrganizationToOrganization } from './attach-child-organization-to-organization.js';
+import { createCertificationCenter } from './create-certification-center.usecase.js';
+import { createOrganization } from './create-organization.js';
+import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizations-with-tags-and-target-profiles.usecase.js';
+import { createTag } from './create-tag.js';
+import { findAllTags } from './find-all-tags.usecase.js';
+import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
+import { findOrganizationFeatures } from './find-organization-features.js';
+import { findPaginatedFilteredCertificationCenters } from './find-paginated-filtered-certification-centers.usecase.js';
+import { findPaginatedFilteredOrganizations } from './find-paginated-filtered-organizations.usecase.js';
+import { getCenterForAdmin } from './get-center-for-admin.usecase.js';
+import { getOrganizationById } from './get-organization-by-id.js';
+import { getOrganizationDetails } from './get-organization-details.usecase.js';
+import { getRecentlyUsedTags } from './get-recently-used-tags.usecase.js';
+import { updateCertificationCenter } from './update-certification-center.usecase.js';
+import { updateCertificationCenterDataProtectionOfficerInformation } from './update-certification-center-data-protection-officer-information.usecase.js';
+import { updateOrganizationInformation } from './update-organization-information.usecase.js';
+import { updateOrganizationsInBatch } from './update-organizations-in-batch.usecase.js';
 
+const usecasesWithoutInjectedDependencies = {
+  addOrganizationFeatureInBatch,
+  addTagsToOrganizations,
+  archiveCertificationCenter,
+  archiveCertificationCentersInBatch,
+  archiveOrganization,
+  archiveOrganizationsInBatch,
+  attachChildOrganizationToOrganization,
+  createCertificationCenter,
+  createOrganization,
+  createOrganizationsWithTagsAndTargetProfiles,
+  createTag,
+  findAllTags,
+  findChildrenOrganizations,
+  findOrganizationFeatures,
+  findPaginatedFilteredCertificationCenters,
+  findPaginatedFilteredOrganizations,
+  getCenterForAdmin,
+  getOrganizationById,
+  getOrganizationDetails,
+  getRecentlyUsedTags,
+  updateCertificationCenterDataProtectionOfficerInformation,
+  updateCertificationCenter,
+  updateOrganizationInformation,
+  updateOrganizationsInBatch,
+};
 /**
  * @typedef OrganizationalEntitiesUsecases
  * @property {addOrganizationFeatureInBatch} addOrganizationFeatureInBatch

--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as learningContentRepository from '../../../../../src/prescription/shared/infrastructure/repositories/learning-content-repository.js';
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
@@ -20,7 +17,6 @@ import { repositories as injectedSharedRepositories } from '../../../../shared/i
 import { eventLoggingJobRepository } from '../../../../shared/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import * as knowledgeElementSnapshotRepository from '../../../campaign/infrastructure/repositories/knowledge-element-snapshot-repository.js';
 import * as stageCollectionRepository from '../../../campaign/infrastructure/repositories/stage-collection-repository.js';
@@ -85,13 +81,54 @@ const dependencies = {
   userRecommendedTrainingRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { beginCampaignParticipationImprovement } from './begin-campaign-participation-improvement.js';
+import { computeCampaignParticipationAnalysis } from './compute-campaign-participation-analysis.js';
+import { deleteCampaignParticipation } from './delete-campaign-participation.js';
+import { findCampaignParticipationsForUserManagement } from './find-campaign-participations-for-user-management.js';
+import { findPaginatedParticipationsForCampaignManagement } from './find-paginated-participations-for-campaign-management.js';
+import { findUserAnonymisedCampaignAssessments } from './find-user-anonymised-campaign-assessments.js';
+import { findUserCampaignParticipationOverviews } from './find-user-campaign-participation-overviews.js';
+import { getCampaignAssessmentParticipation } from './get-campaign-assessment-participation.js';
+import { getCampaignAssessmentParticipationResult } from './get-campaign-assessment-participation-result.js';
+import { getCampaignParticipationsForOrganizationLearner } from './get-campaign-participations-for-organization-learner.js';
+import { getCampaignProfile } from './get-campaign-profile.js';
+import { getPoleEmploiSendings } from './get-pole-emploi-sendings.js';
+import { getSharedCampaignParticipationProfile } from './get-shared-campaign-participation-profile.js';
+import { getUserCampaignAssessmentResult } from './get-user-campaign-assessment-result.js';
+import { getUserCampaignParticipationToCampaign } from './get-user-campaign-participation-to-campaign.js';
+import { hasCampaignParticipations } from './has-campaign-participations.js';
+import { saveComputedCampaignParticipationResult } from './save-computed-campaign-participation-result.js';
+import { sendCompletedParticipationResultsToPoleEmploi } from './send-completed-participation-results-to-pole-emploi.js';
+import { sendSharedParticipationResultsToPoleEmploi } from './send-shared-participation-results-to-pole-emploi.js';
+import { sendStartedParticipationResultsToPoleEmploi } from './send-started-participation-results-to-pole-emploi.js';
+import { shareCampaignResult } from './share-campaign-result.js';
+import { startCampaignParticipation } from './start-campaign-participation.js';
+import { updateParticipantExternalId } from './update-participant-external-id.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  beginCampaignParticipationImprovement,
+  computeCampaignParticipationAnalysis,
+  deleteCampaignParticipation,
+  findCampaignParticipationsForUserManagement,
+  findPaginatedParticipationsForCampaignManagement,
+  findUserAnonymisedCampaignAssessments,
+  findUserCampaignParticipationOverviews,
+  getCampaignAssessmentParticipationResult,
+  getCampaignAssessmentParticipation,
+  getCampaignParticipationsForOrganizationLearner,
+  getCampaignProfile,
+  getPoleEmploiSendings,
+  getSharedCampaignParticipationProfile,
+  getUserCampaignAssessmentResult,
+  getUserCampaignParticipationToCampaign,
+  hasCampaignParticipations,
+  saveComputedCampaignParticipationResult,
+  sendCompletedParticipationResultsToPoleEmploi,
+  sendSharedParticipationResultsToPoleEmploi,
+  sendStartedParticipationResultsToPoleEmploi,
+  shareCampaignResult,
+  startCampaignParticipation,
+  updateParticipantExternalId,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as tutorialRepository from '../../../../devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as userRecommendedTrainingRepository from '../../../../devcomp/infrastructure/repositories/user-recommended-training-repository.js';
 import * as badgeAcquisitionRepository from '../../../../evaluation/infrastructure/repositories/badge-acquisition-repository.js';
@@ -19,7 +16,6 @@ import { eventLoggingJobRepository } from '../../../../shared/infrastructure/rep
 import * as knowledgeElementRepository from '../../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as membershipRepository from '../../../../team/infrastructure/repositories/membership.repository.js';
 import * as campaignAnalysisRepository from '../../../campaign-participation/infrastructure/repositories/campaign-analysis-repository.js';
 import * as campaignParticipationRepository from '../../../campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
@@ -88,17 +84,80 @@ const dependencies = {
   userRecommendedTrainingRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { archiveCampaign } from './archive-campaign.js';
+import { archiveCampaigns } from './archive-campaigns.js';
+import { computeCampaignCollectiveResult } from './compute-campaign-collective-result.js';
+import { createCampaign } from './create-campaign.js';
+import { createCampaigns } from './create-campaigns.js';
+import { deleteCampaigns } from './delete-campaigns.js';
+import { findAssessmentParticipationResultList } from './find-assessment-participation-result-list.js';
+import { findCampaignProfilesCollectionParticipationSummaries } from './find-campaign-profiles-collection-participation-summaries.js';
+import { findCampaignSkillIdsForCampaignParticipations } from './find-campaign-skill-ids-for-campaign-participations.js';
+import { findPaginatedCampaignManagements } from './find-paginated-campaign-managements.js';
+import { findPaginatedCampaignParticipantsActivities } from './find-paginated-campaign-participants-activities.js';
+import { findPaginatedFilteredOrganizationCampaigns } from './find-paginated-filtered-organization-campaigns.js';
+import { getCampaign } from './get-campaign.js';
+import { getCampaignByCode } from './get-campaign-by-code.js';
+import { getCampaignManagement } from './get-campaign-management.js';
+import { getCampaignOfCampaignParticipation } from './get-campaign-of-campaign-participation.js';
+import { getCampaignParticipations } from './get-campaign-participations.js';
+import { getKnowledgeElementSnapshotForParticipation } from './get-knowledge-element-snapshot-for-participation.js';
+import { getParticipantsDivision } from './get-participants-division.js';
+import { getParticipantsGroup } from './get-participants-group.js';
+import { getPresentationSteps } from './get-presentation-steps.js';
+import { getResultLevelsPerTubesAndCompetences } from './get-result-levels-per-tubes-and-competences.js';
+import { getTargetProfile } from './get-target-profile.js';
+import { saveKnowledgeElementSnapshotForParticipation } from './save-knowledge-element-snapshot-for-participation.js';
+import { startWritingCampaignAssessmentResultsToStream } from './start-writing-campaign-assessment-results-to-stream.js';
+import { startWritingCampaignProfilesCollectionResultsToStream } from './start-writing-campaign-profiles-collection-results-to-stream.js';
+import { getBadgeAcquisitionsStatistics } from './statistics/get-badge-acquisitions-statistics.js';
+import { getCampaignParticipationsActivityByDay } from './statistics/get-campaign-participations-activity-by-day.js';
+import { getCampaignParticipationsCountByStage } from './statistics/get-campaign-participations-counts-by-stage.js';
+import { getCampaignParticipationsCountsByStatus } from './statistics/get-campaign-participations-counts-by-status.js';
+import { getParticipationsCountByMasteryRate } from './statistics/get-participations-count-by-mastery-rate.js';
+import { swapCampaignCodes } from './swap-campaign-code.js';
+import { unarchiveCampaign } from './unarchive-campaign.js';
+import { updateCampaign } from './update-campaign.js';
+import { updateCampaignCode } from './update-campaign-code.js';
+import { updateCampaignDetails } from './update-campaign-details.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './statistics/'),
-    ignoredFileNames: ['index.js'],
-  })),
+  archiveCampaign,
+  archiveCampaigns,
+  computeCampaignCollectiveResult,
+  createCampaign,
+  createCampaigns,
+  deleteCampaigns,
+  findAssessmentParticipationResultList,
+  findCampaignProfilesCollectionParticipationSummaries,
+  findCampaignSkillIdsForCampaignParticipations,
+  findPaginatedCampaignManagements,
+  findPaginatedCampaignParticipantsActivities,
+  findPaginatedFilteredOrganizationCampaigns,
+  getCampaignByCode,
+  getCampaignManagement,
+  getCampaignOfCampaignParticipation,
+  getCampaignParticipations,
+  getCampaign,
+  getKnowledgeElementSnapshotForParticipation,
+  getParticipantsDivision,
+  getParticipantsGroup,
+  getPresentationSteps,
+  getResultLevelsPerTubesAndCompetences,
+  getTargetProfile,
+  saveKnowledgeElementSnapshotForParticipation,
+  startWritingCampaignAssessmentResultsToStream,
+  startWritingCampaignProfilesCollectionResultsToStream,
+  swapCampaignCodes,
+  unarchiveCampaign,
+  updateCampaignCode,
+  updateCampaignDetails,
+  updateCampaign,
+  getBadgeAcquisitionsStatistics,
+  getCampaignParticipationsActivityByDay,
+  getCampaignParticipationsCountByStage,
+  getCampaignParticipationsCountsByStatus,
+  getParticipationsCountByMasteryRate,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/organization-learner-feature/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner-feature/domain/usecases/index.js
@@ -1,10 +1,6 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as featureRepository from '../../../../shared/infrastructure/repositories/feature-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as organizationLearnerFeatureRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-feature-repository.js';
 import * as organizationLearnerRepository from '../../../organization-learner/infrastructure/repositories/organization-learner-repository.js';
 
@@ -15,13 +11,12 @@ const dependencies = {
   featureRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { createOrganizationLearnerFeature } from './create-organization-learner-feature.js';
+import { unlinkOrganizationLearnerFeature } from './unlink-organization-learner-feature.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  createOrganizationLearnerFeature,
+  unlinkOrganizationLearnerFeature,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as passwordGenerator from '../../../../identity-access-management/domain/services/password-generator.service.js';
 import * as authenticationMethodRepository from '../../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { emailValidationDemandRepository } from '../../../../identity-access-management/infrastructure/repositories/email-validation-demand.repository.js';
@@ -31,7 +28,6 @@ import * as organizationRepository from '../../../../shared/infrastructure/repos
 import * as userLoginRepository from '../../../../shared/infrastructure/repositories/user-login-repository.js';
 import * as writeCsvUtils from '../../../../shared/infrastructure/utils/csv/write-csv-utils.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as emailRepository from '../../../../shared/mail/infrastructure/repositories/email.repository.js';
 import * as campaignRepository from '../../../campaign/infrastructure/repositories/campaign-repository.js';
 import * as divisionRepository from '../../../campaign/infrastructure/repositories/division-repository.js';
@@ -91,15 +87,53 @@ const dependencies = {
   writeCsvUtils,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { createAndReconcileUserToOrganizationLearner } from './create-and-reconcile-user-to-organization-learner.js';
+import { createUserAndReconcileToOrganizationLearnerFromExternalUser } from './create-user-and-reconcile-to-organization-learner-from-external-user.js';
+import { findAssociationBetweenUserAndOrganizationLearner } from './find-association-between-user-and-organization-learner.js';
+import { findDivisionsByOrganization } from './find-divisions-by-organization.js';
+import { findGroupsByOrganization } from './find-groups-by-organization.js';
+import { findOrganizationLearnersWithParticipations } from './find-organization-learners-with-participations.js';
+import { findPaginatedFilteredAttestationParticipantsStatus } from './find-paginated-filtered-attestation-participants-status.js';
+import { findPaginatedFilteredParticipants } from './find-paginated-filtered-participants.js';
+import { findPaginatedFilteredScoParticipants } from './find-paginated-filtered-sco-participants.js';
+import { findPaginatedFilteredSupParticipants } from './find-paginated-filtered-sup-participants.js';
+import { findPaginatedOrganizationLearners } from './find-paginated-organization-learners.js';
+import { generateOrganizationLearnersUsernameAndTemporaryPassword } from './generate-organization-learners-username-and-temporary-password.js';
+import { generateResetOrganizationLearnersPasswordCsvContent } from './generate-reset-organization-learners-password-cvs-content.js';
+import { generateUsername } from './generate-username.js';
+import { generateUsernameWithTemporaryPassword } from './generate-username-with-temporary-password.js';
+import { getAnalysisByTubes } from './get-analysis-by-tubes.js';
+import { getAttestationZipForDivisions } from './get-attestation-zip-for-divisions.js';
+import { getOrganizationLearner } from './get-organization-learner.js';
+import { getOrganizationLearnerActivity } from './get-organization-learner-activity.js';
+import { getOrganizationLearnerWithParticipations } from './get-organization-learner-with-participations.js';
+import { getOrganizationToJoin } from './get-organization-to-join.js';
+import { updateOrganizationLearnerDependentUserPassword } from './update-organization-learner-dependent-user-password.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  createAndReconcileUserToOrganizationLearner,
+  createUserAndReconcileToOrganizationLearnerFromExternalUser,
+  findAssociationBetweenUserAndOrganizationLearner,
+  findDivisionsByOrganization,
+  findGroupsByOrganization,
+  findOrganizationLearnersWithParticipations,
+  findPaginatedFilteredAttestationParticipantsStatus,
+  findPaginatedFilteredParticipants,
+  findPaginatedFilteredScoParticipants,
+  findPaginatedFilteredSupParticipants,
+  findPaginatedOrganizationLearners,
+  generateOrganizationLearnersUsernameAndTemporaryPassword,
+  generateResetOrganizationLearnersPasswordCsvContent,
+  generateUsernameWithTemporaryPassword,
+  generateUsername,
+  getAnalysisByTubes,
+  getAttestationZipForDivisions,
+  getOrganizationLearnerActivity,
+  getOrganizationLearnerWithParticipations,
+  getOrganizationLearner,
+  getOrganizationToJoin,
+  updateOrganizationLearnerDependentUserPassword,
 };
-
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
 export { usecases };

--- a/api/src/prescription/organization-place/domain/usecases/index.js
+++ b/api/src/prescription/organization-place/domain/usecases/index.js
@@ -1,11 +1,7 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as organizationFeatureApi from '../../../../organizational-entities/application/api/organization-features-api.js';
 import * as organizationLearnerRepository from '../../../../prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as organizationPlacesCapacityRepository from '../../infrastructure/repositories/organization-places-capacity-repository.js';
 import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organization-places-lot-repository.js';
 
@@ -17,13 +13,22 @@ const dependencies = {
   organizationFeatureApi,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { createOrganizationPlacesLot } from './create-organization-places-lot.js';
+import { deleteOrganizationPlacesLot } from './delete-organization-places-lot.js';
+import { findOrganizationPlacesLot } from './find-organization-places-lot.js';
+import { getDataOrganizationsPlacesStatistics } from './get-data-organizations-places-statistics.js';
+import { getOrganizationPlacesCapacity } from './get-organization-places-capacity.js';
+import { getOrganizationPlacesLots } from './get-organization-places-lots.js';
+import { getOrganizationPlacesStatistics } from './get-organization-places-statistics.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  createOrganizationPlacesLot,
+  deleteOrganizationPlacesLot,
+  findOrganizationPlacesLot,
+  getDataOrganizationsPlacesStatistics,
+  getOrganizationPlacesCapacity,
+  getOrganizationPlacesLots,
+  getOrganizationPlacesStatistics,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/prescription/target-profile/domain/usecases/index.js
+++ b/api/src/prescription/target-profile/domain/usecases/index.js
@@ -1,11 +1,7 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as learningContentConversionService from '../../../../../lib/domain/services/learning-content/learning-content-conversion-service.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as learningContentRepository from '../../../shared/infrastructure/repositories/learning-content-repository.js';
 import * as targetProfileRepository from '../../../target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
@@ -43,13 +39,46 @@ const dependencies = {
   targetProfileSummaryForAdminRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { attachOrganizationsFromExistingTargetProfile } from './attach-organizations-from-existing-target-profile.js';
+import { attachOrganizationsToTargetProfile } from './attach-organizations-to-target-profile.js';
+import { attachTargetProfilesToOrganization } from './attach-target-profiles-to-organization.js';
+import { copyTargetProfile } from './copy-target-profile.js';
+import { createTargetProfile } from './create-target-profile.js';
+import { detachOrganizationsFromTargetProfile } from './detach-organizations-from-target-profile.js';
+import { findOrganizationTargetProfileSummariesForAdmin } from './find-organization-target-profile-summaries-for-admin.js';
+import { findPaginatedFilteredOrganizationByTargetProfileId } from './find-paginated-filtered-target-profile-organizations.js';
+import { findPaginatedFilteredTargetProfileSummariesForAdmin } from './find-paginated-filtered-target-profile-summaries-for-admin.js';
+import { findSkillsByTargetProfileIds } from './find-skills-by-target-profile-ids.js';
+import { getAvailableTargetProfilesForOrganization } from './get-available-target-profiles-for-organization.js';
+import { getLearningContentByTargetProfile } from './get-learning-content-by-target-profile.js';
+import { getLearningContentForTargetProfileSubmission } from './get-learning-content-for-target-profile-submission.js';
+import { getTargetProfile } from './get-target-profile.js';
+import { getTargetProfileContentAsJson } from './get-target-profile-content-as-json.js';
+import { getTargetProfileForAdmin } from './get-target-profile-for-admin.js';
+import { markTargetProfileAsSimplifiedAccess } from './mark-target-profile-as-simplified-access.js';
+import { outdateTargetProfile } from './outdate-target-profile.js';
+import { updateTargetProfile } from './update-target-profile.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, './'),
-    ignoredFileNames: ['index.js'],
-  })),
+  attachOrganizationsFromExistingTargetProfile,
+  attachOrganizationsToTargetProfile,
+  attachTargetProfilesToOrganization,
+  copyTargetProfile,
+  createTargetProfile,
+  detachOrganizationsFromTargetProfile,
+  findOrganizationTargetProfileSummariesForAdmin,
+  findPaginatedFilteredOrganizationByTargetProfileId,
+  findPaginatedFilteredTargetProfileSummariesForAdmin,
+  findSkillsByTargetProfileIds,
+  getAvailableTargetProfilesForOrganization,
+  getLearningContentByTargetProfile,
+  getLearningContentForTargetProfileSubmission,
+  getTargetProfileContentAsJson,
+  getTargetProfileForAdmin,
+  getTargetProfile,
+  markTargetProfileAsSimplifiedAccess,
+  outdateTargetProfile,
+  updateTargetProfile,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/privacy/domain/usecases/index.js
+++ b/api/src/privacy/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as authenticationMethodRepository from '../../../identity-access-management/infrastructure/repositories/authentication-method.repository.js';
 import { lastUserApplicationConnectionsRepository } from '../../../identity-access-management/infrastructure/repositories/last-user-application-connections.repository.js';
 import { refreshTokenRepository } from '../../../identity-access-management/infrastructure/repositories/refresh-token.repository.js';
@@ -12,15 +9,12 @@ import { featureToggles as featureTogglesService } from '../../../shared/infrast
 import { eventLoggingJobRepository } from '../../../shared/infrastructure/repositories/jobs/event-logging-job.repository.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { certificationCenterMembershipRepository } from '../../../team/infrastructure/repositories/certification-center-membership.repository.js';
 import * as membershipRepository from '../../../team/infrastructure/repositories/membership.repository.js';
 import * as campaignParticipationsApiRepository from '../../infrastructure/repositories/campaign-participations-api.repository.js';
 import * as candidatesApiRepository from '../../infrastructure/repositories/candidates-api.repository.js';
 import * as learnersApiRepository from '../../infrastructure/repositories/learners-api.repository.js';
 import * as userTeamsApiRepository from '../../infrastructure/repositories/user-teams-api.repository.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const repositories = {
   authenticationMethodRepository,
@@ -44,8 +38,12 @@ const services = {
   featureTogglesService,
 };
 
+import { anonymizeUser } from './anonymize-user.usecase.js';
+import { canSelfDeleteAccount } from './can-self-delete-account.usecase.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  anonymizeUser,
+  canSelfDeleteAccount,
 };
 
 const dependencies = Object.assign({}, repositories, services);

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as competenceEvaluationRepository from '../../../evaluation/infrastructure/repositories/competence-evaluation-repository.js';
 import { repositories } from '../../../profile/infrastructure/repositories/index.js';
 import * as profileRewardRepository from '../../../profile/infrastructure/repositories/profile-reward-repository.js';
@@ -8,19 +5,12 @@ import * as areaRepository from '../../../shared/infrastructure/repositories/are
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils.js';
 import * as stringUtils from '../../../shared/infrastructure/utils/string-utils.js';
 import * as attestationRepository from '../../infrastructure/repositories/attestation-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as organizationProfileRewardRepository from '../../infrastructure/repositories/organizations-profile-reward-repository.js';
 import * as rewardRepository from '../../infrastructure/repositories/reward-repository.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
-
-const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
-};
 
 const dependencies = {
   competenceRepository,
@@ -35,6 +25,28 @@ const dependencies = {
   campaignParticipationRepository,
   stringUtils,
   PromiseUtils,
+};
+
+import { getAttestationDataForUsers } from './get-attestation-data-for-users.js';
+import { getAttestationDetails } from './get-attestation-details.js';
+import { getProfileRewardsByUserId } from './get-profile-rewards-by-user-id.js';
+import { getRewardByIdAndType } from './get-reward-by-id-and-type.js';
+import { getSharedAttestationsForOrganizationByUserIds } from './get-shared-attestations-for-organization-by-user-ids.js';
+import { getSharedAttestationsUserDetailForOrganizationByUserIds } from './get-shared-attestations-user-detail-for-organization-by-user-ids.js';
+import { getUserProfile } from './get-user-profile.js';
+import { rewardUser } from './reward-user.js';
+import { shareProfileReward } from './share-profile-reward.js';
+
+const usecasesWithoutInjectedDependencies = {
+  getAttestationDataForUsers,
+  getAttestationDetails,
+  getProfileRewardsByUserId,
+  getRewardByIdAndType,
+  getSharedAttestationsForOrganizationByUserIds,
+  getSharedAttestationsUserDetailForOrganizationByUserIds,
+  getUserProfile,
+  rewardUser,
+  shareProfileReward,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -1,16 +1,6 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
-
-const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
-};
 
 const dependencies = {
   eligibilityRepository: repositories.eligibilityRepository,
@@ -25,6 +15,26 @@ const dependencies = {
   campaignRepository: repositories.campaignRepository,
   userRepository: repositories.userRepository,
   logger,
+};
+
+import { checkUserQuest } from './check-user-quest-success.js';
+import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
+import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
+import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
+import { getVerifiedCode } from './get-verified-code.js';
+import { rewardUser } from './reward-user.js';
+import { startCombinedCourse } from './start-combined-course.js';
+import { updateCombinedCourse } from './update-combined-course.js';
+
+const usecasesWithoutInjectedDependencies = {
+  checkUserQuest,
+  createOrUpdateQuestsInBatch,
+  getCombinedCourseByCode,
+  getQuestResultsForCampaignParticipation,
+  getVerifiedCode,
+  rewardUser,
+  startCombinedCourse,
+  updateCombinedCourse,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/school/domain/usecases/index.js
+++ b/api/src/school/domain/usecases/index.js
@@ -1,12 +1,8 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as activityAnswerRepository from '../../infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -27,10 +23,44 @@ const dependencies = {
   challengeRepository,
 };
 
-const path = dirname(fileURLToPath(import.meta.url));
+import { activateSchoolSession } from './activate-school-session.js';
+import { correctPreviewAnswer } from './correct-preview-answer.js';
+import { createPreviewAssessment } from './create-preview-assessment.js';
+import { findAllActiveMissions } from './find-all-active-missions.js';
+import {
+  filterByGlobalResult,
+  filterByStatuses,
+  findPaginatedMissionLearners,
+} from './find-paginated-mission-learners.js';
+import { getAssessmentById } from './get-assessment-by-id.js';
+import { getChallenge } from './get-challenge.js';
+import { getCurrentActivity } from './get-current-activity.js';
+import { getDivisions } from './get-divisions.js';
+import { getMission } from './get-mission.js';
+import { getNextChallenge } from './get-next-challenge.js';
+import { getOrganizationLearnerWithMissionIdsByState } from './get-organization-learner-with-completed-mission-ids.js';
+import { getSchoolByCode } from './get-school-by-code.js';
+import { handleActivityAnswer } from './handle-activity-answer.js';
+import { playMission } from './play-mission.js';
 
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  activateSchoolSession,
+  correctPreviewAnswer,
+  createPreviewAssessment,
+  findAllActiveMissions,
+  filterByGlobalResult,
+  filterByStatuses,
+  findPaginatedMissionLearners,
+  getAssessmentById,
+  getChallenge,
+  getCurrentActivity,
+  getDivisions,
+  getMission,
+  getNextChallenge,
+  getOrganizationLearnerWithMissionIdsByState,
+  getSchoolByCode,
+  handleActivityAnswer,
+  playMission,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as complementaryCertificationBadgeRepository from '../../../certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as certificationCompanionAlertRepository from '../../../certification/shared/infrastructure/repositories/certification-companion-alert-repository.js';
@@ -13,12 +10,6 @@ import * as competenceRepository from '../../infrastructure/repositories/compete
 import * as courseRepository from '../../infrastructure/repositories/course-repository.js';
 import { repositories as sharedInjectedRepositories } from '../../infrastructure/repositories/index.js';
 import { injectDependencies } from '../../infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../infrastructure/utils/import-named-exports-from-directory.js';
-const path = dirname(fileURLToPath(import.meta.url));
-
-const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
-};
 
 const dependencies = {
   assessmentRepository,
@@ -32,6 +23,18 @@ const dependencies = {
   challengeRepository,
   evaluationUsecases,
   ...sharedInjectedRepositories,
+};
+
+import { deleteUnassociatedBadge } from './delete-unassociated-badge.js';
+import { getAssessment } from './get-assessment.js';
+import { updateAssessmentWithNextChallenge } from './update-assessment-with-next-challenge.js';
+import { updateLastQuestionState } from './update-last-question-state.js';
+
+const usecasesWithoutInjectedDependencies = {
+  deleteUnassociatedBadge,
+  getAssessment,
+  updateAssessmentWithNextChallenge,
+  updateLastQuestionState,
 };
 
 const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/infrastructure/utils/import-named-exports-from-directory.js
+++ b/api/src/shared/infrastructure/utils/import-named-exports-from-directory.js
@@ -1,15 +1,12 @@
 import { readdir } from 'node:fs/promises';
-import { dirname, join, relative } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export async function importNamedExportsFromDirectory({ path, ignoredFileNames = [] }) {
   const imports = {};
   const exportsLocations = {};
   const files = await readdir(path, { withFileTypes: true });
 
-  const appelantDir = getAppelantUrl();
-
-  const importLogs = [];
   for (const file of files) {
     if (file.isDirectory()) {
       continue;
@@ -22,7 +19,6 @@ export async function importNamedExportsFromDirectory({ path, ignoredFileNames =
     const fileURL = pathToFileURL(join(path, file.name));
     const module = await import(fileURL);
     const namedExports = Object.entries(module);
-    const fileExports = {};
 
     for (const [exportName, exportedValue] of namedExports) {
       if (exportName === 'default') {
@@ -32,43 +28,10 @@ export async function importNamedExportsFromDirectory({ path, ignoredFileNames =
         throw new Error(`Duplicate export name ${exportName} : ${exportsLocations[exportName]} and ${file.name}`);
       }
       imports[exportName] = exportedValue;
-      fileExports[exportName] = exportedValue;
       exportsLocations[exportName] = file.name;
     }
-
-    const moduleAbs = fileURLToPath(fileURL);
-    let relativePath = relative(appelantDir, moduleAbs);
-    if (!relativePath.startsWith('.')) {
-      relativePath = './' + relativePath;
-    }
-
-    importLogs.push(`import { ${Object.keys(fileExports).join(', ')} } from '${relativePath}';`);
   }
-
-  console.log(`\n\n\n IMPORT DYNAMIQUE DEPUIS ${appelantDir}`);
-  console.log(importLogs.join('\n'));
-  console.log('\n');
-  console.log(`const usecasesWithoutInjectedDependencies = {
-    ${Object.keys(imports).join(',\n')}
-   };`);
   return imports;
-}
-
-function getAppelantUrl() {
-  const err = new Error();
-  const stack = err.stack.split('\n');
-  // console.log(stack.slice(0, 4));
-  const line = stack[3];
-  const match = line.match(/\((file:\/\/\/?.*):\d+:\d+\)/) || line.match(/at (?:async )?(file:\/\/\/?.*):\d+:\d+/);
-  if (!match) {
-    return '';
-  }
-
-  let appelantAbs = match[1];
-  if (appelantAbs.startsWith('file://')) {
-    appelantAbs = fileURLToPath(appelantAbs);
-  }
-  return dirname(appelantAbs);
 }
 
 export async function importNamedExportFromFile(filepath) {

--- a/api/src/shared/infrastructure/utils/import-named-exports-from-directory.js
+++ b/api/src/shared/infrastructure/utils/import-named-exports-from-directory.js
@@ -1,12 +1,15 @@
 import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export async function importNamedExportsFromDirectory({ path, ignoredFileNames = [] }) {
   const imports = {};
   const exportsLocations = {};
   const files = await readdir(path, { withFileTypes: true });
 
+  const appelantDir = getAppelantUrl();
+
+  const importLogs = [];
   for (const file of files) {
     if (file.isDirectory()) {
       continue;
@@ -19,6 +22,7 @@ export async function importNamedExportsFromDirectory({ path, ignoredFileNames =
     const fileURL = pathToFileURL(join(path, file.name));
     const module = await import(fileURL);
     const namedExports = Object.entries(module);
+    const fileExports = {};
 
     for (const [exportName, exportedValue] of namedExports) {
       if (exportName === 'default') {
@@ -28,10 +32,43 @@ export async function importNamedExportsFromDirectory({ path, ignoredFileNames =
         throw new Error(`Duplicate export name ${exportName} : ${exportsLocations[exportName]} and ${file.name}`);
       }
       imports[exportName] = exportedValue;
+      fileExports[exportName] = exportedValue;
       exportsLocations[exportName] = file.name;
     }
+
+    const moduleAbs = fileURLToPath(fileURL);
+    let relativePath = relative(appelantDir, moduleAbs);
+    if (!relativePath.startsWith('.')) {
+      relativePath = './' + relativePath;
+    }
+
+    importLogs.push(`import { ${Object.keys(fileExports).join(', ')} } from '${relativePath}';`);
   }
+
+  console.log(`\n\n\n IMPORT DYNAMIQUE DEPUIS ${appelantDir}`);
+  console.log(importLogs.join('\n'));
+  console.log('\n');
+  console.log(`const usecasesWithoutInjectedDependencies = {
+    ${Object.keys(imports).join(',\n')}
+   };`);
   return imports;
+}
+
+function getAppelantUrl() {
+  const err = new Error();
+  const stack = err.stack.split('\n');
+  // console.log(stack.slice(0, 4));
+  const line = stack[3];
+  const match = line.match(/\((file:\/\/\/?.*):\d+:\d+\)/) || line.match(/at (?:async )?(file:\/\/\/?.*):\d+:\d+/);
+  if (!match) {
+    return '';
+  }
+
+  let appelantAbs = match[1];
+  if (appelantAbs.startsWith('file://')) {
+    appelantAbs = fileURLToPath(appelantAbs);
+  }
+  return dirname(appelantAbs);
 }
 
 export async function importNamedExportFromFile(filepath) {

--- a/api/src/team/domain/usecases/index.js
+++ b/api/src/team/domain/usecases/index.js
@@ -1,6 +1,3 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import * as mailService from '../../../../src/shared/domain/services/mail-service.js';
 import * as sharedMembershipRepository from '../../../../src/shared/infrastructure/repositories/membership-repository.js';
 import * as organizationRepository from '../../../../src/shared/infrastructure/repositories/organization-repository.js';
@@ -9,7 +6,6 @@ import { refreshTokenRepository } from '../../../identity-access-management/infr
 import * as userRepository from '../../../identity-access-management/infrastructure/repositories/user.repository.js';
 import { adminMemberRepository } from '../../../shared/infrastructure/repositories/admin-member.repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
-import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
 import { certificationCenterInvitedUserRepository } from '../../infrastructure/repositories/certification-center-invited-user.repository.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
@@ -22,8 +18,6 @@ import { userOrgaSettingsRepository } from '../../infrastructure/repositories/us
 import { userOrganizationsForAdminRepository } from '../../infrastructure/repositories/user-organizations-for-admin.repository.js';
 import * as certificationCenterInvitationService from '../services/certification-center-invitation-service.js';
 import { organizationInvitationService } from '../services/organization-invitation.service.js';
-
-const path = dirname(fileURLToPath(import.meta.url));
 
 const dependencies = {
   adminMemberRepository,
@@ -47,8 +41,94 @@ const dependencies = {
   userRepository,
 };
 
+import { acceptCertificationCenterInvitation } from './accept-certification-center-invitation.usecase.js';
+import { acceptOrganizationInvitation } from './accept-organization-invitation.usecase.js';
+import { archiveCertificationCenterData } from './archive-certification-center-data.usecase.js';
+import { cancelCertificationCenterInvitation } from './cancel-certification-center-invitation.js';
+import { cancelOrganizationInvitation } from './cancel-organization-invitation.js';
+import { createCertificationCenterMembershipByEmail } from './create-certification-center-membership-by-email.usecase.js';
+import { createCertificationCenterMembershipForScoOrganizationAdminMember } from './create-certification-center-membership-for-sco-organization-admin-member.usecase.js';
+import { createMembership } from './create-membership.usecase.js';
+import { createOrUpdateCertificationCenterInvitation } from './create-or-update-certification-center-invitation.js';
+import { createOrUpdateCertificationCenterInvitationForAdmin } from './create-or-update-certification-center-invitation-for-admin.js';
+import { createOrUpdateUserOrgaSettings } from './create-or-update-user-orga-settings.usecase.js';
+import { createOrganizationInvitationByAdmin } from './create-organization-invitation-by-admin.usecase.js';
+import { createOrganizationInvitations } from './create-organization-invitations.usecase.js';
+import { createProOrganizationInvitation } from './create-pro-organization-invitation.usecase.js';
+import { deactivateAdminMember } from './deactivate-admin-member.usecase.js';
+import { disableCertificationCenterMembershipFromPixAdmin } from './disable-certification-center-membership-from-pix-admin.usecase.js';
+import { disableCertificationCenterMembershipFromPixCertif } from './disable-certification-center-membership-from-pix-certif.js';
+import { disableMembership } from './disable-membership.usecase.js';
+import { disableOwnOrganizationMembership } from './disable-own-organization-membership.usecase.js';
+import { findCertificationCenterMembershipsByCertificationCenter } from './find-certification-center-memberships-by-certification-center.usecase.js';
+import { findCertificationCenterMembershipsByUser } from './find-certification-center-memberships-by-user.js';
+import { findPaginatedFilteredOrganizationMemberships } from './find-paginated-filtered-organization-memberships.js';
+import { findPendingCertificationCenterInvitations } from './find-pending-certification-center-invitations.usecase.js';
+import { findPendingOrganizationInvitations } from './find-pending-organization-invitations.js';
+import { findUserOrganizationsForAdmin } from './find-user-organizations-for-admin.usecase.js';
+import { getAdminMemberDetails } from './get-admin-member-details.usecase.js';
+import { getAdminMembers } from './get-admin-members.usecase.js';
+import { getCertificationCenterInvitation } from './get-certification-center-invitation.usecase.js';
+import { getOrganizationInvitation } from './get-organization-invitation.js';
+import { getOrganizationMemberIdentities } from './get-organization-member-identities.usecase.js';
+import { getOrganizationMembership } from './get-organization-membership.js';
+import { getPrescriber } from './get-prescriber.js';
+import { getUserTeamsInfo } from './get-user-teams-info.usecase.js';
+import { resendCertificationCenterInvitation } from './resend-certification-center-invitation.usecase.js';
+import { resendOrganizationInvitation } from './resend-organization-invitation.usecase.js';
+import { saveAdminMember } from './save-admin-member.usecase.js';
+import { sendScoInvitation } from './send-sco-invitation.js';
+import { updateAdminMember } from './update-admin-member.usecase.js';
+import { updateCertificationCenterMembership } from './update-certification-center-membership.usecase.js';
+import { updateCertificationCenterMembershipLastAccessedAt } from './update-certification-center-membership-last-accessed-at.usecase.js';
+import { updateCertificationCenterReferer } from './update-certification-center-referer.js';
+import { updateMembership } from './update-membership.usecase.js';
+import { updateMembershipLastAccessedAt } from './update-membership-last-accessed-at.usecase.js';
+
 const usecasesWithoutInjectedDependencies = {
-  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+  acceptCertificationCenterInvitation,
+  acceptOrganizationInvitation,
+  archiveCertificationCenterData,
+  cancelCertificationCenterInvitation,
+  cancelOrganizationInvitation,
+  createCertificationCenterMembershipByEmail,
+  createCertificationCenterMembershipForScoOrganizationAdminMember,
+  createMembership,
+  createOrUpdateCertificationCenterInvitationForAdmin,
+  createOrUpdateCertificationCenterInvitation,
+  createOrUpdateUserOrgaSettings,
+  createOrganizationInvitationByAdmin,
+  createOrganizationInvitations,
+  createProOrganizationInvitation,
+  deactivateAdminMember,
+  disableCertificationCenterMembershipFromPixAdmin,
+  disableCertificationCenterMembershipFromPixCertif,
+  disableMembership,
+  disableOwnOrganizationMembership,
+  findCertificationCenterMembershipsByCertificationCenter,
+  findCertificationCenterMembershipsByUser,
+  findPaginatedFilteredOrganizationMemberships,
+  findPendingCertificationCenterInvitations,
+  findPendingOrganizationInvitations,
+  findUserOrganizationsForAdmin,
+  getAdminMemberDetails,
+  getAdminMembers,
+  getCertificationCenterInvitation,
+  getOrganizationInvitation,
+  getOrganizationMemberIdentities,
+  getOrganizationMembership,
+  getPrescriber,
+  getUserTeamsInfo,
+  resendCertificationCenterInvitation,
+  resendOrganizationInvitation,
+  saveAdminMember,
+  sendScoInvitation,
+  updateAdminMember,
+  updateCertificationCenterMembershipLastAccessedAt,
+  updateCertificationCenterMembership,
+  updateCertificationCenterReferer,
+  updateMembershipLastAccessedAt,
+  updateMembership,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);


### PR DESCRIPTION
## 🔆 Problème
Actuellement, nous avons des fichiers index.js dans lesquels sont fait de l'injection de dépendances. Ces fichiers importent tous les fichiers à côté pour récupérer les fonctions exportées via la fonction `importNamedExportsFromDirectory`. 

On a des erreurs dans ce style : 
```
ReferenceError: Cannot access 'repositories' before initialization
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init

Les imports dynamiques, ne sont pas résolues au moment où on initie les modules.

Cependant, depuis l'arrivée des API internes, nous avons rencontrés plusieurs fois des soucis de dépendances circulaires, en partie dus à des attentes de top level await. 

Typiquement une API interne Prescription qui dans le fin fond appel une api interne eval qui dans le fin fond appel une API interne accès qui elle-même appelle prescription.

## ⛱️ Proposition

Nous repassons les imports en statiques, ce qui permettra à la résolution des modules d'avoir directement les variables instanciées au lieu de devoir gérer les top level await

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
