### PR TITLE
[TECH] Ajouter un test e2e pour un parcours combiné (PIX-19121)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1094,6 +1094,7 @@ jobs:
             PIX_CERTIF_URL: http://localhost:4203
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
             AUTH_SECRET: 'secret'
+            REDIRECTION_URL_SECRET: 'secret'
       - store_test_results:
           path: ./node_modules/.playwright/junit
       - store_artifacts:

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -26,7 +26,7 @@ export async function buildFreshPixAppUser(
   rawPassword: string,
   mustRevalidateCgu: boolean,
 ) {
-  await createUserInDB(firstName, lastName, email, rawPassword, true, false, mustRevalidateCgu, undefined);
+  return createUserInDB(firstName, lastName, email, rawPassword, true, false, mustRevalidateCgu, undefined);
 }
 
 export async function buildFreshPixCertifUser(firstName: string, lastName: string, email: string, rawPassword: string) {
@@ -232,7 +232,7 @@ async function createLegalDocumentVersionInDB() {
   return id;
 }
 
-async function createOrganizationInDB({
+export async function createOrganizationInDB({
   type,
   externalId,
   isManagingStudents,
@@ -324,7 +324,7 @@ async function createCertificationCenterMembershipInDB(userId: number, certifica
   });
 }
 
-async function createTargetProfileInDB(name: string) {
+export async function createTargetProfileInDB(name: string) {
   const someDate = new Date();
   const [{ id }] = await knex('target-profiles')
     .insert({

--- a/high-level-tests/e2e-playwright/pages/pix-app/ReconciliationLoginPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/ReconciliationLoginPage.ts
@@ -1,0 +1,11 @@
+import { Page } from '@playwright/test';
+
+export class ReconciliationLoginPage {
+  constructor(private readonly page: Page) {}
+
+  async login(emailOrUsername: string, rawPassword: string) {
+    await this.page.getByLabel('Adresse e-mail ou identifiant').fill(emailOrUsername);
+    await this.page.getByLabel('Mot de passe').fill(rawPassword);
+    await this.page.getByRole('button', { name: 'Se connecter' }).click();
+  }
+}

--- a/high-level-tests/e2e-playwright/pages/pix-app/ReconciliationPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/ReconciliationPage.ts
@@ -1,0 +1,22 @@
+import { Page } from '@playwright/test';
+
+export class ReconciliationPage {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Fill reconciation form
+   * @param firstName
+   * @param lastName
+   * @param birthDate with dd/mm/yyyy format
+   */
+  async reconcile(firstName: string, lastName: string, birthDate: string) {
+    await this.page.getByRole('textbox', { name: 'Prénom' }).fill(firstName);
+    await this.page.getByRole('textbox', { name: 'Nom', exact: true }).fill(lastName);
+    const [day, month, year] = birthDate.split('/');
+    await this.page.getByRole('textbox', { name: 'jour de naissance' }).fill(day);
+    await this.page.getByRole('textbox', { name: 'mois de naissance' }).fill(month);
+    await this.page.getByRole('textbox', { name: 'année de naissance' }).fill(year);
+    await this.page.getByRole('button', { name: "C'est parti !" }).click();
+    await this.page.getByRole('button', { name: 'Associer' }).click();
+  }
+}

--- a/high-level-tests/e2e-playwright/playwright.config.ts
+++ b/high-level-tests/e2e-playwright/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   globalSetup: './global-setup',
   outputDir: `${playwrightFolder}/output`,
   forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
+  retries: 0,
   workers: 1,
   fullyParallel: true,
   reporter: isCI ? [['junit', { outputFile: `${playwrightFolder}/junit/results.xml` }]] : 'list',

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -1,0 +1,117 @@
+import { buildFreshPixAppUser, createOrganizationInDB, createTargetProfileInDB, knex } from '../../helpers/db.js';
+import { expect, test } from '../../helpers/fixtures.js';
+
+test('pass a combined course as sco user and see the final result', async ({ page }) => {
+  const TARGET_PROFILE_TUBES = [
+    {
+      id: 'recSqw34xWSLgEgt',
+      level: 1,
+    },
+  ];
+  const CAMPAIGN_SKILLS = ['rec1aqbvWEqtoMOLw'];
+  const email = 'alain.terieur@example.net';
+  const firstName = 'Alain';
+  const lastName = 'Terieur';
+  const birthdate = new Date('2010-07-10');
+  const userId = await buildFreshPixAppUser(firstName, lastName, email, 'pix123', false);
+  const organizationId = await createOrganizationInDB({ type: 'SCO', externalId: '123', isManagingStudents: true });
+  await knex('organization-learners').insert({ firstName, lastName, birthdate, organizationId });
+  const targetProfileId = await createTargetProfileInDB('targetProfile');
+  const [{ id: campaignId }] = await knex('campaigns')
+    .insert({
+      targetProfileId,
+      name: 'campagne diag',
+      code: 'ASSDIAG12',
+      organizationId,
+      creatorId: userId,
+      ownerId: userId,
+      type: 'ASSESSMENT',
+      customResultPageButtonText: 'Continuer',
+      customResultPageButtonUrl: 'http://localhost:4200/parcours/COMBINIX1',
+    })
+    .returning('id');
+  await knex('campaign_skills').insert({ campaignId, skillId: CAMPAIGN_SKILLS[0] });
+  await knex('target-profile_tubes').insert({
+    targetProfileId,
+    level: TARGET_PROFILE_TUBES[0].level,
+    tubeId: TARGET_PROFILE_TUBES[0].id,
+  });
+  const [{ id: trainingId }] = await knex('trainings')
+    .insert({
+      title: 'demo combinix 1',
+      link: '/modules/demo-combinix-1',
+      type: 'modulix',
+      duration: 1,
+      locale: 'fr',
+      editorName: 'demo',
+      editorLogoUrl: 'demo',
+    })
+    .returning('id');
+
+  const moduleId1 = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+  await knex('target-profile-trainings').insert({ targetProfileId, trainingId });
+  await knex('training-triggers').insert({ trainingId, threshold: 0, type: 'prerequisite' });
+  await knex('training-triggers').insert({ trainingId, threshold: 100, type: 'goal' });
+
+  const successRequirements = JSON.stringify([
+    {
+      requirement_type: 'campaignParticipations',
+      comparison: 'all',
+      data: {
+        campaignId: {
+          data: campaignId,
+          comparison: 'equal',
+        },
+        status: {
+          data: 'SHARED',
+          comparison: 'equal',
+        },
+      },
+    },
+    {
+      requirement_type: 'passages',
+      comparison: 'all',
+      data: {
+        moduleId: {
+          data: moduleId1,
+          comparison: 'equal',
+        },
+        isTerminated: {
+          data: true,
+          comparison: 'equal',
+        },
+      },
+    },
+  ]);
+  const eligibilityRequirements = JSON.stringify([]);
+  await knex('quests').insert({ code: 'COMBINIX1', organizationId, successRequirements, eligibilityRequirements });
+
+  await page.goto('http://localhost:4200/parcours/COMBINIX1/');
+  await page.getByRole('button', { name: 'Se connecter' }).click();
+  await page.getByRole('textbox', { name: 'Adresse e-mail ou identifiant' }).fill('alain.terieur@example.net');
+  await page.getByRole('textbox', { name: 'Mot de passe *' }).fill('pix123');
+  await page.getByRole('button', { name: 'Se connecter' }).click();
+  await page.getByRole('textbox', { name: 'Prénom' }).fill('Alain');
+  await page.getByRole('textbox', { name: 'Nom', exact: true }).fill('Terieur');
+  await page.getByRole('textbox', { name: 'jour de naissance' }).fill('10');
+  await page.getByRole('textbox', { name: 'mois de naissance' }).fill('07');
+  await page.getByRole('textbox', { name: 'année de naissance' }).fill('2010');
+  await page.getByRole('button', { name: "C'est parti !" }).click();
+  await page.getByRole('button', { name: 'Associer' }).click();
+  await page.getByRole('button', { name: 'Commencer mon parcours' }).click();
+  await page.getByRole('link', { name: 'campagne diag' }).click();
+  await page.getByRole('button', { name: 'Je commence' }).click();
+  await page.getByRole('button', { name: 'Ignorer' }).click();
+  await page.getByRole('button', { name: 'Je passe et je vais à la' }).click();
+  //Le bouton "Voir mes résultats" existe deux fois à ce moment, on doit donc faire autrement en attendant de corriger cette page
+  await page.locator('#ember138').click();
+  await page.getByRole('button', { name: "J'envoie mes résultats" }).click();
+  await page.getByRole('button', { name: 'Fermer', exact: true }).click();
+  await page.getByRole('link', { name: 'Continuer' }).click();
+  await page.getByRole('link', { name: 'Demo combinix' }).click();
+  await page.getByRole('button', { name: 'Commencer le module' }).click();
+  await page.getByRole('button', { name: 'Terminer' }).click();
+  //Sera enlevé au prochain ticket pour passer l'url en relative, on aura plus les problèmes liés à l'host
+  await page.goto('http://localhost:4200/parcours/COMBINIX1/');
+  await expect(page.getByRole('heading', { name: 'Félicitations ! Vous avez terminé !' })).toBeVisible();
+});


### PR DESCRIPTION
## 🔆 Problème
Maintenant que nous avons mis en place le scénario d'un parcours combiné de la reconciliation d'un user jusqu'à la fin de son parcours combiné. On aimerait se proteger pour les futurs développement avec un test e2e retraçant ce scénario

## ⛱️ Proposition
Ajouter un test e2e complet, qui jouera le scénario suivant : 
- Se connecter avec un utilisateur
- Accéder à la page du parcours combiné 
- Rentrer ses infos pour avoir la reconciliation avec l'orga détentrice du parcours
- Jouer la campagne de diagnostique
- Jouer le module recommandé
- Voir l'encart de félicitation en fin de parcours combiné

## 🌊 Remarques
On a remarqué que les tests e2e échouaient systématiquement en cas de retry, car les bases des tests e2e ne sont pas clean entre chaque tests. Ce qui fait qu'il y a des conflits lors des insertions avec contrainte d'unicité.
Donc on passe le retry a 0 dans la config playwright afin de ne pas les faire tourner pour rien

## 🏄 Pour tester
Les tests sont verts 